### PR TITLE
Fixes handling network error on loading chunklist + Exception on Object.keys in FragmentTracker

### DIFF
--- a/src/helper/fragment-tracker.js
+++ b/src/helper/fragment-tracker.js
@@ -103,6 +103,11 @@ export class FragmentTracker extends EventHandler {
     let fragmentEntity = this.fragments[fragKey];
     fragmentEntity.buffered = true;
 
+    // May be null
+    if (!this.timeRanges) {
+      return
+    }
+
     Object.keys(this.timeRanges).forEach(elementaryStream => {
       if(fragment.hasElementaryStream(elementaryStream) === true) {
         let timeRange = this.timeRanges[elementaryStream];

--- a/src/helper/fragment-tracker.js
+++ b/src/helper/fragment-tracker.js
@@ -20,7 +20,7 @@ export class FragmentTracker extends EventHandler {
     this.bufferPadding = 0.2;
 
     this.fragments = Object.create(null);
-    this.timeRanges = null;
+    this.timeRanges = Object.create(null);
 
     this.config = hls.config;
   }
@@ -102,11 +102,6 @@ export class FragmentTracker extends EventHandler {
     let fragKey = this.getFragmentKey(fragment);
     let fragmentEntity = this.fragments[fragKey];
     fragmentEntity.buffered = true;
-
-    // May be null
-    if (!this.timeRanges) {
-      return
-    }
 
     Object.keys(this.timeRanges).forEach(elementaryStream => {
       if(fragment.hasElementaryStream(elementaryStream) === true) {

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -430,7 +430,7 @@ class PlaylistLoader extends EventHandler {
     let details;
     let fatal;
 
-    const loader = context.loader;
+    const loader = this.getInternalLoader(context);
 
     switch(context.type) {
     case ContextType.MANIFEST:

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -115,7 +115,7 @@ describe('testing hls.js playback in the browser on "'+browserDescription+'"', f
 
   afterEach(function() {
     var browser = this.browser;
-    browser.executeScript('return logString').then(function(return_value){
+    return browser.executeScript('return logString').then(function(return_value){
       console.log('travis_fold:start:debug_logs');
       console.log('logs');
       console.log(return_value);


### PR DESCRIPTION
context.loader points to constructor of the used loader. getInternalLoader is the right way to get the loader instance.

### Description of the Changes


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
