### PR TITLE
Add captions OutputFilter

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -24,6 +24,66 @@ function intersection(x1, x2, y1, y2) {
   return Math.min(x2, y2) - Math.max(x1, y1);
 }
 
+class OutputFilter {
+  constructor(timelineController, track) {
+    this.timelineController = timelineController;
+    this.track = track;
+    this.startTime = null;
+    this.endTime = null;
+    this.screen = null;
+  }
+
+  createTextTrack() {
+    let trackVar = 'textTrack' + this.track;
+    if (!this.timelineController[trackVar]) {
+      //Enable reuse of existing text track.
+      let existingTrack = this.timelineController.getExistingTrack(this.track);
+      if (!existingTrack) {
+        const textTrack = this.timelineController.createTextTrack('captions', this.timelineController.config['captionsTextTrack' + this.track + 'Label'], this.timelineController.config.captionsTextTrack1LanguageCode);
+        if (textTrack) {
+          textTrack[trackVar] = true;
+          this.timelineController[trackVar] = textTrack;
+        }
+      } else {
+        this.timelineController[trackVar] = existingTrack;
+        clearCurrentCues(this.timelineController[trackVar]);
+
+        this.sendAddTrackEvent(this.timelineController[trackVar], this.timelineController.media);
+      }
+    }
+  }
+
+  dispatchCue() {
+    if (this.startTime === null) {
+      return;
+    }
+    this.timelineController.addCues('textTrack' + this.track, this.startTime, this.endTime, this.screen);
+    this.startTime = null;
+  }
+
+  newCue(startTime, endTime, screen) {
+    if (this.startTime === null || this.startTime > startTime) {
+      this.startTime = startTime;
+    }
+    this.endTime = endTime;
+    this.screen = screen;
+    this.createTextTrack();
+  }
+
+  sendAddTrackEvent(track, media) {
+    var e = null;
+    try {
+      e = new window.Event('addtrack');
+    } catch (err) {
+      //for IE11
+      e = document.createEvent('Event');
+      e.initEvent('addtrack', false, false);
+    }
+    e.track = track;
+    media.dispatchEvent(e);
+  }
+}
+
 class TimelineController extends EventHandler {
 
   constructor(hls) {
@@ -49,76 +109,8 @@ class TimelineController extends EventHandler {
 
     if (this.config.enableCEA708Captions)
     {
-      var self = this;
-      var sendAddTrackEvent = function (track, media)
-      {
-        var e = null;
-        try {
-          e = new window.Event('addtrack');
-        } catch (err) {
-          //for IE11
-          e = document.createEvent('Event');
-          e.initEvent('addtrack', false, false);
-        }
-        e.track = track;
-        media.dispatchEvent(e);
-      };
-
-      var channel1 =
-      {
-        'newCue': function(startTime, endTime, screen)
-        {
-          if (!self.textTrack1)
-          {
-            //Enable reuse of existing text track.
-            var existingTrack1 = self.getExistingTrack('1');
-            if (!existingTrack1)
-            {
-              const textTrack1 = self.createTextTrack('captions', self.config.captionsTextTrack1Label, self.config.captionsTextTrack1LanguageCode);
-              if (textTrack1) {
-                textTrack1.textTrack1 = true;
-                self.textTrack1 = textTrack1;
-              }
-            }
-            else
-            {
-              self.textTrack1 = existingTrack1;
-              clearCurrentCues(self.textTrack1);
-
-              sendAddTrackEvent(self.textTrack1, self.media);
-            }
-          }
-          self.addCues('textTrack1', startTime, endTime, screen);
-        }
-      };
-
-      var channel2 =
-      {
-        'newCue': function(startTime, endTime, screen)
-        {
-          if (!self.textTrack2)
-          {
-            //Enable reuse of existing text track.
-            var existingTrack2 = self.getExistingTrack('2');
-            if (!existingTrack2)
-            {
-              const textTrack2 = self.createTextTrack('captions', self.config.captionsTextTrack2Label, self.config.captionsTextTrack1LanguageCode);
-              if (textTrack2) {
-                textTrack2.textTrack2 = true;
-                self.textTrack2 = textTrack2;
-              }
-            }
-            else
-            {
-              self.textTrack2 = existingTrack2;
-              clearCurrentCues(self.textTrack2);
-
-              sendAddTrackEvent(self.textTrack2, self.media);
-            }
-          }
-          self.addCues('textTrack2', startTime, endTime, screen);
-        }
-      };
+      var channel1 = new OutputFilter(this, 1);
+      var channel2 = new OutputFilter(this, 2);
 
       this.cea608Parser = new Cea608Parser(0, channel1, channel2);
     }

--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -743,13 +743,13 @@ class Cea608Channel
     ccEDM() { // Erase Displayed Memory
         logger.log('INFO', 'EDM - Erase Displayed Memory');
         this.displayedMemory.reset();
-        this.outputDataUpdate();
+        this.outputDataUpdate(true);
     }
 
     ccCR() { // Carriage Return
         logger.log('CR - Carriage Return');
         this.writeScreen.rollUp();
-        this.outputDataUpdate();
+        this.outputDataUpdate(true);
     }
 
     ccENM() { //Erase Non-Displayed Memory
@@ -766,7 +766,7 @@ class Cea608Channel
             this.writeScreen = this.nonDisplayedMemory;
             logger.log('TEXT', 'DISP: ' + this.displayedMemory.getDisplayText());
         }
-        this.outputDataUpdate();
+        this.outputDataUpdate(true);
     }
 
     ccTO(nrCols) { // Tab Offset 1,2, or 3 columns
@@ -789,21 +789,21 @@ class Cea608Channel
         this.writeScreen.setPen(styles);
     }
 
-    outputDataUpdate() {
-        var t = logger.time;
+    outputDataUpdate(dispatch = false) {
+        let t = logger.time;
         if (t === null) {
             return;
         }
         if (this.outputFilter) {
-            if (this.outputFilter.updateData) {
-                this.outputFilter.updateData(t, this.displayedMemory);
-            }
             if (this.cueStartTime === null && !this.displayedMemory.isEmpty()) { // Start of a new cue
                 this.cueStartTime = t;
             } else {
                 if (!this.displayedMemory.equals(this.lastOutputScreen)) {
                     if (this.outputFilter.newCue) {
                         this.outputFilter.newCue(this.cueStartTime, t, this.lastOutputScreen);
+                        if (dispatch === true && this.outputFilter.dispatchCue) {
+                            this.outputFilter.dispatchCue();
+                        }
                     }
                     this.cueStartTime = this.displayedMemory.isEmpty() ? null : t;
                 }

--- a/src/utils/output-filter.js
+++ b/src/utils/output-filter.js
@@ -1,0 +1,27 @@
+export default class OutputFilter {
+
+  constructor(timelineController, track) {
+    this.timelineController = timelineController;
+    this.track = track;
+    this.startTime = null;
+    this.endTime = null;
+    this.screen = null;
+  }
+
+  dispatchCue() {
+    if (this.startTime === null) {
+      return;
+    }
+    this.timelineController.addCues('textTrack' + this.track, this.startTime, this.endTime, this.screen);
+    this.startTime = null;
+  }
+
+  newCue(startTime, endTime, screen) {
+    if (this.startTime === null || this.startTime > startTime) {
+      this.startTime = startTime;
+    }
+    this.endTime = endTime;
+    this.screen = screen;
+    this.timelineController.createCaptionsTrack(this.track);
+  }
+}

--- a/tests/unit/utils/output-filter.js
+++ b/tests/unit/utils/output-filter.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+import OutputFilter from '../../../src/utils/output-filter';
+
+describe('OutputFilter', () => {
+  let createMockTimelineController = () => {
+    let callCount = 0;
+    let lastCueArguments = null;
+    let captionsTrackCalled = false;
+    return {
+      addCues: (trackName, startTime, endTime, screen) => {
+        lastCueArguments = { trackName, startTime, endTime, screen };
+        callCount++;
+      },
+      createCaptionsTrack: (track) => { 
+        captionsTrackCalled = true;
+      },
+      getCallCount: () => callCount,
+      getLastCueAdded: () => lastCueArguments,
+      didCaptionsTrackInvoke: () => captionsTrackCalled,
+    }
+  }
+
+  let timelineController, outputFilter;
+
+  beforeEach(function() {
+    timelineController = createMockTimelineController();
+    outputFilter = new OutputFilter(timelineController, 1);
+  });
+
+  it('handles new cue without dispatching', () => {
+    outputFilter.newCue(0, 1, {});
+    let lastCueAdded = timelineController.getLastCueAdded();
+    assert.strictEqual(lastCueAdded, null);
+    assert.strictEqual(timelineController.getCallCount(), 0);
+    assert.strictEqual(timelineController.didCaptionsTrackInvoke(), true);
+  });
+
+  it('handles single cue and dispatch', () => {
+    let lastScreen = {};
+    outputFilter.newCue(0, 1, lastScreen);
+    outputFilter.dispatchCue();
+    let lastCueAdded = timelineController.getLastCueAdded();
+    assert.strictEqual(lastCueAdded.screen, lastScreen);
+    assert.strictEqual(timelineController.getCallCount(), 1);
+  });
+
+  it('handles multiple cues and dispatch', () => {
+    outputFilter.newCue(0, 1, {});
+    outputFilter.newCue(1, 2, {});
+    let lastScreen = {};
+    outputFilter.newCue(3, 4, lastScreen);
+    outputFilter.dispatchCue();
+    let lastCueAdded = timelineController.getLastCueAdded();
+    assert.strictEqual(timelineController.getCallCount(), 1);
+    assert.strictEqual(lastCueAdded.startTime, 0);
+    assert.strictEqual(lastCueAdded.endTime, 4);
+    assert.strictEqual(lastCueAdded.screen, lastScreen);
+  });
+
+  it('does not dispatch empty cues', () => {
+    outputFilter.newCue(0, 1, {});
+    assert.strictEqual(timelineController.getCallCount(), 0);
+    outputFilter.dispatchCue();
+    assert.strictEqual(timelineController.getCallCount(), 1);
+    outputFilter.dispatchCue();
+    assert.strictEqual(timelineController.getCallCount(), 1);
+  });
+});


### PR DESCRIPTION
### Description of the Changes
Update TimelineController for CEA-608 to dispatch VTTCues every time a row finishes updating for Roll-up and Paint-on modes.

**Current Behavior:**
VTTCue is created whenever characters are appended onto the displayed row for Roll-up and Paint-on modes.

**Issue with current behavior:**
Since there are a lot of VTTCue objects that get created with very close start and end times, some of them get ignored by the textTrack and will not dispatch a `cuechange` event. There will be even more dropped VTTCue events when there is load on the browser.

**Resolution:**
I've abstracted out the outputFilter channels into it's own class that will ignore cue creation requests when the line is not complete. This new change will allow VTTCues to be created on a per line bases.

**Results:**
In my environment, I've tested the change and compared with the original on a standard news station. Please keep in mind these results are based on how much load the browser has.
Over 5 seconds of playback, the original implementation created 274 VTTCue objects that will get added to the textTrack and has dropped about 50% of VTTCue objects
With the new implementation with the same test, there is 26 VTTCue objects created and no dropped VTTCue events

### Current Behavior
**VTTCue Created:**
```
[50.233, 50.266] a
[50.266, 50.3] a fe
[50.3, 50.333] a fest
[50.333, 50.366] a festiv
[50.366, 50.4] a festival
[50.4, 50.433] a festival o
[50.433, 50.466] a festival of
[50.466, 50.5] a festival of th
[50.5, 50.533] a festival of the
[50.533, 50.566] a festival of the pr
[50.566, 50.6] a festival of the pres
[50.6, 50.633] a festival of the presse
[50.633, 54.933] a festival of the presses,
[54.966, 55] an
[55 55,.033] and
[55.033, 55.066] and a
[55.066, 55.1] and a co
[55.1, 55.133] and a comi
[55.133, 55.166] and a comic
[55.166, 55.2] and a comic st
[55.2, 55.233] and a comic stri
[55.233, 55.266] and a comic strip
[55.266, 55.3] and a comic strip ar
[55.3, 55.333] and a comic strip arti
[55.333, 55.366] and a comic strip artist
[55.366, 57.766] and a comic strip artist.
```

**Actually dispatched:**
```
[50.366, 50.4]: a festival
[50.6, 50.633]: a festival of the presse
[50.633, 54.933]: a festival of the presses,
[55.1, 55.133]: and a comi
[55.366, 57.766]: and a comic strip artist.
```


### New Behavior
**VTTCue Created:**
```
[50.233, 54.933]: a festival of the presses,
[54.966, 57.766]: and a comic strip artist.
```

**Actually dispatched:**
```
[50.233, 54.933]: a festival of the presses,
[54.966, 57.766]: and a comic strip artist.
```

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
