### PR TITLE
align timestamps of first audio and video frame

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -36,7 +36,8 @@ class MP4Remuxer {
   remux(audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset) {
     // generate Init Segment if needed
     if (!this.ISGenerated) {
-      if (audioTrack.samples.length && videoTrack.samples.length) {
+      // align first audio/video PTS in case of discontinuity / IS not generated
+      if (!contiguous && audioTrack.samples.length && videoTrack.samples.length) {
         const firstAudioSample = audioTrack.samples[0];
         const firstVideoSample = videoTrack.samples[0];
         logger.log('adjusting first video PTS/DTS to first audio PTS');

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -36,6 +36,12 @@ class MP4Remuxer {
   remux(audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset) {
     // generate Init Segment if needed
     if (!this.ISGenerated) {
+      if (audioTrack.samples.length && videoTrack.samples.length) {
+        const firstAudioSample = audioTrack.samples[0];
+        const firstVideoSample = videoTrack.samples[0];
+        logger.log('adjusting first video PTS/DTS to first audio PTS');
+        firstVideoSample.dts = firstVideoSample.pts = firstAudioSample.pts;
+      }
       this.generateIS(audioTrack,videoTrack,timeOffset);
     }
 


### PR DESCRIPTION
this avoids a buffer hole at mediaOffset 0, and thus a seek on `buffered(0).start`

related to #1369

### Description of the Changes

just align first audio / video PTS/DTS on non contiguous fragment parsing

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
