### PR TITLE
Move isSupported method to module

### DIFF
--- a/src/helper/is-supported.js
+++ b/src/helper/is-supported.js
@@ -13,5 +13,5 @@ export function isSupported() {
     (sourceBuffer.prototype &&
       typeof sourceBuffer.prototype.appendBuffer === 'function' &&
       typeof sourceBuffer.prototype.remove === 'function');
-  return isTypeSupported && sourceBufferValidAPI;
+  return !!isTypeSupported && !!sourceBufferValidAPI;
 }

--- a/src/helper/issupported.js
+++ b/src/helper/issupported.js
@@ -1,0 +1,17 @@
+import {getMediaSource} from './mediasource-helper';
+
+export function isSupported() {
+  const mediaSource = getMediaSource();
+  const sourceBuffer = window.SourceBuffer || window.WebKitSourceBuffer;
+  const isTypeSupported = mediaSource &&
+    typeof mediaSource.isTypeSupported === 'function' &&
+    mediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"');
+
+  // if SourceBuffer is exposed ensure its API is valid
+  // safari and old version of Chrome doe not expose SourceBuffer globally so checking SourceBuffer.prototype is impossible
+  const sourceBufferValidAPI = !sourceBuffer ||
+    (sourceBuffer.prototype &&
+      typeof sourceBuffer.prototype.appendBuffer === 'function' &&
+      typeof sourceBuffer.prototype.remove === 'function');
+  return isTypeSupported && sourceBufferValidAPI;
+}

--- a/src/hls.js
+++ b/src/hls.js
@@ -12,7 +12,7 @@ import StreamController from  './controller/stream-controller';
 import LevelController from  './controller/level-controller';
 import ID3TrackController from './controller/id3-track-controller';
 
-import {isSupported} from './helper/issupported';
+import {isSupported} from './helper/is-supported';
 import {logger, enableLogs} from './utils/logger';
 import EventEmitter from 'events';
 import {hlsDefaultConfig} from './config';
@@ -22,8 +22,8 @@ export default class Hls {
     return __VERSION__;
   }
 
-  static get isSupported() {
-    return isSupported;
+  static isSupported() {
+    return isSupported();
   }
 
   static get Events() {

--- a/src/hls.js
+++ b/src/hls.js
@@ -21,7 +21,7 @@ export default class Hls {
   static get version() {
     return __VERSION__;
   }
-  static isSupported = isSupported();
+  static isSupported = isSupported;
 
   static get Events() {
     return Event;

--- a/src/hls.js
+++ b/src/hls.js
@@ -12,7 +12,7 @@ import StreamController from  './controller/stream-controller';
 import LevelController from  './controller/level-controller';
 import ID3TrackController from './controller/id3-track-controller';
 
-import {getMediaSource} from './helper/mediasource-helper';
+import {isSupported} from './helper/issupported';
 import {logger, enableLogs} from './utils/logger';
 import EventEmitter from 'events';
 import {hlsDefaultConfig} from './config';
@@ -21,21 +21,7 @@ export default class Hls {
   static get version() {
     return __VERSION__;
   }
-  static isSupported() {
-    const mediaSource = getMediaSource();
-    const sourceBuffer = window.SourceBuffer || window.WebKitSourceBuffer;
-    const isTypeSupported = mediaSource &&
-                            typeof mediaSource.isTypeSupported === 'function' &&
-                            mediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"');
-
-    // if SourceBuffer is exposed ensure its API is valid
-    // safari and old version of Chrome doe not expose SourceBuffer globally so checking SourceBuffer.prototype is impossible
-    const sourceBufferValidAPI = !sourceBuffer ||
-                                 (sourceBuffer.prototype &&
-                                 typeof sourceBuffer.prototype.appendBuffer === 'function' &&
-                                 typeof sourceBuffer.prototype.remove === 'function');
-    return isTypeSupported && sourceBufferValidAPI;
-  }
+  static isSupported = isSupported();
 
   static get Events() {
     return Event;

--- a/src/hls.js
+++ b/src/hls.js
@@ -21,7 +21,10 @@ export default class Hls {
   static get version() {
     return __VERSION__;
   }
-  static isSupported = isSupported;
+
+  static get isSupported() {
+    return isSupported;
+  }
 
   static get Events() {
     return Event;


### PR DESCRIPTION
### Description of the Changes
This change is needed for detecting hls.js support without loading full hls.js 
it makes a profit when hls.js imported on page as external script.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
