### PR TITLE
Rewrite setSubtitleTrackInternal method.

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -95,6 +95,10 @@
 - [Audio Tracks Control API](#audio-tracks-control-api)
   - [`hls.audioTracks`](#hlsaudiotracks)
   - [`hls.audioTrack`](#hlsaudiotrack)
+- [Subtitle Tracks Control API](#subtitle-tracks-control-api)
+  - [`hls.subtitleTracks`](#hlssubtitletracks)
+  - [`hls.subtitleTrack`](#hlssubtitletrack)
+  - [`hls.subtitleDisplay`](#hlssubtitledisplay)
 - [Live stream API](#live-stream-api)
   - [`hls.liveSyncPosition`](#hlslivesyncposition)
 - [Runtime Events](#runtime-events)
@@ -1074,6 +1078,22 @@ get : array of audio tracks exposed in manifest
 ### `hls.audioTrack`
 
 get/set : audio track id (returned by)
+
+## Subtitle Tracks Control API
+
+### `hls.subtitleTracks`
+
+get : array of subtitle tracks exposed in manifest
+
+### `hls.subtitleTrack`
+
+get/set : subtitle track id (returned by)
+
+### `hls.subtitleDisplay`
+
+(default: `false`)
+
+get/set : boolean to enable/disable subtitle display by hls.js
 
 ## Live stream API
 

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -164,23 +164,40 @@ class SubtitleTrackController extends EventHandler {
 
  setSubtitleTrackInternal(newId) {
     // check if level idx is valid
-    if (newId >= 0 && newId < this.tracks.length) {
-      // stopping live reloading timer if any
-      if (this.timer) {
-       clearInterval(this.timer);
-       this.timer = null;
-      }
-      this.trackId = newId;
-      logger.log(`switching to subtitle track ${newId}`);
-      let subtitleTrack = this.tracks[newId];
-      this.hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {id: newId});
-       // check if we need to load playlist for this subtitle Track
-      let details = subtitleTrack.details;
-      if (details === undefined || details.live === true) {
-        // track not retrieved yet, or live playlist we need to (re)load it
-        logger.log(`(re)loading playlist for subtitle track ${newId}`);
-        this.hls.trigger(Event.SUBTITLE_TRACK_LOADING, {url: subtitleTrack.url, id: newId});
-      }
+    if (newId < -1 || newId >= this.tracks.length) {
+      return;
+    }
+
+    // stopping live reloading timer if any
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+
+    let textTracks = filterSubtitleTracks(this.media.textTracks);
+
+    // hide currently enabled subtitle track
+    if (this.trackId !== -1) {
+      textTracks[this.trackId].mode = 'hidden';
+    }
+
+    this.trackId = newId;
+    logger.log(`switching to subtitle track ${newId}`);
+    this.hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {id: newId});
+
+    if (newId === -1) {
+      return;
+    }
+
+    let subtitleTrack = this.tracks[newId];
+    textTracks[newId].mode = 'showing';
+
+    // check if we need to load playlist for this subtitle Track
+    let details = subtitleTrack.details;
+    if (details === undefined || details.live === true) {
+      // track not retrieved yet, or live playlist we need to (re)load it
+      logger.log(`(re)loading playlist for subtitle track ${newId}`);
+      this.hls.trigger(Event.SUBTITLE_TRACK_LOADING, {url: subtitleTrack.url, id: newId});
     }
   }
 }

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -28,6 +28,7 @@ class SubtitleTrackController extends EventHandler {
     this.tracks = [];
     this.trackId = -1;
     this.media = undefined;
+    this.subtitleDisplay = false;
   }
 
   _onTextTracksChanged() {
@@ -177,7 +178,7 @@ class SubtitleTrackController extends EventHandler {
     let textTracks = filterSubtitleTracks(this.media.textTracks);
 
     // hide currently enabled subtitle track
-    if (this.trackId !== -1) {
+    if (this.trackId !== -1 && this.subtitleDisplay) {
       textTracks[this.trackId].mode = 'hidden';
     }
 
@@ -190,7 +191,9 @@ class SubtitleTrackController extends EventHandler {
     }
 
     let subtitleTrack = this.tracks[newId];
-    textTracks[newId].mode = 'showing';
+    if (this.subtitleDisplay) {
+      textTracks[newId].mode = 'showing';
+    }
 
     // check if we need to load playlist for this subtitle Track
     let details = subtitleTrack.details;

--- a/src/hls.js
+++ b/src/hls.js
@@ -385,4 +385,16 @@ export default class Hls {
       subtitleTrackController.subtitleTrack = subtitleTrackId;
     }
   }
+
+  get subtitleDisplay() {
+    const subtitleTrackController = this.subtitleTrackController;
+    return subtitleTrackController ? subtitleTrackController.subtitleDisplay : false;
+  }
+
+  set subtitleDisplay(value) {
+    const subtitleTrackController = this.subtitleTrackController;
+    if (subtitleTrackController) {
+      subtitleTrackController.subtitleDisplay = value;
+    }
+  }
 }


### PR DESCRIPTION
### Description of the Changes

We needed to enable subtitles support at France Télévisions and we thought it was cleaner to make it work inside hls.js instead of implementing our own layer on top of this library.

I just rewrote the setSubtitleTrackInternal method to update dom textTracks when needed and to support subtitle disabling.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
