### PR TITLE
Fix seek to buffered start position

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1431,7 +1431,7 @@ _checkBuffer() {
         if (currentTime !== startPosition || startNotBufferedButClose) {
           logger.log(`target start position:${startPosition}`);
           // if startPosition not buffered, let's seek to buffered.start(0)
-          if(!startNotBufferedButClose) {
+          if(startNotBufferedButClose) {
             startPosition = firstbufferedPosition;
             logger.log(`target start position not buffered, seek to buffered.start(0) ${startPosition}`);
           }


### PR DESCRIPTION
### Description of the Changes

With version 0.8.3 some of our streams (LIVE HLS playlist) wouldn't start playing. Fragments were loading but playback never started (black screen, no audio).

After some digging I found the cause of this issue was the commit bc24f55cc51e57128f55e8a9886f2b41b9790fa5. The start position was never set to the first buffered position.

On our streams the buffered start position is always between 1.5 and 2.0 seconds. The player was waiting for a lower position to get buffered which obviously never happened. But I still wondered why the default 2 second maxSeekHole didn't work. Then I saw that "startPositionBuffered" was replaced with "startNotBufferedButClose" and negation in if clause still present which is most certainly not correct.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
