### PR TITLE
Adjust webvtt cue offsets with mpegts rollovers

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -1,6 +1,9 @@
 import VTTParser from './vttparser';
 import { utf8ArrayToStr } from '../demux/id3';
 
+const PTS_MAX = 8589934592; // 2^33
+const TIMESCALE = 90000;
+
 // String.prototype.startsWith is not supported in IE11
 const startsWith = function (inputString, searchString, position) {
   return inputString.substr(position || 0, searchString.length) === searchString;
@@ -88,6 +91,17 @@ const WebVTTParser = {
         } else {
           calculateOffset(vttCCs, cc, presentationTime);
         }
+
+        // Calculate how many times the mpegts clock has rolled over
+        if (currCC.rolloverOffset === undefined) {
+          const numberOfRollovers = (cue.startTime * TIMESCALE / PTS_MAX) | 0;
+
+          if (numberOfRollovers > 0)
+            currCC.rolloverOffset = (numberOfRollovers * PTS_MAX + syncPTS) / TIMESCALE;
+          else
+            currCC.rolloverOffset = 0;
+        }
+        cueOffset -= currCC.rolloverOffset;
       }
 
       if (presentationTime) {
@@ -136,14 +150,15 @@ const WebVTTParser = {
           });
           try {
             // Calculate subtitle offset in milliseconds.
-            // If sync PTS is less than zero, we have a 33-bit wraparound, which is fixed by adding 2^33 = 8589934592.
-            syncPTS = syncPTS < 0 ? syncPTS + 8589934592 : syncPTS;
-            // Adjust MPEGTS by sync PTS.
-            mpegTs -= syncPTS;
+            // If sync PTS is less than zero, we have a 33-bit wraparound, which is fixed by adding 2^33.
+            syncPTS = syncPTS < 0 ? syncPTS + PTS_MAX : syncPTS;
+            if (mpegTs !== 0) // Adjust MPEGTS by sync PTS
+              mpegTs -= syncPTS;
+
             // Convert cue time to seconds
             localTime = cueString2millis(cueTime) / 1000;
             // Convert MPEGTS to seconds from 90kHz.
-            presentationTime = mpegTs / 90000;
+            presentationTime = mpegTs / TIMESCALE;
 
             if (localTime === -1)
               parsingError = new Error(`Malformed X-TIMESTAMP-MAP: ${line}`);

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -160,11 +160,11 @@ describe('testing hls.js playback in the browser on "' + browserDescription + '"
           window.switchToHighestLevel('next');
         };
         window.hls.on(window.Hls.Events.LEVEL_SWITCHED, function (event, data) {
-          var currentTime = video.currentTime;
+          let currentTime = video.currentTime;
           if (data.level === window.hls.levels.length - 1) {
             console.log('[log] > switched on level:' + data.level);
             window.setTimeout(function () {
-              var newCurrentTime = video.currentTime;
+              let newCurrentTime = video.currentTime;
               console.log('[log] > currentTime delta :' + (newCurrentTime - currentTime));
               callback({ code: newCurrentTime > currentTime, logs: window.logString });
             }, 2000);

--- a/tests/unit/utils/webvtt-parser.js
+++ b/tests/unit/utils/webvtt-parser.js
@@ -70,7 +70,6 @@ describe('WebVTTParser', function () {
     assert.equal(cue.text, 'Never drink liquid nitrogen.');
   });
 
-
   it('can handle this redbull.tv stream', () => {
     const vtt = `WEBVTT
                  X-TIMESTAMP-MAP=MPEGTS:131940,LOCAL:00:00:00.000
@@ -90,11 +89,11 @@ describe('WebVTTParser', function () {
     //   document.getElementsByTagName('video')[0].textTracks[1].cues[0].startTime
     assert.equal(cues[0].startTime, 15.547266666666667);
     assert.equal(cues[0].endTime, 17.68326666666667);
-    assert.equal(cues[0].text, `I'm thinking if possible,`)
+    assert.equal(cues[0].text, 'I\'m thinking if possible,');
 
     assert.equal(cues[1].startTime, 17.850266666666666);
     assert.equal(cues[1].endTime, 20.953266666666668);
-    assert.equal(cues[1].text, `in a perfect world,`)
+    assert.equal(cues[1].text, 'in a perfect world,');
   });
 
   it('can handle this stream from SVT', () => {
@@ -114,12 +113,12 @@ describe('WebVTTParser', function () {
     const cues = parse(vtt, initPTS);
     assert.equal(2, cues.length);
 
-    assert.equal(cues[0].startTime, 23.180333333333332);  // safari says 23.18
-    assert.equal(cues[0].endTime,   29.420333333333332);  // safari says 29.419
-    assert.equal(cues[0].text, `Det är onsdag, och jag hoppas\natt ni har papper och penna-`)
+    assert.equal(cues[0].startTime, 23.180333333333332); // safari says 23.18
+    assert.equal(cues[0].endTime, 29.420333333333332); // safari says 29.419
+    assert.equal(cues[0].text, 'Det är onsdag, och jag hoppas\natt ni har papper och penna-');
 
-    assert.equal(cues[1].startTime, 29.580333333333332);  // safari says 29.58
-    assert.equal(cues[1].endTime,   35.580333333333336);  // safari says 35.58
-    assert.equal(cues[1].text, `-sinnet vaket och öronen spetsade. Vi\ntävlar i konst, litteratur och musik.`)
+    assert.equal(cues[1].startTime, 29.580333333333332); // safari says 29.58
+    assert.equal(cues[1].endTime, 35.580333333333336); // safari says 35.58
+    assert.equal(cues[1].text, '-sinnet vaket och öronen spetsade. Vi\ntävlar i konst, litteratur och musik.');
   });
 });

--- a/tests/unit/utils/webvtt-parser.js
+++ b/tests/unit/utils/webvtt-parser.js
@@ -1,0 +1,72 @@
+let assert = require('assert');
+import WebVTTParser from '../../../src/utils/webvtt-parser';
+
+const parse = function (webVttString, initPTS) {
+  const enc = new TextEncoder('utf-8');
+  let result;
+
+  let vttByteArray = enc.encode(webVttString.split('\n').map(s => s.trim()).join('\n'));
+
+  const vttCCs = { ccOffset: 0, presentationOffset: 0 };
+  const cc = 0;
+  vttCCs[cc] = { start: 0, prevCC: -1, new: true };
+
+  WebVTTParser.parse(vttByteArray, initPTS, vttCCs, cc, function (cues) {
+    result = cues;
+  }, function (e) {
+    result = e;
+  });
+
+  return result;
+};
+
+describe('WebVTTParser', function () {
+  it('can parse webvtt without X-TIMESTAMP-MAP', () => {
+    const vtt = `WEBVTT
+
+                 00:01.000 --> 00:04.000
+                 Never drink liquid nitrogen.`;
+
+    const cues = parse(vtt, 0);
+    assert.equal(1, cues.length);
+
+    const cue = cues[0];
+    assert.equal(cue.startTime, 1);
+    assert.equal(cue.endTime, 4);
+    assert.equal(cue.text, 'Never drink liquid nitrogen.');
+  });
+
+  it('can parse webvtt with X-TIMESTAMP-MAP', () => {
+    const vtt = `WEBVTT
+                 X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
+
+                 00:01.000 --> 00:04.000
+                 Never drink liquid nitrogen.`;
+
+    const cues = parse(vtt, 900000);
+    assert.equal(1, cues.length);
+
+    const cue = cues[0];
+    assert.equal(cue.startTime, 1);
+    assert.equal(cue.endTime, 4);
+    assert.equal(cue.text, 'Never drink liquid nitrogen.');
+  });
+
+  it('can handle PTS rollovers', () => {
+    const vtt = `WEBVTT
+                 X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000
+
+                 100:00:01.000 --> 100:00:04.000
+                 Never drink liquid nitrogen.`;
+
+    const initPTS = 100 * 3600 * 90000 % Math.pow(2, 33); // 100 hours, with wrapping
+
+    const cues = parse(vtt, initPTS);
+    assert.equal(1, cues.length);
+
+    const cue = cues[0];
+    assert.equal(cue.startTime, 1);
+    assert.equal(cue.endTime, 4);
+    assert.equal(cue.text, 'Never drink liquid nitrogen.');
+  });
+});

--- a/tests/unit/utils/webvtt-parser.js
+++ b/tests/unit/utils/webvtt-parser.js
@@ -69,4 +69,57 @@ describe('WebVTTParser', function () {
     assert.equal(cue.endTime, 4);
     assert.equal(cue.text, 'Never drink liquid nitrogen.');
   });
+
+
+  it('can handle this redbull.tv stream', () => {
+    const vtt = `WEBVTT
+                 X-TIMESTAMP-MAP=MPEGTS:131940,LOCAL:00:00:00.000
+
+                 00:00:15.548 --> 00:00:17.684
+                 I'm thinking if possible,
+
+                 00:00:17.851 --> 00:00:20.954
+                 in a perfect world,`;
+
+    const initPTS = 132006;
+
+    const cues = parse(vtt, initPTS);
+    assert.equal(2, cues.length);
+
+    // Start and end times extracted from Safari using something like this:
+    //   document.getElementsByTagName('video')[0].textTracks[1].cues[0].startTime
+    assert.equal(cues[0].startTime, 15.547266666666667);
+    assert.equal(cues[0].endTime, 17.68326666666667);
+    assert.equal(cues[0].text, `I'm thinking if possible,`)
+
+    assert.equal(cues[1].startTime, 17.850266666666666);
+    assert.equal(cues[1].endTime, 20.953266666666668);
+    assert.equal(cues[1].text, `in a perfect world,`)
+  });
+
+  it('can handle this stream from SVT', () => {
+    const vtt = `WEBVTT
+                 X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
+
+                 00:00:23.280 --> 00:00:29.520 line:44%
+                 Det är onsdag, och jag hoppas
+                 att ni har papper och penna-
+
+                 00:00:29.680 --> 00:00:35.680
+                 -sinnet vaket och öronen spetsade. Vi
+                 tävlar i konst, litteratur och musik.`;
+
+    const initPTS = 908970;
+
+    const cues = parse(vtt, initPTS);
+    assert.equal(2, cues.length);
+
+    assert.equal(cues[0].startTime, 23.180333333333332);  // safari says 23.18
+    assert.equal(cues[0].endTime,   29.420333333333332);  // safari says 29.419
+    assert.equal(cues[0].text, `Det är onsdag, och jag hoppas\natt ni har papper och penna-`)
+
+    assert.equal(cues[1].startTime, 29.580333333333332);  // safari says 29.58
+    assert.equal(cues[1].endTime,   35.580333333333336);  // safari says 35.58
+    assert.equal(cues[1].text, `-sinnet vaket och öronen spetsade. Vi\ntävlar i konst, litteratur och musik.`)
+  });
 });


### PR DESCRIPTION
This is a fix for live streams where the mpegts clock wraps multiple times during a long running stream. The `rolloverOffset` is based on the start time of the first cue which is assumed to be absolute to the stream start. It's unclear if this fix supports webvtt discontinuities and other special cases, but it handles the basic case where X-TIMESTAMP-MAP is unset, or set to LOCAL=0, MPEGTS=0.

I also changed so that `syncPTS` is only subtracted from `mpegTs`/`presentation`, when it's non-zero.

Related: #1018 , #1531 



### Description of the Changes


### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
