### PR TITLE
Properly calculate the amount of sourcebuffers needed for streams with multiple non-alternate audio renditions

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -83,7 +83,7 @@ class BufferController extends EventHandler {
 
   onManifestParsed (data) {
     let audioExpected = data.audio,
-      videoExpected = data.video || (data.levels.length && data.audio),
+      videoExpected = data.video || (data.levels.length && data.altAudio),
       sourceBufferNb = 0;
     // in case of alt audio 2 BUFFER_CODECS events will be triggered, one per stream controller
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -35,7 +35,8 @@ class CapLevelController extends EventHandler {
   onManifestParsed (data) {
     const hls = this.hls;
     this.restrictedLevels = [];
-    if (hls.config.capLevelToPlayerSize) {
+    // Only fire getMaxLevel or detectPlayerSize if video is expected in the manifest
+    if (hls.config.capLevelToPlayerSize && (data.video || (data.levels.length && data.altAudio))) {
       this.autoLevelCapping = Number.POSITIVE_INFINITY;
       this.levels = data.levels;
       hls.firstLevel = this.getMaxLevel(data.firstLevel);

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -127,7 +127,7 @@ export default class LevelController extends EventHandler {
         stats: data.stats,
         audio: audioCodecFound,
         video: videoCodecFound,
-        altAudio: audioTracks.length > 0
+        altAudio: audioTracks.length > 0 && videoCodecFound
       });
     } else {
       this.hls.trigger(Event.ERROR, {

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -141,6 +141,12 @@ module.exports = {
   {
     widevineLicenseUrl: 'https://cwip-shaka-proxy.appspot.com/no_auth',
     emeEnabled: true
-  }
-  )
+  },
+  ),
+  audioOnlyMultipleLevels: {
+    'url': 'https://s3.amazonaws.com/bob.jwplayer.com/~alex/121628/new_master.m3u8',
+    'description': 'Multiple non-alternate audio levels',
+    'live': false,
+    'abr': false
+  },
 };

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -141,12 +141,12 @@ module.exports = {
   {
     widevineLicenseUrl: 'https://cwip-shaka-proxy.appspot.com/no_auth',
     emeEnabled: true
-  },
+  }
   ),
   audioOnlyMultipleLevels: {
     'url': 'https://s3.amazonaws.com/bob.jwplayer.com/~alex/121628/new_master.m3u8',
     'description': 'Multiple non-alternate audio levels',
     'live': false,
     'abr': false
-  },
+  }
 };


### PR DESCRIPTION
### Description of the Changes
This PR allows multiple audio tracks to be set without them being considered alternate audio tracks, which avoids miscalculation of the amount of sourcebuffers needed.

Resolves https://github.com/video-dev/hls.js/issues/1604, https://github.com/video-dev/hls.js/issues/1605

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
