### PR TITLE
Remove old, insecure (404) favicons in demo HTML pages

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,9 +7,6 @@
 
     <title>hls.js demo</title>
 
-    <link rel="icon" type="image/png" href="http://static1.dmcdn.net/images/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="http://static1.dmcdn.net/images/favicon-16x16.png" sizes="16x16" />
-
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 

--- a/demo/metrics.html
+++ b/demo/metrics.html
@@ -2,8 +2,6 @@
 
 <head>
   <title>hls.js metrics page</title>
-<link rel="icon" type="image/png" href="http://static1.dmcdn.net/images/favicon-32x32.png" sizes="32x32" />
-<link rel="icon" type="image/png" href="http://static1.dmcdn.net/images/favicon-16x16.png" sizes="16x16" />
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>


### PR DESCRIPTION
### Description of the Changes

Removes old references to favicons from the demo HTML pages.  These resources pointed to 404s and were loading on http://, which causes errors in the console on page load.  The favicon could be replaced with a `hls.js`-specific one, if so inclined, but this is a simple fix.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] ~~new unit / functional tests have been added (whenever applicable)~~
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] ~~API or design changes are documented in API.md~~
