### PR TITLE
fix use of null pointer when SLICE is received before IDR

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -494,7 +494,10 @@
         //NDR
          case 1:
            push = true;
-           if(debug && avcSample) {
+           if (!avcSample) {
+            avcSample = this.avcSample = createAVCSample(true,pes.pts,pes.dts,'');
+           }
+           if(debug) {
             avcSample.debug += 'NDR ';
            }
            avcSample.frame = true;


### PR DESCRIPTION
### Description of the Changes
Allocate avcSample before using it. This occurs when TS contains a NDR before an IDR

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
