### PR TITLE
Remove erroneous docs for startFragPrefetch

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -583,7 +583,6 @@ Prefetch start fragment although media not attached.
 (default: `false`)
 
 Start prefetching start fragment although media not attached yet.
-Max number of append retries.
 
 ### `appendErrorMaxRetry`
 


### PR DESCRIPTION
### Description of the Changes
Remove erroneous docs for startFragPrefetch

Reviewing the code that uses `startFragPrefetch` it doesn't appear to do anything with "Max number of append retries". This appears to have been added as part of a23d8cd1b086a2c988a35bd32964997b0b1ed624

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [X] new unit / functional tests have been added (whenever applicable)
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [X] API or design changes are documented in API.md
