### PR TITLE
Allow AAC streams without ID3 to play

### DIFF
--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -66,11 +66,13 @@ class DemuxerInline {
       const observer = this.observer;
       const typeSupported = this.typeSupported;
       const config = this.config;
-      // probing order is AAC/MP3/TS/MP4
-      const muxConfig = [{ demux: AACDemuxer, remux: MP4Remuxer },
-      { demux: MP3Demuxer, remux: MP4Remuxer },
-      { demux: TSDemuxer, remux: MP4Remuxer },
-      { demux: MP4Demuxer, remux: PassThroughRemuxer }];
+      // probing order is TS/AAC/MP3/MP4
+      const muxConfig = [
+        { demux: TSDemuxer, remux: MP4Remuxer },
+        { demux: AACDemuxer, remux: MP4Remuxer },
+        { demux: MP3Demuxer, remux: MP4Remuxer },
+        { demux: MP4Demuxer, remux: PassThroughRemuxer }
+      ];
 
       // probe for content type
       for (let i = 0, len = muxConfig.length; i < len; i++) {


### PR DESCRIPTION
### Description of the Changes
- Allow AAC demuxing without a timestamp or ID3 data
- Scan entire fragment for ADTS syncword if no ID3 is found
- For AAC streams without ID3, calculate PTS using a default value + time offset
- Probe for TS before AAC because TS demuxing is more accurate (prevents TS streams with AAC audio from being demuxed with the AAC demuxer)

AAC streams do not need to have ID3 data if they don't need to synchronize with a video track, i.e. in audio-only streams.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
