### PR TITLE
modules are always in strict mode

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -1,8 +1,6 @@
 /**
  * HLS interface
  */
-'use strict';
-
 import URLToolkit from 'url-toolkit';
 import Event from './events';
 import {ErrorTypes, ErrorDetails} from './errors';

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function noop() {}
 
 const fakeLogger = {


### PR DESCRIPTION
### Description of the Changes

Modules are always in strict mode, remove redundant "use strict" statement.

Again, making some baby-step PRs to get to know the library better.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
