### PR TITLE
Assign the instance of the loader to the context object

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -100,7 +100,7 @@ class PlaylistLoader extends EventHandler {
 
     const loader = new InternalLoader(config);
 
-    context.loader = Loader;
+    context.loader = loader;
     this.loaders[context.type] = loader;
 
     return loader;


### PR DESCRIPTION
### Description of the Changes
This fixes a typo when assigning the loader to the context. We had been previously assigning the loader constructor (capital L), but have been using it as an instance, causing errors. This PR assigns the lowercase l loader to context.

Resolves https://github.com/video-dev/hls.js/issues/1517


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
