### PR TITLE
Avoid polluting window object

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -6,7 +6,9 @@ import Event from '../events';
 import EventHandler from '../event-handler';
 import {logger} from '../utils/logger';
 import {ErrorTypes, ErrorDetails} from '../errors';
+import {getMediaSource} from '../helper/mediasource-helper';
 
+const MediaSource = getMediaSource();
 
 class BufferController extends EventHandler {
 

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -4,6 +4,9 @@ import {logger} from '../utils/logger';
 import {ErrorTypes, ErrorDetails} from '../errors';
 import EventEmitter from 'events';
 import work from 'webworkify-webpack';
+import {getMediaSource} from '../helper/mediasource-helper';
+
+const MediaSource = getMediaSource();
 
 class Demuxer {
 

--- a/src/helper/mediasource-helper.js
+++ b/src/helper/mediasource-helper.js
@@ -1,0 +1,9 @@
+/**
+ * MediaSource helper
+ */
+
+export function getMediaSource() {
+  if (typeof window !== 'undefined') {
+    return window.MediaSource || window.WebKitMediaSource;
+  }
+}

--- a/src/hls.js
+++ b/src/hls.js
@@ -21,8 +21,8 @@ export default class Hls {
     return __VERSION__;
   }
   static isSupported() {
-    const mediaSource = window.MediaSource = window.MediaSource || window.WebKitMediaSource;
-    const sourceBuffer = window.SourceBuffer = window.SourceBuffer || window.WebKitSourceBuffer;
+    const mediaSource = window.MediaSource || window.WebKitMediaSource;
+    const sourceBuffer = window.SourceBuffer || window.WebKitSourceBuffer;
     const isTypeSupported = mediaSource &&
                             typeof mediaSource.isTypeSupported === 'function' &&
                             mediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"');

--- a/src/hls.js
+++ b/src/hls.js
@@ -12,6 +12,7 @@ import StreamController from  './controller/stream-controller';
 import LevelController from  './controller/level-controller';
 import ID3TrackController from './controller/id3-track-controller';
 
+import {getMediaSource} from './helper/mediasource-helper';
 import {logger, enableLogs} from './utils/logger';
 import EventEmitter from 'events';
 import {hlsDefaultConfig} from './config';
@@ -21,7 +22,7 @@ export default class Hls {
     return __VERSION__;
   }
   static isSupported() {
-    const mediaSource = window.MediaSource || window.WebKitMediaSource;
+    const mediaSource = getMediaSource();
     const sourceBuffer = window.SourceBuffer || window.WebKitSourceBuffer;
     const isTypeSupported = mediaSource &&
                             typeof mediaSource.isTypeSupported === 'function' &&


### PR DESCRIPTION
### Description of the Changes

By assigning values to window.MediaSource and window.SourceBuffer
we create properties on the window object which did not necessarily
exist before. On iPhones, for example, window.MediaSource does not
exist, but when we do window.MediaSource = window.MediaSource || window.WebKitMediaSource
we declare the property with an undefined value. This changes the
outcome of an (arguably) common method for checking whether the
browser supports a certain Web API, namely by using the "in" operator
like so:

if ('MediaSource' in window) { ... }

The property declaration was introduced in 66ed87a7

This commit lets window.MediaSource and window.SourceBuffer remain
undeclared on the window object on browsers which do not support
MediaSource/SourceBuffer.

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
