### PR TITLE
Emit 'loadError' instead of 'loadTimeout' when playlist request retries exhaust

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -268,7 +268,7 @@ class PlaylistLoader extends EventHandler {
   }
 
   loadtimeout (stats, context, networkDetails = null) {
-    this._handleNetworkError(context, networkDetails);
+    this._handleNetworkError(context, networkDetails, true);
   }
 
   _handleMasterPlaylist (response, stats, context, networkDetails) {
@@ -409,7 +409,7 @@ class PlaylistLoader extends EventHandler {
     });
   }
 
-  _handleNetworkError (context, networkDetails) {
+  _handleNetworkError (context, networkDetails, timeout = false) {
     let details;
     let fatal;
 
@@ -417,15 +417,15 @@ class PlaylistLoader extends EventHandler {
 
     switch (context.type) {
     case ContextType.MANIFEST:
-      details = ErrorDetails.MANIFEST_LOAD_TIMEOUT;
+      details = (timeout ? ErrorDetails.MANIFEST_LOAD_TIMEOUT : ErrorDetails.MANIFEST_LOAD_ERROR);
       fatal = true;
       break;
     case ContextType.LEVEL:
-      details = ErrorDetails.LEVEL_LOAD_TIMEOUT;
+      details = (timeout ? ErrorDetails.LEVEL_LOAD_TIMEOUT : ErrorDetails.LEVEL_LOAD_ERROR);
       fatal = false;
       break;
     case ContextType.AUDIO_TRACK:
-      details = ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT;
+      details = (timeout ? ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT : ErrorDetails.AUDIO_TRACK_LOAD_ERROR);
       fatal = false;
       break;
     default:


### PR DESCRIPTION

### Description of the Changes
Emitting `loadError`s instead of `loadTimeOut`s when playlist request retries exhaust.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
