### PR TITLE
RemuxVideo method called with incorrect number of parameters; accurateTimeOffset is lost

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -77,13 +77,12 @@ class MP4Remuxer {
           this.remuxVideo(videoTrack,videoTimeOffset,contiguous,audioTrackLength, accurateTimeOffset);
         }
       } else {
-        let videoData;
         //logger.log('nb AVC samples:' + videoTrack.samples.length);
         if (nbVideoSamples) {
-          videoData = this.remuxVideo(videoTrack,videoTimeOffset,contiguous, accurateTimeOffset);
-        }
-        if (videoData && audioTrack.codec) {
-          this.remuxEmptyAudio(audioTrack, audioTimeOffset, contiguous, videoData);
+          let videoData = this.remuxVideo(videoTrack,videoTimeOffset,contiguous, 0, accurateTimeOffset);
+          if (videoData && audioTrack.codec) {
+            this.remuxEmptyAudio(audioTrack, audioTimeOffset, contiguous, videoData);
+          }
         }
       }
     }
@@ -206,6 +205,9 @@ class MP4Remuxer {
     let nextAvcDts = this.nextAvcDts;
 
     const isSafari = this.isSafari;
+	
+	if(inputSamples.length == 0)
+		return null;
 
     // Safari does not like overlapping DTS on consecutive fragments. let's use nextAvcDts to overcome this if fragments are consecutive
     if (isSafari) {


### PR DESCRIPTION
Fixes issue where line#82 of mp4-remuxer.js was calling remuxVideo with the incorrect number of parameters.  Also moved the next condition statement inside of the same block because it was unnecessary to have the variable and statement outside of the same block.  Added quick check for (inputSamples.length == 0) for remuxVideo just like what remuxAudio has.  Successfully compiled and tested with the default playlist.

### CheckLists

- [x ] changes have been done against master branch, and PR does not conflict
- [ x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md