### PR TITLE
Improve cap-level-controller to choose the maximum level by both dimensions and bandwidth

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -349,7 +349,7 @@ This configuration will be applied by default to all instances.
 
 (default: `false`)
 
-  - if set to true, the adaptive algorithm with limit levels usable in auto-quality by the HTML video element dimensions (width and height)
+  - if set to true, the adaptive algorithm with limit levels usable in auto-quality by the HTML video element dimensions (width and height). If dimensions between multiple levels are equal, the cap is chosen as the level with the greatest bandwidth.
   - if set to false, levels will not be limited. All available levels could be used in auto-quality mode taking only bandwidth into consideration.
 
 ### `debug`

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -36,6 +36,7 @@ class CapLevelController extends EventHandler {
 
   onManifestParsed(data) {
     const hls = this.hls;
+    this.restrictedLevels = [];
     if (hls.config.capLevelToPlayerSize) {
       this.autoLevelCapping = Number.POSITIVE_INFINITY;
       this.levels = data.levels;

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -24,10 +24,8 @@ class CapLevelController extends EventHandler {
   }
 
   onFpsDropLevelCapping(data) {
-    if (!this.restrictedLevels) {
-      this.restrictedLevels = [];
-    }
-    if (!this.isLevelRestricted(data.droppedLevel)) {
+	  // Don't add a restricted level more than once
+    if (CapLevelController.isLevelAllowed(data.droppedLevel, this.restrictedLevels)) {
       this.restrictedLevels.push(data.droppedLevel);
     }
   }
@@ -68,39 +66,15 @@ class CapLevelController extends EventHandler {
   * returns level should be the one with the dimensions equal or greater than the media (player) dimensions (so the video will be downscaled)
   */
   getMaxLevel(capLevelIndex) {
-    let result = 0,
-        i,
-        level,
-        mWidth = this.mediaWidth,
-        mHeight = this.mediaHeight,
-        lWidth = 0,
-        lHeight = 0;
-
-    for (i = 0; i <= capLevelIndex; i++) {
-      level = this.levels[i];
-      if (this.isLevelRestricted(i)) {
-        break;
-      }
-      result = i;
-      lWidth = level.width;
-      lHeight = level.height;
-      if (mWidth <= lWidth || mHeight <= lHeight) {
-        break;
-      }
+    if (!this.levels) {
+      return -1;
     }
-    return result;
-  }
 
-  isLevelRestricted(level) {
-    return (this.restrictedLevels && this.restrictedLevels.indexOf(level) !== -1) ? true : false;
-  }
+    const validLevels = this.levels.filter((level, index) =>
+      CapLevelController.isLevelAllowed(index, this.restrictedLevels) && index <= capLevelIndex
+    );
 
-  get contentScaleFactor() {
-    let pixelRatio = 1;
-    try {
-      pixelRatio =  window.devicePixelRatio;
-    } catch(e) {}
-    return pixelRatio;
+    return CapLevelController.getMaxLevelByMediaSize(validLevels, this.mediaWidth, this.mediaHeight);
   }
 
   get mediaWidth() {
@@ -108,7 +82,7 @@ class CapLevelController extends EventHandler {
     const media = this.media;
     if (media) {
       width = media.width || media.clientWidth || media.offsetWidth;
-      width *= this.contentScaleFactor;
+      width *= CapLevelController.contentScaleFactor;
     }
     return width;
   }
@@ -118,9 +92,50 @@ class CapLevelController extends EventHandler {
     const media = this.media;
     if (media) {
       height = media.height || media.clientHeight || media.offsetHeight;
-      height *= this.contentScaleFactor;
+      height *= CapLevelController.contentScaleFactor;
     }
     return height;
+  }
+
+  static get contentScaleFactor() {
+    let pixelRatio = 1;
+    try {
+      pixelRatio =  window.devicePixelRatio;
+    } catch(e) {}
+    return pixelRatio;
+  }
+
+  static isLevelAllowed(level, restrictedLevels = []) {
+    return restrictedLevels.indexOf(level) === -1;
+  }
+
+  static getMaxLevelByMediaSize(levels, width, height) {
+    if (!levels || (levels && !levels.length)) {
+      return -1;
+    }
+
+    // Levels can have the same dimensions but differing bandwidths - since levels are ordered, we can look to the next
+    // to determine whether we've chosen the greatest bandwidth for the media's dimensions
+    const atGreatestBandiwdth = (curLevel, nextLevel) => {
+      if (!nextLevel) {
+        return true;
+      }
+      return curLevel.width !== nextLevel.width || curLevel.height !== nextLevel.height;
+    };
+
+    // If we run through the loop without breaking, the media's dimensions are greater than every level, so default to
+    // the max level
+    let maxLevelIndex = levels.length - 1;
+
+    for (let i = 0; i < levels.length; i+= 1) {
+      const level = levels[i];
+      if ((level.width >= width || level.height >= height) && atGreatestBandiwdth(level, levels[i + 1])) {
+        maxLevelIndex = i;
+        break;
+      }
+    }
+
+    return maxLevelIndex;
   }
 }
 

--- a/tests/unit/controller/cap-level-controller.js
+++ b/tests/unit/controller/cap-level-controller.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+
+import CapLevelController from '../../../src/controller/cap-level-controller';
+
+const levels = [
+  {
+    width: 360,
+    height: 360,
+    bandwidth: 1000
+  },
+  {
+    width: 540,
+    height: 540,
+    bandwidth: 2000,
+  },
+  {
+    width: 540,
+    height: 540,
+    bandwidth: 3000,
+  },
+  {
+    width: 720,
+    height: 720,
+    bandwidth: 4000
+  }
+];
+
+describe('CapLevelController', function () {
+  describe('getMaxLevelByMediaSize', function () {
+    it('Should choose the level whose dimensions are >= the media dimensions', function () {
+      const expected = 0;
+      const actual = CapLevelController.getMaxLevelByMediaSize(levels, 300, 300);
+      assert.equal(expected, actual);
+    });
+
+    it('Should choose the level whose bandwidth is greater if level dimensions are equal', function () {
+      const expected = 2;
+      const actual = CapLevelController.getMaxLevelByMediaSize(levels, 500, 500);
+      assert.equal(expected, actual);
+    });
+
+    it('Should choose the highest level if the media is greater than every level', function () {
+      const expected = 3;
+      const actual = CapLevelController.getMaxLevelByMediaSize(levels, 5000, 5000);
+      assert.equal(expected, actual);
+    });
+
+    it('Should return -1 if there levels is empty', function () {
+      const expected = -1;
+      const actual = CapLevelController.getMaxLevelByMediaSize([], 5000, 5000);
+      assert.equal(expected, actual);
+    });
+
+    it('Should return -1 if there levels is undefined', function () {
+      const expected = -1;
+      const actual = CapLevelController.getMaxLevelByMediaSize(undefined, 5000, 5000);
+      assert.equal(expected, actual);
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Changes

This PR improves the getMaxLevel, which chooses a level greater than or equal to the current video dimensions, to choose the level with the greatest bandwidth matching the video's dimensions. The current algorithm chooses the first level matching the current dimensions. However, if we have multiple quality levels with the same dimensions yet increasing bandwidths, we do not choose the level with the greatest bandwidth.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
