### PR TITLE
Update audio-stream-controller to respect maxMaxBufferLength.

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -184,9 +184,11 @@ class AudioStreamController extends TaskLoop {
             bufferLen = bufferInfo.len,
             bufferEnd = bufferInfo.end,
             fragPrevious = this.fragPrevious,
-            // ensure we buffer at least config.maxBufferLength (default 30s)
+            // ensure we buffer at least config.maxBufferLength (default 30s) or config.maxMaxBufferLength (default: 600s)
+            // whichever is smaller.
             // once we reach that threshold, don't buffer more than video (mainBufferInfo.len)
-            maxBufLen = Math.max(config.maxBufferLength,mainBufferInfo.len),
+            maxConfigBuffer = Math.min(config.maxBufferLength,config.maxMaxBufferLength),
+            maxBufLen = Math.max(maxConfigBuffer,mainBufferInfo.len),
             audioSwitch = this.audioSwitch,
             trackId = this.trackId;
 


### PR DESCRIPTION
### Description of the Changes
This ensures that when maxMaxBufferLength is set to something smaller than,
maxBufferLength the value is respected for both audio and video.

I have a use case where I want to adjust the size of the buffers once the user starts playback. I want to set `maxBufferLength` to the desired length when playback starts. I then set `maxMaxBufferLength` to something extremely small for initial buffering (something like 2 seconds). Then once the action to increase buffer length is taken I can simply update `maxMaxBufferLength` to be something more reasonable (like the default of 600). Without this update the audio stream ends up buffering far more content since it doesn't respect the `maxMaxBufferLength` configuration property.

No docs changes are included since I think this is bringing the code more in line with the current docs around [`maxMaxBufferLength`](https://github.com/video-dev/hls.js/blob/master/doc/API.md#maxmaxbufferlength)

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [X] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [X] API or design changes are documented in API.md
