### PR TITLE
Add fragment errors for level loading

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -17,7 +17,6 @@ class LevelController extends EventHandler {
       Event.LEVEL_LOADED,
       Event.FRAG_LOADED,
       Event.ERROR);
-    this.ontick = this.tick.bind(this);
     this._manualLevel = -1;
     this.timer = null;
   }
@@ -292,7 +291,7 @@ class LevelController extends EventHandler {
           // FIXME Rely on Level Retry parameters, now it's possible to retry as long as media is buffered
           if (mediaBuffered === true) {
             logger.warn(`level controller,${details}, but media buffered, retry in ${config.levelLoadingRetryDelay}ms`);
-            this.timer = setTimeout(this.ontick, config.levelLoadingRetryDelay);
+            this.timer = setTimeout(() => this.tick(), config.levelLoadingRetryDelay);
             // boolean used to inform stream controller not to switch back to IDLE on non fatal error
             data.levelRetry = true;
           } else {
@@ -345,7 +344,7 @@ class LevelController extends EventHandler {
         // in any case, don't reload more than every second
         reloadInterval = Math.max(1000, Math.round(reloadInterval));
         logger.log(`live playlist, reload in ${reloadInterval} ms`);
-        this.timer = setTimeout(this.ontick, reloadInterval);
+        this.timer = setTimeout(() => this.tick(), reloadInterval);
       } else {
         this.cleanTimer();
       }
@@ -380,4 +379,3 @@ class LevelController extends EventHandler {
 }
 
 export default LevelController;
-

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -57,25 +57,28 @@ class LevelController extends EventHandler {
   }
 
   onManifestLoaded(data) {
-    var levels0 = [],
-        levels = [],
+    let levels0         = [],
+        levels          = [],
         bitrateStart,
-        bitrateSet = {},
+        bitrateSet      = {},
         videoCodecFound = false,
         audioCodecFound = false,
-        hls = this.hls,
-        brokenmp4inmp3 = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
+        brokenmp4inmp3  = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
 
-    // regroup redundant level together
+    // regroup redundant levels together
     data.levels.forEach(level => {
-      if(level.videoCodec) {
+      level.loadError = 0;
+      level.fragmentError = false;
+
+      if (level.videoCodec) {
         videoCodecFound = true;
       }
-      // erase audio codec info if browser does not support mp4a.40.34. demuxer will autodetect codec and fallback to mpeg/audio
-      if(brokenmp4inmp3 && level.audioCodec && level.audioCodec.indexOf('mp4a.40.34') !== -1) {
+      // erase audio codec info if browser does not support mp4a.40.34.
+      // demuxer will autodetect codec and fallback to mpeg/audio
+      if (brokenmp4inmp3 && level.audioCodec && level.audioCodec.indexOf('mp4a.40.34') !== -1) {
         level.audioCodec = undefined;
       }
-      if(level.audioCodec || (level.attrs && level.attrs.AUDIO)) {
+      if (level.audioCodec || (level.attrs && level.attrs.AUDIO)) {
         audioCodecFound = true;
       }
       let redundantLevelId = bitrateSet[level.bitrate];
@@ -90,23 +93,22 @@ class LevelController extends EventHandler {
     });
 
     // remove audio-only level if we also have levels with audio+video codecs signalled
-    if(videoCodecFound && audioCodecFound) {
+    if (videoCodecFound && audioCodecFound) {
       levels0.forEach(level => {
-        if(level.videoCodec) {
+        if (level.videoCodec) {
           levels.push(level);
         }
       });
     } else {
       levels = levels0;
     }
-    // only keep level with supported audio/video codecs
-    levels = levels.filter(function(level) {
-    let audioCodec = level.audioCodec, videoCodec = level.videoCodec;
-      return (!audioCodec || isCodecSupportedInMp4(audioCodec)) &&
-             (!videoCodec || isCodecSupportedInMp4(videoCodec));
+
+    // only keep levels with supported audio/video codecs
+    levels = levels.filter(({audioCodec, videoCodec}) => {
+      return (!audioCodec || isCodecSupportedInMp4(audioCodec)) && (!videoCodec || isCodecSupportedInMp4(videoCodec));
     });
 
-    if(levels.length) {
+    if (levels.length > 0) {
       // start bitrate is the first bitrate of the manifest
       bitrateStart = levels[0].bitrate;
       // sort level on bitrate
@@ -122,11 +124,23 @@ class LevelController extends EventHandler {
           break;
         }
       }
-      hls.trigger(Event.MANIFEST_PARSED, {levels: levels, firstLevel: this._firstLevel, stats: data.stats, audio : audioCodecFound, video : videoCodecFound, altAudio : data.audioTracks.length > 0});
+      this.hls.trigger(Event.MANIFEST_PARSED, {
+        levels    : levels,
+        firstLevel: this._firstLevel,
+        stats     : data.stats,
+        audio     : audioCodecFound,
+        video     : videoCodecFound,
+        altAudio  : data.audioTracks.length > 0
+      });
     } else {
-      hls.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.MANIFEST_INCOMPATIBLE_CODECS_ERROR, fatal: true, url: hls.url, reason: 'no level with compatible codecs found in manifest'});
+      this.hls.trigger(Event.ERROR, {
+        type   : ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.MANIFEST_INCOMPATIBLE_CODECS_ERROR,
+        fatal  : true,
+        url    : this.hls.url,
+        reason : 'no level with compatible codecs found in manifest'
+      });
     }
-    return;
   }
 
   get levels() {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -233,7 +233,7 @@ class LevelController extends EventHandler {
       return;
     }
 
-    let details = data.details, hls = this.hls, levelId, level, levelError = false;
+    let details = data.details, levelId, level, levelError = false;
     // try to recover not fatal errors
     switch (details) {
       case ErrorDetails.FRAG_LOAD_ERROR:
@@ -277,7 +277,7 @@ class LevelController extends EventHandler {
         let recoverable = ((this._manualLevel === -1) && levelId);
         if (recoverable) {
           logger.warn(`level controller,${details}: switch-down for next fragment`);
-          hls.nextAutoLevel = Math.max(0, levelId - 1);
+          this.hls.nextAutoLevel = Math.max(0, levelId - 1);
         } else if (level && level.details && level.details.live) {
           logger.warn(`level controller,${details} on live stream, discard`);
           if (levelError) {
@@ -286,11 +286,11 @@ class LevelController extends EventHandler {
           }
           // other errors are handled by stream controller
         } else if (levelError === true) {
-          let media         = hls.media,
+          let media         = this.hls.media,
               // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
               mediaBuffered = media && BufferHelper.isBuffered(media, media.currentTime) && BufferHelper.isBuffered(media, media.currentTime + 0.5);
           if (mediaBuffered) {
-            let retryDelay = hls.config.levelLoadingRetryDelay;
+            let retryDelay = this.hls.config.levelLoadingRetryDelay;
             logger.warn(`level controller,${details}, but media buffered, retry in ${retryDelay}ms`);
             this.timer = setTimeout(this.ontick, retryDelay);
             // boolean used to inform stream controller not to switch back to IDLE on non fatal error

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -275,7 +275,7 @@ class LevelController extends EventHandler {
         logger.warn(`level controller,${details} for level ${levelIndex}: switching to redundant stream id ${level.urlId}`);
       } else {
         // we could try to recover if in auto mode and current level not lowest level (0)
-        if (this._manualLevel === -1 && levelIndex !== 0) {
+        if ((this._manualLevel === -1) && levelIndex !== 0) {
           logger.warn(`level controller,${details}: switch-down for next fragment`);
           this.hls.nextAutoLevel = Math.max(0, levelIndex - 1);
         } else if (level && level.details && level.details.live) {
@@ -287,8 +287,9 @@ class LevelController extends EventHandler {
           // other errors are handled by stream controller
         } else if (levelError === true) {
           // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
-          let mediaBuffered = media && BufferHelper.isBuffered(media, media.currentTime) && BufferHelper.isBuffered(media, media.currentTime + 0.5);
-          if (mediaBuffered) {
+          let mediaBuffered = !!media && BufferHelper.isBuffered(media, media.currentTime) && BufferHelper.isBuffered(media, media.currentTime + 0.5);
+          // FIXME Rely on Level Retry parameters, now it's possible to retry as long as media is buffered
+          if (mediaBuffered === true) {
             logger.warn(`level controller,${details}, but media buffered, retry in ${config.levelLoadingRetryDelay}ms`);
             this.timer = setTimeout(this.ontick, config.levelLoadingRetryDelay);
             // boolean used to inform stream controller not to switch back to IDLE on non fatal error

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -63,7 +63,7 @@ class LevelController extends EventHandler {
         levelFromSet    = null,
         videoCodecFound = false,
         audioCodecFound = false,
-        brokenmp4inmp3  = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
+        chromeOrFirefox = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
 
     // regroup redundant levels together
     data.levels.forEach(level => {
@@ -75,10 +75,9 @@ class LevelController extends EventHandler {
       }
       // erase audio codec info if browser does not support mp4a.40.34.
       // demuxer will autodetect codec and fallback to mpeg/audio
-      if (brokenmp4inmp3 && level.audioCodec && level.audioCodec.indexOf('mp4a.40.34') !== -1) {
+      if (chromeOrFirefox === true && level.audioCodec && level.audioCodec.indexOf('mp4a.40.34') !== -1) {
         level.audioCodec = undefined;
-      }
-      if (level.audioCodec || (level.attrs && level.attrs.AUDIO)) {
+      } else if (level.audioCodec || (level.attrs && level.attrs.AUDIO)) {
         audioCodecFound = true;
       }
 

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -308,12 +308,12 @@ class LevelController extends EventHandler {
     }
   }
 
-  // reset level load error counter on successful frag loaded
-  onFragLoaded(data) {
-    const fragLoaded = data.frag;
-    if (fragLoaded && fragLoaded.type === 'main') {
-      const level = this._levels[fragLoaded.level];
-      if (level) {
+  // reset errors on the successful load of a fragment
+  onFragLoaded({frag}) {
+    if (frag !== undefined && frag.type === 'main') {
+      const level = this._levels[frag.level];
+      if (level !== undefined) {
+        level.fragmentError = false;
         level.loadError = 0;
       }
     }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -19,6 +19,7 @@ class LevelController extends EventHandler {
       Event.ERROR);
     this.ontick = this.tick.bind(this);
     this._manualLevel = -1;
+    this.timer = null;
   }
 
   destroy() {
@@ -27,7 +28,7 @@ class LevelController extends EventHandler {
   }
 
   cleanTimer() {
-    if (this.timer) {
+    if (this.timer !== null) {
       clearTimeout(this.timer);
       this.timer = null;
     }
@@ -344,7 +345,7 @@ class LevelController extends EventHandler {
         logger.log(`live playlist, reload in ${reloadInterval} ms`);
         this.timer = setTimeout(this.ontick,reloadInterval);
       } else {
-        this.timer = null;
+        this.cleanTimer();
       }
     }
   }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -321,29 +321,31 @@ class LevelController extends EventHandler {
 
   onLevelLoaded(data) {
     const levelId = data.level;
-     // only process level loaded events matching with expected level
+    // only process level loaded events matching with expected level
     if (levelId === this._level) {
       let curLevel = this._levels[levelId];
-      // reset level load error counter on successful level loaded
-      curLevel.loadError = 0;
+      // reset level load error counter on successful level loaded only if there is no issues with fragments
+      if(curLevel.fragmentError === false){
+        curLevel.loadError = 0;
+      }
       let newDetails = data.details;
       // if current playlist is a live playlist, arm a timer to reload it
       if (newDetails.live) {
-        let reloadInterval = 1000*( newDetails.averagetargetduration ? newDetails.averagetargetduration : newDetails.targetduration),
-            curDetails = curLevel.details;
+        let reloadInterval = 1000 * ( newDetails.averagetargetduration ? newDetails.averagetargetduration : newDetails.targetduration),
+            curDetails     = curLevel.details;
         if (curDetails && newDetails.endSN === curDetails.endSN) {
           // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
           // changed then it MUST wait for a period of one-half the target
           // duration before retrying.
-          reloadInterval /=2;
+          reloadInterval /= 2;
           logger.log(`same live playlist, reload twice faster`);
         }
         // decrement reloadInterval with level loading delay
         reloadInterval -= performance.now() - data.stats.trequest;
         // in any case, don't reload more than every second
-        reloadInterval = Math.max(1000,Math.round(reloadInterval));
+        reloadInterval = Math.max(1000, Math.round(reloadInterval));
         logger.log(`live playlist, reload in ${reloadInterval} ms`);
-        this.timer = setTimeout(this.ontick,reloadInterval);
+        this.timer = setTimeout(this.ontick, reloadInterval);
       } else {
         this.cleanTimer();
       }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -57,10 +57,10 @@ class LevelController extends EventHandler {
   }
 
   onManifestLoaded(data) {
-    let levels0         = [],
-        levels          = [],
+    let levels          = [],
         bitrateStart,
-        bitrateSet      = {},
+        levelSet        = {},
+        levelFromSet    = null,
         videoCodecFound = false,
         audioCodecFound = false,
         brokenmp4inmp3  = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
@@ -81,26 +81,22 @@ class LevelController extends EventHandler {
       if (level.audioCodec || (level.attrs && level.attrs.AUDIO)) {
         audioCodecFound = true;
       }
-      let redundantLevelId = bitrateSet[level.bitrate];
-      if (redundantLevelId === undefined) {
-        bitrateSet[level.bitrate] = levels0.length;
+
+      levelFromSet = levelSet[level.bitrate];
+
+      if (levelFromSet === undefined) {
         level.url = [level.url];
         level.urlId = 0;
-        levels0.push(level);
+        levelSet[level.bitrate] = level;
+        levels.push(level);
       } else {
-        levels0[redundantLevelId].url.push(level.url);
+        levelFromSet.url.push(level.url);
       }
     });
 
     // remove audio-only level if we also have levels with audio+video codecs signalled
-    if (videoCodecFound && audioCodecFound) {
-      levels0.forEach(level => {
-        if (level.videoCodec) {
-          levels.push(level);
-        }
-      });
-    } else {
-      levels = levels0;
+    if (videoCodecFound === true && audioCodecFound === true) {
+      levels = levels.filter(({videoCodec}) => !!videoCodec);
     }
 
     // only keep levels with supported audio/video codecs

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -226,7 +226,7 @@ class LevelController extends EventHandler {
   }
 
   onError(data) {
-    if(data.fatal) {
+    if (data.fatal) {
       if (data.type === ErrorTypes.NETWORK_ERROR) {
         this.cleanTimer();
       }
@@ -235,14 +235,14 @@ class LevelController extends EventHandler {
 
     let details = data.details, hls = this.hls, levelId, level, levelError = false;
     // try to recover not fatal errors
-    switch(details) {
+    switch (details) {
       case ErrorDetails.FRAG_LOAD_ERROR:
       case ErrorDetails.FRAG_LOAD_TIMEOUT:
       case ErrorDetails.FRAG_LOOP_LOADING_ERROR:
       case ErrorDetails.KEY_LOAD_ERROR:
       case ErrorDetails.KEY_LOAD_TIMEOUT:
-         levelId = data.frag.level;
-         break;
+        levelId = data.frag.level;
+        break;
       case ErrorDetails.LEVEL_LOAD_ERROR:
       case ErrorDetails.LEVEL_LOAD_TIMEOUT:
         levelId = data.context.level;
@@ -260,7 +260,7 @@ class LevelController extends EventHandler {
      */
     if (levelId !== undefined) {
       level = this._levels[levelId];
-      if(!level.loadError) {
+      if (!level.loadError) {
         level.loadError = 1;
       } else {
         level.loadError++;
@@ -268,7 +268,7 @@ class LevelController extends EventHandler {
       // if any redundant streams available and if we haven't try them all (level.loadError is reseted on successful frag/level load.
       // if level.loadError reaches nbRedundantLevel it means that we tried them all, no hope  => let's switch down
       const nbRedundantLevel = level.url.length;
-     if (nbRedundantLevel > 1 && level.loadError < nbRedundantLevel) {
+      if (nbRedundantLevel > 1 && level.loadError < nbRedundantLevel) {
         level.urlId = (level.urlId + 1) % nbRedundantLevel;
         level.details = undefined;
         logger.warn(`level controller,${details} for level ${levelId}: switching to redundant stream id ${level.urlId}`);
@@ -277,23 +277,22 @@ class LevelController extends EventHandler {
         let recoverable = ((this._manualLevel === -1) && levelId);
         if (recoverable) {
           logger.warn(`level controller,${details}: switch-down for next fragment`);
-          hls.nextAutoLevel = Math.max(0,levelId-1);
-        } else if(level && level.details && level.details.live) {
+          hls.nextAutoLevel = Math.max(0, levelId - 1);
+        } else if (level && level.details && level.details.live) {
           logger.warn(`level controller,${details} on live stream, discard`);
           if (levelError) {
             // reset this._level so that another call to set level() will retrigger a frag load
             this._level = undefined;
           }
           // other errors are handled by stream controller
-        } else if (details === ErrorDetails.LEVEL_LOAD_ERROR ||
-                   details === ErrorDetails.LEVEL_LOAD_TIMEOUT) {
-          let media = hls.media,
-            // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
-              mediaBuffered = media && BufferHelper.isBuffered(media,media.currentTime) && BufferHelper.isBuffered(media,media.currentTime+0.5);
+        } else if (levelError === true) {
+          let media         = hls.media,
+              // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
+              mediaBuffered = media && BufferHelper.isBuffered(media, media.currentTime) && BufferHelper.isBuffered(media, media.currentTime + 0.5);
           if (mediaBuffered) {
             let retryDelay = hls.config.levelLoadingRetryDelay;
             logger.warn(`level controller,${details}, but media buffered, retry in ${retryDelay}ms`);
-            this.timer = setTimeout(this.ontick,retryDelay);
+            this.timer = setTimeout(this.ontick, retryDelay);
             // boolean used to inform stream controller not to switch back to IDLE on non fatal error
             data.levelRetry = true;
           } else {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -226,14 +226,17 @@ class LevelController extends EventHandler {
   }
 
   onError(data) {
-    if (data.fatal) {
+    if (data.fatal === true) {
       if (data.type === ErrorTypes.NETWORK_ERROR) {
         this.cleanTimer();
       }
       return;
     }
 
-    let details = data.details, levelId, level, levelError = false;
+    let details = data.details, levelError = false, fragmentError = false;
+    let levelIndex, level;
+    let {config, media} = this.hls;
+
     // try to recover not fatal errors
     switch (details) {
       case ErrorDetails.FRAG_LOAD_ERROR:
@@ -241,58 +244,53 @@ class LevelController extends EventHandler {
       case ErrorDetails.FRAG_LOOP_LOADING_ERROR:
       case ErrorDetails.KEY_LOAD_ERROR:
       case ErrorDetails.KEY_LOAD_TIMEOUT:
-        levelId = data.frag.level;
+        levelIndex = data.frag.level;
+        fragmentError = true;
         break;
       case ErrorDetails.LEVEL_LOAD_ERROR:
       case ErrorDetails.LEVEL_LOAD_TIMEOUT:
-        levelId = data.context.level;
+        levelIndex = data.context.level;
         levelError = true;
         break;
       case ErrorDetails.REMUX_ALLOC_ERROR:
-        levelId = data.level;
-        break;
-      default:
+        levelIndex = data.level;
         break;
     }
     /* try to switch to a redundant stream if any available.
      * if no redundant stream available, emergency switch down (if in auto mode and current level not 0)
      * otherwise, we cannot recover this network error ...
      */
-    if (levelId !== undefined) {
-      level = this._levels[levelId];
-      if (!level.loadError) {
-        level.loadError = 1;
-      } else {
-        level.loadError++;
-      }
+    if (levelIndex !== undefined) {
+      level = this._levels[levelIndex];
+      level.loadError++;
+      level.fragmentError = fragmentError;
+
       // if any redundant streams available and if we haven't try them all (level.loadError is reseted on successful frag/level load.
-      // if level.loadError reaches nbRedundantLevel it means that we tried them all, no hope  => let's switch down
-      const nbRedundantLevel = level.url.length;
-      if (nbRedundantLevel > 1 && level.loadError < nbRedundantLevel) {
-        level.urlId = (level.urlId + 1) % nbRedundantLevel;
+      // if level.loadError reaches redundantLevels it means that we tried them all, no hope  => let's switch down
+      const redundantLevels = level.url.length;
+
+      if (redundantLevels > 1 && level.loadError < redundantLevels) {
+        level.urlId = (level.urlId + 1) % redundantLevels;
         level.details = undefined;
-        logger.warn(`level controller,${details} for level ${levelId}: switching to redundant stream id ${level.urlId}`);
+        logger.warn(`level controller,${details} for level ${levelIndex}: switching to redundant stream id ${level.urlId}`);
       } else {
         // we could try to recover if in auto mode and current level not lowest level (0)
-        let recoverable = ((this._manualLevel === -1) && levelId);
-        if (recoverable) {
+        if (this._manualLevel === -1 && levelIndex !== 0) {
           logger.warn(`level controller,${details}: switch-down for next fragment`);
-          this.hls.nextAutoLevel = Math.max(0, levelId - 1);
+          this.hls.nextAutoLevel = Math.max(0, levelIndex - 1);
         } else if (level && level.details && level.details.live) {
           logger.warn(`level controller,${details} on live stream, discard`);
-          if (levelError) {
-            // reset this._level so that another call to set level() will retrigger a frag load
+          if (levelError === true) {
+            // reset this._level so that another call to set level() will trigger again a frag load
             this._level = undefined;
           }
           // other errors are handled by stream controller
         } else if (levelError === true) {
-          let media         = this.hls.media,
-              // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
-              mediaBuffered = media && BufferHelper.isBuffered(media, media.currentTime) && BufferHelper.isBuffered(media, media.currentTime + 0.5);
+          // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
+          let mediaBuffered = media && BufferHelper.isBuffered(media, media.currentTime) && BufferHelper.isBuffered(media, media.currentTime + 0.5);
           if (mediaBuffered) {
-            let retryDelay = this.hls.config.levelLoadingRetryDelay;
-            logger.warn(`level controller,${details}, but media buffered, retry in ${retryDelay}ms`);
-            this.timer = setTimeout(this.ontick, retryDelay);
+            logger.warn(`level controller,${details}, but media buffered, retry in ${config.levelLoadingRetryDelay}ms`);
+            this.timer = setTimeout(this.ontick, config.levelLoadingRetryDelay);
             // boolean used to inform stream controller not to switch back to IDLE on non fatal error
             data.levelRetry = true;
           } else {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -70,15 +70,13 @@ class LevelController extends EventHandler {
       level.loadError = 0;
       level.fragmentError = false;
 
-      if (level.videoCodec) {
-        videoCodecFound = true;
-      }
+      videoCodecFound = videoCodecFound || !!level.videoCodec;
+      audioCodecFound = audioCodecFound || !!level.audioCodec || !!(level.attrs && level.attrs.AUDIO);
+
       // erase audio codec info if browser does not support mp4a.40.34.
       // demuxer will autodetect codec and fallback to mpeg/audio
       if (chromeOrFirefox === true && level.audioCodec && level.audioCodec.indexOf('mp4a.40.34') !== -1) {
         level.audioCodec = undefined;
-      } else if (level.audioCodec || (level.attrs && level.attrs.AUDIO)) {
-        audioCodecFound = true;
       }
 
       levelFromSet = levelSet[level.bitrate];


### PR DESCRIPTION
### Description of the Changes

It’s a fix/improvement of current fragment down-shifting logic. If there is an issue with a fragment and we have backup/redundant streams, the library would retry the same level over and over. This change brings Fragment Error concern to Level Controller. It’s part of HLS design, where we need to reload level in order to try fragments.

It’s recommended to adjust fragment retry values to achieve the best retry outcome.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md