### PR TITLE
Add limitMetrics option for demo page to limit the total number of metric entries per class

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -95,6 +95,11 @@
         </label>
 
         <label class="innerControls">
+          Metrics history (max limit, -1 is unlimited):
+          <input id="limitMetrics" style="width: 8em" type=number/>
+        </label>
+
+        <label class="innerControls">
           Player size:
           <select id="videoSize" style="float:right;">
             <option value="240">Tiny (240p)</option>


### PR DESCRIPTION
Description of the Changes

Add limitMetrics option for demo page to limit the total number of metric entries per class; this prevents memory leaks when using the demo player for long periods of time. Default is set to -1; which means Unlimited.