### PR TITLE
Add level retry constraints

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -66,8 +66,9 @@ design idea is pretty simple :
   - [src/controller/level-controller.js][]
     - level controller is handling quality level set/get ((re)loading stream manifest/switching levels)  
     - in charge of scheduling playlist (re)loading
-    - monitor fragment/key/level loading error. handle fallback mechanism in case of errors : switch to redundant level, then level switch down till lowest rendition is reached. if `LEVEL_LOAD_ERROR`/`LEVEL_LOAD_TIMEOUT` is raised while media.currentTime is not buffered  and it is not possible to fallback (either because we are already on the lowest rendition or because we are in manual level selection), then `LEVEL_LOAD_ERROR`/`LEVEL_LOAD_TIMEOUT` will be converted into a fatal error.
-    - a timer is armed to periodically refresh active live playlist.
+    - monitors fragment and key loading errors. Performs fragment hunt by switching between primary and backup streams and down-shifting a level till `fragLoadingMaxRetry` limit is reached.
+    - monitors level loading errors. Reloads level manifest with an exponential falloff and converts an error to fatal when `levelLoadingMaxRetry` limit is reached.
+    - a timer is armed to periodically refresh active live playlist
   - [src/controller/stream-controller.js][]
     - stream controller is in charge of:
       - triggering BUFFER_RESET on MANIFEST_PARSED or startLoad()    

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -290,7 +290,6 @@ class LevelController extends EventHandler {
           }
         }
       } else if (levelError === true){
-        // FIXME Rely on Level Retry parameters, now it's possible to retry as long as media is buffered
         if ((this.levelRetryCount + 1) <= config.levelLoadingMaxRetry) {
           // exponential backoff capped to max retry timeout
           const delay = Math.min(Math.pow(2, this.levelRetryCount) * config.levelLoadingRetryDelay, config.levelLoadingMaxRetryTimeout);

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -293,7 +293,7 @@ class LevelController extends EventHandler {
         // FIXME Rely on Level Retry parameters, now it's possible to retry as long as media is buffered
         if ((this.levelRetryCount + 1) <= config.levelLoadingMaxRetry) {
           // exponential backoff capped to max retry timeout
-          const delay = Math.min(Math.pow(2, this.levelRetryCount) * this.config.levelLoadingRetryDelay, this.config.levelLoadingMaxRetryTimeout);
+          const delay = Math.min(Math.pow(2, this.levelRetryCount) * config.levelLoadingRetryDelay, config.levelLoadingMaxRetryTimeout);
           // reset load counter to avoid frag loop loading error
           this.timer = setTimeout(() => this.tick(), delay);
           // boolean used to inform stream controller not to switch back to IDLE on non fatal error


### PR DESCRIPTION
### Description of the Changes

We are lacking retry constraints for level loading. This change brings level retry configuration in the same way as we have for fragments. Since there is a dependency between fragments and levels by design, level retry management gives an unlimited retry budget for fragments.

Related to https://github.com/video-dev/hls.js/pull/1317

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md