### PR TITLE
Captions - configuration for text tracks

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -57,6 +57,10 @@
   - [`abrController`](#abrcontroller)
   - [`timelineController`](#timelinecontroller)
   - [`enableCEA708Captions`](#enablecea708captions)
+    [`captionsTextTrack1Label`](#captionsTextTrack1Label)
+    [`captionsTextTrack1LanguageCode`](#captionsTextTrack1LanguageCode)
+    [`captionsTextTrack2Label`](#captionsTextTrack2Label)
+    [`captionsTextTrack2LanguageCode`](#captionsTextTrack2LanguageCode)
   - [`stretchShortVideoTrack`](#stretchshortvideotrack)
   - [`forceKeyFrameOnDiscontinuity`](#forcekeyframeondiscontinuity)
   - [`abrEwmaFastLive`](#abrewmafastlive)
@@ -758,6 +762,38 @@ Parameter should be a class with a `destroy()` method:
 whether or not to enable CEA-708 captions
 
 parameter should be a boolean
+
+### `captionsTextTrack1Label`
+
+(default: `English`)
+
+Label for the text track generated for CEA-708 captions track 1. This is how it will appear in the browser's native menu for subtitles and captions.
+
+parameter should be a string
+
+### `captionsTextTrack1LanguageCode`
+
+(default: `en`)
+
+RFC 3066 language code for the text track generated for CEA-708 captions track 1.
+
+parameter should be a string
+
+### `captionsTextTrack2Label`
+
+(default: `Spanish`)
+
+Label for the text track generated for CEA-708 captions track 2. This is how it will appear in the browser's native menu for subtitles and captions.
+
+parameter should be a string
+
+### `captionsTextTrack2LanguageCode`
+
+(default: `es`)
+
+RFC 3066 language code for the text track generated for CEA-708 captions track 2.
+
+parameter should be a string
 
 ### `stretchShortVideoTrack`
 

--- a/src/config.js
+++ b/src/config.js
@@ -84,6 +84,10 @@ export var hlsDefaultConfig = {
       cueHandler: Cues,
       enableCEA708Captions: true,               // used by timeline-controller
       enableWebVTT: true,                       // used by timeline-controller
+      captionsTextTrack1Label: 'English',       // used by timeline-controller
+      captionsTextTrack1LanguageCode: 'en',      // used by timeline-controller
+      captionsTextTrack2Label: 'Spanish',       // used by timeline-controller
+      captionsTextTrack2LanguageCode: 'es',     // used by timeline-controller
 //#endif
       stretchShortVideoTrack: false,            // used by mp4-remuxer
       forceKeyFrameOnDiscontinuity: true,       // used by ts-demuxer

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -73,7 +73,7 @@ class TimelineController extends EventHandler {
             var existingTrack1 = self.getExistingTrack('1');
             if (!existingTrack1)
             {
-              const textTrack1 = self.createTextTrack('captions', 'English', 'en');
+              const textTrack1 = self.createTextTrack('captions', self.config.captionsTextTrack1Label, self.config.captionsTextTrack1LanguageCode);
               if (textTrack1) {
                 textTrack1.textTrack1 = true;
                 self.textTrack1 = textTrack1;
@@ -101,7 +101,7 @@ class TimelineController extends EventHandler {
             var existingTrack2 = self.getExistingTrack('2');
             if (!existingTrack2)
             {
-              const textTrack2 = self.createTextTrack('captions', 'Spanish', 'es');
+              const textTrack2 = self.createTextTrack('captions', self.config.captionsTextTrack2Label, self.config.captionsTextTrack1LanguageCode);
               if (textTrack2) {
                 textTrack2.textTrack2 = true;
                 self.textTrack2 = textTrack2;


### PR DESCRIPTION
### Description of the Changes
Addresses issue #1019 by adding configuration options for the caption text track label and language code for both generated text tracks. They default to the prior hard-coded values.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
