### PR TITLE
Issue#1096

### DIFF
--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -94,7 +94,19 @@ export function mergeDetails(oldDetails,newDetails) {
 
     // check if old/new playlists have fragments in common
     if ( end < start) {
-      newDetails.PTSKnown = false;
+      newDetails.PTSKnown = oldDetails.PTSKnown
+      //if the new segments start before the previous segments, adjust the start/end
+      //so that they occur after the previous segments.
+      var numOldFragments = oldDetails.fragments.length;
+      var lastOldFragment = oldDetails.fragments[numOldFragments -1];
+      var lastOldFragmentEndPTS = lastOldFragment.endPTS;
+      var numNewFragments = newDetails.fragments.length;
+      for (var newFragmentCtr = 0; newFragmentCtr < numNewFragments; newFragmentCtr++)
+      {
+         newDetails.fragments[newFragmentCtr].start += lastOldFragmentEndPTS;
+         newDetails.fragments[newFragmentCtr].startPTS += lastOldFragmentEndPTS;
+         newDetails.fragments[newFragmentCtr].endPTS += lastOldFragmentEndPTS;
+      }
       return;
     }
     // loop through overlapping SN and update startPTS , cc, and duration if any found

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -103,9 +103,9 @@ export function mergeDetails(oldDetails,newDetails) {
       var numNewFragments = newDetails.fragments.length;
       for (var newFragmentCtr = 0; newFragmentCtr < numNewFragments; newFragmentCtr++)
       {
-         newDetails.fragments[newFragmentCtr].start += lastOldFragmentEndPTS;
-         newDetails.fragments[newFragmentCtr].startPTS += lastOldFragmentEndPTS;
-         newDetails.fragments[newFragmentCtr].endPTS += lastOldFragmentEndPTS;
+        newDetails.fragments[newFragmentCtr].start += lastOldFragmentEndPTS;
+        newDetails.fragments[newFragmentCtr].startPTS += lastOldFragmentEndPTS;
+        newDetails.fragments[newFragmentCtr].endPTS += lastOldFragmentEndPTS;
       }
       return;
     }

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -94,7 +94,7 @@ export function mergeDetails(oldDetails,newDetails) {
 
     // check if old/new playlists have fragments in common
     if ( end < start) {
-      newDetails.PTSKnown = oldDetails.PTSKnown
+      newDetails.PTSKnown = oldDetails.PTSKnown;
       //if the new segments start before the previous segments, adjust the start/end
       //so that they occur after the previous segments.
       var numOldFragments = oldDetails.fragments.length;


### PR DESCRIPTION
### Description of the Changes
Support discontinuity better in the use case that the sequence number of new ts segments is less than the sequence number of old ts segments.  Set the end/start PTS of new segments to it's value + the value of the last old fragment's end PTS.  

Now when data is added to the MSE buffer, it has PTS set properly so that the transition between 2 streams can occur immediately, instead of having to wait for the new stream data to exceed the previous stream's PTS.

### CheckLists

- [ X] changes have been done against master branch, and PR does not conflict
- [ X] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
