### PR TITLE
Editorconfig fix: Indent should be same as jshint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root                     = true
 [*]
 indent_style             = space
-indent_size              = 2
+indent_size              = 4
 end_of_line              = lf
 charset                  = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
### Description of the Changes

Wether it's 2 or 4, we need to decide. In Jshint config it's 4.

Also this shows that jshint fails to very this basic rule.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
