### PR TITLE
Fix cue id generation in WebVTT parser

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -101,7 +101,7 @@ const WebVTTParser = {
 
             // Create a unique hash id for a cue based on start/end times and text.
             // This helps timeline-controller to avoid showing repeated captions.
-            cue.id = hash(cue.startTime) + hash(cue.endTime) + hash(cue.text);
+            cue.id = hash(cue.startTime.toString()) + hash(cue.endTime.toString()) + hash(cue.text);
 
             // Fix encoding of special characters. TODO: Test with all sorts of weird characters.
             cue.text = decodeURIComponent(escape(cue.text));


### PR DESCRIPTION
### Description of the Changes
The `hash` function in the webvtt parser requires that the input argument is a string. If not, it will always return the same initial seed (5381). This means that `cue.id` is only based on the cue text and not the timestamps, which breaks the cue de-duplication feature for cues with the same content.

This PR fixes that :)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [X] new unit / functional tests have been added (whenever applicable)
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [X] API or design changes are documented in API.md
