### PR TITLE
Update vttLines conversion to avoid stack overflow

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -60,7 +60,10 @@ const WebVTTParser = {
     parse: function(vttByteArray, syncPTS, vttCCs, cc, callBack, errorCallBack) {
         // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
         let re = /\r\n|\n\r|\n|\r/g;
-        let vttLines = String.fromCharCode.apply(null, new Uint8Array(vttByteArray)).trim().replace(re, '\n').split('\n');
+        let vttLines = new Uint8Array(vttByteArray)
+          .reduce((raw, vttByte) => raw + String.fromCharCode(vttByte), '')
+          .trim().replace(re, '\n').split('\n');
+
         let cueTime = '00:00.000';
         let mpegTs = 0;
         let localTime = 0;


### PR DESCRIPTION
### Description of the Changes
We've started using hls.js in production at France Télévisions but we noticed that on Chrome, certain textTracks were not parsed correctly (ie : 0 cue points when inspecting), no errors were triggered by hls.js, and textTracks were hence not displayed.

This is due to the way vttLines are parsed:
```String.fromCharCode.apply(null, new Uint8Array(vttByteArray))```

-> when vttByteArray is huge and has a length greater than the _theoretical_ maximum number of arguments a javascript function can accept (which varies depending on browser implementation), the call to `apply` fails and raises an error:
 **Uncaught RangeError: Maximum call stack size exceeded**

To avoid this quirk, I instead call `reduce` on the array to create the raw string.

To reproduce the error, just open up your console and type : ```
String.fromCharCode.apply(null, new Uint8Array(9999999));```

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
