### PR TITLE
deprecate LEVEL_SWITCH/AUDIO_TRACK_SWITCH

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
- 
+
 
 - [Getting started](#getting-started)
   - [First step: setup and support](#first-step-setup-and-support)
@@ -536,8 +536,8 @@ A value too close from `liveSyncDuration` is likely to cause playback stalls.
 
 (default: `false`)
 
-Override current Media Source duration to `Infinity` for a live broadcast. 
-Useful, if you are building a player which relies on native UI capabilities in modern browsers. 
+Override current Media Source duration to `Infinity` for a live broadcast.
+Useful, if you are building a player which relies on native UI capabilities in modern browsers.
 If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
 
 ### `enableWorker`
@@ -1093,7 +1093,7 @@ get/set : subtitle track id (returned by). Returns -1 if no track is visible. Se
 
 (default: `false`)
 
-get/set : if set to true the active subtitle track mode will be set to `showing` and the browser will display the active subtitles. If set to false, the mode will be set to `hidden`. 
+get/set : if set to true the active subtitle track mode will be set to `showing` and the browser will display the active subtitles. If set to false, the mode will be set to `hidden`.
 
 ## Live stream API
 
@@ -1142,8 +1142,6 @@ Full list of Events is available below:
     -  data: { levels : [available quality levels], audioTracks : [ available audio tracks], url : manifestURL, stats : { trequest, tfirst, tload, mtime}}
   - `Hls.Events.MANIFEST_PARSED`  - fired after manifest has been parsed
     -  data: { levels : [ available quality levels ], firstLevel : index of first quality level appearing in Manifest }
-  - `Hls.Events.LEVEL_SWITCH`  - fired when a level switch is requested (deprecated in favor of `LEVEL_SWITCHING`)
-    -  data: { level : id of new level }
   - `Hls.Events.LEVEL_SWITCHING`  - fired when a level switch is requested
     -  data: { `level` object (please see [below](#level) for more information) }
   - `Hls.Events.LEVEL_SWITCHED`  - fired when a level switch is effective
@@ -1157,8 +1155,6 @@ Full list of Events is available below:
   - `Hls.Events.LEVEL_PTS_UPDATED`  - fired when a level's PTS information has been updated after parsing a fragment
     -  data: { details : `levelDetails` object (please see [below](#leveldetails) for more information), level : id of updated level, drift: PTS drift observed when parsing last fragment }
   - `Hls.Events.AUDIO_TRACKS_UPDATED`  - fired to notify that audio track lists has been updated
-    -  data: { audioTracks : audioTracks }
-  - `Hls.Events.AUDIO_TRACK_SWITCH`  - fired when an audio track switch occurs (deprecated in favor of `AUDIO_TRACK_SWITCHING`)
     -  data: { audioTracks : audioTracks }
   - `Hls.Events.AUDIO_TRACK_SWITCHING`  - fired when an audio track switching is requested
     -  data: { id : audio track id }

--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -121,8 +121,6 @@ class AudioTrackController extends EventHandler {
         type = audioTrack.type,
         url = audioTrack.url,
         eventObj = { id: newId, type: type, url: url };
-      // keep AUDIO_TRACK_SWITCH for legacy reason
-      hls.trigger(Event.AUDIO_TRACK_SWITCH, eventObj);
       hls.trigger(Event.AUDIO_TRACK_SWITCHING, eventObj);
       // check if we need to load playlist for this audio Track
       let details = audioTrack.details;

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -169,8 +169,6 @@ export default class LevelController extends EventHandler {
         this.currentLevelIndex = newLevel;
         let levelProperties = levels[newLevel];
         levelProperties.level = newLevel;
-        // LEVEL_SWITCH to be deprecated in next major release
-        hls.trigger(Event.LEVEL_SWITCH, levelProperties);
         hls.trigger(Event.LEVEL_SWITCHING, levelProperties);
       }
       let level = levels[newLevel], levelDetails = level.details;

--- a/src/events.js
+++ b/src/events.js
@@ -33,8 +33,6 @@ const HlsEvents = {
   MANIFEST_LOADED: 'hlsManifestLoaded',
   // fired after manifest has been parsed - data: { levels : [available quality levels], firstLevel : index of first quality level appearing in Manifest}
   MANIFEST_PARSED: 'hlsManifestParsed',
-  // fired when a level switch is requested - data: { level : id of new level } // deprecated in favor LEVEL_SWITCHING
-  LEVEL_SWITCH: 'hlsLevelSwitch',
   // fired when a level switch is requested - data: { level : id of new level }
   LEVEL_SWITCHING: 'hlsLevelSwitching',
   // fired when a level switch is effective - data: { level : id of new level }
@@ -49,8 +47,6 @@ const HlsEvents = {
   LEVEL_PTS_UPDATED: 'hlsLevelPtsUpdated',
   // fired to notify that audio track lists has been updated - data: { audioTracks : audioTracks }
   AUDIO_TRACKS_UPDATED: 'hlsAudioTracksUpdated',
-  // fired when an audio track switch occurs - data: { id : audio track id } // deprecated in favor AUDIO_TRACK_SWITCHING
-  AUDIO_TRACK_SWITCH: 'hlsAudioTrackSwitch',
   // fired when an audio track switching is requested - data: { id : audio track id }
   AUDIO_TRACK_SWITCHING: 'hlsAudioTrackSwitching',
   // fired when an audio track switch actually occurs - data: { id : audio track id }

--- a/tests/unit/controller/level-controller.js
+++ b/tests/unit/controller/level-controller.js
@@ -76,7 +76,7 @@ describe('LevelController', () => {
     levelController.onManifestLoaded(data);
     levelController.level = nextLevel;
 
-    assert.equal(levelController.hls.trigger.args[1][0], Event.LEVEL_SWITCH);
+    assert.equal(levelController.hls.trigger.args[1][0], Event.LEVEL_SWITCHING);
     assert.equal(levelController.hls.trigger.args[1][1].level, nextLevel);
   });
 });


### PR DESCRIPTION
### Description of the Changes

these events have been deprecated for a while, and replaced by `LEVEL_SWITCHING` and `AUDIO_TRACK_SWITCHING`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
