### PR TITLE
Do not calculate nextLoadPos using bitrate test frag

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -515,13 +515,15 @@ class StreamController extends EventHandler {
         frag.loadCounter = 1;
       }
       frag.loadIdx = this.fragLoadIdx;
-      this.fragCurrent = frag;
-      this.startFragRequested = true;
-      if (!isNaN(frag.sn)) {
-        this.nextLoadPosition = frag.start + frag.duration;
-      }
       frag.autoLevel = hls.autoLevelEnabled;
       frag.bitrateTest = this.bitrateTest;
+
+      this.fragCurrent = frag;
+      this.startFragRequested = true;
+      // Don't update nextLoadPosition for fragments which are not buffered
+      if (!isNaN(frag.sn) && !frag.bitrateTest) {
+        this.nextLoadPosition = frag.start + frag.duration;
+      }
       hls.trigger(Event.FRAG_LOADING, {frag: frag});
       // lazy demuxer init, as this could take some time ... do it during frag loading
       if (!this.demuxer) {


### PR DESCRIPTION
### Description of the Changes
This PR will prevent incrementing `nextLoadPos` from the bitrate test frag, which is not appended to the buffer. While this normally does not cause an issue a race condition with start time (as in the case of preloading and autostarting) will cause the first segment to be skipped.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
