### PR TITLE
Fix issue #1179 with playlist parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,15 +54,14 @@
     "exorcist": "^0.4.0",
     "http-server": "^0.9.0",
     "jshint": "^2.9.4",
-    "live-reload": "^1.1.0",
     "mocha": "^3.0.2",
     "mversion": "^1.10.1",
     "opener": "^1.4.0",
     "parallelshell": "^2.0.0",
     "rimraf": "^2.6.1",
+    "selenium-webdriver": "^3.1.0",
     "uglify-js": "^2.8.11",
     "url-toolkit": "^2.0.1",
-    "selenium-webdriver": "^3.1.0",
     "watchify": "^3.7.0",
     "webworkify": "^1.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "watchify --debug -s Hls src/index.js -t [babelify] -o dist/hls.js",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-register --recursive tests/unit",
-    "testfunc": "mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 40000",
+    "testfunc": "mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 80000",
     "lint": "jshint src/",
     "serve": "http-server -p 8000 .",
     "open": "opener http://localhost:8000/demo/",

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -12,7 +12,17 @@ import {logger} from '../utils/logger';
 // https://regex101.com is your friend
 const MASTER_PLAYLIST_REGEX = /#EXT-X-STREAM-INF:([^\n\r]*)[\r\n]+([^\r\n]+)/g;
 const MASTER_PLAYLIST_MEDIA_REGEX = /#EXT-X-MEDIA:(.*)/g;
-const LEVEL_PLAYLIST_REGEX_FAST = /#EXTINF:(\d*(?:\.\d+)?)(?:,(.*))?|(?!#)(\S.+)|#EXT-X-BYTERANGE: *(.+)|#EXT-X-PROGRAM-DATE-TIME:(.+)|#.*/g;
+//const LEVEL_PLAYLIST_REGEX_FAST = /#EXTINF:(\d*(?:\.\d+)?)(?:,(.*)\s+)?|(?!#)(\S+)|#EXT-X-BYTERANGE:*(.+)|#EXT-X-PROGRAM-DATE-TIME:(.+)|#.*/g;
+
+const LEVEL_PLAYLIST_REGEX_PARTS = [
+  //'/',
+  /#EXTINF:(\d*(?:\.\d+)?)(?:,(.*)\s+)?/.source, // duration (#EXTINF:<duration>,<title>), group 1 => duration, group 2 => title
+  /|(?!#)(\S+)/.source,                          // segment URI, group 3 => the URI (note newline is not eaten)
+  /|#EXT-X-BYTERANGE:*(.+)/.source,              // next segment's byterange, group 4 => range spec (x@y)
+  /|#EXT-X-PROGRAM-DATE-TIME:(.+)/.source,       // next segment's program date/time group 5 => the datetime spec
+  /|#.*/.source                                  // All other non-segment oriented tags will match with all groups empty
+];
+const LEVEL_PLAYLIST_REGEX_FAST = new RegExp(LEVEL_PLAYLIST_REGEX_PARTS.join(''), 'g');
 const LEVEL_PLAYLIST_REGEX_SLOW = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DISCONTINUITY-SEQ)UENCE:(\d+))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(VERSION):(\d+))|(?:#EXT-X-(MAP):(.+))|(?:(#)(.*):(.*))|(?:(#)(.*))(?:.*)\r?\n?/;
 
 class LevelKey {

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -12,17 +12,15 @@ import {logger} from '../utils/logger';
 // https://regex101.com is your friend
 const MASTER_PLAYLIST_REGEX = /#EXT-X-STREAM-INF:([^\n\r]*)[\r\n]+([^\r\n]+)/g;
 const MASTER_PLAYLIST_MEDIA_REGEX = /#EXT-X-MEDIA:(.*)/g;
-//const LEVEL_PLAYLIST_REGEX_FAST = /#EXTINF:(\d*(?:\.\d+)?)(?:,(.*)\s+)?|(?!#)(\S+)|#EXT-X-BYTERANGE:*(.+)|#EXT-X-PROGRAM-DATE-TIME:(.+)|#.*/g;
 
-const LEVEL_PLAYLIST_REGEX_PARTS = [
-  //'/',
+const LEVEL_PLAYLIST_REGEX_FAST = new RegExp([
   /#EXTINF:(\d*(?:\.\d+)?)(?:,(.*)\s+)?/.source, // duration (#EXTINF:<duration>,<title>), group 1 => duration, group 2 => title
   /|(?!#)(\S+)/.source,                          // segment URI, group 3 => the URI (note newline is not eaten)
   /|#EXT-X-BYTERANGE:*(.+)/.source,              // next segment's byterange, group 4 => range spec (x@y)
   /|#EXT-X-PROGRAM-DATE-TIME:(.+)/.source,       // next segment's program date/time group 5 => the datetime spec
   /|#.*/.source                                  // All other non-segment oriented tags will match with all groups empty
-];
-const LEVEL_PLAYLIST_REGEX_FAST = new RegExp(LEVEL_PLAYLIST_REGEX_PARTS.join(''), 'g');
+].join(''), 'g');
+
 const LEVEL_PLAYLIST_REGEX_SLOW = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DISCONTINUITY-SEQ)UENCE:(\d+))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(VERSION):(\d+))|(?:#EXT-X-(MAP):(.+))|(?:(#)(.*):(.*))|(?:(#)(.*))(?:.*)\r?\n?/;
 
 class LevelKey {

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -139,8 +139,7 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
     var level = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-PLAYLIST-TYPE:VOD
-#EXT-X-TARGETDURATION:14
-#EXTINF:11.360,`;
+#EXT-X-TARGETDURATION:14`;
     var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
     assert.strictEqual(result.fragments.length, 0);
     assert.strictEqual(result.totalduration,0);
@@ -180,6 +179,31 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
     assert.strictEqual(result.fragments[4].start, 47.36);
     assert.strictEqual(result.fragments[4].duration, 3.88);
     assert.strictEqual(result.fragments[4].url, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.ts');
+  });
+
+  it('parse level with single char fragment URI', () => {
+    var level = `#EXTM3U
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-TARGETDURATION:2
+#EXTINF:2,
+0
+#EXTINF:2,
+1
+#EXT-X-ENDLIST`;
+     var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
+     assert.strictEqual(result.totalduration, 4);
+     assert.strictEqual(result.startSN, 0);
+     assert.strictEqual(result.targetduration, 2);
+     assert.strictEqual(result.live, false);
+     assert.strictEqual(result.fragments.length, 2);
+     assert.strictEqual(result.fragments[0].cc, 0);
+     assert.strictEqual(result.fragments[0].duration, 2);
+     assert.strictEqual(result.fragments[0].sn, 0);
+     assert.strictEqual(result.fragments[0].relurl, '0');
+     assert.strictEqual(result.fragments[1].cc, 0);
+     assert.strictEqual(result.fragments[1].duration, 2);
+     assert.strictEqual(result.fragments[1].sn, 1);
+     assert.strictEqual(result.fragments[1].relurl, '1');
   });
 
   it('parse level with EXTINF line without comma', () => {


### PR DESCRIPTION
### Description of the Changes
This fixes issue #1179.

For encrypted playlist that use the SN as the initialization vector the content will not play at all.   This is because the playlist regex skips the first N segments and sets the SN to 0 for the Nth segment.
For unencrypted content it simply skips segments.

The problem was with the regex, it does not deal with segment URL that is one character or less.
 
See checkin/pull comments for why.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md