### PR TITLE
Fix: Switching audio, blocked by buffer.

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -199,7 +199,7 @@ class AudioStreamController extends EventHandler {
             trackId = this.trackId;
 
         // if buffer length is less than maxBufLen try to load a new fragment
-        if (bufferLen < maxBufLen && trackId < tracks.length) {
+        if ((bufferLen < maxBufLen || audioSwitch) && trackId < tracks.length) {
           trackDetails = tracks[trackId].details;
           // if track info not retrieved yet, switch state and wait for track retrieval
           if (typeof trackDetails === 'undefined') {


### PR DESCRIPTION
## Description of the Changes
Audio switching independent of buffer.

### Description of the problem
```
Segment duration: 40s.
maxBufferLength: 90s.
```
The player loads into buffer 120s. For 30 seconds will not change the audio track. 


