### PR TITLE
Add XHR object to manifest/frag loader callback args

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -2,7 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
- 
+
 
 - [Getting started](#getting-started)
   - [First step: setup and support](#first-step-setup-and-support)
@@ -636,6 +636,7 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
       @param [stats.bw] {number} - download bandwidth in bit/s
       @param stats.total {number} - total nb of bytes
       @param context {object} - loader context
+      @param xhr {object} - the XHR object used in the request
 
       @callback onProgressCallback
       @param stats {object} - loading stats
@@ -646,12 +647,14 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
       @param [stats.bw] {number} - current download bandwidth in bit/s (monitored by ABR controller to control emergency switch down)
       @param context {object} - loader context
       @param data {string/arraybuffer} - onProgress data (should be defined only if context.progressData === true)
+      @param xhr {object} - the XHR object used in the request
 
       @callback onErrorCallback
       @param error {object} - error data
       @param error.code {number} - error status code
       @param error.text {string} - error description
       @param context {object} - loader context
+      @param xhr {object} - the XHR object used in the request
 
       @callback onTimeoutCallback
       @param stats {object} - loading stats
@@ -881,7 +884,7 @@ If `abrBandWidthUpFactor * bandwidth average < level.bitrate` then ABR can switc
 (default: `false`)
 
 max bitrate used in ABR by avg measured bitrate
-i.e. if bitrate signaled in variant manifest for a given level is 2Mb/s but average bitrate measured on this level is 2.5Mb/s, 
+i.e. if bitrate signaled in variant manifest for a given level is 2Mb/s but average bitrate measured on this level is 2.5Mb/s,
 then if config value is set to `true`, ABR will use 2.5 Mb/s for this quality level.
 
 ### `minAutoBitrate`
@@ -1142,16 +1145,16 @@ import Hls from 'hls.js';
 let myHls = new Hls({
   pLoader: function (config) {
     let loader = new Hls.DefaultConfig.loader(config);
-    
+
     this.abort = () => loader.abort();
     this.destroy = () => loader.destroy();
     this.load = (context, config, callbacks) => {
       let {type, url} = context;
-  
+
       if (type === 'manifest') {
         console.log(`Manifest ${url} will be loaded.`);
       }
-  
+
       loader.load(context, config, callbacks);
     };
   }

--- a/doc/API.md
+++ b/doc/API.md
@@ -636,7 +636,7 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
       @param [stats.bw] {number} - download bandwidth in bit/s
       @param stats.total {number} - total nb of bytes
       @param context {object} - loader context
-      @param xhr {object} - the XHR object used in the request
+      @param networkDetails {object} - loader network details (the xhr for default loaders)
 
       @callback onProgressCallback
       @param stats {object} - loading stats
@@ -647,14 +647,14 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
       @param [stats.bw] {number} - current download bandwidth in bit/s (monitored by ABR controller to control emergency switch down)
       @param context {object} - loader context
       @param data {string/arraybuffer} - onProgress data (should be defined only if context.progressData === true)
-      @param xhr {object} - the XHR object used in the request
+      @param networkDetails {object} - loader network details (the xhr for default loaders)
 
       @callback onErrorCallback
       @param error {object} - error data
       @param error.code {number} - error status code
       @param error.text {string} - error description
       @param context {object} - loader context
-      @param xhr {object} - the XHR object used in the request
+      @param networkDetails {object} - loader network details (the xhr for default loaders)
 
       @callback onTimeoutCallback
       @param stats {object} - loading stats

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -51,37 +51,37 @@ class FragmentLoader extends EventHandler {
     loader.load(loaderContext,loaderConfig,loaderCallbacks);
   }
 
-  loadsuccess(response, stats, context, xhr) {
+  loadsuccess(response, stats, context, networkDetails=null) {
     let payload = response.data, frag = context.frag;
     // detach fragment loader on load success
     frag.loader = undefined;
     this.loaders[frag.type] = undefined;
-    this.hls.trigger(Event.FRAG_LOADED, {payload: payload, frag: frag, stats: stats, xhr: xhr});
+    this.hls.trigger(Event.FRAG_LOADED, {payload: payload, frag: frag, stats: stats, networkDetails: networkDetails});
   }
 
-  loaderror(response, context, xhr) {
+  loaderror(response, context, networkDetails=null) {
     let loader = context.loader;
     if (loader) {
       loader.abort();
     }
     this.loaders[context.type] = undefined;
-    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: context.frag, response: response, xhr: xhr});
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: context.frag, response: response, networkDetails: networkDetails});
   }
 
-  loadtimeout(stats, context) {
+  loadtimeout(stats, context, networkDetails=null) {
     let loader = context.loader;
     if (loader) {
       loader.abort();
     }
     this.loaders[context.type] = undefined;
-    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_TIMEOUT, fatal: false, frag: context.frag});
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_TIMEOUT, fatal: false, frag: context.frag, networkDetails: networkDetails});
   }
 
   // data will be used for progressive parsing
-  loadprogress(stats, context, data, xhr) { // jshint ignore:line
+  loadprogress(stats, context, data, networkDetails=null) { // jshint ignore:line
     let frag = context.frag;
     frag.loaded = stats.loaded;
-    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: frag, stats: stats, xhr: xhr});
+    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: frag, stats: stats, networkDetails: networkDetails});
   }
 }
 

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -51,21 +51,21 @@ class FragmentLoader extends EventHandler {
     loader.load(loaderContext,loaderConfig,loaderCallbacks);
   }
 
-  loadsuccess(response, stats, context) {
+  loadsuccess(response, stats, context, xhr) {
     let payload = response.data, frag = context.frag;
     // detach fragment loader on load success
     frag.loader = undefined;
     this.loaders[frag.type] = undefined;
-    this.hls.trigger(Event.FRAG_LOADED, {payload: payload, frag: frag, stats: stats});
+    this.hls.trigger(Event.FRAG_LOADED, {payload: payload, frag: frag, stats: stats, xhr: xhr});
   }
 
-  loaderror(response, context) {
+  loaderror(response, context, xhr) {
     let loader = context.loader;
     if (loader) {
       loader.abort();
     }
     this.loaders[context.type] = undefined;
-    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: context.frag, response: response});
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: context.frag, response: response, xhr: xhr});
   }
 
   loadtimeout(stats, context) {
@@ -78,10 +78,10 @@ class FragmentLoader extends EventHandler {
   }
 
   // data will be used for progressive parsing
-  loadprogress(stats, context, data) { // jshint ignore:line
+  loadprogress(stats, context, data, xhr) { // jshint ignore:line
     let frag = context.frag;
     frag.loaded = stats.loaded;
-    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: frag, stats: stats});
+    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: frag, stats: stats, xhr: xhr});
   }
 }
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -436,7 +436,7 @@ class PlaylistLoader extends EventHandler {
     return level;
   }
 
-  loadsuccess(response, stats, context, xhr) {
+  loadsuccess(response, stats, context, networkDetails=null) {
     var string = response.data,
         url = response.url,
         type = context.type,
@@ -461,22 +461,22 @@ class PlaylistLoader extends EventHandler {
             levelDetails.tload = stats.tload;
         if (type === 'manifest') {
         // first request, stream manifest (no master playlist), fire manifest loaded event with level details
-          hls.trigger(Event.MANIFEST_LOADED, {levels: [{url: url, details : levelDetails}], audioTracks : [], url: url, stats: stats, xhr: xhr});
+          hls.trigger(Event.MANIFEST_LOADED, {levels: [{url: url, details : levelDetails}], audioTracks : [], url: url, stats: stats, networkDetails: networkDetails});
         }
         stats.tparsed = performance.now();
         if (levelDetails.targetduration) {
           if (isLevel) {
-            hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: level || 0, id: id || 0, stats: stats, xhr: xhr});
+            hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: level || 0, id: id || 0, stats: stats, networkDetails: networkDetails});
           } else {
             if (type === 'audioTrack') {
-              hls.trigger(Event.AUDIO_TRACK_LOADED, {details: levelDetails, id: id, stats: stats, xhr: xhr});
+              hls.trigger(Event.AUDIO_TRACK_LOADED, {details: levelDetails, id: id, stats: stats, networkDetails: networkDetails});
             }
             else if (type === 'subtitleTrack') {
-              hls.trigger(Event.SUBTITLE_TRACK_LOADED, {details: levelDetails, id: id, stats: stats, xhr: xhr});
+              hls.trigger(Event.SUBTITLE_TRACK_LOADED, {details: levelDetails, id: id, stats: stats, networkDetails: networkDetails});
             }
           }
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'invalid targetduration', xhr: xhr});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'invalid targetduration', networkDetails: networkDetails});
         }
       } else {
         let levels = this.parseMasterPlaylist(string, url);
@@ -499,17 +499,17 @@ class PlaylistLoader extends EventHandler {
               audioTracks.unshift({ type : 'main', name : 'main'});
             }
           }
-          hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats, xhr});
+          hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats, networkDetails});
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest', xhr: xhr});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest', networkDetails: networkDetails});
         }
       }
     } else {
-      hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no EXTM3U delimiter', xhr: xhr});
+      hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no EXTM3U delimiter', networkDetails: networkDetails});
     }
   }
 
-  loaderror(response, context, xhr) {
+  loaderror(response, context, networkDetails=null) {
     var details, fatal,loader = context.loader;
     switch(context.type) {
       case 'manifest':
@@ -529,10 +529,10 @@ class PlaylistLoader extends EventHandler {
       loader.abort();
       this.loaders[context.type] = undefined;
     }
-    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: loader.url, loader: loader, response: response, context : context, xhr: xhr});
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: loader.url, loader: loader, response: response, context : context, networkDetails: networkDetails});
   }
 
-  loadtimeout(stats, context) {
+  loadtimeout(stats, context, networkDetails=null) {
     var details, fatal, loader = context.loader;
     switch(context.type) {
       case 'manifest':
@@ -552,7 +552,7 @@ class PlaylistLoader extends EventHandler {
       loader.abort();
       this.loaders[context.type] = undefined;
     }
-    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: loader.url, loader: loader, context : context});
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: loader.url, loader: loader, context : context, networkDetails: networkDetails});
   }
 }
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -436,7 +436,7 @@ class PlaylistLoader extends EventHandler {
     return level;
   }
 
-  loadsuccess(response, stats, context) {
+  loadsuccess(response, stats, context, xhr) {
     var string = response.data,
         url = response.url,
         type = context.type,
@@ -461,22 +461,22 @@ class PlaylistLoader extends EventHandler {
             levelDetails.tload = stats.tload;
         if (type === 'manifest') {
         // first request, stream manifest (no master playlist), fire manifest loaded event with level details
-          hls.trigger(Event.MANIFEST_LOADED, {levels: [{url: url, details : levelDetails}], audioTracks : [], url: url, stats: stats});
+          hls.trigger(Event.MANIFEST_LOADED, {levels: [{url: url, details : levelDetails}], audioTracks : [], url: url, stats: stats, xhr: xhr});
         }
         stats.tparsed = performance.now();
         if (levelDetails.targetduration) {
           if (isLevel) {
-            hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: level || 0, id: id || 0, stats: stats});
+            hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: level || 0, id: id || 0, stats: stats, xhr: xhr});
           } else {
             if (type === 'audioTrack') {
-              hls.trigger(Event.AUDIO_TRACK_LOADED, {details: levelDetails, id: id, stats: stats});
+              hls.trigger(Event.AUDIO_TRACK_LOADED, {details: levelDetails, id: id, stats: stats, xhr: xhr});
             }
             else if (type === 'subtitleTrack') {
-              hls.trigger(Event.SUBTITLE_TRACK_LOADED, {details: levelDetails, id: id, stats: stats});
+              hls.trigger(Event.SUBTITLE_TRACK_LOADED, {details: levelDetails, id: id, stats: stats, xhr: xhr});
             }
           }
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'invalid targetduration'});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'invalid targetduration', xhr: xhr});
         }
       } else {
         let levels = this.parseMasterPlaylist(string, url);
@@ -499,17 +499,17 @@ class PlaylistLoader extends EventHandler {
               audioTracks.unshift({ type : 'main', name : 'main'});
             }
           }
-          hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats});
+          hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats, xhr});
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest'});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest', xhr: xhr});
         }
       }
     } else {
-      hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no EXTM3U delimiter'});
+      hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no EXTM3U delimiter', xhr: xhr});
     }
   }
 
-  loaderror(response, context) {
+  loaderror(response, context, xhr) {
     var details, fatal,loader = context.loader;
     switch(context.type) {
       case 'manifest':
@@ -529,7 +529,7 @@ class PlaylistLoader extends EventHandler {
       loader.abort();
       this.loaders[context.type] = undefined;
     }
-    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: loader.url, loader: loader, response: response, context : context});
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: loader.url, loader: loader, response: response, context : context, xhr: xhr});
   }
 
   loadtimeout(stats, context) {

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -68,7 +68,7 @@ class XhrLoader {
       }
     } catch (e) {
       // IE11 throws an exception on xhr.open if attempting to access an HTTP resource over HTTPS
-      this.callbacks.onError({ code : xhr.status, text: e.message }, context);
+      this.callbacks.onError({ code : xhr.status, text: e.message }, context, xhr);
       return;
     }
 
@@ -118,12 +118,12 @@ class XhrLoader {
           }
           stats.loaded = stats.total = len;
           let response = { url : xhr.responseURL, data : data };
-          this.callbacks.onSuccess(response, stats, context);
+          this.callbacks.onSuccess(response, stats, context, xhr);
         } else {
             // if max nb of retries reached or if http status between 400 and 499 (such error cannot be recovered, retrying is useless), return error
           if (stats.retry >= config.maxRetry || (status >= 400 && status < 499)) {
             logger.error(`${status} while loading ${context.url}` );
-            this.callbacks.onError({ code : status, text : xhr.statusText}, context);
+            this.callbacks.onError({ code : status, text : xhr.statusText}, context, xhr);
           } else {
             // retry
             logger.warn(`${status} while loading ${context.url}, retrying in ${this.retryDelay}...`);
@@ -149,7 +149,9 @@ class XhrLoader {
   }
 
   loadprogress(event) {
-    var stats = this.stats;
+    var xhr = event.currentTarget,
+        stats = this.stats;
+
     stats.loaded = event.loaded;
     if (event.lengthComputable) {
       stats.total = event.total;
@@ -157,7 +159,7 @@ class XhrLoader {
     let onProgress = this.callbacks.onProgress;
     if (onProgress) {
       // last args is to provide on progress data
-      onProgress(stats, this.context, null);
+      onProgress(stats, this.context, null, xhr);
     }
   }
 }

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -145,7 +145,7 @@ class XhrLoader {
 
   loadtimeout() {
     logger.warn(`timeout while loading ${this.context.url}` );
-    this.callbacks.onTimeout(this.stats, this.context);
+    this.callbacks.onTimeout(this.stats, this.context, null);
   }
 
   loadprogress(event) {
@@ -158,7 +158,7 @@ class XhrLoader {
     }
     let onProgress = this.callbacks.onProgress;
     if (onProgress) {
-      // last args is to provide on progress data
+      // third arg is to provide on progress data
       onProgress(stats, this.context, null, xhr);
     }
   }


### PR DESCRIPTION
### Description of the Changes
This change simply adds the XHR object to the args passed to the loader callbacks for the purpose of getting more details about the request/response.

Specifically we need this at Mux to get the headers of the response, which can tell us:
- Whether or not the file was cached, and at what level
- Which CDN was used in the case of a dns-level CDN switcher like Cedexis
- Which edge node
- CDN internal timing stats

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
