### PR TITLE
Added option to disable setting PTS/DTS to 0 in the MP4 remuxer.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -90,7 +90,8 @@ export var hlsDefaultConfig = {
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: undefined, // used by eme-controller
   requestMediaKeySystemAccessFunc:
-            requestMediaKeySystemAccess // used by eme-controller
+            requestMediaKeySystemAccess, // used by eme-controller
+  disablePtsDtsCorrectionInMp4Remux: false // used by MP4 remuxer
 };
 
 if (__USE_SUBTITLES__) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -163,8 +163,13 @@ class MP4Remuxer {
       observer.trigger(Event.FRAG_PARSING_INIT_SEGMENT, data);
       this.ISGenerated = true;
       if (computePTSDTS) {
-        this._initPTS = initPTS;
-        this._initDTS = initDTS;
+        if (this.config.disablePtsDtsCorrectionInMp4Remux) {
+          this._initPTS = 0;
+          this._initDTS = 0;
+        } else {
+          this._initPTS = initPTS;
+          this._initDTS = initDTS;
+        }
       }
     } else {
       observer.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: false, reason: 'no audio/video samples found' });


### PR DESCRIPTION
### Description of the Changes
Added option to disable the PTS / DTS offset in the MP4 remuxer.
Required because in certain video files we want to keep the original PTSes so that we can accurately navigate in the video and use the timestamps reported by the player in other applications.

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable) - this would probably deserve some unit tests, but the MP4 remuxer does not have any.
- [X] Travis tests are passing (or test results are not worse than on master branch :)) - 3 tests are failing both on master and this branch
- [X] API or design changes are documented in API.md
