### PR TITLE
Add karma test runner

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,92 +4,79 @@
 var path = require('path');
 
 module.exports = function(config) {
-  config.set({
+	config.set({
+		// base path that will be used to resolve all patterns (eg. files, exclude)
+		basePath: '',
 
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
+		// frameworks to use
+		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+		frameworks: ['mocha'],
 
+		// list of files / patterns to load in the browser
+		files: ['tests/tests.webpack.js'],
 
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha'],
+		// list of files to exclude
+		exclude: [],
 
+		// preprocess matching files before serving them to the browser
+		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+		preprocessors: {
+			'tests/tests.webpack.js': ['webpack', 'sourcemap']
+		},
 
-    // list of files / patterns to load in the browser
-    files: [
-      'tests/tests.webpack.js'
-    ],
+		// test results reporter to use
+		// possible values: 'dots', 'progress'
+		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
+		reporters: ['mocha', 'coverage-istanbul'],
 
+		coverageIstanbulReporter: {
+			reports: ['lcov', 'text-summary'],
+			fixWebpackSourcePaths: true
+		},
 
-    // list of files to exclude
-    exclude: [
-    ],
+		webpack: {
+			devtool: 'inline-source-map',
+			module: {
+				rules: [
+					// instrument only testing sources with Istanbul
+					{
+						test: /\.js$/,
+						include: path.resolve('src/'),
+						exclude: path.resolve(__dirname, 'node_modules'),
+						use: [
+							{
+								loader: 'istanbul-instrumenter-loader',
+								options: { esModules: true }
+							}
+						]
+					}
+				]
+			}
+		},
 
+		// web server port
+		port: 9876,
 
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-        'tests/tests.webpack.js': ['webpack']
-    },
+		// enable / disable colors in the output (reporters and logs)
+		colors: true,
 
+		// level of logging
+		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+		logLevel: config.LOG_INFO,
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: [ 'progress', 'coverage-istanbul' ],
+		// enable / disable watching file and executing tests whenever any file changes
+		autoWatch: false,
 
-    coverageIstanbulReporter: {
-      reports: [ 'lcov', 'text-summary' ],
-      fixWebpackSourcePaths: true
-    },
+		// start these browsers
+		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+		browsers: ['ChromeHeadless'],
 
-    webpack: {
-        module: {
-          rules: [
-            // instrument only testing sources with Istanbul
-            {
-              test: /\.js$/,
-               include: path.resolve('src/'),
-               exclude: path.resolve(__dirname, 'node_modules'),
-               use: [
-                  { 
-                    loader: 'istanbul-instrumenter-loader', 
-                    options: { esModules: true } 
-                  }
-              ],
-            }
-          ]
-      }
-    },
+		// Continuous Integration mode
+		// if true, Karma captures browsers, runs the tests and exits
+		singleRun: true,
 
-    // web server port
-    port: 9876,
-
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
-
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['ChromeHeadless'],
-
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true,
-
-    // Concurrency level
-    // how many browser should be started simultaneous
-    concurrency: Infinity
-  })
-}
+		// Concurrency level
+		// how many browser should be started simultaneous
+		concurrency: Infinity
+	});
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,95 @@
+// Karma configuration
+// Generated on Tue Jul 18 2017 12:17:16 GMT-0700 (PDT)
+
+var path = require('path');
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'tests/tests.webpack.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+        'tests/tests.webpack.js': ['webpack']
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: [ 'progress', 'coverage-istanbul' ],
+
+    coverageIstanbulReporter: {
+      reports: [ 'lcov', 'text-summary' ],
+      fixWebpackSourcePaths: true
+    },
+
+    webpack: {
+        module: {
+          rules: [
+            // instrument only testing sources with Istanbul
+            {
+              test: /\.js$/,
+               include: path.resolve('src/'),
+               exclude: path.resolve(__dirname, 'node_modules'),
+               use: [
+                  { 
+                    loader: 'istanbul-instrumenter-loader', 
+                    options: { esModules: true } 
+                  }
+              ],
+            }
+          ]
+      }
+    },
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['ChromeHeadless'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test": "cross-env BABEL_ENV=test mocha --compilers js:babel-register --recursive tests/unit",
     "testfunc": "cross-env BABEL_ENV=test mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 40000",
     "lint": "jshint src/",
-    "dev": "webpack-dev-server --env.debug --port 8000"
+    "dev": "webpack-dev-server --env.debug --port 8000",
+    "coverage": "karma start karma.conf.js"
   },
   "dependencies": {
     "url-toolkit": "^2.0.1"
@@ -50,7 +51,13 @@
     "cross-env": "^5.0.2",
     "deep-strict-equal": "^0.2.0",
     "http-server": "^0.10.0",
+    "istanbul-instrumenter-loader": "^2.0.0",
     "jshint": "^2.9.4",
+    "karma": "^1.7.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage-istanbul-reporter": "^1.3.0",
+    "karma-mocha": "^1.3.0",
+    "karma-webpack": "^2.0.4",
     "mocha": "^3.0.2",
     "mversion": "^1.10.1",
     "selenium-webdriver": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
     "minor": "mversion mi && npm run preparerelease",
     "major": "mversion ma && npm run preparerelease",
     "pretest": "npm run lint",
-    "test": "cross-env BABEL_ENV=test mocha --compilers js:babel-register --recursive tests/unit",
+    "test": "karma start karma.conf.js",
     "testfunc": "cross-env BABEL_ENV=test mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 40000",
     "lint": "jshint src/",
-    "dev": "webpack-dev-server --env.debug --port 8000",
-    "coverage": "karma start karma.conf.js"
+    "dev": "webpack-dev-server --env.debug --port 8000"
   },
   "dependencies": {
     "url-toolkit": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.3",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.4",
     "mocha": "^3.0.2",
     "mversion": "^1.10.1",

--- a/tests/tests.webpack.js
+++ b/tests/tests.webpack.js
@@ -1,0 +1,7 @@
+const tests = require.context('./unit/', true, /\.js$/);
+
+tests.keys().forEach(tests);
+
+const components = require.context('../src/', true, /\.js$/);
+
+components.keys().forEach(components);


### PR DESCRIPTION
### Description of the Changes

**Note**: Closed old PR (#1276) due to bad merge. Pulled latest and cherry-picked changes on top.

This goal of this PR is gain the ability to unit test in a browser environment. 

Example of test that would fail if we ran test with `mocha`:

```
    it('should test error handling', (done) => { 

        hls.loadSource('https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u');
        hls.attachMedia(video);

       hls.on(Hls.Events.ERROR, function(event, data) {
              assert.equal(data.networkDetails.status, 404);
              done();
        });
    });
```

The test would complain about `document` being unavailable. For those unfamiliar, `karma` is a test runner which can run the `mocha` tests ( or any other unit tests ) in a browser environment. With the inclusion of `karma-chrome-launcher`, the tests can be run via Headless Chrome which allows us to run tests in the command line. I've also added `coverage` as a task for code coverage of said unit tests. 

**TLDR**

**What was added** - _Why_

**karma** - _run unit tests in browser environment_ 
**karma-webpack** - _webpack integration to transpile ES6 code_ 
**karma-chrome-launcher** - _chrome launcher_
**karma-coverage-istanbul-reporter** - _generate code coverage_
**karma-mocha-reporter** - _mocha unit test reporter_
**karma-sourcemap-loader** - _loads source maps which helps when unit tests fail_
**karma-mocha** - _adapter for mocha unit tests_
**istanbul-instrumenter-loader** - _adds istanbul instrumentation to ES6 code_


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
