### PR TITLE
Remove PKCS7 padding in AESDecryptor

### DIFF
--- a/src/crypt/aes-decryptor.js
+++ b/src/crypt/aes-decryptor.js
@@ -248,13 +248,13 @@ class AESDecryptor {
       offset = offset + 4;
     }
  
-    // padding (PKCS7)
-    let paddingBytes = 0;
     if (outputInt32.buffer.byteLength) {
-      paddingBytes = (new DataView(outputInt32.buffer)).getInt8(outputInt32.buffer.byteLength - 1);
+      // padding (PKCS7)
+      let paddingBytes = (new DataView(outputInt32.buffer)).getInt8(outputInt32.buffer.byteLength - 1);
+      return outputInt32.buffer.slice(0, outputInt32.buffer.byteLength - paddingBytes);
     }
 
-    return outputInt32.buffer.slice(0, outputInt32.buffer.byteLength - paddingBytes);
+    return outputInt32.buffer;
   }
 
   destroy() {

--- a/src/crypt/aes-decryptor.js
+++ b/src/crypt/aes-decryptor.js
@@ -1,3 +1,14 @@
+// PKCS7
+export function removePadding(buffer) {
+  const outputBytes = buffer.byteLength;
+  const paddingBytes = outputBytes && (new DataView(buffer)).getUint8(outputBytes - 1);
+  if (paddingBytes) {
+    return buffer.slice(0, outputBytes - paddingBytes);
+  } else {
+    return buffer;
+  }
+}
+
 class AESDecryptor {
   constructor() {
     // Static after running initTable
@@ -247,15 +258,8 @@ class AESDecryptor {
 
       offset = offset + 4;
     }
- 
-    // padding (PKCS7)
-    let outputBytes = outputInt32.buffer.byteLength;
-    let paddingBytes = outputBytes && (new DataView(outputInt32.buffer)).getUint8(outputBytes - 1);
-    if (paddingBytes) {
-      return outputInt32.buffer.slice(0, outputBytes - paddingBytes);
-    } else {
-      return outputInt32.buffer;
-    }
+
+    return removePadding(outputInt32.buffer);
   }
 
   destroy() {

--- a/src/crypt/aes-decryptor.js
+++ b/src/crypt/aes-decryptor.js
@@ -247,8 +247,14 @@ class AESDecryptor {
 
       offset = offset + 4;
     }
+ 
+    // padding (PKCS7)
+    let paddingBytes = 0;
+    if (outputInt32.buffer.byteLength) {
+      paddingBytes = (new DataView(outputInt32.buffer)).getInt8(outputInt32.buffer.byteLength - 1);
+    }
 
-    return outputInt32.buffer;
+    return outputInt32.buffer.slice(0, outputInt32.buffer.byteLength - paddingBytes);
   }
 
   destroy() {

--- a/src/crypt/aes-decryptor.js
+++ b/src/crypt/aes-decryptor.js
@@ -250,7 +250,7 @@ class AESDecryptor {
  
     if (outputInt32.buffer.byteLength) {
       // padding (PKCS7)
-      let paddingBytes = (new DataView(outputInt32.buffer)).getInt8(outputInt32.buffer.byteLength - 1);
+      let paddingBytes = (new DataView(outputInt32.buffer)).getUint8(outputInt32.buffer.byteLength - 1);
       return outputInt32.buffer.slice(0, outputInt32.buffer.byteLength - paddingBytes);
     }
 

--- a/src/crypt/aes-decryptor.js
+++ b/src/crypt/aes-decryptor.js
@@ -248,13 +248,14 @@ class AESDecryptor {
       offset = offset + 4;
     }
  
-    if (outputInt32.buffer.byteLength) {
-      // padding (PKCS7)
-      let paddingBytes = (new DataView(outputInt32.buffer)).getUint8(outputInt32.buffer.byteLength - 1);
-      return outputInt32.buffer.slice(0, outputInt32.buffer.byteLength - paddingBytes);
+    // padding (PKCS7)
+    let outputBytes = outputInt32.buffer.byteLength;
+    let paddingBytes = outputBytes && (new DataView(outputInt32.buffer)).getUint8(outputBytes - 1);
+    if (paddingBytes) {
+      return outputInt32.buffer.slice(0, outputBytes - paddingBytes);
+    } else {
+      return outputInt32.buffer;
     }
-
-    return outputInt32.buffer;
   }
 
   destroy() {

--- a/tests/unit/crypt/aes-decryptor.js
+++ b/tests/unit/crypt/aes-decryptor.js
@@ -1,0 +1,27 @@
+import { removePadding } from '../../../src/crypt/aes-decryptor';
+const assert = require('assert');
+
+describe('AESDecryptor', () => {
+  describe('removePadding()', () => {
+    // this should never happen with a valid stream
+    it('is a no-op when the last byte is 0', () => {
+      const arr = new Uint8Array([1, 2, 3, 0]);
+      assert.strictEqual(removePadding(arr.buffer), arr.buffer);
+    });
+
+    it('removes 1 byte when the last byte is 1', () => {
+      const arr = new Uint8Array([1, 2, 3, 1]);
+      assert.deepEqual(Array.from(new Uint8Array(removePadding(arr.buffer))), [1, 2, 3]);
+    });
+
+    it('removes 3 bytes when the last byte is 3', () => {
+      const arr = new Uint8Array([1, 2, 3, 3]);
+      assert.deepEqual(Array.from(new Uint8Array(removePadding(arr.buffer))), [1]);
+    });
+
+    it('removes 4 bytes when the last byte is 3', () => {
+      const arr = new Uint8Array([1, 2, 3, 4]);
+      assert.deepEqual(Array.from(new Uint8Array(removePadding(arr.buffer))), []);
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Changes
Encrypted segments should end with padding ([PKCS7](https://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS7)), but currently we are not removing these additional bytes, which are all set to the number of padding bytes.

> An encryption method of AES-128 signals that Media Segments are completely encrypted using the Advanced Encryption Standard [AES_128] with a 128-bit key, Cipher Block Chaining, and PKCS7 padding [RFC5652].  CBC is restarted on each segment boundary, using either the IV attribute value or the Media Sequence Number as the IV; see Section 5.2.

https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.4

This PR updates the decryptor so that we remove these bytes.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
