### PR TITLE
functional test / smooth switch : use currentTime instead of readyState as test condition

### DIFF
--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -159,13 +159,19 @@ describe('testing hls.js playback in the browser on "' + browserDescription + '"
         video.onloadeddata = function () {
           window.switchToHighestLevel('next');
         };
-        window.setTimeout(function () {
-          let readyState = video.readyState;
-          console.log('[log] > readyState:' + readyState);
-          callback({ code: readyState, logs: window.logString });
-        }, 12000);
+        window.hls.on(window.Hls.Events.LEVEL_SWITCHED, function (event, data) {
+          var currentTime = video.currentTime;
+          if (data.level === window.hls.levels.length - 1) {
+            console.log('[log] > switched on level:' + data.level);
+            window.setTimeout(function () {
+              var newCurrentTime = video.currentTime;
+              console.log('[log] > currentTime delta :' + (newCurrentTime - currentTime));
+              callback({ code: newCurrentTime > currentTime, logs: window.logString });
+            }, 2000);
+          }
+        });
       }, url, config).then(function (result) {
-        assert.strictEqual(result.code, 4);
+        assert.strictEqual(result.code, true);
       });
     };
   };


### PR DESCRIPTION
### Description of the Changes

try to workaround readyState not being reliable on Saucelabs VM

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [?] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
