### PR TITLE
Add Live Duration Infinity config parameter

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -2,7 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
+ 
 
 - [Getting started](#getting-started)
   - [First step: setup and support](#first-step-setup-and-support)
@@ -40,6 +40,7 @@
   - [`liveMaxLatencyDurationCount`](#livemaxlatencydurationcount)
   - [`liveSyncDuration`](#livesyncduration)
   - [`liveMaxLatencyDuration`](#livemaxlatencyduration)
+  - [`liveDurationInfinity`](#livedurationinfinity)
   - [`enableWorker`](#enableworker)
   - [`enableSoftwareAES`](#enablesoftwareaes)
   - [`startLevel`](#startlevel)
@@ -58,12 +59,12 @@
   - [`timelineController`](#timelinecontroller)
   - [`enableWebVTT`](#enablewebvtt)
   - [`enableCEA708Captions`](#enablecea708captions)
-    [`captionsTextTrack1Label`](#captionsTextTrack1Label)
-    [`captionsTextTrack1LanguageCode`](#captionsTextTrack1LanguageCode)
-    [`captionsTextTrack2Label`](#captionsTextTrack2Label)
-    [`captionsTextTrack2LanguageCode`](#captionsTextTrack2LanguageCode)
+  - [`captionsTextTrack1Label`](#captionstexttrack1label)
+  - [`captionsTextTrack1LanguageCode`](#captionstexttrack1languagecode)
+  - [`captionsTextTrack2Label`](#captionstexttrack2label)
+  - [`captionsTextTrack2LanguageCode`](#captionstexttrack2languagecode)
   - [`stretchShortVideoTrack`](#stretchshortvideotrack)
-  - [`maxAudioFramesDrift`](#maxAudioFramesDrift)
+  - [`maxAudioFramesDrift`](#maxaudioframesdrift)
   - [`forceKeyFrameOnDiscontinuity`](#forcekeyframeondiscontinuity)
   - [`abrEwmaFastLive`](#abrewmafastlive)
   - [`abrEwmaSlowLive`](#abrewmaslowlive)
@@ -77,6 +78,7 @@
 - [Video Binding/Unbinding API](#video-bindingunbinding-api)
   - [`hls.attachMedia(videoElement)`](#hlsattachmediavideoelement)
   - [`hls.detachMedia()`](#hlsdetachmedia)
+    - [`hls.media`](#hlsmedia)
 - [Quality switch Control API](#quality-switch-control-api)
   - [`hls.levels`](#hlslevels)
   - [`hls.currentLevel`](#hlscurrentlevel)
@@ -525,7 +527,7 @@ a value too close from `liveSyncDurationCount` is likely to cause playback stall
 
 (default: `undefined`)
 
-Alternative parameter to ```liveSyncDurationCount```, expressed in seconds vs number of segments.
+Alternative parameter to `liveSyncDurationCount`, expressed in seconds vs number of segments.
 If defined in the configuration object, `liveSyncDuration` will take precedence over the default `liveSyncDurationCount`.
 You can't define this parameter and either `liveSyncDurationCount` or `liveMaxLatencyDurationCount` in your configuration object at the same time.
 A value too low (inferior to ~3 segment durations) is likely to cause playback stalls.
@@ -539,6 +541,14 @@ If defined in the configuration object, `liveMaxLatencyDuration` will take prece
 If set, this value must be stricly superior to `liveSyncDuration` which must be defined as well.
 You can't define this parameter and either `liveSyncDurationCount` or `liveMaxLatencyDurationCount` in your configuration object at the same time.
 A value too close from `liveSyncDuration` is likely to cause playback stalls.
+
+### `liveDurationInfinity`
+
+(default: `false`)
+
+Override current Media Source duration to `Infinity` for a live broadcast. 
+Useful, if you are building a player which relies on native UI capabilities in modern browsers. 
+If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
 
 ### `enableWorker`
 
@@ -1315,7 +1325,7 @@ Full list of errors is described below:
 
 ## Objects
 
-### <a name="level"> Level
+### Level
 
 A `Level` object represents a given quality level.
 It contains quality level related info, retrieved from manifest, such as:

--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,7 @@ export var hlsDefaultConfig = {
   liveMaxLatencyDurationCount: Infinity,  // used by stream-controller
   liveSyncDuration: undefined,            // used by stream-controller
   liveMaxLatencyDuration: undefined,      // used by stream-controller
+  liveDurationInfinity: false,            // used by buffer-controller
   maxMaxBufferLength: 600,                // used by stream-controller
   enableWorker: true,                     // used by demuxer
   enableSoftwareAES: true,                // used by decrypter

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -30,6 +30,8 @@ class BufferController extends EventHandler {
     this._msDuration = null;
     // the value that we want to set mediaSource.duration to
     this._levelDuration = null;
+    // current stream state: true - for live broadcast, false - for VoD content
+    this._live = null;
     // cache the self generated object url to detect hijack of video tag
     this._objectUrl = null;
 
@@ -365,7 +367,8 @@ class BufferController extends EventHandler {
   onLevelUpdated({details}) {
     if (details.fragments.length > 0) {
       this._levelDuration = details.totalduration + details.fragments[0].start;
-      this.updateMediaElementDuration(details.live);
+      this._live = details.live;
+      this.updateMediaElementDuration();
     }
   }
 
@@ -373,10 +376,8 @@ class BufferController extends EventHandler {
    * Update Media Source duration to current level duration or override to Infinity if configuration parameter
    * 'liveDurationInfinity` is set to `true`
    * More details: https://github.com/video-dev/hls.js/issues/355
-   *
-   * @param {Boolean} live
    */
-  updateMediaElementDuration(live) {
+  updateMediaElementDuration() {
     let {config} = this.hls;
     let duration;
 
@@ -402,7 +403,7 @@ class BufferController extends EventHandler {
       this._msDuration = this.mediaSource.duration;
     }
 
-    if (live === true && config.liveDurationInfinity === true) {
+    if (this._live === true && config.liveDurationInfinity === true) {
       // Override duration to Infinity
       logger.log('Media Source duration is set to Infinity');
       this._msDuration = this.mediaSource.duration = Infinity;

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -402,11 +402,16 @@ class BufferController extends EventHandler {
       this._msDuration = this.mediaSource.duration;
     }
 
-    // levelDuration was the last value we set.
-    // not using mediaSource.duration as the browser may tweak this value
-    // only update Media Source duration if its value increase, this is to avoid
-    // flushing already buffered portion when switching between quality level
-    if ((this._levelDuration > this._msDuration && this._levelDuration > duration) || (duration === Infinity || isNaN(duration) )) {
+    if (live === true && config.liveDurationInfinity === true) {
+      // Override duration to Infinity
+      logger.log('Media Source duration is set to Infinity');
+      this._msDuration = this.mediaSource.duration = Infinity;
+    } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration)
+      || (duration === Infinity || isNaN(duration) )) {
+      // levelDuration was the last value we set.
+      // not using mediaSource.duration as the browser may tweak this value
+      // only update Media Source duration if its value increase, this is to avoid
+      // flushing already buffered portion when switching between quality level
       logger.log(`Updating Media Source duration to ${this._levelDuration.toFixed(3)}`);
       this._msDuration = this.mediaSource.duration = this._levelDuration;
     }


### PR DESCRIPTION
### Description of the Changes

If you are trying to build a player with Native UI capabilities in modern browsers it is not possible to provide proper UI feedback since we override MediaSource duration to duration of the current level. Also, most Native UI implementations do not support DVR. 

We are introducing a new configuration parameter `liveDurationInfinity` which sets duration to `Infinity` thus various MSE implementations can provide corresponding UI to a Live broadcast. The parameter is `false` by default.

Notes:

- resolve https://github.com/video-dev/hls.js/pull/1371

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md