### PR TITLE
Update mediaSource duration if duration is Infinty

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -377,11 +377,12 @@ class BufferController extends EventHandler {
       this._msDuration = mediaSource.duration;
     }
     let duration = media.duration;
+    let infiniteDuration = mediaSource.duration === Infinity && (duration === Infinity || isNaN(duration));
     // levelDuration was the last value we set.
     // not using mediaSource.duration as the browser may tweak this value
     // only update mediasource duration if its value increase, this is to avoid
     // flushing already buffered portion when switching between quality level
-    if ((levelDuration > this._msDuration && levelDuration > duration) || (duration === Infinity || isNaN(duration) )) {
+    if ((levelDuration > this._msDuration && levelDuration > duration) || infiniteDuration) {
       logger.log(`Updating mediasource duration to ${levelDuration.toFixed(3)}`);
       this._msDuration = mediaSource.duration = levelDuration;
     }


### PR DESCRIPTION
- Make sure both the mediaSource duration and the media duration is Infinity before adjusting the mediaSource duration
- On audio-only broadcasts, mediaSource.duration is set to Infinity, which is why we want to set it to a valid value.
However, when playing a live stream where the duration explicitly is set to Infinity (but where mediaSource.duration contains the so far known, finite duration), don’t override the mediaSource duration.
- When mediaSource duration was overridden (since 0.6.17), this caused frequent playback stalls resulting in waiting events and spinners as the the mediaSource duration got updated on every segment download

### Description of the Changes


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
