### PR TITLE
fix angelOneShakaWidevine function test

### DIFF
--- a/tests/functional/auto/hlsjs.html
+++ b/tests/functional/auto/hlsjs.html
@@ -42,7 +42,32 @@
     <script>
       var video, hls, logString ='';
 
-      function startStream(streamUrl, callback) {
+      // Object.assign polyfill
+      function objectAssign(target, firstSource) {
+        if (target === undefined || target === null) {
+          throw new TypeError('Cannot convert first argument to object');
+        }
+
+        var to = Object(target);
+        for (var i = 1; i < arguments.length; i++) {
+          var nextSource = arguments[i];
+          if (nextSource === undefined || nextSource === null) {
+            continue;
+          }
+
+          var keysArray = Object.keys(Object(nextSource));
+          for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
+            var nextKey = keysArray[nextIndex];
+            var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+            if (desc !== undefined && desc.enumerable) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+        return to;
+      }
+
+      function startStream(streamUrl, config, callback) {
         if (Hls.isSupported()) {
           if (hls) {
             callback({ code : 'hlsjsAlreadyInitialised', logs : logString});
@@ -50,7 +75,7 @@
           }
           video = document.getElementById('video');
           try {
-            hls = new Hls({debug: true});
+            hls = new Hls(objectAssign({}, config, {debug: true}));
             console.log(navigator.userAgent);
             hls.loadSource(streamUrl);
             hls.attachMedia(video);

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -127,93 +127,93 @@ describe('testing hls.js playback in the browser on "'+browserDescription+'"', f
     });
   });
 
-  const testLoadedData = function(url) {
+  const testLoadedData = function(url, config) {
     return function() {
-      return this.browser.executeAsyncScript(function(url) {
+      return this.browser.executeAsyncScript(function(url, config) {
         var callback = arguments[arguments.length - 1];
-        startStream(url, callback);
+        startStream(url, config, callback);
         video.onloadeddata = function() {
           callback({ code : 'loadeddata', logs : logString});
         };
-      }, url).then(function(result) {
+      }, url ,config).then(function(result) {
         assert.strictEqual(result.code, 'loadeddata');
       });
     }
   }
 
-  const testSmoothSwitch = function(url) {
+  const testSmoothSwitch = function(url, config) {
     return function() {
-      return this.browser.executeAsyncScript(function(url) {
+      return this.browser.executeAsyncScript(function(url, config) {
         var callback = arguments[arguments.length - 1];
-        startStream(url, callback);
+        startStream(url, config, callback);
         video.onloadeddata = function() {
           switchToHighestLevel('next');
         };
         window.setTimeout(function() {
           callback({ code : video.readyState, logs : logString});
         }, 12000);
-      }, url).then(function(result) {
+      }, url ,config).then(function(result) {
         assert.strictEqual(result.code, 4);
       });
     }
   }
 
-  const testSeekOnLive = function(url) {
+  const testSeekOnLive = function(url, config) {
     return function() {
-      return this.browser.executeAsyncScript(function(url) {
+      return this.browser.executeAsyncScript(function(url, config) {
         var callback = arguments[arguments.length - 1];
-        startStream(url, callback);
+        startStream(url, config, callback);
         video.onloadeddata = function() {
           window.setTimeout(function() { video.currentTime = video.duration - 5;}, 5000);
         };
         video.onseeked = function() {
           callback({ code : 'seeked', logs : logString});
         };
-      }, url).then(function(result) {
+      }, url ,config).then(function(result) {
         assert.strictEqual(result.code, 'seeked');
       });
     }
   }
 
-  const testSeekOnVOD = function(url) {
+  const testSeekOnVOD = function(url, config) {
     return function() {
-      return this.browser.executeAsyncScript(function(url) {
+      return this.browser.executeAsyncScript(function(url, config) {
         var callback = arguments[arguments.length - 1];
-        startStream(url, callback);
+        startStream(url, config, callback);
         video.onloadeddata = function() {
           window.setTimeout(function() { video.currentTime = video.duration - 5;}, 5000);
         };
         video.onended = function() {
           callback({ code : 'ended', logs : logString});
         };
-      }, url).then(function(result) {
+      }, url ,config).then(function(result) {
         assert.strictEqual(result.code, 'ended');
       });
     }
   }
 
-  const testSeekEndVOD = function(url) {
+  const testSeekEndVOD = function(url, config) {
     return function() {
-      return this.browser.executeAsyncScript(function(url) {
+      return this.browser.executeAsyncScript(function(url, config) {
         var callback = arguments[arguments.length - 1];
-        startStream(url, callback);
+        startStream(url, config, callback);
         video.onloadeddata = function() {
           window.setTimeout(function() { video.currentTime = video.duration;}, 5000);
         };
         video.onended = function() {
           callback({ code : 'ended', logs : logString});
         };
-      }, url).then(function(result) {
+      }, url ,config).then(function(result) {
         assert.strictEqual(result.code, 'ended');
       });
     }
   }
 
-  const testIsPlayingVOD = function(url) {
+  const testIsPlayingVOD = function(url, config) {
     return function() {
-      return this.browser.executeAsyncScript(function(url) {
+      return this.browser.executeAsyncScript(function(url, config) {
         var callback = arguments[arguments.length - 1];
-        startStream(url, callback);
+        startStream(url, config, callback);
         video.onloadeddata = function() {
           let expectedPlaying = !(video.paused || // not playing when video is paused
             video.ended  || // not playing when video is ended
@@ -229,7 +229,7 @@ describe('testing hls.js playback in the browser on "'+browserDescription+'"', f
             callback({ playing : false });
           }
         };
-      }, url).then(function(result) {
+      }, url ,config).then(function(result) {
         assert.strictEqual(result.playing, true);
       });
     }
@@ -238,17 +238,18 @@ describe('testing hls.js playback in the browser on "'+browserDescription+'"', f
   for (var name in streams) {
     var stream = streams[name];
     var url = stream.url;
+    var config = stream.config || {};
     if (!stream.blacklist_ua || stream.blacklist_ua.indexOf(browserConfig.name) === -1) {
-      it('should receive video loadeddata event for ' + stream.description, testLoadedData(url));
+      it('should receive video loadeddata event for ' + stream.description, testLoadedData(url, config));
       if (stream.abr) {
-        it('should "smooth switch" to highest level and still play(readyState === 4) after 12s for ' + stream.description, testSmoothSwitch(url));
+        it('should "smooth switch" to highest level and still play(readyState === 4) after 12s for ' + stream.description, testSmoothSwitch(url, config));
       }
 
       if (stream.live) {
-        it('should seek near the end and receive video seeked event for ' + stream.description, testSeekOnLive(url));
+        it('should seek near the end and receive video seeked event for ' + stream.description, testSeekOnLive(url, config));
       } else {
-        it('should play ' + stream.description, testIsPlayingVOD(url));
-        it('should seek 5s from end and receive video ended event for ' + stream.description, testSeekOnVOD(url));
+        it('should play ' + stream.description, testIsPlayingVOD(url, config));
+        it('should seek 5s from end and receive video ended event for ' + stream.description, testSeekOnVOD(url, config));
         //it('should seek on end and receive video ended event for ' + stream.description, testSeekEndVOD(url));
       }
     }


### PR DESCRIPTION
### Description of the Changes

Pass `config` to HlsJs correctly if the `config` object is defined in `test-streams.js`

Previously, the test does not pass `config` object to hlsJs constructor.
As as result, `angelOneShakaWidevine` stream could not played in the test.
Because, this stream require `widevineLicenseUrl` and `emeEnabled` config.

https://github.com/video-dev/hls.js/blob/6d227c187a2c0ab9fbe90d6d7aadfd49c3176495/tests/test-streams.js#L114-L120

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
