### PR TITLE
enable saucelabs avoidProxy option

### DIFF
--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -79,6 +79,7 @@ describe('testing hls.js playback in the browser on "'+browserDescription+'"', f
       capabilities.build = 'HLSJS-'+process.env.TRAVIS_BUILD_NUMBER;
       capabilities.username = process.env.SAUCE_USERNAME;
       capabilities.accessKey = process.env.SAUCE_ACCESS_KEY;
+      capabilities.avoidProxy = true;
       this.browser = new webdriver.Builder().usingServer('http://'+process.env.SAUCE_USERNAME+':'+process.env.SAUCE_ACCESS_KEY+'@ondemand.saucelabs.com:80/wd/hub');
     }
     else {


### PR DESCRIPTION
This might be causing connectivity issues

> By default, Sauce routes traffic from some WebDriver browsers (Internet Explorer and Safari) through the Selenium HTTP proxy server so that HTTPS connections with self-signed certificates work everywhere. The Selenium proxy server can cause problems for some users. If that's the case for you, you can configure Sauce to avoid using the proxy server and have browsers communicate directly with your servers.