### PR TITLE
set currentTime error

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1400,8 +1400,11 @@ _checkBuffer() {
           logger.log(`target start position:${startPosition}`);
           // if startPosition not buffered, let's seek to buffered.start(0)
           if(!startPositionBuffered) {
-            startPosition = buffered.start(0);
-            logger.log(`target start position not buffered, seek to buffered.start(0) ${startPosition}`);
+            var bufferedStart = buffered.start(0);
+            if (Math.abs(bufferedStart - startPosition) <= this.config.maxSeekHole) {
+              startPosition = bufferedStart;
+              _logger.logger.log('target start position not buffered, seek to buffered.start(0) ' + startPosition);
+            }
           }
           logger.log(`adjust currentTime from ${currentTime} to ${startPosition}`);
           media.currentTime = startPosition;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1403,7 +1403,7 @@ _checkBuffer() {
             var bufferedStart = buffered.start(0);
             if (Math.abs(bufferedStart - startPosition) <= this.config.maxSeekHole) {
               startPosition = bufferedStart;
-              _logger.logger.log('target start position not buffered, seek to buffered.start(0) ' + startPosition);
+              logger.log('target start position not buffered, seek to buffered.start(0) ' + startPosition);
             }
           }
           logger.log(`adjust currentTime from ${currentTime} to ${startPosition}`);


### PR DESCRIPTION
##### Environment
- [ x] The stream has correct Access-Control-Allow-Origin headers (CORS)
- [x ] There are no network errors such as 404s in the browser console when trying to play the stream
- [x ] The issue observed is not already reported by searching on Github under https://github.com/video-dev/hls.js/issues
- [ x] The issue occurs in the latest reference client on http://video-dev.github.io/hls.js/demo and not just on my page

##### Steps to reproduce
1. Go to page http://jsbin.com/culemenefa/edit?html,css,js,output
(page with hls.js with parameter `startPosition: 60`)
2. Wait for lvideo loading
3. When `durationchange` event is dispatched by video-tag, videoCurrentTime will be changed to 120 sec

##### Expected behavior
Video starting from 120 sec

##### Actual behavior
Video sometimes starting from 120 sec and sometimes from 60 sec

##### Console output

60 sec starting:
```
[log] > loadSource:http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8
runner-4.0.2.min.js:1 [log] > trigger BUFFER_RESET
runner-4.0.2.min.js:1 [log] > attachMedia
runner-4.0.2.min.js:1 [log] > media source opened
runner-4.0.2.min.js:1 [log] > manifest loaded,5 level(s) found, first bitrate:2149280
runner-4.0.2.min.js:1 [log] > both AAC/HE-AAC audio found in levels; declaring level codec as HE-AAC
runner-4.0.2.min.js:1 [log] > startLoad(60)
runner-4.0.2.min.js:1 [log] > switching to level 3
runner-4.0.2.min.js:1 [log] > loading playlist for level 3
runner-4.0.2.min.js:1 [log] > main stream:STOPPED->IDLE
runner-4.0.2.min.js:1 [log] > main stream:IDLE->WAITING_LEVEL
runner-4.0.2.min.js:1 [log] > audio tracks updated
runner-4.0.2.min.js:1 [log] > subtitle tracks updated
runner-4.0.2.min.js:1 [log] > level 3 loaded [0,63],duration:634.584
runner-4.0.2.min.js:1 [log] > main stream:WAITING_LEVEL->IDLE
runner-4.0.2.min.js:1 [log] > Loading 6 of [0 ,63],level 3, currentTime:60.000,bufferEnd:60.000
runner-4.0.2.min.js:1 [log] > demuxing in webworker
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
runner-4.0.2.min.js:1 [log] > Loaded  6 of [0 ,63],level 3
runner-4.0.2.min.js:1 [log] > main stream:FRAG_LOADING->PARSING
runner-4.0.2.min.js:1 [log] > Parsing 6 of [0 ,63],level 3, cc 0
runner-4.0.2.min.js:1 [log] > main:discontinuity detected
runner-4.0.2.min.js:1 [log] > main:switch detected
blob:http://null.jsbin.com/56a8ec3b-4738-4cd5-b65c-6f29ec71094a:5167 [log] > manifest codec:mp4a.40.2,ADTS data:type:2,sampleingIndex:4[44100Hz],channelConfig:2
blob:http://null.jsbin.com/56a8ec3b-4738-4cd5-b65c-6f29ec71094a:5167 [log] > parsed codec:mp4a.40.5,rate:44100,nb channel:2
blob:http://null.jsbin.com/56a8ec3b-4738-4cd5-b65c-6f29ec71094a:5167 [log] > audio sampling rate : 44100
runner-4.0.2.min.js:1 [log] > InitPTS for cc:0 found from video track:900942
runner-4.0.2.min.js:1 [log] > creating sourceBuffer(audio/mp4;codecs=mp4a.40.5)
runner-4.0.2.min.js:1 [log] > creating sourceBuffer(video/mp4;codecs=avc1.64001f)
runner-4.0.2.min.js:1 [log] > main track:audio,container:audio/mp4,codecs[level/parsed]=[mp4a.40.5/mp4a.40.5]
runner-4.0.2.min.js:1 [log] > main track:video,container:video/mp4,codecs[level/parsed]=[avc1.64001f/avc1.64001f]
runner-4.0.2.min.js:1 [log] > Parsed audio,PTS:[60.000,70.008],DTS:[60.000/70.008],nb:431,dropped:0
runner-4.0.2.min.js:1 [log] > media seeking to 120.000
runner-4.0.2.min.js:1 [log] > Updating mediasource duration to 634.584
runner-4.0.2.min.js:1 [log] > media seeking to 120.000
runner-4.0.2.min.js:1 [log] > Parsed video,PTS:[60.033,70.000],DTS:[60.000/70.000],nb:600,dropped:0
runner-4.0.2.min.js:1 [log] > main stream:PARSING->PARSED
runner-4.0.2.min.js:1 [log] > main buffered : [60.000,70.000]
runner-4.0.2.min.js:1 [log] > latency/loading/parsing/append/kbps:919/88/470/28/7747
runner-4.0.2.min.js:1 [log] > main stream:PARSED->IDLE
runner-4.0.2.min.js:1 [log] > Loading 12 of [0 ,63],level 3, currentTime:120.000,bufferEnd:120.000
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
runner-4.0.2.min.js:1 [log] > target start position:120
runner-4.0.2.min.js:1 [log] > target start position not buffered, seek to buffered.start(0) 60
runner-4.0.2.min.js:1 [log] > adjust currentTime from 120 to 60
runner-4.0.2.min.js:1 [log] > media seeking to 60.000
runner-4.0.2.min.js:1 [log] > media seeked to 60.000
runner-4.0.2.min.js:1 [log] > Loaded  12 of [0 ,63],level 3
runner-4.0.2.min.js:1 [log] > main stream:FRAG_LOADING->PARSING
runner-4.0.2.min.js:1 [log] > Parsing 12 of [0 ,63],level 3, cc 0
runner-4.0.2.min.js:1 [log] > Parsed audio,PTS:[120.008,130.016],DTS:[120.008/130.016],nb:431,dropped:0
runner-4.0.2.min.js:1 [log] > Parsed video,PTS:[120.033,130.033],DTS:[120.000/130.000],nb:600,dropped:0
runner-4.0.2.min.js:1 [log] > main stream:PARSING->PARSED
runner-4.0.2.min.js:1 [log] > main buffered : [60.000,70.000][120.008,130.000]
runner-4.0.2.min.js:1 [log] > latency/loading/parsing/append/kbps:918/167/320/76/15470
runner-4.0.2.min.js:1 [log] > main stream:PARSED->IDLE
runner-4.0.2.min.js:1 [log] > switching to level 4
runner-4.0.2.min.js:1 [log] > loading playlist for level 4
runner-4.0.2.min.js:1 [log] > main stream:IDLE->WAITING_LEVEL
runner-4.0.2.min.js:1 [log] > level 4 loaded [0,63],duration:634.567
runner-4.0.2.min.js:1 [log] > main stream:WAITING_LEVEL->IDLE
runner-4.0.2.min.js:1 [log] > Loading 7 of [0 ,63],level 4, currentTime:61.389,bufferEnd:70.000
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
runner-4.0.2.min.js:1 [log] > Loaded  7 of [0 ,63],level 4
runner-4.0.2.min.js:1 [log] > main stream:FRAG_LOADING->PARSING
runner-4.0.2.min.js:1 [log] > Parsing 7 of [0 ,63],level 4, cc 0
runner-4.0.2.min.js:1 [log] > main:switch detected
blob:http://null.jsbin.com/56a8ec3b-4738-4cd5-b65c-6f29ec71094a:5167 [log] > manifest codec:mp4a.40.2,ADTS data:type:2,sampleingIndex:4[44100Hz],channelConfig:2
blob:http://null.jsbin.com/56a8ec3b-4738-4cd5-b65c-6f29ec71094a:5167 [log] > parsed codec:mp4a.40.5,rate:44100,nb channel:2
blob:http://null.jsbin.com/56a8ec3b-4738-4cd5-b65c-6f29ec71094a:5167 [log] > audio sampling rate : 44100
runner-4.0.2.min.js:1 [log] > main track:audio,container:audio/mp4,codecs[level/parsed]=[mp4a.40.5/mp4a.40.5]
runner-4.0.2.min.js:1 [log] > main track:video,container:video/mp4,codecs[level/parsed]=[avc1.640028/avc1.640028]
runner-4.0.2.min.js:1 [log] > Parsed audio,PTS:[70.000,79.938],DTS:[70.000/79.938],nb:428,dropped:0
runner-4.0.2.min.js:1 [log] > Parsed video,PTS:[70.033,79.933],DTS:[70.000/79.933],nb:596,dropped:0
runner-4.0.2.min.js:1 [log] > main stream:PARSING->PARSED
runner-4.0.2.min.js:1 [log] > main buffered : [60.000,79.933][120.008,130.000]
runner-4.0.2.min.js:1 [log] > latency/loading/parsing/append/kbps:1109/1447/460/55/16300
runner-4.0.2.min.js:1 [log] > main stream:PARSED->IDLE
runner-4.0.2.min.js:1 [log] > Loading 8 of [0 ,63],level 4, currentTime:62.461,bufferEnd:79.933
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
```

120 sec starting:
```
[log] > loadSource:http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8
runner-4.0.2.min.js:1 [log] > trigger BUFFER_RESET
runner-4.0.2.min.js:1 [log] > attachMedia
runner-4.0.2.min.js:1 [log] > media source opened
runner-4.0.2.min.js:1 [log] > manifest loaded,5 level(s) found, first bitrate:2149280
runner-4.0.2.min.js:1 [log] > both AAC/HE-AAC audio found in levels; declaring level codec as HE-AAC
runner-4.0.2.min.js:1 [log] > startLoad(60)
runner-4.0.2.min.js:1 [log] > switching to level 3
runner-4.0.2.min.js:1 [log] > loading playlist for level 3
runner-4.0.2.min.js:1 [log] > main stream:STOPPED->IDLE
runner-4.0.2.min.js:1 [log] > main stream:IDLE->WAITING_LEVEL
runner-4.0.2.min.js:1 [log] > audio tracks updated
runner-4.0.2.min.js:1 [log] > subtitle tracks updated
runner-4.0.2.min.js:1 [log] > level 3 loaded [0,63],duration:634.584
runner-4.0.2.min.js:1 [log] > main stream:WAITING_LEVEL->IDLE
runner-4.0.2.min.js:1 [log] > Loading 6 of [0 ,63],level 3, currentTime:60.000,bufferEnd:60.000
runner-4.0.2.min.js:1 [log] > demuxing in webworker
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
runner-4.0.2.min.js:1 [log] > Loaded  6 of [0 ,63],level 3
runner-4.0.2.min.js:1 [log] > main stream:FRAG_LOADING->PARSING
runner-4.0.2.min.js:1 [log] > Parsing 6 of [0 ,63],level 3, cc 0
runner-4.0.2.min.js:1 [log] > main:discontinuity detected
runner-4.0.2.min.js:1 [log] > main:switch detected
blob:http://null.jsbin.com/2e081dbc-98a3-4a25-983b-75b86acab820:5167 [log] > manifest codec:mp4a.40.2,ADTS data:type:2,sampleingIndex:4[44100Hz],channelConfig:2
blob:http://null.jsbin.com/2e081dbc-98a3-4a25-983b-75b86acab820:5167 [log] > parsed codec:mp4a.40.5,rate:44100,nb channel:2
blob:http://null.jsbin.com/2e081dbc-98a3-4a25-983b-75b86acab820:5167 [log] > audio sampling rate : 44100
runner-4.0.2.min.js:1 [log] > InitPTS for cc:0 found from video track:900942
runner-4.0.2.min.js:1 [log] > creating sourceBuffer(audio/mp4;codecs=mp4a.40.5)
runner-4.0.2.min.js:1 [log] > creating sourceBuffer(video/mp4;codecs=avc1.64001f)
runner-4.0.2.min.js:1 [log] > main track:audio,container:audio/mp4,codecs[level/parsed]=[mp4a.40.5/mp4a.40.5]
runner-4.0.2.min.js:1 [log] > main track:video,container:video/mp4,codecs[level/parsed]=[avc1.64001f/avc1.64001f]
runner-4.0.2.min.js:1 [log] > Parsed audio,PTS:[60.000,70.008],DTS:[60.000/70.008],nb:431,dropped:0
runner-4.0.2.min.js:1 [log] > Parsed video,PTS:[60.033,70.000],DTS:[60.000/70.000],nb:600,dropped:0
runner-4.0.2.min.js:1 [log] > main stream:PARSING->PARSED
runner-4.0.2.min.js:1 [log] > media seeking to 120.000
runner-4.0.2.min.js:1 [log] > main buffered : [60.000,70.000]
runner-4.0.2.min.js:1 [log] > latency/loading/parsing/append/kbps:1253/1094/421/77/4096
runner-4.0.2.min.js:1 [log] > main stream:PARSED->IDLE
runner-4.0.2.min.js:1 [log] > switching to level 2
runner-4.0.2.min.js:1 [log] > loading playlist for level 2
runner-4.0.2.min.js:1 [log] > main stream:IDLE->WAITING_LEVEL
runner-4.0.2.min.js:1 [log] > target start position:120
runner-4.0.2.min.js:1 [log] > target start position not buffered, seek to buffered.start(0) 60
runner-4.0.2.min.js:1 [log] > adjust currentTime from 120 to 60
runner-4.0.2.min.js:1 [log] > Updating mediasource duration to 634.584
runner-4.0.2.min.js:1 [log] > media seeking to 60.000
runner-4.0.2.min.js:1 [log] > media seeking to 120.000
runner-4.0.2.min.js:1 [log] > level 2 loaded [0,63],duration:634.6
runner-4.0.2.min.js:1 [log] > Updating mediasource duration to 634.600
runner-4.0.2.min.js:1 [log] > main stream:WAITING_LEVEL->IDLE
runner-4.0.2.min.js:1 [log] > Loading 12 of [0 ,63],level 2, currentTime:120.000,bufferEnd:120.000
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
runner-4.0.2.min.js:1 [log] > media seeking to 120.000
runner-4.0.2.min.js:1 [log] > seeking outside of buffer but within currently loaded fragment range
runner-4.0.2.min.js:1 [log] > Loaded  12 of [0 ,63],level 2
runner-4.0.2.min.js:1 [log] > main stream:FRAG_LOADING->PARSING
runner-4.0.2.min.js:1 [log] > Parsing 12 of [0 ,63],level 2, cc 0
runner-4.0.2.min.js:1 [log] > main:switch detected
blob:http://null.jsbin.com/2e081dbc-98a3-4a25-983b-75b86acab820:5167 [log] > manifest codec:mp4a.40.2,ADTS data:type:2,sampleingIndex:4[44100Hz],channelConfig:2
blob:http://null.jsbin.com/2e081dbc-98a3-4a25-983b-75b86acab820:5167 [log] > parsed codec:mp4a.40.5,rate:44100,nb channel:2
blob:http://null.jsbin.com/2e081dbc-98a3-4a25-983b-75b86acab820:5167 [log] > audio sampling rate : 44100
runner-4.0.2.min.js:1 [log] > main track:audio,container:audio/mp4,codecs[level/parsed]=[mp4a.40.5/mp4a.40.5]
runner-4.0.2.min.js:1 [log] > main track:video,container:video/mp4,codecs[level/parsed]=[avc1.64001f/avc1.64001f]
runner-4.0.2.min.js:1 [log] > Parsed audio,PTS:[120.011,130.019],DTS:[120.011/130.019],nb:431,dropped:0
runner-4.0.2.min.js:1 [log] > Parsed video,PTS:[120.033,130.033],DTS:[120.000/130.000],nb:600,dropped:0
runner-4.0.2.min.js:1 [log] > main stream:PARSING->PARSED
runner-4.0.2.min.js:1 [log] > main buffered : [60.000,70.000][120.011,130.000]
runner-4.0.2.min.js:1 [log] > latency/loading/parsing/append/kbps:1249/503/303/29/4843
runner-4.0.2.min.js:1 [log] > main stream:PARSED->IDLE
runner-4.0.2.min.js:1 [log] > switching to level 3
runner-4.0.2.min.js:1 [log] > Loading 13 of [0 ,63],level 3, currentTime:120.000,bufferEnd:130.000
runner-4.0.2.min.js:1 [log] > main stream:IDLE->FRAG_LOADING
runner-4.0.2.min.js:1 [log] > media seeked to 120.000
```
