### PR TITLE
Change fragment retry

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -572,6 +572,7 @@ Max number of load retries.
 (default: `64000` ms)
 
 Maximum frag/manifest/key retry timeout (in milliseconds) in case I/O errors are met.
+This value is used as capping value for exponential grow of `loading retry delays`, i.e.  the retry delay can not be bigger than this value, but overall time will be based on the overall number of retries.
 
 ### `fragLoadingRetryDelay` / `manifestLoadingRetryDelay` / `levelLoadingRetryDelay`
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1315,8 +1315,9 @@ class StreamController extends EventHandler {
       case ErrorDetails.KEY_LOAD_ERROR:
       case ErrorDetails.KEY_LOAD_TIMEOUT:
         if (!data.fatal) {
-          // keep retrying / don't raise fatal network error if current position is buffered or if in automode with current level not 0
-          if ((this.fragLoadError + 1) <= this.config.fragLoadingMaxRetry || mediaBuffered || (frag.autoLevel && frag.level)) {
+          // keep retrying until the limit will be reached
+          // TODO Introduce an ability to hunt for the fragments from other available levels
+          if ((this.fragLoadError + 1) <= this.config.fragLoadingMaxRetry && mediaBuffered === true) {
             // exponential backoff capped to config.fragLoadingMaxRetryTimeout
             let delay = Math.min(Math.pow(2, this.fragLoadError) * this.config.fragLoadingRetryDelay, this.config.fragLoadingMaxRetryTimeout);
             // reset load counter to avoid frag loop loading error

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1305,9 +1305,7 @@ class StreamController extends EventHandler {
       return;
     }
     // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
-    let mediaBuffered = this.media
-      && BufferHelper.isBuffered(this.media, this.media.currentTime)
-      && BufferHelper.isBuffered(this.media, this.media.currentTime + 0.5);
+    let mediaBuffered = !!this.media && BufferHelper.isBuffered(this.media, this.media.currentTime) && BufferHelper.isBuffered(this.media, this.media.currentTime + 0.5);
 
     switch(data.details) {
       case ErrorDetails.FRAG_LOAD_ERROR:

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1314,8 +1314,7 @@ class StreamController extends EventHandler {
       case ErrorDetails.KEY_LOAD_TIMEOUT:
         if (!data.fatal) {
           // keep retrying until the limit will be reached
-          // TODO Introduce an ability to hunt for the fragments from other available levels
-          if ((this.fragLoadError + 1) <= this.config.fragLoadingMaxRetry && mediaBuffered === true) {
+          if ((this.fragLoadError + 1) <= this.config.fragLoadingMaxRetry) {
             // exponential backoff capped to config.fragLoadingMaxRetryTimeout
             let delay = Math.min(Math.pow(2, this.fragLoadError) * this.config.fragLoadingRetryDelay, this.config.fragLoadingMaxRetryTimeout);
             // reset load counter to avoid frag loop loading error


### PR DESCRIPTION
### Description of the Changes

Retries for the fragments are honored. Current implementation can retry until buffer is available. With this changes it is not allowed to retry more than specified in the configuration.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md