### PR TITLE
Attempt to seek over holes only when media.readyState is greater than 1

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1413,8 +1413,8 @@ class StreamController extends EventHandler {
 _checkBuffer() {
     var media = this.media,
         config = this.config;
-    // if ready state different from HAVE_NOTHING (numeric value 0), we are allowed to seek
-    if(media && media.readyState) {
+    // Only attempt to seek when readyState is > 1
+    if(media && media.readyState > 1) {
         let currentTime = media.currentTime,
             mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media,
              buffered = mediaBuffer.buffered;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1413,7 +1413,7 @@ class StreamController extends EventHandler {
 _checkBuffer() {
     var media = this.media,
         config = this.config;
-    // Only attempt to seek when readyState is > 1
+    // Only attempt to seek when readyState is > 1 to avoid freezing the video tag
     if(media && media.readyState > 1) {
         let currentTime = media.currentTime,
             mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media,


### PR DESCRIPTION
### Description of the Changes
- In `checkBuffer()`, exit early if the readyState isn't greater than 1. In MacOS High Sierra, this prevents the video from freezing if video isn't buffered starting at 0 and we try to seek to the buffered start.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
