### PR TITLE
AAC audio container on Safari

### DIFF
--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -14,7 +14,8 @@ class AACDemuxer {
   }
 
   resetInitSegment(initSegment, audioCodec, videoCodec, duration) {
-    this._audioTrack = { container: 'audio/adts', type: 'audio', id: -1, sequenceNumber: 0, isAAC: true, samples: [], len: 0, manifestCodec: audioCodec, duration: duration, inputTimeScale: 90000 };
+    // The id must be different from -1 to work on Safari
+    this._audioTrack = { container: 'audio/adts', type: 'audio', id: 1, sequenceNumber: 0, isAAC: true, samples: [], len: 0, manifestCodec: audioCodec, duration: duration, inputTimeScale: 90000 };
   }
 
   resetTimeStamp() {


### PR DESCRIPTION
### Description of the Changes
In Safari if the audio id outputted from the aac demuxer is -1 it won't work.
Changing the id from -1 to 1 makes it work on Safari (and other browsers).

Fixes #1226, Fixes #1272

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
