### PR TITLE
Demo: Reset tracks when media is detached

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -293,6 +293,7 @@ $(document).ready(function() {
        hls.on(Hls.Events.MEDIA_DETACHED,function() {
         $("#HlsStatus").text('MediaSource detached...');
           bufferingIdx = -1;
+          tracks = [];
           events.video.push({time : performance.now() - events.t0, type : "Media detached"});
        });
        hls.on(Hls.Events.FRAG_PARSING_INIT_SEGMENT,function(event,data) {


### PR DESCRIPTION
### Description of the Changes

This PR fixes a DOMException that was raised because source buffers in `tracks` were not available from the media source.

```
(index):851 Uncaught DOMException: Failed to read the 'buffered' property from 'SourceBuffer': 
    This SourceBuffer has been removed from the parent media source.
            at checkBuffer (https://video-dev.github.io/hls.js/demo/:851:79)
```


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
