### PR TITLE
fix(func-test): add `nudgeMaxRetry` option for slow seek env

### DIFF
--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -17,7 +17,15 @@ function createTestStream(url, description, live = false, abr = true, blacklist_
   }
 }
 
+/**
+ * @param {Object} target
+ * @param {Object} [config]
+ * @returns {{url: string, description: string, live: boolean, abr: boolean, blacklist_ua: string[]}}
+ */
 function createTestStreamWithConfig(target, config) {
+  if (typeof target !== "object") {
+    throw new Error("target should be object");
+  }
   const testStream = createTestStream(target.url, target.description, target.live, target.abr, target.blacklist_ua);
 
   testStream.config = config;
@@ -26,9 +34,14 @@ function createTestStreamWithConfig(target, config) {
 }
 
 module.exports = {
-  bbb: createTestStream(
-    "https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8",
-    "Big Buck Bunny - adaptive qualities"
+  bbb: createTestStreamWithConfig({
+      url: "https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8",
+      description: "Big Buck Bunny - adaptive qualities",
+    },
+    {
+      // try to workaround test failing because of slow seek on Chrome/Win10
+      nudgeMaxRetry: 5
+    }
   ),
   bigBuckBunny480p: {
     "url": "https://video-dev.github.io/streams/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8",


### PR DESCRIPTION
### Description of the Changes

Apply `nudgeMaxRetry: 5` to "Big Buck Bunny - adaptive qualities" func test.
It is a workaround for test failing because of slow seek on Chrome/Win10.

- <https://video-dev.slack.com/archives/C4FC8GGEP/p1519718130000397>

Also, We may need to change the default value of `nudgeMaxRetry`.
(Current `nudgeMaxRetry` is `3` by default)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
