### PR TITLE
Non-transferable SharedArrayBuffer payload support

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -638,7 +638,7 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
       @callback onSuccessCallback
       @param response {object} - response data
       @param response.url {string} - response URL (which might have been redirected)
-      @param response.data {string/arraybuffer} - response data (reponse type should be as per context.responseType)
+      @param response.data {string/arraybuffer/sharedarraybuffer} - response data (reponse type should be as per context.responseType)
       @param stats {object} - loading stats
       @param stats.trequest {number} - performance.now() just after load() has been called
       @param stats.tfirst {number} - performance.now() of first received byte
@@ -657,7 +657,7 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
       @param [stats.total] {number} - total nb of bytes
       @param [stats.bw] {number} - current download bandwidth in bit/s (monitored by ABR controller to control emergency switch down)
       @param context {object} - loader context
-      @param data {string/arraybuffer} - onProgress data (should be defined only if context.progressData === true)
+      @param data {string/arraybuffer/sharedarraybuffer} - onProgress data (should be defined only if context.progressData === true)
       @param networkDetails {object} - loader network details (the xhr for default loaders)
 
       @callback onErrorCallback

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -109,8 +109,8 @@ class Demuxer {
     }
     this.frag = frag;
     if (w) {
-      // post fragment payload as transferable objects (no copy)
-      w.postMessage({cmd: 'demux', data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset,defaultInitPTS}, [data]);
+      // post fragment payload as transferable objects for ArrayBuffer (no copy)
+      w.postMessage({cmd: 'demux', data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset,defaultInitPTS}, data instanceof ArrayBuffer ? [data] : []);
     } else {
       let demuxer = this.demuxer;
       if (demuxer) {


### PR DESCRIPTION
### Description of the Changes

I am using custom loader that stores HLS segments in memory for future use. Transfering ArrayBuffer to Web Worker (demuxer) inside hls.js makes them detached and data not accessible any more. To share data between hls.js Web Workers and custom loader without copying it (i.e. calling ArrayBuffer.slice) it is good idea to add support of SharedArrayBuffer.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
