### PR TITLE
Added PLAYBACK_NOT_STUCK_ANYMORE event.

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1406,7 +1406,12 @@ _checkBuffer() {
         if (playheadMoving) {
           // played moving, but was previously stalled => now not stuck anymore
           if (this.stallReported) {
-            logger.warn(`playback not stuck anymore @${currentTime}, after ${Math.round(performance.now()-this.stalled)}ms`);
+            const data = {
+              currentTime,
+              after: Math.round(performance.now()-this.stalled)
+            };
+            logger.warn(`playback not stuck anymore @${data.currentTime}, after ${data.after}ms`);
+            this.hls.trigger(Event.PLAYBACK_NOT_STUCK_ANYMORE,data);
             this.stallReported = false;
           }
           this.stalled = undefined;

--- a/src/events.js
+++ b/src/events.js
@@ -104,5 +104,7 @@ module.exports = {
   // fired when a decrypt key loading is completed - data: { frag : fragment object, payload : key payload, stats : { trequest, tfirst, tload, length}}
   KEY_LOADED: 'hlsKeyLoaded',
   // fired upon stream controller state transitions - data: {previousState, nextState}
-  STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
+  STREAM_STATE_TRANSITION: 'hlsStreamStateTransition',
+  // fired when playback unstack after a stall report - data: {currentTime, after}
+  PLAYBACK_NOT_STUCK_ANYMORE: 'hlsPlaybackNotStuckAnymore'
 };

--- a/src/events.js
+++ b/src/events.js
@@ -105,6 +105,6 @@ module.exports = {
   KEY_LOADED: 'hlsKeyLoaded',
   // fired upon stream controller state transitions - data: {previousState, nextState}
   STREAM_STATE_TRANSITION: 'hlsStreamStateTransition',
-  // fired when playback unstack after a stall report - data: {currentTime, after}
+  // fired when playback unstuck after a stall report - data: {currentTime, after}
   PLAYBACK_NOT_STUCK_ANYMORE: 'hlsPlaybackNotStuckAnymore'
 };


### PR DESCRIPTION
PLAYBACK_NOT_STUCK_ANYMORE event triggered in stream-controller as soon as it detects that the playback restart after a stall report.

### Description of the Changes
Added a new event that notify when a stucked playback becomes unstucked.
This can be useful to handle loaders during buffering or to react accordingly in case the playback recover itself.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
