### PR TITLE
Fix for VTT subtitles don't show up on IE11 or Edge

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -285,7 +285,13 @@ class TimelineController extends EventHandler {
               // cue can appear more than once in different vtt files.
               // This avoid showing duplicated cues with same timecode and text.
               if (!currentTrack.cues.getCueById(cue.id)) {
-                currentTrack.addCue(cue);
+                try {
+                  currentTrack.addCue(cue);
+                } catch (err) {
+                  const textTrackCue = new window.TextTrackCue(cue.startTime, cue.endTime, cue.text);
+                  textTrackCue.id = cue.id;
+                  currentTrack.addCue(textTrackCue);
+                }
               }
             });
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: true, frag: frag});


### PR DESCRIPTION
### Description of the Changes
IE11 and Edge do not allow calls to addTrack with non TextTrackCue objects, so it is necessary to convert the custom WebVTT cues into TextTrackCues.

This partially fixes:
https://github.com/video-dev/hls.js/issues/1054

There is still an additional issue when switching between textTracks, at that point new captions will not display because IE11 and Edge do not fire the textTrack onchange event which triggers the loading of new TextTracks