### PR TITLE
Fix/subtitles nyt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - TRAVIS_MODE=funcTests UA=chrome              OS="Windows 7"
     - TRAVIS_MODE=funcTests UA=firefox             OS="Windows 7"
     # - TRAVIS_MODE=funcTests UA=MicrosoftEdge       OS="Windows 10"
-    # - TRAVIS_MODE=funcTests UA="internet explorer" OS="Windows 8.1"  UA_VERSION="11.0"
+    - TRAVIS_MODE=funcTests UA="internet explorer" OS="Windows 8.1"  UA_VERSION="11.0"
     - TRAVIS_MODE=funcTests UA="internet explorer" OS="Windows 10"
     - TRAVIS_MODE=funcTests UA=chrome              OS="OS X 10.11"
     # - TRAVIS_MODE=funcTests UA=firefox             OS="OS X 10.11"

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -60,8 +60,9 @@ const WebVTTParser = {
     parse: function(vttByteArray, syncPTS, vttCCs, cc, callBack, errorCallBack) {
         // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
         let re = /\r\n|\n\r|\n|\r/g;
-        let vttLines = new Uint8Array(vttByteArray)
-          .reduce((raw, vttByte) => raw + String.fromCharCode(vttByte), '')
+        // Uint8Array.prototype.reduce is not implemented in IE11
+        let vttLines = Array.prototype.reduce
+          .call(new Uint8Array(vttByteArray), (raw, vttByte) => raw + String.fromCharCode(vttByte), '')
           .trim().replace(re, '\n').split('\n');
 
         let cueTime = '00:00.000';


### PR DESCRIPTION
### Description of the Changes
fixes #1415 (for the steps to reproduce the bug)

In IE11 : the `reduce` function is not implemented on `Uint8Array.prototype.reduce`
The fix involves calling`Array.prototype.reduce` on the Uint8Array (works fine on IE11, chrome latest, FF latest and safari 11)

Also: I noticed a bug in the handling of the default textTrack in Chrome : 
If the manifest is loaded before the media is attached, setting the default track will throw an error (media being undefined, we cannot attach/retrieve textTracks from the video tag element).
I fixed it by checking the existence of `this.media` and by keeping a reference to the default track's id if `!this.media`. 

It's all documented in the code.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
