### PR TITLE
Lookup type for codec in mp4ra sample entry code list

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -7,6 +7,7 @@ import EventHandler from '../event-handler';
 import {logger} from '../utils/logger';
 import {ErrorTypes, ErrorDetails} from '../errors';
 import BufferHelper from '../helper/buffer-helper';
+import {isCodecSupportedInMp4} from '../utils/codecs';
 
 class LevelController extends EventHandler {
 
@@ -59,8 +60,7 @@ class LevelController extends EventHandler {
         videoCodecFound = false,
         audioCodecFound = false,
         hls = this.hls,
-        brokenmp4inmp3 = /chrome|firefox/.test(navigator.userAgent.toLowerCase()),
-        checkSupported = function(type,codec) { return MediaSource.isTypeSupported(`${type}/mp4;codecs=${codec}`);};
+        brokenmp4inmp3 = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
 
     // regroup redundant level together
     data.levels.forEach(level => {
@@ -98,8 +98,8 @@ class LevelController extends EventHandler {
     // only keep level with supported audio/video codecs
     levels = levels.filter(function(level) {
     let audioCodec = level.audioCodec, videoCodec = level.videoCodec;
-      return (!audioCodec || checkSupported('audio',audioCodec)) &&
-             (!videoCodec || checkSupported('video',videoCodec));
+      return (!audioCodec || isCodecSupportedInMp4(audioCodec)) &&
+             (!videoCodec || isCodecSupportedInMp4(videoCodec));
     });
 
     if(levels.length) {

--- a/src/utils/codecs.js
+++ b/src/utils/codecs.js
@@ -1,0 +1,75 @@
+// from http://mp4ra.org/codecs.html
+const sampleEntryCodesISO = {
+    audio: {
+        'a3ds': true,
+        'ac-3': true,
+        'ac-4': true,
+        'alac': true,
+        'alaw': true,
+        'dra1': true,
+        'dts+': true,
+        'dts-': true,
+        'dtsc': true,
+        'dtse': true,
+        'dtsh': true,
+        'ec-3': true,
+        'enca': true,
+        'g719': true,
+        'g726': true,
+        'm4ae': true,
+        'mha1': true,
+        'mha2': true,
+        'mhm1': true,
+        'mhm2': true,
+        'mlpa': true,
+        'mp4a': true,
+        'raw ': true,
+        'Opus': true,
+        'samr': true,
+        'sawb': true,
+        'sawp': true,
+        'sevc': true,
+        'sqcp': true,
+        'ssmv': true,
+        'twos': true,
+        'ulaw': true
+    },
+    video: {
+        'avc1': true,
+        'avc2': true,
+        'avc3': true,
+        'avc4': true,
+        'avcp': true,
+        'drac': true,
+        'dvav': true,
+        'dvhe': true,
+        'encv': true,
+        'hev1': true,
+        'hvc1': true,
+        'mjp2': true,
+        'mp4v': true,
+        'mvc1': true,
+        'mvc2': true,
+        'mvc3': true,
+        'mvc4': true,
+        'resv': true,
+        'rv60': true,
+        's263': true,
+        'svc1': true,
+        'svc2': true,
+        'vc-1': true,
+        'vp08': true,
+        'vp09': true
+    }
+};
+
+function isCodecType(codec, type) {
+    const typeCodes = sampleEntryCodesISO[type];
+    return !!typeCodes && typeCodes[codec.slice(0, 4)] === true;
+}
+
+function isCodecSupportedInMp4(codec) {
+    return MediaSource.isTypeSupported(`video/mp4;codecs="${codec}"`);
+}
+
+export { isCodecType, isCodecSupportedInMp4 };


### PR DESCRIPTION
Fixes issues when eg. a "wvtt" subtitle codec is included in the list. Currently, it breaks in interesting ways, depending on whether the browser advertise support for `'audio/mp4; codecs="wvtt"'` or not.

### Description of the Changes

I created a new `codecs.js` util class that can determine the media type from the codec value. Doing this lookup avoids `"wvtt"` being set to `level.audioCodec`.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md