### PR TITLE
avoid repeated request for init segment on live fmp4 playlist and fix regression introduced by FragmentTracker 

### DIFF
--- a/src/helper/fragment-tracker.js
+++ b/src/helper/fragment-tracker.js
@@ -99,16 +99,18 @@ export class FragmentTracker extends EventHandler {
   detectPartialFragments (fragment) {
     let fragKey = this.getFragmentKey(fragment);
     let fragmentEntity = this.fragments[fragKey];
-    fragmentEntity.buffered = true;
+    if (fragmentEntity) {
+      fragmentEntity.buffered = true;
 
-    Object.keys(this.timeRanges).forEach(elementaryStream => {
-      if (fragment.hasElementaryStream(elementaryStream) === true) {
-        let timeRange = this.timeRanges[elementaryStream];
-        // Check for malformed fragments
-        // Gaps need to be calculated for each elementaryStream
-        fragmentEntity.range[elementaryStream] = this.getBufferedTimes(fragment.startPTS, fragment.endPTS, timeRange);
-      }
-    });
+      Object.keys(this.timeRanges).forEach(elementaryStream => {
+        if (fragment.hasElementaryStream(elementaryStream) === true) {
+          let timeRange = this.timeRanges[elementaryStream];
+          // Check for malformed fragments
+          // Gaps need to be calculated for each elementaryStream
+          fragmentEntity.range[elementaryStream] = this.getBufferedTimes(fragment.startPTS, fragment.endPTS, timeRange);
+        }
+      });
+    }
   }
 
   getBufferedTimes (startPTS, endPTS, timeRange) {
@@ -226,13 +228,16 @@ export class FragmentTracker extends EventHandler {
    */
   onFragLoaded (e) {
     let fragment = e.frag;
-    let fragKey = this.getFragmentKey(fragment);
-    let fragmentEntity = {
-      body: fragment,
-      range: Object.create(null),
-      buffered: false
-    };
-    this.fragments[fragKey] = fragmentEntity;
+    // dont track initsegment (for which sn is not a number)
+    if (!isNaN(fragment.sn)) {
+      let fragKey = this.getFragmentKey(fragment);
+      let fragmentEntity = {
+        body: fragment,
+        range: Object.create(null),
+        buffered: false
+      };
+      this.fragments[fragKey] = fragmentEntity;
+    }
   }
 
   /**

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -91,7 +91,11 @@ export function mergeDetails (oldDetails, newDetails) {
     ccOffset = 0,
     PTSFrag;
 
-    // check if old/new playlists have fragments in common
+  // potentially retrieve cached initsegment
+  if (newDetails.initSegment && oldDetails.initSegment)
+    newDetails.initSegment = oldDetails.initSegment;
+
+  // check if old/new playlists have fragments in common
   if (end < start) {
     newDetails.PTSKnown = false;
     return;


### PR DESCRIPTION
### Description of the Changes

level-helper: merge initSegment info to avoid requesting it again on each live playlist refresh
related to #1607

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
