### PR TITLE
Do not remove padding for sample aes

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -124,10 +124,10 @@ design idea is pretty simple :
     - subtitle track controller handles subtitle track loading and switching
   - [src/controller/timeline-controller.js][]
     - Manages pulling CEA-708 caption data from the fragments, running them through the cea-608-parser, and handing them off to a display class, which defaults to src/utils/cues.js
-  - [src/crypt/aes.js][]
+  - [src/crypt/aes-crypto.js][]
     - AES 128 software decryption routine, low level class handling decryption of 128 bit of data.
-  - [src/crypt/aes128-decrypter.js][]  
-    - AES 128-CBC software decryption routine, high-level class handling cipher-block chaining (CBC), and that should also handle padding (TODO).
+  - [src/crypt/aes-decrypter.js][]  
+    - AES 128-CBC software decryption routine, high-level class handling cipher-block chaining (CBC), handles PKCS7 padding when the option is enabled.
   - [src/crypt/decrypter.js][]
     - decrypter interface, use either WebCrypto API if available and enabled, or fallback on AES 128 software decryption routine.
   - [src/demux/aacdemuxer.js][]

--- a/src/crypt/aes-decryptor.js
+++ b/src/crypt/aes-decryptor.js
@@ -182,7 +182,7 @@ class AESDecryptor {
     return (word << 24) | ((word & 0xff00) << 8) | ((word & 0xff0000) >> 8) | (word >>> 24);
   }
 
-  decrypt(inputArrayBuffer, offset, aesIV) {
+  decrypt(inputArrayBuffer, offset, aesIV, removePKCS7Padding) {
     let nRounds = this.keySize + 6;
     let invKeySchedule = this.invKeySchedule;
     let invSBOX = this.invSBox;
@@ -259,7 +259,7 @@ class AESDecryptor {
       offset = offset + 4;
     }
 
-    return removePadding(outputInt32.buffer);
+    return removePKCS7Padding ? removePadding(outputInt32.buffer) : outputInt32.buffer;
   }
 
   destroy() {

--- a/src/crypt/decrypter.js
+++ b/src/crypt/decrypter.js
@@ -8,14 +8,18 @@ import {logger} from '../utils/logger';
 /*globals self: false */
 
 class Decrypter {
-  constructor(observer,config) {
+  constructor(observer, config, { removePKCS7Padding = true } = {}) {
+    this.logEnabled = true;
     this.observer = observer;
     this.config = config;
-    this.logEnabled = true;
-    try {
-      const browserCrypto = crypto ? crypto : self.crypto;
-      this.subtle = browserCrypto.subtle || browserCrypto.webkitSubtle;
-    } catch (e) {}
+    this.removePKCS7Padding = removePKCS7Padding;
+    // built in decryptor expects PKCS7 padding
+    if (removePKCS7Padding) {
+      try {
+        const browserCrypto = crypto ? crypto : self.crypto;
+        this.subtle = browserCrypto.subtle || browserCrypto.webkitSubtle;
+      } catch (e) {}
+    }
     this.disableWebCrypto = !this.subtle;
   }
 
@@ -34,7 +38,7 @@ class Decrypter {
         this.decryptor = decryptor = new AESDecryptor();
       }
       decryptor.expandKey(key);
-      callback(decryptor.decrypt(data, 0, iv));
+      callback(decryptor.decrypt(data, 0, iv, this.removePKCS7Padding));
     }
     else {
       if (this.logEnabled) {

--- a/src/demux/sample-aes.js
+++ b/src/demux/sample-aes.js
@@ -9,7 +9,7 @@
   constructor(observer, config, decryptdata, discardEPB) {
     this.decryptdata = decryptdata;
     this.discardEPB = discardEPB;
-    this.decrypter = new Decrypter(observer, config);
+    this.decrypter = new Decrypter(observer, config, { removePKCS7Padding: false });
   }
 
   decryptBuffer(encryptedData, callback) {


### PR DESCRIPTION
### Description of the Changes
We now explicitly inform the decryptor that pkcs7 padding removal should not happen for sample aes streams. From the documentation it looks like [sample-aes streams should not include this padding](https://developer.apple.com/library/content/documentation/AudioVideo/Conceptual/HLS_Sample_Encryption/Encryption/Encryption.html).

This also disables web crypto, which expects the padding. Currently for sample-aes streams the web decryptor is failing, and then we were falling back to the js decryptor (which previously never removing padding).

fixes https://github.com/video-dev/hls.js/issues/1512

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
