### PR TITLE
Seeking with captions

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -24,19 +24,6 @@ class TimelineController extends EventHandler {
     if (this.config.enableCEA708Captions)
     {
       var self = this;
-      var sendAddTrackEvent = function (track, media)
-      {
-        var e = null;
-        try {
-          e = new window.Event('addtrack');
-        } catch (err) {
-          //for IE11
-          e = document.createEvent('Event');
-          e.initEvent('addtrack', false, false);
-        }
-        e.track = track;
-        media.dispatchEvent(e);
-      };
 
       var channel1 =
       {
@@ -56,7 +43,9 @@ class TimelineController extends EventHandler {
               self.textTrack1 = existingTrack1;
               self.clearCurrentCues(self.textTrack1);
 
-              sendAddTrackEvent(self.textTrack1, self.media);
+              let e = new window.Event('addtrack');
+              e.track = self.textTrack1;
+              self.media.dispatchEvent(e);
             }
           }
 
@@ -82,7 +71,9 @@ class TimelineController extends EventHandler {
               self.textTrack2 = existingTrack2;
               self.clearCurrentCues(self.textTrack2);
 
-              sendAddTrackEvent(self.textTrack2, self.media);
+              let e = new window.Event('addtrack');
+              e.track = self.textTrack2;
+              self.media.dispatchEvent(e);
             }
           }
 

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -1,3 +1,83 @@
+var FRAG_TOLERANCE = 0.5;
+var CUE_TOLERANCE = 0.01;
+var LEVEL_CUE_TOLERANCE = 0.1;
+var ROLLUP_MAX_ROWS = 4;
+
+function updateEndTimeForMultiFragCues(cue, track){
+  //Check for sequential fragment loading - necessary for captions that span multiple fragments.
+  if (track.curFragStartTime && track.prevFragEndTime && Math.abs(track.curFragStartTime - track.prevFragEndTime) > FRAG_TOLERANCE) {
+    //We cannot fully rely on the endTime value for captions that span multiple fragments.
+    //Confirm first if its startTime is in the previous fragment. This can be checked by its startTime not within the current fragment.
+    if (cue.startTime < track.curFragStartTime - FRAG_TOLERANCE || cue.startTime > track.curFragEndTime + FRAG_TOLERANCE) {
+      //Then check if its endTime is not in the previous fragment.
+      if (cue.endTime < track.prevFragStartTime - FRAG_TOLERANCE || cue.endTime > track.prevFragEndTime + FRAG_TOLERANCE) {
+        //For Pop-On captions, they could be parsed way before curFrag and prevFrag and are just waiting for an EOC command.
+        if (track.prevFragEndTime > track.curFragEndTime && cue.endTime < track.prevFragEndTime) {
+          return;
+        }
+        //By this point, we can only guarantee that its endTime should only be the endTime of the previous fragment.
+        cue.endTime = track.prevFragEndTime;
+      }
+    }
+  }
+}
+
+function binarySearchCue(num, arr){
+  var mid;
+  var lo = 0;
+  var hi = arr.length - 1;
+  var retVal = 0;
+  if(arr.length > 0) {
+    while (hi - lo > 1) {
+      mid = Math.floor((lo + hi) / 2);
+      if (Math.abs(arr[mid].startTime - num) < CUE_TOLERANCE) {
+        return mid;
+      }
+      if (arr[mid].startTime < num) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    if (Math.abs(arr[hi].startTime - num) < CUE_TOLERANCE || arr[hi].startTime < num) {
+      retVal = hi;
+    } else {
+      retVal = lo;
+    }
+  }
+  return retVal;
+}
+
+function isADuplicate(cue, track){
+  var duplicateFound = false;
+  var tCues = track.cues;
+  if (tCues && tCues.length > 0) {
+    var len = tCues.length;
+    var cueStartIndex = binarySearchCue(cue.startTime, tCues);
+    if( cueStartIndex >= 0 && cueStartIndex < len) {
+      //Consider up to +/-ROLLUP_MAX_ROWS cues for roll-up captions
+      var cueStart = (cueStartIndex - ROLLUP_MAX_ROWS) < 0   ? 0 :   (cueStartIndex - ROLLUP_MAX_ROWS);
+      var cueEnd   = (cueStartIndex + ROLLUP_MAX_ROWS) > len ? len : (cueStartIndex + ROLLUP_MAX_ROWS);
+      for(var i = cueStart; i < cueEnd; i++) {
+        var obj = tCues[i];
+        var tol = CUE_TOLERANCE;
+        if (obj && track && obj.curFragLevel !== track.curFragLevel) {
+          tol += LEVEL_CUE_TOLERANCE;
+        }
+        //The || here is necessary to filter out the case when the endTime was added mainly because we found an EOC, RCL, RDL or EDM on a different fragment.
+        if ((Math.abs(obj.startTime - cue.startTime) <= tol || Math.abs(obj.endTime - cue.endTime) <= tol) && obj.line === cue.line) {
+          duplicateFound = true;
+          break;
+        }
+        if (track.curFragEndTime && track.curFragEndTime + FRAG_TOLERANCE <= obj.startTime) {
+          break;
+        }
+      }
+    }
+  }
+  return duplicateFound;
+}
+
 var Cues = {
 
   newCue: function(track, startTime, endTime, captionScreen) {
@@ -55,7 +135,13 @@ var Cues = {
         cue.align = 'left';
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
         cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
-        track.addCue(cue);
+
+        updateEndTimeForMultiFragCues(cue, track);
+
+        if (isADuplicate(cue, track) === false) {
+          cue.curFragLevel = track.curFragLevel;
+          track.addCue(cue);
+        }
       }
     }
   }


### PR DESCRIPTION
With the current code, seeking and rendition switching can corrupt 608/708 captions data. This can be easily reproduced with any stream with 608/708 captions and by seeking back and forth while fragments are being loaded.

The issues that I fixed here include the following:
1. Cues got cleared when a fragment with a lesser presentation timestamp is loaded. 
The new code now only clear cues when initializing the text track and when destroying the library.

2. Captions whose startTime and endTime are in different fragments.
I have the following scenario to illustrate this:
```
    cue1.startTime                         cue2.startTime
                      cue1.endTime                              cue2.endTime
          |--------------------|              |----------------------|
 ...<----------------><----------------><----------------><---------------->....
         frag11               frag12             frag13            frag14
```
Let's say we are currently parsing frag13 and then we seek to frag12. What happens in the previous code is cue2.endTime will be set to cue1.endTime which is incorrect.
Since it would be too much of a burden to reload/re-parse the relevant fragments to get the correct startTime and endTime for this case, what I did is when a non-sequential fragment loading is detected (like when we seek), the endTime is re-evaluated and set to the endTime of the fragment where it was found. In the example above, cue2.endTime is set to (frag13.startTime + frag13.duration). There will be times when we lose having captions (cue2 not showing from frag14.start until cue2.endTime) but I think this a compromise that we can live with (rather than having to keep track of previously loaded fragments and reload them).

3. Searching through TextTrack's cues to determine if it's a duplicate.
We have a problem with having captions doubled or duplicated. This can be easily reproduced on Android Chrome browsers with a roll-up caption stream. I found out that cues in a TextTrack object are sorted by startTime so I just used binary search to find the relevant cue. I then checked its line number and of its adjacent cues in deciding for duplicates.
