### PR TITLE
fix nextAutoLevel blocking when fragment aborted

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -71,6 +71,8 @@ class AbrController extends EventHandler {
     if(!loader || ( loader.stats && loader.stats.aborted)) {
       logger.warn('frag loader destroy or aborted, disarm abandonRules');
       this.clearTimer();
+      // reset forced auto level value so that next level will be selected
+      this._nextAutoLevel = -1;
       return;
     }
     let stats = loader.stats;


### PR DESCRIPTION
Fix AbrController._nextAutoLevel blocking when fragment aborted.
If the fragment is already loaded, _nextAutoLevel = -1 and level up is possible, but not if the current fragment is still loaded.
This happens if user presses the full screen button and the current fragment is still loaded.