### PR TITLE
add `npm run bundle-check` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test": "karma start karma.conf.js",
     "testfunc": "cross-env BABEL_ENV=test mocha --compilers js:babel-register tests/functional/auto/hlsjs.js --timeout 40000",
     "lint": "jshint src/",
-    "dev": "webpack-dev-server --progress --env.debug --port 8000"
+    "dev": "webpack-dev-server --progress --env.debug --port 8000",
+    "bundle-check": "webpack -p --config './webpack.config.bundle-analyzer.js'"
   },
   "dependencies": {
     "url-toolkit": "^2.0.1"
@@ -47,6 +48,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.24.0",
     "chromedriver": "^2.28.0",
+    "clone": "^2.1.1",
     "cross-env": "^5.0.2",
     "deep-strict-equal": "^0.2.0",
     "http-server": "^0.10.0",
@@ -63,6 +65,7 @@
     "mversion": "^1.10.1",
     "selenium-webdriver": "^3.1.0",
     "webpack": "^3.5.5",
+    "webpack-bundle-analyzer": "^2.9.1",
     "webpack-dev-server": "^2.7.1",
     "webworkify-webpack": "^2.0.0"
   }

--- a/webpack.config.bundle-analyzer.js
+++ b/webpack.config.bundle-analyzer.js
@@ -7,7 +7,7 @@ const configs = clone(webpackConfigDev)();
 configs.forEach(function(config) {
   if (config.name === 'dist') {
     // filter out ModuleConcatenationPlugin
-    // https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/115j
+    // https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/115
     config.plugins = config.plugins.filter(plugin => plugin.constructor.name != 'ModuleConcatenationPlugin');
     
     config.plugins = config.plugins.concat([new BundleAnalyzerPlugin()]);

--- a/webpack.config.bundle-analyzer.js
+++ b/webpack.config.bundle-analyzer.js
@@ -1,0 +1,17 @@
+const clone = require('clone');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const webpackConfigDev = require('./webpack.config.js');
+
+const configs = clone(webpackConfigDev)();
+
+configs.forEach(function(config) {
+  if (config.name === 'dist') {
+    // filter out ModuleConcatenationPlugin
+    // https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/115j
+    config.plugins = config.plugins.filter(plugin => plugin.constructor.name != 'ModuleConcatenationPlugin');
+    
+    config.plugins = config.plugins.concat([new BundleAnalyzerPlugin()]);
+  }
+});
+
+module.exports = configs;


### PR DESCRIPTION
this pull request adds the `$ npm run bundle-check` command that will analyze the bundle and spin up a browser with a visual representation of how big are the components of hlsjs:

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/244265/33858460-b2781ca8-de9d-11e7-8d65-31800a67554b.png">

