### PR TITLE
replace http to https and add `demo` property

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -35,6 +35,10 @@ $(document).ready(function() {
 
   Object.keys(testStreams).forEach((key) => {
     const stream = testStreams[key];
+    // Disallow to use some streams for demo
+    if (stream["demo"] === false) {
+      return;
+    }
     const option = new Option(stream.description, key);
     $('#streamSelect').append(option);
   })

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -68,23 +68,25 @@ module.exports = {
     "description": "hls.js/issues/666",
     "live": false,
     "abr": false,
-    "blacklist_ua": ["internet explorer"]
+    "blacklist_ua": ["internet explorer"],
+    // does not support https
+    "demo": true
   },
   issue649: {
-    "url": "http://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw",
+    "url": "https://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw",
     "description": "hls.js/issues/649",
     "live": false,
     "abr": false
   },
   closedCaptions: {
-    "url": "http://playertest.longtailvideo.com/adaptive/captions/playlist.m3u8",
+    "url": "https://playertest.longtailvideo.com/adaptive/captions/playlist.m3u8",
     "description": "CNN special report, with CC",
     "live": false,
     "abr": false,
     "blacklist_ua": ["safari"]
   },
   oceansAES: {
-    "url": "http://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8",
+    "url": "https://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8",
     "description": "AES encrypted,ABR",
     "live": false,
     "abr": true
@@ -93,7 +95,9 @@ module.exports = {
     "url": "http://streambox.fr/playlists/sample_aes/index.m3u8",
     "description": "SAMPLE-AES encrypted",
     "live": false,
-    "abr": false
+    "abr": false,
+    // does not support https
+    "demo": false
   },
   mp3Audio: {
     "url": "https://player.webvideocore.net/CL1olYogIrDWvwqiIKK7eLBkzvO18gwo9ERMzsyXzwt_t-ya8ygf2kQBZww38JJT/8i4vvznv8408.m3u8",
@@ -130,7 +134,7 @@ module.exports = {
     "abr": false
   },
   uspHLSAteam: createTestStream(
-    "http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.m3u8?session_id=27199",
+    "https://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.m3u8?session_id=27199",
     "A-Team movie trailer - HLS by Unified Streaming Platform"
   ),
   angelOneShakaWidevine: createTestStreamWithConfig({


### PR DESCRIPTION
### Description of the Changes

- Replace `http` to `https` for avoiding mixed content in demo page
- Add `demo` property that disallow to use the stream in demo page

As a results, `streambox.fr`'s stream is hidden in demo page.

![image](https://user-images.githubusercontent.com/19714/36826610-e60ee5cc-1d51-11e8-8b11-3bbaae910b01.png)

fix #1589 


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
