### PR TITLE
Remove dead code XDomainRequest reference

### DIFF
--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -41,12 +41,8 @@ class XhrLoader {
 
   loadInternal() {
     var xhr, context = this.context;
-
-    if (typeof XDomainRequest !== 'undefined') {
-       xhr = this.loader = new XDomainRequest();
-    } else {
-       xhr = this.loader = new XMLHttpRequest();
-    }
+    xhr = this.loader = new XMLHttpRequest();
+    
     let stats = this.stats;
     stats.tfirst = 0;
     stats.loaded = 0;


### PR DESCRIPTION
There is an XDomainRequest reference here from https://github.com/video-dev/hls.js/commit/7f772ef86b83972df0c5d8f74e1c5b36fcf4f2f7#diff-5b5ca1c2ac7acf4ca9be5b53329cc1a2 but this only works in IE9 and IE10 which don't have MSE anyway and aren't supported by hls.js

Remove this tidbit of dead code.