### PR TITLE
Add textTrack polling for browsers that don't have textTrack onchange events

### DIFF
--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -60,15 +60,26 @@ class SubtitleTrackController extends EventHandler {
     }
 
     this.trackChangeListener = this._onTextTracksChanged.bind(this);
-    this.media.textTracks.addEventListener('change', this.trackChangeListener);
+
+    this.useTextTrackPolling = !(this.media.textTracks && 'onchange' in this.media.textTracks);
+    if (this.useTextTrackPolling) {
+      this.subtitlePollingInterval = setInterval(() => {
+        this.trackChangeListener();
+      }, 500);
+    } else {
+      this.media.textTracks.addEventListener('change', this.trackChangeListener);
+    }
   }
 
   onMediaDetaching() {
     if (!this.media) {
       return;
     }
-
-    this.media.textTracks.removeEventListener('change', this.trackChangeListener);
+    if (this.useTextTrackPolling) {
+      clearInterval(this.subtitlePollingInterval);
+    } else {
+      this.media.textTracks.removeEventListener('change', this.trackChangeListener);
+    }
 
     this.media = undefined;
   }


### PR DESCRIPTION
### Description of the Changes
This pull request adds polling for textTrack changes in browsers that don't fire textTrack change events when switching tracks (IE11 and Edge). It is an additional fix for https://github.com/video-dev/hls.js/issues/1054.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
