### PR TITLE
Improve `StreamController#_checkAppendedParsed` performance

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1258,11 +1258,13 @@ class StreamController extends TaskLoop {
         const media = this.mediaBuffer ? this.mediaBuffer : this.media;
         logger.log(`main buffered : ${TimeRanges.toString(media.buffered)}`);
         // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
-        let bufferedFrags = this._bufferedFrags.filter(frag => {return BufferHelper.isBuffered(media,(frag.startPTS + frag.endPTS) / 2);});
+        let bufferedFrags = BufferHelper.filterLivingFragments(this._bufferedFrags, media);
         // push new range
         bufferedFrags.push(frag);
         // sort frags, as we use BinarySearch for lookup in getBufferedFrag ...
-        this._bufferedFrags = bufferedFrags.sort(function(a,b) {return (a.startPTS - b.startPTS);});
+        this._bufferedFrags = bufferedFrags.sort(function(a, b) {
+          return (a.startPTS - b.startPTS);
+        });
         this.fragPrevious = frag;
         const stats = this.stats;
         stats.tbuffered = performance.now();

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1258,7 +1258,7 @@ class StreamController extends TaskLoop {
         const media = this.mediaBuffer ? this.mediaBuffer : this.media;
         logger.log(`main buffered : ${TimeRanges.toString(media.buffered)}`);
         // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
-        let bufferedFrags = BufferHelper.filterLivingFragments(this._bufferedFrags, media);
+        let bufferedFrags = BufferHelper.filterEvictedFragments(this._bufferedFrags, media);
         // push new range
         bufferedFrags.push(frag);
         // sort frags, as we use BinarySearch for lookup in getBufferedFrag ...

--- a/src/helper/buffer-helper.js
+++ b/src/helper/buffer-helper.js
@@ -9,13 +9,18 @@ const BufferHelper = {
   filterEvictedFragments: function(bufferedFrags, media) {
     try {
       if (media) {
-        // Cache `buffered` at first for performance
-        // To access `media.buffered` have a cost
+        // Cache `media.buffered` at first for performance
+        // accessing `media.buffered` have a cost
         const mediaBuffered = media.buffered;
+        // accessing MediaElement property through a function call should be quite expensive
+        const bufferedPositions = [];
+        for (let i = 0; i < mediaBuffered.length; i++) {
+          bufferedPositions.push({ start: mediaBuffered.start(i), end: mediaBuffered.end(i) });
+        }
         return bufferedFrags.filter(frag => {
           const position = (frag.startPTS + frag.endPTS) / 2;
-          for (let i = 0; i < mediaBuffered.length; i++) {
-            if (position >= mediaBuffered.start(i) && position <= mediaBuffered.end(i)) {
+          for (let i = 0; i < bufferedPositions.length; i++) {
+            if (position >= bufferedPositions[i].start && position <= bufferedPositions[i].end) {
               return true;
             }
           }

--- a/src/helper/buffer-helper.js
+++ b/src/helper/buffer-helper.js
@@ -5,12 +5,11 @@
 const BufferHelper = {
   /**
    * filter fragments potentially evicted from buffer.
-   * @param {{startPTS:number, endPTS:number}[]} bufferedFrags
-   * @param {HTMLMediaElement} media
-   * @returns {{startPTS:number, endPTS:number}[]}
    */
   filterLivingFragments: function(bufferedFrags, media) {
     try {
+      // Cache `buffered` at first for performance
+      // To access `media.buffered` have a cost
       const mediaBuffered = media.buffered;
       return bufferedFrags.filter(frag => {
         return this.bufferedIncludesPosition(mediaBuffered, (frag.startPTS + frag.endPTS) / 2);
@@ -22,8 +21,8 @@ const BufferHelper = {
     return [];
   },
   /**
-   * If `media`'s buffered include `position`, return true.
-   * @param {HTMLMediaElement} media
+   * Return true if `media`'s buffered include `position`
+   * @param {HTMLMediaElement|SourceBuffer} media
    * @param {number} position
    * @returns {boolean}
    */
@@ -41,7 +40,7 @@ const BufferHelper = {
     return false;
   },
   /**
-   * If `mediaBuffered` includes `position`, return true.
+   * Return true if `mediaBuffered` includes `position`
    * @param {TimeRanges} mediaBuffered
    * @param {number} position
    * @returns {boolean}

--- a/src/helper/buffer-helper.js
+++ b/src/helper/buffer-helper.js
@@ -6,7 +6,7 @@ const BufferHelper = {
   /**
    * filter fragments potentially evicted from buffer.
    */
-  filterLivingFragments: function(bufferedFrags, media) {
+  filterEvictedFragments: function(bufferedFrags, media) {
     try {
       // Cache `buffered` at first for performance
       // To access `media.buffered` have a cost

--- a/src/helper/buffer-helper.js
+++ b/src/helper/buffer-helper.js
@@ -39,16 +39,15 @@ const BufferHelper = {
    * @param {number} position
    * @returns {boolean}
    */
-  isBuffered: function(media,position) {
+  isBuffered : function(media,position) {
     try {
       if (media) {
-        const mediaBuffered = media.buffered;
-        for (let i = 0; i < mediaBuffered.length; i++) {
-          if (position >= mediaBuffered.start(i) && position <= mediaBuffered.end(i)) {
+        let buffered = media.buffered;
+        for (let i = 0; i < buffered.length; i++) {
+          if (position >= buffered.start(i) && position <= buffered.end(i)) {
             return true;
           }
         }
-        return false;
       }
     } catch(error) {
       // this is to catch
@@ -57,6 +56,7 @@ const BufferHelper = {
     }
     return false;
   },
+
   bufferInfo : function(media, pos,maxHoleDuration) {
     try {
       if (media) {

--- a/tests/unit/helper/buffer-helper.js
+++ b/tests/unit/helper/buffer-helper.js
@@ -78,44 +78,6 @@ describe('BufferHelper', function() {
       assert.deepEqual(filteredFragments, [fragments[2], fragments[3]]);
     });
   });
-  describe('filterFragByMedia', function() {
-    const media = {
-      get buffered() {
-        return createMockBuffer([
-          {
-            startPTS: 0,
-            endPTS: 0.5
-          },
-          {
-            startPTS: 1,
-            endPTS: 2.0
-          },
-        ]);
-      }
-    };
-
-    it('should return true if media.buffered throw error', function() {
-      const invalidMedia = {
-        get buffered() {
-          throw new Error("InvalidStateError");
-        }
-      };
-      assert.equal(BufferHelper.filterLivingFragments(invalidMedia, 0), false);
-    });
-    it('should return true if some media.buffered includes the position', function() {
-      assert.equal(BufferHelper.isBuffered(media, 0), true);
-      assert.equal(BufferHelper.isBuffered(media, 0.1), true);
-      assert.equal(BufferHelper.isBuffered(media, 0.5), true);
-      assert.equal(BufferHelper.isBuffered(media, 1), true);
-      assert.equal(BufferHelper.isBuffered(media, 2), true);
-    });
-    it('should return false if any media.buffered does not includes the position', function() {
-      assert.equal(BufferHelper.isBuffered(media, -0.1), false);
-      assert.equal(BufferHelper.isBuffered(media, 0.51), false);
-      assert.equal(BufferHelper.isBuffered(media, 0.9), false);
-      assert.equal(BufferHelper.isBuffered(media, 2.1), false);
-    });
-  });
   describe('isBuffered', function() {
     // |////////|__________|////////////////|
     // 0       0.5         1               2.0

--- a/tests/unit/helper/buffer-helper.js
+++ b/tests/unit/helper/buffer-helper.js
@@ -10,6 +10,112 @@ function createMockBuffer(buffered) {
 }
 
 describe('BufferHelper', function() {
+  describe('filterLivingFragments', function() {
+    it("should return empty array if the media is invalid", () => {
+      const invalidMedia = {
+        get buffered() {
+          throw new Error("InvalidStateError");
+        }
+      };
+      const fragments = [
+        {
+          startPTS: 0,
+          endPTS: 0.5
+        },
+        {
+          startPTS: 1,
+          endPTS: 2.0
+        }
+      ];
+      const filteredFragments = BufferHelper.filterLivingFragments(fragments, invalidMedia);
+      assert.equal(filteredFragments.length, 0);
+    });
+    it("should return fragments that are not evicted", () => {
+      // |__________|//////////|//////////|__________|
+      // 0         1.0        2.0        3.0        4.0
+      const media = {
+        get buffered() {
+          return createMockBuffer([
+            {
+              startPTS: 1,
+              endPTS: 2.0
+            },
+            {
+              startPTS: 2.0,
+              endPTS: 3.0
+            }
+          ]);
+        }
+      };
+      // |////|/////|//////////|//////////|//////////|
+      // 0         1.0        2.0        3.0        4.0
+      const fragments = [
+        // ↓ out of buffer ↓
+        {
+          startPTS: 0,
+          endPTS: 0.5
+        },
+        {
+          startPTS: 0.5,
+          endPTS: 1.0
+        },
+        // ↑ out of buffer ↑
+        {
+          startPTS: 1.0,
+          endPTS: 2.0
+        },
+        {
+          startPTS: 2.0,
+          endPTS: 3.0
+        },
+        // ↓ out of buffer ↓
+        {
+          startPTS: 3.0,
+          endPTS: 4.0
+        }
+      ];
+      const filteredFragments = BufferHelper.filterLivingFragments(fragments, media);
+      assert.deepEqual(filteredFragments, [fragments[2], fragments[3]]);
+    });
+  });
+  describe('filterFragByMedia', function() {
+    const media = {
+      get buffered() {
+        return createMockBuffer([
+          {
+            startPTS: 0,
+            endPTS: 0.5
+          },
+          {
+            startPTS: 1,
+            endPTS: 2.0
+          },
+        ]);
+      }
+    };
+
+    it('should return true if media.buffered throw error', function() {
+      const invalidMedia = {
+        get buffered() {
+          throw new Error("InvalidStateError");
+        }
+      };
+      assert.equal(BufferHelper.filterLivingFragments(invalidMedia, 0), false);
+    });
+    it('should return true if some media.buffered includes the position', function() {
+      assert.equal(BufferHelper.isBuffered(media, 0), true);
+      assert.equal(BufferHelper.isBuffered(media, 0.1), true);
+      assert.equal(BufferHelper.isBuffered(media, 0.5), true);
+      assert.equal(BufferHelper.isBuffered(media, 1), true);
+      assert.equal(BufferHelper.isBuffered(media, 2), true);
+    });
+    it('should return false if any media.buffered does not includes the position', function() {
+      assert.equal(BufferHelper.isBuffered(media, -0.1), false);
+      assert.equal(BufferHelper.isBuffered(media, 0.51), false);
+      assert.equal(BufferHelper.isBuffered(media, 0.9), false);
+      assert.equal(BufferHelper.isBuffered(media, 2.1), false);
+    });
+  });
   describe('isBuffered', function() {
     // |////////|__________|////////////////|
     // 0       0.5         1               2.0
@@ -43,7 +149,7 @@ describe('BufferHelper', function() {
       assert.equal(BufferHelper.isBuffered(media, 1), true);
       assert.equal(BufferHelper.isBuffered(media, 2), true);
     });
-    it('should return false if some media.buffered includes the position', function() {
+    it('should return false if any media.buffered does not includes the position', function() {
       assert.equal(BufferHelper.isBuffered(media, -0.1), false);
       assert.equal(BufferHelper.isBuffered(media, 0.51), false);
       assert.equal(BufferHelper.isBuffered(media, 0.9), false);

--- a/tests/unit/helper/buffer-helper.js
+++ b/tests/unit/helper/buffer-helper.js
@@ -10,7 +10,7 @@ function createMockBuffer(buffered) {
 }
 
 describe('BufferHelper', function() {
-  describe('filterLivingFragments', function() {
+  describe('filterEvictedFragments', function() {
     it("should return empty array if the media is invalid", () => {
       const invalidMedia = {
         get buffered() {
@@ -27,7 +27,7 @@ describe('BufferHelper', function() {
           endPTS: 2.0
         }
       ];
-      const filteredFragments = BufferHelper.filterLivingFragments(fragments, invalidMedia);
+      const filteredFragments = BufferHelper.filterEvictedFragments(fragments, invalidMedia);
       assert.equal(filteredFragments.length, 0);
     });
     it("should return fragments that are not evicted", () => {
@@ -74,7 +74,7 @@ describe('BufferHelper', function() {
           endPTS: 4.0
         }
       ];
-      const filteredFragments = BufferHelper.filterLivingFragments(fragments, media);
+      const filteredFragments = BufferHelper.filterEvictedFragments(fragments, media);
       assert.deepEqual(filteredFragments, [fragments[2], fragments[3]]);
     });
   });


### PR DESCRIPTION
### Description of the Changes

I've improved `_checkAppendedParsed` function on StreamController.
This method is called high-frequently.

- [ ] TODO: the how and why

## Main improvements

- Cache `media.buffered` during filtering fragments
  - It can reduce DOM acesss to `media.buffered`


## Environment

- macOS: 10.12.5
- Chrome: 63.0.3239.132
- CPU 6x slowdown

### Measure

I've measured the time of `_checkAppendedParsed` by following simple script.

```diff
diff --git a/src/controller/stream-controller.js b/src/controller/stream-controller.js
index a72758ff..62027855 100644
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -15,6 +15,7 @@ import {logger} from '../utils/logger';
 import { alignDiscontinuities } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
 
+window.__HLSJS__CheckAppendedParsedPerf = [];
 const State = {
   STOPPED : 'STOPPED',
   IDLE : 'IDLE',
@@ -1255,21 +1256,29 @@ class StreamController extends TaskLoop {
     if (this.state === State.PARSED && (!this.appended || !this.pendingBuffering)) {
       const frag = this.fragCurrent;
       if (frag) {
+        const FragsCount = this._bufferedFrags.length;
+        const startNow = performance.now();
         const media = this.mediaBuffer ? this.mediaBuffer : this.media;
         logger.log(`main buffered : ${TimeRanges.toString(media.buffered)}`);
         // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
-        let bufferedFrags = this._bufferedFrags.filter(frag => {return BufferHelper.isBuffered(media,(frag.startPTS + frag.endPTS) / 2);});
+        let bufferedFrags = BufferHelper.filterLivingFragments(this._bufferedFrags, media);
         // push new range
         bufferedFrags.push(frag);
         // sort frags, as we use BinarySearch for lookup in getBufferedFrag ...
         this._bufferedFrags = bufferedFrags.sort(function(a,b) {return (a.startPTS - b.startPTS);});
         this.fragPrevious = frag;
         const stats = this.stats;
         stats.tbuffered = performance.now();
         // we should get rid of this.fragLastKbps
         this.fragLastKbps = Math.round(8 * stats.total / (stats.tbuffered - stats.tfirst));
         this.hls.trigger(Event.FRAG_BUFFERED, {stats: stats, frag: frag, id : 'main'});
         this.state = State.IDLE;
+        // add result
+        window.__HLSJS__CheckAppendedParsedPerf.push({
+          FragsCount,
+          time: performance.now() - startNow
+        });
       }
       this.tick();
     }
```

## Result

`_checkAppendedParsed` is 2.4 times faster.

[![image](https://user-images.githubusercontent.com/19714/35504197-bd02d718-0525-11e8-8acd-cea93627712b.png)](https://codepen.io/azu_ciao/full/jZOEGr)

X: Fragments Count
Y: time(ms)

- Plot: <https://codepen.io/azu_ciao/pen/jZOEGr>

### Before

Median 3.3849999999802094 ms
(0<= Fragments Count <= 100)

### After

Median 1.4099999999889405 ms
(0<= Fragments Count <= 100)

- Counting scripts: <https://gist.github.com/azu/484a40afc27b2f5317332513d6afa065>

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
