### PR TITLE
fix frag loading loop detection

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -657,7 +657,9 @@ class StreamController extends EventHandler {
     }
     this.fragCurrent = null;
     // increase fragment load Index to avoid frag loop loading error after buffer flush
-    this.fragLoadIdx += 2 * this.config.fragLoadingLoopThreshold;
+    if (this.fragLoadIdx !== undefined) {
+      this.fragLoadIdx += 2 * this.config.fragLoadingLoopThreshold;
+    }
     // flush everything
     this.flushMainBuffer(0,Number.POSITIVE_INFINITY);
   }


### PR DESCRIPTION
### Description of the Changes
There is an issue when trying to set hls.currentLevel immediately after MANIFEST_LOADED event is fired. StreamController immediateLevelSwitch method is incrementing fragLoadIdx property which is `undefined` at the moment so it becomes `NaN` and breaks further frag loop loading detection inside _loadFragmentOrKey method.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
