### PR TITLE
Subtitle decryption support

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -1169,7 +1169,7 @@ Full list of Events is available below:
   - `Hls.Events.FRAG_LOADED`  - fired when a fragment loading is completed
     -  data: { frag : fragment object, payload : fragment payload, stats : { trequest, tfirst, tload, length}}
   - `Hls.Events.FRAG_DECRYPTED`  - fired when a fragment decryption is completed
-    -  data: { id : demuxer id, frag : fragment object, stats : { tstart, tdecrypt}}
+    -  data: { id : demuxer id, frag : fragment object, payload : fragment payload, stats : { tstart, tdecrypt}}
   - `Hls.Events.FRAG_PARSING_INIT_SEGMENT` - fired when Init Segment has been extracted from fragment
     -  data: { id: demuxer id, frag : fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment }
   - `Hls.Events.FRAG_PARSING_USERDATA`  - fired when parsing sei text is completed

--- a/doc/design.md
+++ b/doc/design.md
@@ -91,6 +91,16 @@ design idea is pretty simple :
        if playhead is stuck for more than `config.highBufferWatchdogPeriod` second in a buffered area, hls.js will nudge currentTime until playback recovers (it will retry every seconds, and report a fatal error after config.maxNudgeRetry retries)
     - convert non-fatal `FRAG_LOAD_ERROR`/`FRAG_LOAD_TIMEOUT`/`KEY_LOAD_ERROR`/`KEY_LOAD_TIMEOUT` error into fatal error when media position is not buffered and max load retry has been reached
     - stream controller actions are scheduled by a tick timer (invoked every 100ms) and actions are controlled by a state machine.
+  - [src/controller/subtitle-stream-controller.js][]
+    - subtitle stream controller is in charge of processing subtitle track fragments 
+	- subtitle stream controller takes the following actions:
+	  - once a SUBTITLE_TRACK_LOADED is received, the controller will begin processing the subtitle fragments
+	  - trigger KEY_LOADING event if fragment is encrypted
+	  - trigger FRAG_LOADING event
+	  - invoke decrypter.decrypt method on FRAG_LOADED if frag is encrypted
+	  - trigger FRAG_DECRYPTED event once encrypted fragment is decrypted
+  - [src/controller/subtitle-track-controller.js][]
+    - subtitle track controller handles subtitle track loading and switching
   - [src/controller/timeline-controller.js][]
     - Manages pulling CEA-708 caption data from the fragments, running them through the cea-608-parser, and handing them off to a display class, which defaults to src/utils/cues.js
   - [src/crypt/aes.js][]

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -179,7 +179,8 @@ class SubtitleStreamController extends EventHandler {
   onFragLoaded(data) {
     var fragCurrent = this.fragCurrent,
         decryptData = data.frag.decryptdata;
-    let fragLoaded = data.frag;
+    let fragLoaded = data.frag,
+        hls = this.hls;
     if (this.state === State.FRAG_LOADING &&
         fragCurrent &&
         data.frag.type === 'subtitle' &&
@@ -200,7 +201,7 @@ class SubtitleStreamController extends EventHandler {
               } catch (error) {
                 endTime = Date.now();
               }
-              this.hls.trigger(Event.FRAG_DECRYPTED, { frag: fragLoaded, payload : decryptedData, stats: { tstart: startTime, tdecrypt: endTime } });
+              hls.trigger(Event.FRAG_DECRYPTED, { frag: fragLoaded, payload : decryptedData, stats: { tstart: startTime, tdecrypt: endTime } });
             });
           }
         }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -5,7 +5,7 @@
 import Event from '../events';
 import EventHandler from '../event-handler';
 import {logger} from '../utils/logger';
-import Decrypter from '../crypt/decrypter'
+import Decrypter from '../crypt/decrypter';
 
 const State = {
   STOPPED : 'STOPPED',
@@ -91,7 +91,7 @@ class SubtitleStreamController extends EventHandler {
     if (this.ticks === 1) {
       this.doTick();
       if (this.ticks > 1) {
-        setTimeout(() => { this.tick() }, 1);
+        setTimeout(() => { this.tick(); }, 1);
       }
       this.ticks = 0;
     }
@@ -136,7 +136,7 @@ class SubtitleStreamController extends EventHandler {
             if ((frag.decryptdata && frag.decryptdata.uri != null) && (frag.decryptdata.key == null)) {
               logger.log(`Loading key for ${frag.sn}`);
               this.state = State.KEY_LOADING;
-              hls.trigger(Event.KEY_LOADING, {frag: frag});
+              this.hls.trigger(Event.KEY_LOADING, {frag: frag});
             } else {
               // Frags don't know their subtitle track ID, so let's just add that...
               frag.trackId = trackId;
@@ -165,7 +165,7 @@ class SubtitleStreamController extends EventHandler {
   }
 
   // Got a new set of subtitle fragments.
-  onSubtitleTrackLoaded(data) {
+  onSubtitleTrackLoaded() {
     this.tick();
   }
 
@@ -200,7 +200,7 @@ class SubtitleStreamController extends EventHandler {
               } catch (error) {
                 endTime = Date.now();
               }
-              hls.trigger(Event.FRAG_DECRYPTED, { frag: fragLoaded, payload : decryptedData, stats: { tstart: startTime, tdecrypt: endTime } });
+              this.hls.trigger(Event.FRAG_DECRYPTED, { frag: fragLoaded, payload : decryptedData, stats: { tstart: startTime, tdecrypt: endTime } });
             });
           }
         }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -5,12 +5,23 @@
 import Event from '../events';
 import EventHandler from '../event-handler';
 import {logger} from '../utils/logger';
+import Decrypter from '../crypt/decrypter'
+
+const State = {
+  STOPPED : 'STOPPED',
+  IDLE : 'IDLE',
+  KEY_LOADING : 'KEY_LOADING',
+  FRAG_LOADING : 'FRAG_LOADING'
+};
 
 class SubtitleStreamController extends EventHandler {
 
   constructor(hls) {
     super(hls,
+      Event.MEDIA_ATTACHED,
       Event.ERROR,
+      Event.KEY_LOADED,
+      Event.FRAG_LOADED,
       Event.SUBTITLE_TRACKS_UPDATED,
       Event.SUBTITLE_TRACK_SWITCH,
       Event.SUBTITLE_TRACK_LOADED,
@@ -19,11 +30,15 @@ class SubtitleStreamController extends EventHandler {
     this.vttFragSNsProcessed = {};
     this.vttFragQueues = undefined;
     this.currentlyProcessing = null;
+    this.state = State.STOPPED;
     this.currentTrackId = -1;
+    this.ticks = 0;
+    this.decrypter = new Decrypter(hls.observer, hls.config);
   }
 
   destroy() {
     EventHandler.prototype.destroy.call(this);
+    this.state = State.STOPPED;
   }
 
   // Remove all queued items and create a new, empty queue for each track.
@@ -38,7 +53,9 @@ class SubtitleStreamController extends EventHandler {
   nextFrag() {
     if(this.currentlyProcessing === null && this.currentTrackId > -1 && this.vttFragQueues[this.currentTrackId].length) {
       let frag = this.currentlyProcessing = this.vttFragQueues[this.currentTrackId].shift();
-      this.hls.trigger(Event.FRAG_LOADING, {frag});
+      this.fragCurrent = frag;
+      this.hls.trigger(Event.FRAG_LOADING, {frag: frag});
+      this.state = State.FRAG_LOADING;
     }
   }
 
@@ -48,7 +65,12 @@ class SubtitleStreamController extends EventHandler {
       this.vttFragSNsProcessed[data.frag.trackId].push(data.frag.sn);
     }
     this.currentlyProcessing = null;
+    this.state = State.IDLE;
     this.nextFrag();
+  }
+
+  onMediaAttached() {
+    this.state = State.IDLE;
   }
 
   // If something goes wrong, procede to next frag, if we were processing one.
@@ -62,6 +84,68 @@ class SubtitleStreamController extends EventHandler {
       this.currentlyProcessing = null;
       this.nextFrag();
     }
+  }
+
+  tick() {
+    this.ticks++;
+    if (this.ticks === 1) {
+      this.doTick();
+      if (this.ticks > 1) {
+        setTimeout(() => { this.tick() }, 1);
+      }
+      this.ticks = 0;
+    }
+  }
+
+  doTick() {
+    switch(this.state) {
+      case State.IDLE:
+        const tracks = this.tracks;
+        let trackId = this.currentTrackId;
+
+        const processedFragSNs = this.vttFragSNsProcessed[trackId],
+            fragQueue = this.vttFragQueues[trackId],
+            currentFragSN = !!this.currentlyProcessing ? this.currentlyProcessing.sn : -1;
+
+        const alreadyProcessed = function(frag) {
+          return processedFragSNs.indexOf(frag.sn) > -1;
+        };
+
+        const alreadyInQueue = function(frag) {
+          return fragQueue.some(fragInQueue => {return fragInQueue.sn === frag.sn;});
+        };
+
+        // exit if tracks don't exist
+        if (!tracks) {
+          break;
+        }
+        var trackDetails;
+
+        if (trackId < tracks.length) {
+          trackDetails = tracks[trackId].details;
+        }
+
+        if (typeof trackDetails === 'undefined') {
+          break;
+        }
+
+        // Add all fragments that haven't been, aren't currently being and aren't waiting to be processed, to queue.
+        trackDetails.fragments.forEach(frag => {
+          if(!(alreadyProcessed(frag) || frag.sn === currentFragSN || alreadyInQueue(frag))) {
+            // Load key if subtitles are encrypted
+            if ((frag.decryptdata && frag.decryptdata.uri != null) && (frag.decryptdata.key == null)) {
+              logger.log(`Loading key for ${frag.sn}`);
+              this.state = State.KEY_LOADING;
+              hls.trigger(Event.KEY_LOADING, {frag: frag});
+            } else {
+              // Frags don't know their subtitle track ID, so let's just add that...
+              frag.trackId = trackId;
+              fragQueue.push(frag);
+              this.nextFrag();
+            }
+          }
+        });
+      }
   }
 
   // Got all new subtitle tracks.
@@ -82,29 +166,44 @@ class SubtitleStreamController extends EventHandler {
 
   // Got a new set of subtitle fragments.
   onSubtitleTrackLoaded(data) {
-    const processedFragSNs = this.vttFragSNsProcessed[data.id],
-        fragQueue = this.vttFragQueues[data.id],
-        currentFragSN = !!this.currentlyProcessing ? this.currentlyProcessing.sn : -1;
+    this.tick();
+  }
 
-    const alreadyProcessed = function(frag) {
-      return processedFragSNs.indexOf(frag.sn) > -1;
-    };
+  onKeyLoaded() {
+    if (this.state === State.KEY_LOADING) {
+      this.state = State.IDLE;
+      this.tick();
+    }
+  }
 
-    const alreadyInQueue = function(frag) {
-      return fragQueue.some(fragInQueue => {return fragInQueue.sn === frag.sn;});
-    };
-
-    // Add all fragments that haven't been, aren't currently being and aren't waiting to be processed, to queue.
-    data.details.fragments.forEach(frag => {
-      if(!(alreadyProcessed(frag) || frag.sn === currentFragSN || alreadyInQueue(frag))) {
-        // Frags don't know their subtitle track ID, so let's just add that...
-        frag.trackId = data.id;
-        fragQueue.push(frag);
-      }
-    });
-
-    this.nextFrag();
+  onFragLoaded(data) {
+    var fragCurrent = this.fragCurrent,
+        decryptData = data.frag.decryptdata;
+    let fragLoaded = data.frag;
+    if (this.state === State.FRAG_LOADING &&
+        fragCurrent &&
+        data.frag.type === 'subtitle' &&
+        fragCurrent.sn === data.frag.sn) {
+          // check to see if the payload needs to be decrypted
+          if ((data.payload.byteLength > 0) && (decryptData != null) && (decryptData.key != null) && (decryptData.method === 'AES-128')) {
+            var startTime;
+            try {
+              startTime = performance.now();
+            } catch (error) {
+              startTime = Date.now();
+            }
+            // decrypt the subtitles
+            this.decrypter.decrypt(data.payload, decryptData.key.buffer, decryptData.iv.buffer, function(decryptedData) {
+              var endTime;
+              try {
+                endTime = performance.now();
+              } catch (error) {
+                endTime = Date.now();
+              }
+              hls.trigger(Event.FRAG_DECRYPTED, { frag: fragLoaded, payload : decryptedData, stats: { tstart: startTime, tdecrypt: endTime } });
+            });
+          }
+        }
   }
 }
 export default SubtitleStreamController;
-

--- a/src/events.js
+++ b/src/events.js
@@ -75,7 +75,7 @@ export default {
   FRAG_LOAD_EMERGENCY_ABORTED: 'hlsFragLoadEmergencyAborted',
   // fired when a fragment loading is completed - data: { frag : fragment object, payload : fragment payload, stats : { trequest, tfirst, tload, length } }
   FRAG_LOADED: 'hlsFragLoaded',
-  // fired when a fragment has finished decrypting - data: { id : demuxer id, frag: fragment object, stats : { tstart, tdecrypt } }
+  // fired when a fragment has finished decrypting - data: { id : demuxer id, frag: fragment object, payload : fragment payload, stats : { tstart, tdecrypt } }
   FRAG_DECRYPTED: 'hlsFragDecrypted',
   // fired when Init Segment has been extracted from fragment - data: { id : demuxer id, frag: fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment }
   FRAG_PARSING_INIT_SEGMENT: 'hlsFragParsingInitSegment',


### PR DESCRIPTION
### Description of the Changes
- In the `subtitle-stream-controller`, decrypt subtitle tracks if they are encrypted
  - If the fragment has a `frag.decryptdata.uri` that isn't null, trigger `KEY_LOADING` event
  - Once `KEY_LOADED` fires, fire `FRAG_LOADING` event
  - On `FRAG_LOADED`, decrypt the payload and fire a `FRAG_DECRYPTED` event
- In the `timeline-controller`, do not parse WebVTTs until subtitle frag is decrypted
  - On `FRAG_LOADED`, check if frag is encrypted before parsing VTTs
  - If encrypted, do nothing and wait for `FRAG_DECRYPTED` event to fire before parsing WebVTTs

I tried to model the changes after patterns followed in other controllers. If you want anything to be modified or moved, let me know and I am happy to make the changes.

Here is an m3u8 with encrypted text tracks that can be used for testing (should be valid for 7 days):
https://dev-video-rightnow.akamaized.net/48/195648/dev-02/19564894640379-d41d-336d-4505-298cc9061c5e.m3u8?hdnts=st=1506951006~exp=1507555866~acl=/*~id=681596d4-954d-4c6b-9604-3a29fefe8dbf~hmac=b03712bf69555ae6870d01597e7ceae619d6a95d0a2b1fcadc2d1b32b8628d6f

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [X] API or design changes are documented in API.md
