### PR TITLE
fix `events.js` and `hls.js`

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {string} HlsEvent
- * @enum {HlsEvents}
+ * @readonly
+ * @enum {string}
  */
-export default HlsEvents = {
+const HlsEvents = {
   // fired before MediaSource is attaching to media element - data: { media }
   MEDIA_ATTACHING: 'hlsMediaAttaching',
   // fired when MediaSource has been succesfully attached to media element - data: { }
@@ -110,3 +110,4 @@ export default HlsEvents = {
   // fired upon stream controller state transitions - data: { previousState, nextState }
   STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
 };
+export default HlsEvents;

--- a/src/hls.js
+++ b/src/hls.js
@@ -19,7 +19,6 @@ import {hlsDefaultConfig} from './config';
 import {FragmentTracker} from './helper/fragment-tracker';
 
 import HlsEvents from './events';
-
 import EventEmitter from 'events';
 
 // polyfill for IE11
@@ -50,7 +49,7 @@ export default class Hls {
    * @type {HlsEvents}
    */
   static get Events() {
-    return Event;
+    return HlsEvents;
   }
 
   /**
@@ -239,7 +238,7 @@ export default class Hls {
    */
   destroy() {
     logger.log('destroy');
-    this.trigger(Event.DESTROYING);
+    this.trigger(HlsEvents.DESTROYING);
     this.detachMedia();
     this.coreComponents.concat(this.networkControllers).forEach(component => {component.destroy();});
     this.url = null;
@@ -254,7 +253,7 @@ export default class Hls {
   attachMedia(media) {
     logger.log('attachMedia');
     this.media = media;
-    this.trigger(Event.MEDIA_ATTACHING, {media: media});
+    this.trigger(HlsEvents.MEDIA_ATTACHING, {media: media});
   }
 
   /**
@@ -262,7 +261,7 @@ export default class Hls {
    */
   detachMedia() {
     logger.log('detachMedia');
-    this.trigger(Event.MEDIA_DETACHING);
+    this.trigger(HlsEvents.MEDIA_DETACHING);
     this.media = null;
   }
 
@@ -275,7 +274,7 @@ export default class Hls {
     logger.log(`loadSource:${url}`);
     this.url = url;
     // when attaching to a source URL, trigger a playlist load
-    this.trigger(Event.MANIFEST_LOADING, {url: url});
+    this.trigger(HlsEvents.MANIFEST_LOADING, {url: url});
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Currently

- demo and func test does not work
- `npm run test:unit` is failed.

```
HeadlessChrome 0.0.0 (Mac OS X 10.12.6) ERROR
  {
    "message": "Uncaught ReferenceError: HlsEvents is not defined\nat http://localhost:9877webpack:///src/events.js:5:27 <- tests/tests.webpack.js:75:76\n\nReferenceError: HlsEvents is not defined\n    at Object.defineProperty.value (http://localhost:9877webpack:///src/events.js:5:27 <- tests/tests.webpack.js:75:76)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)\n    at Object.defineProperty.value (http://localhost:9877tests/tests.webpack.js:3560:66)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)\n    at Object.module.exports (http://localhost:9877tests/tests.webpack.js:17763:89)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)\n    at webpackContext (http://localhost:9877webpack:///tests/unit%20/.js$:22:0 <- tests/tests.webpack.js:17742:9)\n    at Array.forEach (<anonymous>)\n    at Object.map../controller/abr-controller.js (http://localhost:9877webpack:///tests/tests.webpack.js:3:0 <- tests/tests.webpack.js:17710:14)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)",
    "str": "Uncaught ReferenceError: HlsEvents is not defined\nat http://localhost:9877webpack:///src/events.js:5:27 <- tests/tests.webpack.js:75:76\n\nReferenceError: HlsEvents is not defined\n    at Object.defineProperty.value (http://localhost:9877webpack:///src/events.js:5:27 <- tests/tests.webpack.js:75:76)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)\n    at Object.defineProperty.value (http://localhost:9877tests/tests.webpack.js:3560:66)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)\n    at Object.module.exports (http://localhost:9877tests/tests.webpack.js:17763:89)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)\n    at webpackContext (http://localhost:9877webpack:///tests/unit%20/.js$:22:0 <- tests/tests.webpack.js:17742:9)\n    at Array.forEach (<anonymous>)\n    at Object.map../controller/abr-controller.js (http://localhost:9877webpack:///tests/tests.webpack.js:3:0 <- tests/tests.webpack.js:17710:14)\n    at __webpack_require__ (http://localhost:9877webpack:///webpack/bootstrap%20cd7d57625274bcbcfce8:19:0 <- tests/tests.webpack.js:20:30)"
  }
```

Because, `export default const` is not valid syntax.

```js
export default const HlsEvents = { ... } 
```

This changes is introduced in #1540

- https://github.com/video-dev/hls.js/pull/1540/files#diff-4607e46b15da8ae44c4b47730c6d5963

This PR fix this and correct JSDoc.

**References:**

- [Use JSDoc: @typedef](http://usejsdoc.org/tags-typedef.html)
- [Use JSDoc: @enum](http://usejsdoc.org/tags-enum.html)
- [javascript - how to document enum values in JS Doc - Stack Overflow](https://stackoverflow.com/questions/39965167/how-to-document-enum-values-in-js-doc)


FYI: ESdoc does not support `@enum`.

- [Add new @enum tag · Issue #91 · esdoc/esdoc](https://github.com/esdoc/esdoc/issues/91 "Add new @enum tag · Issue #91 · esdoc/esdoc")

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
