### PR TITLE
Webpack build speed-up in dev mode: Disable occurence-order optimization 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ const demoConfig = clone(baseConfig, {
   devtool: 'source-map'
 });
 
-
+// FIXME: rename to getPluginsForConfigType
 function getPluginsForConfig(type, minify = false) {
   // common plugins.
 
@@ -73,14 +73,16 @@ function getPluginsForConfig(type, minify = false) {
     '\n'
   );
 
+  // functional plugins
   const plugins = [
-    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin(defineConstants)
   ];
 
+  // minification / optimization plugins
+  // we can not use them in debug mode, to optimize for build speed
   if (minify) {
-    // minification plugins.
     return plugins.concat([
+      new webpack.optimize.OccurrenceOrderPlugin(),
       new webpack.optimize.UglifyJsPlugin(uglifyJsOptions),
       new webpack.LoaderOptionsPlugin({
         minimize: true,
@@ -102,6 +104,7 @@ function getPluginsForConfig(type, minify = false) {
   return plugins;
 }
 
+// FIXME: rename to getConstantsForConfigType
 function getConstantsForConfig(type) {
   // By default the "main" dists (hls.js & hls.min.js) are full-featured.
   return {
@@ -213,6 +216,7 @@ multiConfig.push(demoConfig);
 module.exports = (envArgs) => {
   if (!envArgs) {
     // If no arguments are specified, return every configuration
+    console.log('No environment args found, using all configs')
     return multiConfig;
   }
 
@@ -220,10 +224,13 @@ module.exports = (envArgs) => {
   const enabledConfigName = Object.keys(envArgs).find(envName => envArgs[envName]);
   // Filter out config with name
   const enabledConfig = multiConfig.find(config => config.name === enabledConfigName);
+
   if (!enabledConfig) {
     console.error(`Couldn't find a valid config with the name "${enabledConfigName}". Known configs are: ${multiConfig.map(config => config.name).join(', ')}`);
     return;
   }
+
+  console.log('\nFound webpack -env args, only building for config name:', enabledConfigName, '\n')
 
   return [enabledConfig, demoConfig];
 };


### PR DESCRIPTION
### Description of the Changes

https://github.com/webpack/docs/wiki/optimization

This applies enthropy compression methods on webpack chunk IDs by selecting the short ones for the most occuring. It makes sense for distro build, but is unnecessary in dev where this demands additional processing.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
