### PR TITLE
add test stream with dynamic ad-inseration causing codec / PMT/PID discontinuity

### DIFF
--- a/tests/functional/streams.json
+++ b/tests/functional/streams.json
@@ -1,7 +1,7 @@
 {
 	"arte": {"url": "https://video-dev.github.io/streams/test_001/stream.m3u8", "description": "ARTE China,ABR", "live": false , "abr": true},
 	"bigBuckBunny480p": {"url": "https://video-dev.github.io/streams/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8", "description": "big buck bunny,480p", "live": false, "abr": false, "blacklist_ua" : ["internet explorer"]},
-  "deltatreDAI": {"url": "https://video-dev.github.io/dai-discontinuity-deltatre/manifest.m3u8", "description": "Ad-insertion in event stream", "live": false, "abr": false, "blacklist_ua" : []},
+  "deltatreDAI": {"url": "https://video-dev.github.io/streams/dai-discontinuity-deltatre/manifest.m3u8", "description": "Ad-insertion in event stream", "live": false, "abr": false, "blacklist_ua" : []},
 	"issue666": {"url": "http://www.streambox.fr/playlists/cisq0gim60007xzvi505emlxx.m3u8", "description": "hls.js/issues/666", "live": false, "abr": false,"blacklist_ua" : ["internet explorer"]},
   "issue649": {"url": "http://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw", "description": "hls.js/issues/649", "live": false, "abr": false},
 	"nasa": {"url": "https://nasa-i.akamaihd.net/hls/live/253565/NASA-NTV1-Public/master.m3u8", "description": "NASA live stream", "live": true, "abr": false, "blacklist_ua" : ["internet explorer","safari"]},

--- a/tests/functional/streams.json
+++ b/tests/functional/streams.json
@@ -1,6 +1,7 @@
 {
 	"arte": {"url": "https://video-dev.github.io/streams/test_001/stream.m3u8", "description": "ARTE China,ABR", "live": false , "abr": true},
 	"bigBuckBunny480p": {"url": "https://video-dev.github.io/streams/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8", "description": "big buck bunny,480p", "live": false, "abr": false, "blacklist_ua" : ["internet explorer"]},
+  "deltatreDAI": {"url": "https://video-dev.github.io/dai-discontinuity-deltatre/manifest.m3u8", "description": "Ad-insertion in event stream", "live": false, "abr": false, "blacklist_ua" : []},
 	"issue666": {"url": "http://www.streambox.fr/playlists/cisq0gim60007xzvi505emlxx.m3u8", "description": "hls.js/issues/666", "live": false, "abr": false,"blacklist_ua" : ["internet explorer"]},
   "issue649": {"url": "http://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw", "description": "hls.js/issues/649", "live": false, "abr": false},
 	"nasa": {"url": "https://nasa-i.akamaihd.net/hls/live/253565/NASA-NTV1-Public/master.m3u8", "description": "NASA live stream", "live": true, "abr": false, "blacklist_ua" : ["internet explorer","safari"]},


### PR DESCRIPTION
This was the test stream that would make issue-1331 show up: https://github.com/video-dev/hls.js/issues/1331

### Description of the Changes

Adding the test stream which had the PID discontinuity which would make Safari MSE drop buffers from different PID than initially set up ones

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
