### PR TITLE
Fix mpeg audio frame duration

### DIFF
--- a/src/demux/mpegaudio.js
+++ b/src/demux/mpegaudio.js
@@ -19,28 +19,28 @@ const MpegAudio = {
         0, // Reserved
         72, // Layer3
         144, // Layer2
-        12, // Layer1
+        12 // Layer1
       ],
       // Reserved
       [
         0, // Reserved
         0, // Layer3
         0, // Layer2
-        0, // Layer1
+        0 // Layer1
       ],
       // MPEG 2
       [
         0, // Reserved
         72, // Layer3
         144, // Layer2
-        12, // Layer1
+        12 // Layer1
       ],
       // MPEG 1
       [
         0, // Reserved
         144, // Layer3
         144, // Layer2
-        12, // Layer1
+        12 // Layer1
       ]
     ],
 


### PR DESCRIPTION
### Description of the Changes

Make detection of samples per frame for MPEG audio and fix wrong calculated duration for version 2/2.5 Layer III.

Fix #1356

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
