### PR TITLE
Fix for issue 1159 v0.7.8 is showing WebVTT closed captions at the wrong time

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -93,7 +93,7 @@ const WebVTTParser = {
 
             if (presentationTime) {
                 // If we have MPEGTS, offset = presentation time + discontinuity offset
-                cueOffset = presentationTime + vttCCs.ccOffset - vttCCs.presentationOffset;
+                cueOffset = presentationTime + vttCCs.ccOffset - vttCCs.presentationOffset - localTime;
             }
 
             cue.startTime += cueOffset - localTime;

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -85,7 +85,7 @@ const WebVTTParser = {
             if (currCC && currCC.new) {
                 if (localTime !== undefined) {
                     // When local time is provided, offset = discontinuity start time - local time
-                    cueOffset = vttCCs.ccOffset = currCC.start;
+                    cueOffset = vttCCs.ccOffset = currCC.start - localTime;
                 } else {
                     calculateOffset(vttCCs, cc, presentationTime);
                 }
@@ -93,7 +93,7 @@ const WebVTTParser = {
 
             if (presentationTime) {
                 // If we have MPEGTS, offset = presentation time + discontinuity offset
-                cueOffset = presentationTime + vttCCs.ccOffset - vttCCs.presentationOffset - localTime;
+                cueOffset = presentationTime + vttCCs.ccOffset - vttCCs.presentationOffset;
             }
 
             cue.startTime += cueOffset - localTime;

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -66,7 +66,7 @@ const WebVTTParser = {
 
         let cueTime = '00:00.000';
         let mpegTs = 0;
-        let localTime = 0;
+        let localTime;
         let presentationTime = 0;
         let cues = [];
         let parsingError;


### PR DESCRIPTION
### Description of the Changes
This fix handles discontinuities in webVtt fragments.
The issue was the offset for the cues was being calculated incorrectly.
Fixes issue: https://github.com/video-dev/hls.js/issues/1159
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
