### PR TITLE
fix: vtt parser broke after master merge

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -62,9 +62,7 @@ const WebVTTParser = {
         // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
         let re = /\r\n|\n\r|\n|\r/g;
         // Uint8Array.prototype.reduce is not implemented in IE11
-        let vttLines = utf8ArrayToStr(Array.prototype.reduce
-          .call(new Uint8Array(vttByteArray), (raw, vttByte) => raw + String.fromCharCode(vttByte), ''))
-          .trim().replace(re, '\n').split('\n');
+        let vttLines = utf8ArrayToStr(new Uint8Array(vttByteArray)).trim().replace(re, '\n').split('\n');
 
         let cueTime = '00:00.000';
         let mpegTs = 0;


### PR DESCRIPTION
### Description of the Changes

fixed broken merge from master here: ebb2fcc322f90bd0b79feb6df5b2c23660306e4d  which caused captions to break #1422 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
