### PR TITLE
Fix nextLevel quality switch

### DIFF
--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -33,6 +33,7 @@ export function updatePTS(fragments,fromIdx, toIdx) {
 
 export function updateFragPTSDTS(details,frag,startPTS,endPTS,startDTS,endDTS) {
   // update frag PTS/DTS
+  let maxStartPTS = startPTS;
   if (!isNaN(frag.startPTS)) {
     // delta PTS between audio and video
     let deltaPTS = Math.abs(frag.startPTS - startPTS);
@@ -41,6 +42,7 @@ export function updateFragPTSDTS(details,frag,startPTS,endPTS,startDTS,endDTS) {
     } else {
       frag.deltaPTS = Math.max(deltaPTS, frag.deltaPTS);
     }
+    maxStartPTS = Math.max(startPTS,frag.startPTS);
     startPTS = Math.min(startPTS, frag.startPTS);
     endPTS = Math.max(endPTS, frag.endPTS);
     startDTS = Math.min(startDTS, frag.startDTS);
@@ -49,6 +51,7 @@ export function updateFragPTSDTS(details,frag,startPTS,endPTS,startDTS,endDTS) {
 
   const drift = startPTS - frag.start;
   frag.start = frag.startPTS = startPTS;
+  frag.maxStartPTS = maxStartPTS;
   frag.endPTS = endPTS;
   frag.startDTS = startDTS;
   frag.endDTS = endDTS;


### PR DESCRIPTION
### Description of the Changes

nextLevel quality switch is broken since 4a68b557a7f55e1b06c697fc10cdc190fc8c368a
maxStartPTS is never calculated and thus the buffer is not flushed which makes nextLevel switch essentially the same as loadLevel

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
