### PR TITLE
test: add BufferHelper tests

### DIFF
--- a/tests/unit/helper/buffer-helper.js
+++ b/tests/unit/helper/buffer-helper.js
@@ -1,0 +1,144 @@
+const assert = require("assert");
+import BufferHelper from '../../../src/helper/buffer-helper';
+
+function createMockBuffer(buffered) {
+  return {
+    start: i => (buffered.length > i) ? buffered[i].startPTS : null,
+    end: i => (buffered.length > i) ? buffered[i].endPTS : null,
+    length: buffered.length,
+  };
+}
+
+describe('BufferHelper', function() {
+  describe('isBuffered', function() {
+    // |////////|__________|////////////////|
+    // 0       0.5         1               2.0
+    const media = {
+      get buffered() {
+        return createMockBuffer([
+          {
+            startPTS: 0,
+            endPTS: 0.5
+          },
+          {
+            startPTS: 1,
+            endPTS: 2.0
+          },
+        ]);
+      }
+    };
+
+    it('should return true if media.buffered throw error', function() {
+      const invalidMedia = {
+        get buffered() {
+          throw new Error("InvalidStateError");
+        }
+      };
+      assert.equal(BufferHelper.isBuffered(invalidMedia, 0), false);
+    });
+    it('should return true if some media.buffered includes the position', function() {
+      assert.equal(BufferHelper.isBuffered(media, 0), true);
+      assert.equal(BufferHelper.isBuffered(media, 0.1), true);
+      assert.equal(BufferHelper.isBuffered(media, 0.5), true);
+      assert.equal(BufferHelper.isBuffered(media, 1), true);
+      assert.equal(BufferHelper.isBuffered(media, 2), true);
+    });
+    it('should return false if some media.buffered includes the position', function() {
+      assert.equal(BufferHelper.isBuffered(media, -0.1), false);
+      assert.equal(BufferHelper.isBuffered(media, 0.51), false);
+      assert.equal(BufferHelper.isBuffered(media, 0.9), false);
+      assert.equal(BufferHelper.isBuffered(media, 2.1), false);
+    });
+  });
+  describe("bufferInfo", () => {
+    it("should return found buffer info when maxHoleDuration is 0", function() {
+      // |////////|__________|////////////////|
+      // 0       0.5         1               2.0
+      const media = {
+        get buffered() {
+          return createMockBuffer([
+            {
+              startPTS: 0,
+              endPTS: 0.5
+            },
+            {
+              startPTS: 1,
+              endPTS: 2.0
+            },
+          ]);
+        }
+      };
+      const maxHoleDuration = 0;
+      assert.deepEqual(BufferHelper.bufferInfo(media, 0, maxHoleDuration), {
+        len: 0.5,
+        start: 0,
+        end: 0.5,
+        nextStart: 1
+      });
+      assert.deepEqual(BufferHelper.bufferInfo(media, 0.5, maxHoleDuration), {
+        len: 0,
+        start: 0.5,
+        end: 0.5,
+        nextStart: 1
+      });
+      assert.deepEqual(BufferHelper.bufferInfo(media, 1, maxHoleDuration), {
+        len: 1,
+        start: 1,
+        end: 2,
+        nextStart: undefined
+      });
+      assert.deepEqual(BufferHelper.bufferInfo(media, 2, maxHoleDuration), {
+        len: 0,
+        start: 2,
+        end: 2,
+        nextStart: undefined
+      });
+    });
+    it("should return found buffer info when maxHoleDuration is 0.5", function() {
+      // |////////|__________|////////////////|
+      // 0       0.5         1               2.0
+      const media = {
+        get buffered() {
+          return createMockBuffer([
+            {
+              startPTS: 0,
+              endPTS: 0.5
+            },
+            {
+              startPTS: 1,
+              endPTS: 2.0
+            },
+          ]);
+        }
+      };
+      const maxHoleDuration = 0.5;
+      assert.deepEqual(BufferHelper.bufferInfo(media, 0, maxHoleDuration), {
+        len: 0.5,
+        start: 0,
+        end: 0.5,
+        nextStart: 1
+      });
+      // M: maxHoleDuration: 0.5
+      // |////////|__________|////////////////|
+      // 0     0.5 --- M --- 1               2.0
+      assert.deepEqual(BufferHelper.bufferInfo(media, 0.5, maxHoleDuration), {
+        len: 1.5,
+        start: 1,
+        end: 2,
+        nextStart: undefined
+      });
+      assert.deepEqual(BufferHelper.bufferInfo(media, 1, maxHoleDuration), {
+        len: 1,
+        start: 1,
+        end: 2,
+        nextStart: undefined
+      });
+      assert.deepEqual(BufferHelper.bufferInfo(media, 2, maxHoleDuration), {
+        len: 0,
+        start: 2,
+        end: 2,
+        nextStart: undefined
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Changes

Add tests for  `BufferHelper` .

📝 Notes

I want to improve performance of `BufferHelper.isBuffered` util.
Maybe, current `_checkAppendedParsed` paid unnecessary costs at every time.
(To access `media.buffered` should be cached)
This test is a first step of the refactoring.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md


