### PR TITLE
audio-only-probe-demux-aac-before-mp3

### DIFF
--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -29,7 +29,7 @@ class AACDemuxer {
       // Layer bits (position 14 and 15) in header should be always 0 for ADTS
       // More info https://wiki.multimedia.cx/index.php?title=ADTS
       for (offset = id3Data.length, length = Math.min(data.length - 1, offset + 100); offset < length; offset++) {
-        if (ADTS.isHeader(data, offset)) {
+        if (ADTS.probe(data, offset)) {
           logger.log('ADTS sync word found !');
           return true;
         }

--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -2,10 +2,10 @@
  * AAC demuxer
  */
 import ADTS from './adts';
-import {logger} from '../utils/logger';
+import { logger } from '../utils/logger';
 import ID3 from '../demux/id3';
 
- class AACDemuxer {
+class AACDemuxer {
 
   constructor(observer, remuxer, config) {
     this.observer = observer;
@@ -13,8 +13,8 @@ import ID3 from '../demux/id3';
     this.remuxer = remuxer;
   }
 
-  resetInitSegment(initSegment,audioCodec,videoCodec, duration) {
-    this._audioTrack = {container : 'audio/adts', type: 'audio', id :-1, sequenceNumber: 0, isAAC : true , samples : [], len : 0, manifestCodec : audioCodec, duration : duration, inputTimeScale : 90000};
+  resetInitSegment(initSegment, audioCodec, videoCodec, duration) {
+    this._audioTrack = { container: 'audio/adts', type: 'audio', id: -1, sequenceNumber: 0, isAAC: true, samples: [], len: 0, manifestCodec: audioCodec, duration: duration, inputTimeScale: 90000 };
   }
 
   resetTimeStamp() {
@@ -30,7 +30,7 @@ import ID3 from '../demux/id3';
       // More info https://wiki.multimedia.cx/index.php?title=ADTS
       for (offset = id3Data.length, length = Math.min(data.length - 1, offset + 100); offset < length; offset++) {
         if (ADTS.isHeader(data, offset)) {
-          //logger.log('ADTS sync word found !');
+          logger.log('ADTS sync word found !');
           return true;
         }
       }
@@ -41,14 +41,14 @@ import ID3 from '../demux/id3';
   // feed incoming data to the front of the parsing pipeline
   append(data, timeOffset, contiguous, accurateTimeOffset) {
     var track = this._audioTrack,
-        id3Data = ID3.getID3Data(data, 0),
-        pts = 90 * ID3.getTimeStamp(id3Data),
-        frameIndex = 0,
-        stamp = pts,
-        length = data.length,
-        offset = id3Data.length;
+      id3Data = ID3.getID3Data(data, 0),
+      pts = 90 * ID3.getTimeStamp(id3Data),
+      frameIndex = 0,
+      stamp = pts,
+      length = data.length,
+      offset = id3Data.length;
 
-    let id3Samples = [{ pts: stamp, dts : stamp, data : id3Data }];
+    let id3Samples = [{ pts: stamp, dts: stamp, data: id3Data }];
 
     while (offset < length - 1) {
       if (ADTS.isHeader(data, offset) && (offset + 5) < length) {
@@ -64,7 +64,7 @@ import ID3 from '../demux/id3';
         }
       } else if (ID3.isHeader(data, offset)) {
         id3Data = ID3.getID3Data(data, offset);
-        id3Samples.push({ pts: stamp, dts : stamp, data : id3Data });
+        id3Samples.push({ pts: stamp, dts: stamp, data: id3Data });
         offset += id3Data.length;
       } else {
         //nothing found, keep looking
@@ -73,12 +73,12 @@ import ID3 from '../demux/id3';
     }
 
     this.remuxer.remux(track,
-                        {samples : []},
-                        {samples : id3Samples, inputTimeScale : 90000},
-                        {samples : []},
-                        timeOffset,
-                        contiguous,
-                        accurateTimeOffset);
+      { samples: [] },
+      { samples: id3Samples, inputTimeScale: 90000 },
+      { samples: [] },
+      timeOffset,
+      contiguous,
+      accurateTimeOffset);
   }
 
   destroy() {

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -132,20 +132,29 @@ const ADTS = {
     return data[offset] === 0xff && (data[offset + 1] & 0xf6) === 0xf0;
   },
 
-  getHeaderLength: function(data, offset) {
+  getHeaderLength: function (data, offset) {
     return (!!(data[offset + 1] & 0x01) ? 7 : 9);
   },
 
-  getFullFrameLength: function(data, offset) {
+  getFullFrameLength: function (data, offset) {
     return ((data[offset + 3] & 0x03) << 11) |
-          (data[offset + 4] << 3) |
-          ((data[offset + 5] & 0xE0) >>> 5);
+      (data[offset + 4] << 3) |
+      ((data[offset + 5] & 0xE0) >>> 5);
   },
 
   isHeader: function (data, offset) {
     // Look for ADTS header | 1111 1111 | 1111 X00X | where X can be either 0 or 1
     // Layer bits (position 14 and 15) in header should be always 0 for ADTS
     // More info https://wiki.multimedia.cx/index.php?title=ADTS
+    if (offset + 1 < data.length && this.isHeaderPattern(data, offset)) {
+      return true;
+    }
+    return false;
+  },
+
+  probe: function (data, offset) {
+    // same as isHeader but we also check that ADTS frame follows last ADTS frame 
+    // or end of data is reached
     if (offset + 1 < data.length && this.isHeaderPattern(data, offset)) {
       // ADTS header Length
       let headerLength = this.getHeaderLength(data, offset);
@@ -154,7 +163,6 @@ const ADTS = {
       if (offset + 5 < data.length) {
         frameLength = this.getFullFrameLength(data, offset);
       }
-      // check that ADTS frame follows last ADTS frame or end of data is reached
       let newOffset = offset + frameLength;
       if (newOffset === data.length || (newOffset + 1 < data.length && this.isHeaderPattern(data, newOffset))) {
         return true;

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -1,31 +1,31 @@
 /**
  *  ADTS parser helper
  */
-import {logger} from '../utils/logger';
-import {ErrorTypes, ErrorDetails} from '../errors';
+import { logger } from '../utils/logger';
+import { ErrorTypes, ErrorDetails } from '../errors';
 
- const ADTS = {
-  getAudioConfig : function(observer, data, offset, audioCodec) {
+const ADTS = {
+  getAudioConfig: function (observer, data, offset, audioCodec) {
     var adtsObjectType, // :int
-        adtsSampleingIndex, // :int
-        adtsExtensionSampleingIndex, // :int
-        adtsChanelConfig, // :int
-        config,
-        userAgent = navigator.userAgent.toLowerCase(),
-        manifestCodec = audioCodec,
-        adtsSampleingRates = [
-            96000, 88200,
-            64000, 48000,
-            44100, 32000,
-            24000, 22050,
-            16000, 12000,
-            11025, 8000,
-            7350];
+      adtsSampleingIndex, // :int
+      adtsExtensionSampleingIndex, // :int
+      adtsChanelConfig, // :int
+      config,
+      userAgent = navigator.userAgent.toLowerCase(),
+      manifestCodec = audioCodec,
+      adtsSampleingRates = [
+        96000, 88200,
+        64000, 48000,
+        44100, 32000,
+        24000, 22050,
+        16000, 12000,
+        11025, 8000,
+        7350];
     // byte 2
     adtsObjectType = ((data[offset + 2] & 0xC0) >>> 6) + 1;
     adtsSampleingIndex = ((data[offset + 2] & 0x3C) >>> 2);
-    if(adtsSampleingIndex > adtsSampleingRates.length-1) {
-      observer.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: `invalid ADTS sampling index:${adtsSampleingIndex}`});
+    if (adtsSampleingIndex > adtsSampleingRates.length - 1) {
+      observer.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: `invalid ADTS sampling index:${adtsSampleingIndex}` });
       return;
     }
     adtsChanelConfig = ((data[offset + 2] & 0x01) << 2);
@@ -59,8 +59,8 @@ import {ErrorTypes, ErrorDetails} from '../errors';
       config = new Array(4);
       // if (manifest codec is HE-AAC or HE-AACv2) OR (manifest codec not specified AND frequency less than 24kHz)
       if ((audioCodec && ((audioCodec.indexOf('mp4a.40.29') !== -1) ||
-                          (audioCodec.indexOf('mp4a.40.5') !== -1))) ||
-          (!audioCodec && adtsSampleingIndex >= 6)) {
+        (audioCodec.indexOf('mp4a.40.5') !== -1))) ||
+        (!audioCodec && adtsSampleingIndex >= 6)) {
         // HE-AAC uses SBR (Spectral Band Replication) , high frequencies are constructed from low frequencies
         // there is a factor 2 between frame sample rate and output sample rate
         // multiply frequency by 2 (see table below, equivalent to substract 3)
@@ -69,7 +69,7 @@ import {ErrorTypes, ErrorDetails} from '../errors';
         // if (manifest codec is AAC) AND (frequency less than 24kHz AND nb channel is 1) OR (manifest codec not specified and mono audio)
         // Chrome fails to play back with low frequency AAC LC mono when initialized with HE-AAC.  This is not a problem with stereo.
         if (audioCodec && audioCodec.indexOf('mp4a.40.2') !== -1 && (adtsSampleingIndex >= 6 && adtsChanelConfig === 1) ||
-            (!audioCodec && adtsChanelConfig === 1)) {
+          (!audioCodec && adtsChanelConfig === 1)) {
           adtsObjectType = 2;
           config = new Array(2);
         }
@@ -125,22 +125,45 @@ import {ErrorTypes, ErrorDetails} from '../errors';
       config[2] |= 2 << 2;
       config[3] = 0;
     }
-    return {config: config, samplerate: adtsSampleingRates[adtsSampleingIndex], channelCount: adtsChanelConfig, codec: ('mp4a.40.' + adtsObjectType), manifestCodec : manifestCodec};
+    return { config: config, samplerate: adtsSampleingRates[adtsSampleingIndex], channelCount: adtsChanelConfig, codec: ('mp4a.40.' + adtsObjectType), manifestCodec: manifestCodec };
   },
 
-  isHeader: function(data, offset) {
+  isHeaderPattern: function (data, offset) {
+    return data[offset] === 0xff && (data[offset + 1] & 0xf6) === 0xf0;
+  },
+
+  getHeaderLength: function(data, offset) {
+    return (!!(data[offset + 1] & 0x01) ? 7 : 9);
+  },
+
+  getFullFrameLength: function(data, offset) {
+    return ((data[offset + 3] & 0x03) << 11) |
+          (data[offset + 4] << 3) |
+          ((data[offset + 5] & 0xE0) >>> 5);
+  },
+
+  isHeader: function (data, offset) {
     // Look for ADTS header | 1111 1111 | 1111 X00X | where X can be either 0 or 1
     // Layer bits (position 14 and 15) in header should be always 0 for ADTS
     // More info https://wiki.multimedia.cx/index.php?title=ADTS
-    if (offset + 1 < data.length) {
-      if ((data[offset] === 0xff) && ((data[offset + 1] & 0xf6) === 0xf0)) {
+    if (offset + 1 < data.length && this.isHeaderPattern(data, offset)) {
+      // ADTS header Length
+      let headerLength = this.getHeaderLength(data, offset);
+      // ADTS frame Length
+      let frameLength = headerLength;
+      if (offset + 5 < data.length) {
+        frameLength = this.getFullFrameLength(data, offset);
+      }
+      // check that ADTS frame follows last ADTS frame or end of data is reached
+      let newOffset = offset + frameLength;
+      if (newOffset === data.length || (newOffset + 1 < data.length && this.isHeaderPattern(data, newOffset))) {
         return true;
       }
     }
     return false;
   },
 
-  initTrackConfig: function(track, observer, data, offset, audioCodec) {
+  initTrackConfig: function (track, observer, data, offset, audioCodec) {
     if (!track.samplerate) {
       var config = this.getAudioConfig(observer, data, offset, audioCodec);
       track.config = config.config;
@@ -152,11 +175,11 @@ import {ErrorTypes, ErrorDetails} from '../errors';
     }
   },
 
-  getFrameDuration: function(samplerate) {
+  getFrameDuration: function (samplerate) {
     return 1024 * 90000 / samplerate;
   },
 
-  appendFrame: function(track, data, offset, pts, frameIndex) {
+  appendFrame: function (track, data, offset, pts, frameIndex) {
     var frameDuration = this.getFrameDuration(track.samplerate);
     var header = this.parseFrameHeader(data, offset, pts, frameIndex, frameDuration);
     if (header) {
@@ -176,16 +199,14 @@ import {ErrorTypes, ErrorDetails} from '../errors';
     return undefined;
   },
 
-  parseFrameHeader: function(data, offset, pts, frameIndex, frameDuration) {
+  parseFrameHeader: function (data, offset, pts, frameIndex, frameDuration) {
     var headerLength, frameLength, stamp;
     var length = data.length;
 
     // The protection skip bit tells us if we have 2 bytes of CRC data at the end of the ADTS header
-    headerLength = (!!(data[offset + 1] & 0x01) ? 7 : 9);
+    headerLength = this.getHeaderLength(data, offset);
     // retrieve frame size
-    frameLength = ((data[offset + 3] & 0x03) << 11) |
-                   (data[offset + 4] << 3) |
-                  ((data[offset + 5] & 0xE0) >>> 5);
+    frameLength = this.getFullFrameLength(data, offset);
     frameLength -= headerLength;
 
     if ((frameLength > 0) && ((offset + headerLength + frameLength) <= length)) {

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -76,26 +76,26 @@ class DemuxerInline {
       let aacMatch = AACDemuxer.probe(data);
       let mp3Match = MP3Demuxer.probe(data);
       let mp4Match = MP4Demuxer.probe(data);
-
-      let h264Pattern = /^avc/i;
+      
+      let h26XPattern = /^(avc|hvc)/i;
       let aacPattern = /^mp4a(\.40\.2|\.40\.5|\.40\.29)/i;
       let mp3Pattern = /^mp4a.40.34/i;
 
       /* prioritize demuxer:
-       * if tsMatch && h264Pattern  => TSDemuxer
+       * if tsMatch && h26XPattern  => TSDemuxer
        * if aacMatch && aacPattern => AACDemuxer
        * if mp3Match && mp3Pattern => MP3Demuxer
-       * if mp4Match && h264Pattern => MP4Demuxer
+       * if mp4Match && h26XPattern => MP4Demuxer
        * if no codec info in Manifest, use fallback order : AAC/MP3/TS/MP4
        */
       let mux;
-      if (tsMatch && videoCodec && h264Pattern.test(videoCodec)) {
+      if (tsMatch && videoCodec && h26XPattern.test(videoCodec)) {
         mux = muxConfig[0];
       } else if (aacMatch && audioCodec && aacPattern.test(audioCodec)) {
         mux = muxConfig[1];
       } else if (mp3Match && audioCodec && mp3Pattern.test(audioCodec)) {
         mux = muxConfig[2];
-      } else if (mp4Match && videoCodec && h264Pattern.test(videoCodec)) {
+      } else if (mp4Match && videoCodec && h26XPattern.test(videoCodec)) {
         mux = muxConfig[3];
       } else if (aacMatch) {
         mux = muxConfig[1];

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -66,51 +66,22 @@ class DemuxerInline {
       const observer = this.observer;
       const typeSupported = this.typeSupported;
       const config = this.config;
-      const muxConfig = [{ demux: TSDemuxer, remux: MP4Remuxer },
-      { demux: AACDemuxer, remux: MP4Remuxer },
+      // probing order is AAC/MP3/TS/MP4
+      const muxConfig = [{ demux: AACDemuxer, remux: MP4Remuxer },
       { demux: MP3Demuxer, remux: MP4Remuxer },
+      { demux: TSDemuxer, remux: MP4Remuxer },
       { demux: MP4Demuxer, remux: PassThroughRemuxer }];
 
       // probe for content type
-      let tsMatch = TSDemuxer.probe(data);
-      let aacMatch = AACDemuxer.probe(data);
-      let mp3Match = MP3Demuxer.probe(data);
-      let mp4Match = MP4Demuxer.probe(data);
-      
-      let h26XPattern = /^(avc|hvc)/i;
-      let aacPattern = /^mp4a(\.40\.2|\.40\.5|\.40\.29)/i;
-      let mp3Pattern = /^mp4a.40.34/i;
-
-      /* prioritize demuxer:
-       * if tsMatch && h26XPattern  => TSDemuxer
-       * if aacMatch && aacPattern => AACDemuxer
-       * if mp3Match && mp3Pattern => MP3Demuxer
-       * if mp4Match && h26XPattern => MP4Demuxer
-       * if no codec info in Manifest, use fallback order : AAC/MP3/TS/MP4
-       */
-      let mux;
-      if (tsMatch && videoCodec && h26XPattern.test(videoCodec)) {
-        mux = muxConfig[0];
-      } else if (aacMatch && audioCodec && aacPattern.test(audioCodec)) {
-        mux = muxConfig[1];
-      } else if (mp3Match && audioCodec && mp3Pattern.test(audioCodec)) {
-        mux = muxConfig[2];
-      } else if (mp4Match && videoCodec && h26XPattern.test(videoCodec)) {
-        mux = muxConfig[3];
-      } else if (aacMatch) {
-        mux = muxConfig[1];
-      } else if (mp3Match) {
-        mux = muxConfig[2];
-      } else if (tsMatch) {
-        mux = muxConfig[0];
-      } else if (mp4Match) {
-        mux = muxConfig[3];
-      }
-      if (mux) {
+      for (let i = 0, len = muxConfig.length; i < len; i++) {
+        const mux = muxConfig[i];
         const probe = mux.demux.probe;
-        const remuxer = this.remuxer = new mux.remux(observer, config, typeSupported, this.vendor);
-        demuxer = new mux.demux(observer, remuxer, config, typeSupported);
-        this.probe = probe;
+        if (probe(data)) {
+          const remuxer = this.remuxer = new mux.remux(observer, config, typeSupported, this.vendor);
+          demuxer = new mux.demux(observer, remuxer, config, typeSupported);
+          this.probe = probe;
+          break;
+        }
       }
       if (!demuxer) {
         observer.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found' });

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -3,7 +3,7 @@
  */
 
 import Event from '../events';
-import {ErrorTypes, ErrorDetails} from '../errors';
+import { ErrorTypes, ErrorDetails } from '../errors';
 import Decrypter from '../crypt/decrypter';
 import AACDemuxer from '../demux/aacdemuxer';
 import MP4Demuxer from '../demux/mp4demuxer';
@@ -14,7 +14,7 @@ import PassThroughRemuxer from '../remux/passthrough-remuxer';
 
 class DemuxerInline {
 
-  constructor(observer,typeSupported, config, vendor) {
+  constructor(observer, typeSupported, config, vendor) {
     this.observer = observer;
     this.typeSupported = typeSupported;
     this.config = config;
@@ -39,51 +39,81 @@ class DemuxerInline {
       var startTime;
       try {
         startTime = performance.now();
-      } catch(error) {
+      } catch (error) {
         startTime = Date.now();
       }
       decrypter.decrypt(data, decryptdata.key.buffer, decryptdata.iv.buffer, function (decryptedData) {
         var endTime;
         try {
           endTime = performance.now();
-        } catch(error) {
+        } catch (error) {
           endTime = Date.now();
         }
         localthis.observer.trigger(Event.FRAG_DECRYPTED, { stats: { tstart: startTime, tdecrypt: endTime } });
-        localthis.pushDecrypted(new Uint8Array(decryptedData), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset,defaultInitPTS);
+        localthis.pushDecrypted(new Uint8Array(decryptedData), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS);
       });
     } else {
-      this.pushDecrypted(new Uint8Array(data), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration,accurateTimeOffset,defaultInitPTS);
+      this.pushDecrypted(new Uint8Array(data), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS);
     }
   }
 
-  pushDecrypted(data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration,accurateTimeOffset,defaultInitPTS) {
+  pushDecrypted(data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS) {
     var demuxer = this.demuxer;
-    if (!demuxer || 
-       // in case of continuity change, we might switch from content type (AAC container to TS container for example)
-       // so let's check that current demuxer is still valid
-        (discontinuity && !this.probe(data))) {
+    if (!demuxer ||
+      // in case of continuity change, we might switch from content type (AAC container to TS container for example)
+      // so let's check that current demuxer is still valid
+      (discontinuity && !this.probe(data))) {
       const observer = this.observer;
       const typeSupported = this.typeSupported;
       const config = this.config;
-      const muxConfig = [ {demux : TSDemuxer,  remux : MP4Remuxer},
-                          {demux : AACDemuxer, remux : MP4Remuxer},
-                          {demux : MP3Demuxer, remux : MP4Remuxer},
-                          {demux : MP4Demuxer, remux : PassThroughRemuxer}];
+      const muxConfig = [{ demux: TSDemuxer, remux: MP4Remuxer },
+      { demux: AACDemuxer, remux: MP4Remuxer },
+      { demux: MP3Demuxer, remux: MP4Remuxer },
+      { demux: MP4Demuxer, remux: PassThroughRemuxer }];
 
       // probe for content type
-      for (let i in muxConfig) {
-        const mux = muxConfig[i];
-        const probe = mux.demux.probe;
-        if(probe(data)) {
-          const remuxer = this.remuxer = new mux.remux(observer,config,typeSupported, this.vendor);
-          demuxer = new mux.demux(observer,remuxer,config,typeSupported);
-          this.probe = probe;
-          break;
-        }
+      let tsMatch = TSDemuxer.probe(data);
+      let aacMatch = AACDemuxer.probe(data);
+      let mp3Match = MP3Demuxer.probe(data);
+      let mp4Match = MP4Demuxer.probe(data);
+
+      let h264Pattern = /^avc/i;
+      let aacPattern = /^mp4a(\.40\.2|\.40\.5|\.40\.29)/i;
+      let mp3Pattern = /^mp4a.40.34/i;
+
+      /* prioritize demuxer:
+       * if tsMatch && h264Pattern  => TSDemuxer
+       * if aacMatch && aacPattern => AACDemuxer
+       * if mp3Match && mp3Pattern => MP3Demuxer
+       * if mp4Match && h264Pattern => MP4Demuxer
+       * if no codec info in Manifest, use fallback order : AAC/MP3/TS/MP4
+       */
+      let mux;
+      if (tsMatch && videoCodec && h264Pattern.test(videoCodec)) {
+        mux = muxConfig[0];
+      } else if (aacMatch && audioCodec && aacPattern.test(audioCodec)) {
+        mux = muxConfig[1];
+      } else if (mp3Match && audioCodec && mp3Pattern.test(audioCodec)) {
+        mux = muxConfig[2];
+      } else if (mp4Match && videoCodec && h264Pattern.test(videoCodec)) {
+        mux = muxConfig[3];
+      } else if (aacMatch) {
+        mux = muxConfig[1];
+      } else if (mp3Match) {
+        mux = muxConfig[2];
+      } else if (tsMatch) {
+        mux = muxConfig[0];
+      } else if (mp4Match) {
+        mux = muxConfig[3];
       }
-      if(!demuxer) {
-        observer.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found'});
+      if (mux) {
+        const probe = mux.demux.probe;
+        const remuxer = this.remuxer = new mux.remux(observer, config, typeSupported, this.vendor);
+        demuxer = new mux.demux(observer, remuxer, config, typeSupported);
+        this.probe = probe;
+      }
+      if (!demuxer) {
+        observer.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found' });
         return;
       }
       this.demuxer = demuxer;
@@ -91,7 +121,7 @@ class DemuxerInline {
     const remuxer = this.remuxer;
 
     if (discontinuity || trackSwitch) {
-      demuxer.resetInitSegment(initSegment,audioCodec,videoCodec,duration);
+      demuxer.resetInitSegment(initSegment, audioCodec, videoCodec, duration);
       remuxer.resetInitSegment();
     }
     if (discontinuity) {
@@ -101,7 +131,7 @@ class DemuxerInline {
     if (typeof demuxer.setDecryptData === 'function') {
       demuxer.setDecryptData(decryptdata);
     }
-    demuxer.append(data,timeOffset,contiguous,accurateTimeOffset);
+    demuxer.append(data, timeOffset, contiguous, accurateTimeOffset);
   }
 }
 

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -67,8 +67,8 @@ class DemuxerInline {
       const typeSupported = this.typeSupported;
       const config = this.config;
       const muxConfig = [ {demux : TSDemuxer,  remux : MP4Remuxer},
-                          {demux : MP3Demuxer, remux : MP4Remuxer},
                           {demux : AACDemuxer, remux : MP4Remuxer},
+                          {demux : MP3Demuxer, remux : MP4Remuxer},
                           {demux : MP4Demuxer, remux : PassThroughRemuxer}];
 
       // probe for content type

--- a/src/demux/mp3demuxer.js
+++ b/src/demux/mp3demuxer.js
@@ -29,7 +29,7 @@ class MP3Demuxer {
       // Layer bits (position 14 and 15) in header should be always different from 0 (Layer I or Layer II or Layer III)
       // More info http://www.mp3-tech.org/programmer/frame_header.html
       for (offset = id3Data.length, length = Math.min(data.length - 1, offset + 100); offset < length; offset++) {
-        if (MpegAudio.isHeader(data, offset)) {
+        if (MpegAudio.probe(data, offset)) {
           logger.log('MPEG Audio sync word found !');
           return true;
         }

--- a/src/demux/mp3demuxer.js
+++ b/src/demux/mp3demuxer.js
@@ -2,9 +2,10 @@
  * MP3 demuxer
  */
 import ID3 from '../demux/id3';
+import { logger } from '../utils/logger';
 import MpegAudio from './mpegaudio';
 
- class MP3Demuxer {
+class MP3Demuxer {
 
   constructor(observer, remuxer, config) {
     this.observer = observer;
@@ -12,8 +13,8 @@ import MpegAudio from './mpegaudio';
     this.remuxer = remuxer;
   }
 
-  resetInitSegment(initSegment,audioCodec,videoCodec, duration) {
-    this._audioTrack = {container : 'audio/mpeg', type: 'audio', id :-1, sequenceNumber: 0, isAAC : false , samples : [], len : 0, manifestCodec : audioCodec, duration : duration, inputTimeScale : 90000};
+  resetInitSegment(initSegment, audioCodec, videoCodec, duration) {
+    this._audioTrack = { container: 'audio/mpeg', type: 'audio', id: -1, sequenceNumber: 0, isAAC: false, samples: [], len: 0, manifestCodec: audioCodec, duration: duration, inputTimeScale: 90000 };
   }
 
   resetTimeStamp() {
@@ -29,7 +30,7 @@ import MpegAudio from './mpegaudio';
       // More info http://www.mp3-tech.org/programmer/frame_header.html
       for (offset = id3Data.length, length = Math.min(data.length - 1, offset + 100); offset < length; offset++) {
         if (MpegAudio.isHeader(data, offset)) {
-          //logger.log('MPEG sync word found !');
+          logger.log('MPEG Audio sync word found !');
           return true;
         }
       }
@@ -38,7 +39,7 @@ import MpegAudio from './mpegaudio';
   }
 
   // feed incoming data to the front of the parsing pipeline
-  append(data, timeOffset,contiguous,accurateTimeOffset) {
+  append(data, timeOffset, contiguous, accurateTimeOffset) {
     let id3Data = ID3.getID3Data(data, 0);
     let pts = 90 * ID3.getTimeStamp(id3Data);
     var offset = id3Data.length;
@@ -46,7 +47,7 @@ import MpegAudio from './mpegaudio';
     var frameIndex = 0, stamp = 0;
     var track = this._audioTrack;
 
-    let id3Samples = [{ pts: pts, dts : pts, data : id3Data }];
+    let id3Samples = [{ pts: pts, dts: pts, data: id3Data }];
 
     while (offset < length) {
       if (MpegAudio.isHeader(data, offset)) {
@@ -61,7 +62,7 @@ import MpegAudio from './mpegaudio';
         }
       } else if (ID3.isHeader(data, offset)) {
         id3Data = ID3.getID3Data(data, offset);
-        id3Samples.push({ pts: stamp, dts : stamp, data : id3Data });
+        id3Samples.push({ pts: stamp, dts: stamp, data: id3Data });
         offset += id3Data.length;
       } else {
         //nothing found, keep looking
@@ -70,12 +71,12 @@ import MpegAudio from './mpegaudio';
     }
 
     this.remuxer.remux(track,
-                        {samples : []},
-                        {samples : id3Samples, inputTimeScale : 90000},
-                        {samples : []},
-                        timeOffset,
-                        contiguous,
-                        accurateTimeOffset);
+      { samples: [] },
+      { samples: id3Samples, inputTimeScale: 90000 },
+      { samples: [] },
+      timeOffset,
+      contiguous,
+      accurateTimeOffset);
   }
 
   destroy() {

--- a/src/demux/mpegaudio.js
+++ b/src/demux/mpegaudio.js
@@ -69,6 +69,15 @@ const MpegAudio = {
         // Layer bits (position 14 and 15) in header should be always different from 0 (Layer I or Layer II or Layer III)
         // More info http://www.mp3-tech.org/programmer/frame_header.html
         if (offset + 1 < data.length && this.isHeaderPattern(data, offset)) {
+            return true;
+        }
+        return false;
+    },
+
+    probe: function (data, offset) {
+        // same as isHeader but we also check that MPEG frame follows last MPEG frame 
+        // or end of data is reached
+        if (offset + 1 < data.length && this.isHeaderPattern(data, offset)) {
             // MPEG header Length
             let headerLength = 4;
             // MPEG frame Length
@@ -77,7 +86,6 @@ const MpegAudio = {
             if (header && header.frameLength) {
                 frameLength = header.frameLength;
             }
-            // check that MPEG frame follows last MPEG frame or end of data is reached
             let newOffset = offset + frameLength;
             if (newOffset === data.length || (newOffset + 1 < data.length && this.isHeaderPattern(data, newOffset))) {
                 return true;

--- a/src/demux/mpegaudio.js
+++ b/src/demux/mpegaudio.js
@@ -1,6 +1,7 @@
 /**
  *  MPEG parser helper
  */
+
 const MpegAudio = {
 
     BitratesMap: [
@@ -37,10 +38,10 @@ const MpegAudio = {
     },
 
     parseHeader: function (data, offset) {
-        var headerB =   (data[offset + 1] >> 3) & 3;
-        var headerC =   (data[offset + 1] >> 1) & 3;
-        var headerE =   (data[offset + 2] >> 4) & 15;
-        var headerF =   (data[offset + 2] >> 2) & 3;
+        var headerB = (data[offset + 1] >> 3) & 3;
+        var headerC = (data[offset + 1] >> 1) & 3;
+        var headerE = (data[offset + 2] >> 4) & 15;
+        var headerF = (data[offset + 2] >> 2) & 3;
         var headerG = !!(data[offset + 2] & 2);
         if (headerB !== 1 && headerE !== 0 && headerE !== 15 && headerF !== 3) {
             var columnInBitrates = headerB === 3 ? (3 - headerC) : (headerC === 3 ? 3 : 4);
@@ -59,12 +60,26 @@ const MpegAudio = {
         return undefined;
     },
 
+    isHeaderPattern: function (data, offset) {
+        return data[offset] === 0xff && (data[offset + 1] & 0xe0) === 0xe0 && (data[offset + 1] & 0x06) !== 0x00;
+    },
+
     isHeader: function (data, offset) {
         // Look for MPEG header | 1111 1111 | 111X XYZX | where X can be either 0 or 1 and Y or Z should be 1
         // Layer bits (position 14 and 15) in header should be always different from 0 (Layer I or Layer II or Layer III)
         // More info http://www.mp3-tech.org/programmer/frame_header.html
-        if (offset + 1 < data.length) {
-            if ((data[offset] === 0xff) && (data[offset + 1] & 0xe0) === 0xe0 && (data[offset + 1] & 0x06) !== 0x00) {
+        if (offset + 1 < data.length && this.isHeaderPattern(data, offset)) {
+            // MPEG header Length
+            let headerLength = 4;
+            // MPEG frame Length
+            let header = this.parseHeader(data, offset);
+            let frameLength = headerLength;
+            if (header && header.frameLength) {
+                frameLength = header.frameLength;
+            }
+            // check that MPEG frame follows last MPEG frame or end of data is reached
+            let newOffset = offset + frameLength;
+            if (newOffset === data.length || (newOffset + 1 < data.length && this.isHeaderPattern(data, newOffset))) {
                 return true;
             }
         }


### PR DESCRIPTION
### Description of the Changes
https://github.com/video-dev/hls.js/pull/1113 introduces Mpeg audio only support - however in doing so it breaks some audio-only AAC container HLS. It triggers a `[error] > error while trying to add sourceBuffer:Failed to execute 'addSourceBuffer' on 'MediaSource': The type provided ('audio/mpeg;codecs=mp4a.40.2') is unsupported.` in latest Chrome for Windows 10. 

Example of problematic HLS stream: http://61.63.46.166/vod/_definst_/ibrain/14307/mp4:65v014307004.mp4/playlist.m3u8
(mirror at https://www.rmp-streaming.com/media/hls/issues/1/playlist.m3u8)

This is also documented in https://github.com/video-dev/hls.js/issues/1176 (which was closed using a workaround).

After debugging it appears that the probe for MP3Demuxer returns false positive. This pull request fixes this issue by first probing for AACDemuxer rather than MP3Demuxer. 
I have verified that this patch does not break mp3 or AAC audio-only playback with the following test cases:
http://www.rmp-streaming.com:1935/vod/mp3:audio-ad.mp3/playlist.m3u8
http://www.rmp-streaming.com:1935/vod/bbb-audio3.mp4/playlist.m3u8

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
