### PR TITLE
Post-initialization callback in configuration

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -74,6 +74,7 @@
   - [`abrBandWidthUpFactor`](#abrbandwidthupfactor)
   - [`abrMaxWithRealBitrate`](#abrmaxwithrealbitrate)
   - [`minAutoBitrate`](#minautobitrate)
+  - [`postInit`](#postinit)
 - [Video Binding/Unbinding API](#video-bindingunbinding-api)
   - [`hls.attachMedia(videoElement)`](#hlsattachmediavideoelement)
   - [`hls.detachMedia()`](#hlsdetachmedia)
@@ -344,7 +345,8 @@ Configuration parameters could be provided to hls.js upon instantiation of `Hls`
       abrEwmaDefaultEstimate: 500000,
       abrBandWidthFactor: 0.95,
       abrBandWidthUpFactor: 0.7,
-      minAutoBitrate: 0
+      minAutoBitrate: 0,
+      postInit: undefined
   };
 
   var hls = new Hls(config);
@@ -963,6 +965,26 @@ then if config value is set to `true`, ABR will use 2.5 Mb/s for this quality le
 
 Return the capping/min bandwidth value that could be used by automatic level selection algorithm.
 Useful when browser or tab of the browser is not in the focus and bandwidth drops
+
+### `postInit`
+
+(default: `undefined`)
+
+Post init function that should be called after hls.js player is initialized. `Hls` object is passed as the argument to this function.
+This allows user to access emdedded into other players `Hls` object and configure it, determine version, attach events etc.
+
+Example:
+
+```js
+  var player = new Clappr.Player({
+    parentId: "#video",
+    hlsjsConfig: {
+      debug: true
+      postInit: (hls) => console.log("Embedded hls.js version is", hls.constructor.version)
+    },
+    source: videoUrl
+  });
+```
 
 
 ## Video Binding/Unbinding API

--- a/doc/API.md
+++ b/doc/API.md
@@ -979,7 +979,7 @@ Example:
   var player = new Clappr.Player({
     parentId: "#video",
     hlsjsConfig: {
-      debug: true
+      debug: true,
       postInit: (hls) => console.log("Embedded hls.js version is", hls.constructor.version)
     },
     source: videoUrl

--- a/src/hls.js
+++ b/src/hls.js
@@ -142,6 +142,10 @@ export default class Hls {
       }
     });
     this.coreComponents = coreComponents;
+
+    if (config.postInit instanceof Function) {
+      config.postInit(this);
+    }
   }
 
   destroy() {


### PR DESCRIPTION
### Description of the Changes

I am developing P2P assisted video delivery solution that works with hls.js. It requires to implement custom loader and also to know current playback position (attach to events) to determine when download segment over WebRTC and when over XMLHttpRequest.

Currently I have to do different initialization for each hls.js enabled player. It looks like:

```js
//MediaElement

var player = new MediaElementPlayer("video", {
    hls: {
        loader: createP2PLoaderClass()
    },
    success: function (mediaElement) {
        mediaElement.addEventListener("hlsFragChanged", ...);
    }
});

// Clappr

var player = new Clappr.Player({
    parentId: "#video",
    hlsjsConfig: {
        loader: createP2PLoaderClass()
    },
    source: videoUrl
});
player.on("play", () => {
    player.core.getCurrentPlayback()._hls.on("hlsFragChanged", ...);
});

// Flow player

var player = flowplayer("#video", {
    clip: {
        sources: [{
            type: "application/x-mpegurl",
            src: videoUrl
        }]
    },
    hlsjs: {
        loader: createP2PLoaderClass()
    }
});
player.on("ready", () => {
    player.engine.hlsjs.on("hlsFragChanged", ...);
});
```

Adding postInit function will allow to do it in unified way for all the players (including future players) that pass config to hls.js engine:

```js
var player = new Any.Player({
    parentId: "#video",
    hlsjsConfig: {
        loader: createP2PLoaderClass()
        postInit: initP2P
    },
    source: videoUrl
});

function initP2P(hls) {
    if (hls.constructor.version === "8.0.6") { ... }
    hls.on("hlsFragChanged", ...);
}
```

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
