### PR TITLE
Fix comment for VTTCue.align

### DIFF
--- a/src/utils/vttparser.js
+++ b/src/utils/vttparser.js
@@ -129,7 +129,7 @@ function parseOptions(input, callback, keyValueDelim, groupDelim) {
 
 var defaults = new VTTCue(0, 0, 0);
 // 'middle' was changed to 'center' in the spec: https://github.com/w3c/webvtt/pull/244
-// Chrome and Safari don't yet support this change, but FF does
+//  Safari doesn't yet support this change, but FF and Chrome do.
 var center = defaults.align === 'middle' ? 'middle' : 'center';
 
 function parseCue(input, cue, regionList) {


### PR DESCRIPTION
### Description of the Changes

According to https://bugs.chromium.org/p/chromium/issues/detail?id=663797, Chrome now supports "WebVTT: VTTCue.align = 'center'".

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
