### PR TITLE
add cross-env to test so it can be run on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "minor": "mversion mi && npm run preparerelease",
     "major": "mversion ma && npm run preparerelease",
     "pretest": "npm run lint",
-    "test": "BABEL_ENV=test mocha --compilers js:babel-register --recursive tests/unit",
-    "testfunc": "BABEL_ENV=test mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 40000",
+    "test": "cross-env BABEL_ENV=test mocha --compilers js:babel-register --recursive tests/unit",
+    "testfunc": "cross-env BABEL_ENV=test mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 40000",
     "lint": "jshint src/",
     "dev": "webpack-dev-server --env.debug --port 8000"
   },


### PR DESCRIPTION
### Description of the Changes

The `test` command was failing because `BABEL_ENV=test` does not work for windows. Since `cross-env` is already a dependency I figured it was mistakenly removed from `test` and `test-func` so I added it to those commands.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
