### PR TITLE
Do not allow frag.start to be negative

### DIFF
--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -130,7 +130,7 @@ const LevelHelper = {
       if (toIdx > fromIdx) {
         fragTo.start = fragFrom.start + fragFrom.duration;
       } else {
-        fragTo.start = fragFrom.start - fragTo.duration;
+        fragTo.start = Math.max(fragFrom.start - fragTo.duration, 0);
       }
     }
   }

--- a/tests/functional/streams.json
+++ b/tests/functional/streams.json
@@ -3,7 +3,7 @@
 	"bigBuckBunny480p": {"url": "http://www.streambox.fr/playlists/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8", "description": "big buck bunny,480p", "live": false, "abr": false, "blacklist_ua" : ["internet explorer"]},
 	"issue666": {"url": "http://www.streambox.fr/playlists/cisq0gim60007xzvi505emlxx.m3u8", "description": "hls.js/issues/666", "live": false, "abr": false,"blacklist_ua" : ["internet explorer"]},
   "issue649": {"url": "http://level3cdn.screen9.com/M/V/e/X/eXLpum-4HGEg67ECxUnqWQ_720p_hls/playlist.m3u8?token=089899b60a6e85dd2239a", "description": "hls.js/issues/649", "live": false, "abr": false},
-	"nasa": {"url": "http://nasatv-lh.akamaihd.net/i/NASA_101@319270/index_1000_av-p.m3u8?sd=10&rebase=on", "description": "NASA live stream", "live": true, "abr": false, "blacklist_ua" : ["internet explorer","safari"]},
+	"nasa": {"url": "https://nasa-i.akamaihd.net/hls/live/253565/NTV-Public1/master.m3u8", "description": "NASA live stream", "live": true, "abr": false, "blacklist_ua" : ["internet explorer","safari"]},
   "closedcaptions" : {"url": "http://playertest.longtailvideo.com/adaptive/captions/playlist.m3u8", "description": "CNN special report, with CC", "live": false, "abr": false, "blacklist_ua" : ["safari"]},
   "oceans_aes": {"url": "http://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8", "description": "AES encrypted,ABR", "live": false , "abr": true},
   "bbb_aes": {"url": "http://streambox.fr/playlists/sample_aes/index.m3u8", "description": "SAMPLE-AES encrypted", "live": false , "abr": false},


### PR DESCRIPTION
### Description of the Changes
A negative frag start time can lead to DTS becoming non-monotonic when remuxed, causing Chrome to throw a SourceBuffer exception and crashing playback.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md

Test stream (expires in a day or so): https://pubads.g.doubleclick.net/ondemand/hls/content/6698/vid/8f6e0be7-bbdb-4515-b24a-1ae276f08167/CHS/streams/6d0840da-0fb8-4c21-abba-999c73ed78cf/master.m3u8
