### PR TITLE
add SourceBuffer API checks to detect deprecated WebKitMediaSource

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -27,9 +27,18 @@ class Hls {
 
   static isSupported() {
     window.MediaSource = window.MediaSource || window.WebKitMediaSource;
-    return (window.MediaSource &&
-            typeof window.MediaSource.isTypeSupported === 'function' &&
-            window.MediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"'));
+    window.SourceBuffer = window.SourceBuffer || window.WebKitSourceBuffer;
+
+    const isTypeSupported = window.MediaSource &&
+      typeof window.MediaSource.isTypeSupported === 'function' &&
+      window.MediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"');
+    const hasSupportedSourceBuffer = window.SourceBuffer && window.SourceBuffer.prototype &&
+      typeof window.SourceBuffer.prototype.appendBuffer === 'function' &&
+      typeof window.SourceBuffer.prototype.remove === 'function';
+    const isSafari = navigator.vendor && navigator.vendor.indexOf('Apple') > -1;
+
+    // safari does not expose SourceBuffer globally so checking SourceBuffer.prototype is impossible
+    return isTypeSupported && (hasSupportedSourceBuffer || isSafari);
   }
 
   static get Events() {


### PR DESCRIPTION
### Description of the Changes
Some old webkit browsers (the one where I spotted this problem was a stock browser and system webview on Android 4.4.2) have a deprecated MSE API: `WebKitSourceBuffer` there lacks all methods defined by spec and has only `append()` and `abort()`. 
http://caniuse.com/#feat=mediasource states that MSE is supported on Android from 4.4.4 release.

In this browsers `Hls.isSupported` returns `true` (because `WebKitMediaSource` exists and `window.MediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"') === true`), but video playback via hls.js breaks. 

In this PR I suggest additional checks to detect a deprecated MSE API.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
