### PR TITLE
avoid showing repeated webvtt cues

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -277,6 +277,9 @@ class TimelineController extends EventHandler {
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
             // Add cues and trigger event with success true.
             cues.forEach(cue => {
+              // Sometimes there are cue overlaps on segmented vtts so the same
+              // cue can appear more than once in different vtt files.
+              // This avoid showing duplicated cues with same timecode and text.
               if (!textTracks[frag.trackId].cues.getCueById(cue.id)) {
                 textTracks[frag.trackId].addCue(cue);
               }

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -277,7 +277,9 @@ class TimelineController extends EventHandler {
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
             // Add cues and trigger event with success true.
             cues.forEach(cue => {
-              textTracks[frag.trackId].addCue(cue);
+              if (!textTracks[frag.trackId].cues.getCueById(cue.id)) {
+                textTracks[frag.trackId].addCue(cue);
+              }
             });
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: true, frag: frag});
           },

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -275,13 +275,14 @@ class TimelineController extends EventHandler {
 
         // Parse the WebVTT file contents.
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
+            const currentTrack = textTracks[frag.trackId];
             // Add cues and trigger event with success true.
             cues.forEach(cue => {
               // Sometimes there are cue overlaps on segmented vtts so the same
               // cue can appear more than once in different vtt files.
               // This avoid showing duplicated cues with same timecode and text.
-              if (!textTracks[frag.trackId].cues.getCueById(cue.id)) {
-                textTracks[frag.trackId].addCue(cue);
+              if (!currentTrack.cues.getCueById(cue.id)) {
+                currentTrack.addCue(cue);
               }
             });
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: true, frag: frag});

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -25,7 +25,7 @@ const hash = function(text) {
         hash = (hash * 33) ^ text.charCodeAt(--i);
     }
     return (hash >>> 0).toString();
-}
+};
 
 const calculateOffset = function(vttCCs, cc, presentationTime) {
     let currCC = vttCCs[cc];

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -17,6 +17,16 @@ const cueString2millis = function(timeString) {
     return ts;
 };
 
+// From https://github.com/darkskyapp/string-hash
+const hash = function(text) {
+    let hash = 5381;
+    let i = text.length;
+    while (i) {
+        hash = (hash * 33) ^ text.charCodeAt(--i);
+    }
+    return (hash >>> 0).toString();
+}
+
 const calculateOffset = function(vttCCs, cc, presentationTime) {
     let currCC = vttCCs[cc];
     let prevCC = vttCCs[currCC.prevCC];
@@ -80,6 +90,7 @@ const WebVTTParser = {
 
             cue.startTime += cueOffset - localTime;
             cue.endTime += cueOffset - localTime;
+            cue.id = hash(cue.startTime) + hash(cue.endTime) + hash(cue.text);
 
             // Fix encoding of special characters. TODO: Test with all sorts of weird characters.
             cue.text = decodeURIComponent(escape(cue.text));

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -90,6 +90,9 @@ const WebVTTParser = {
 
             cue.startTime += cueOffset - localTime;
             cue.endTime += cueOffset - localTime;
+
+            // Create a unique hash id for a cue based on start/end times and text.
+            // This helps timeline-controller to avoid showing repeated captions.
             cue.id = hash(cue.startTime) + hash(cue.endTime) + hash(cue.text);
 
             // Fix encoding of special characters. TODO: Test with all sorts of weird characters.


### PR DESCRIPTION
### Description of the Changes

Sometimes there are cue overlaps on segmented vtts so the same cue can appear more than once in different vtt files.

This PR adds the ability to avoid showing duplicated cues with same timecode and text.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)

