### PR TITLE
Refactor timeline-controller to refer to 608/708 captions via name instead of number

### DIFF
--- a/src/utils/output-filter.js
+++ b/src/utils/output-filter.js
@@ -1,7 +1,7 @@
 export default class OutputFilter {
-  constructor (timelineController, track) {
+  constructor (timelineController, trackName) {
     this.timelineController = timelineController;
-    this.track = track;
+    this.trackName = trackName;
     this.startTime = null;
     this.endTime = null;
     this.screen = null;
@@ -11,7 +11,7 @@ export default class OutputFilter {
     if (this.startTime === null)
       return;
 
-    this.timelineController.addCues('textTrack' + this.track, this.startTime, this.endTime, this.screen);
+    this.timelineController.addCues(this.trackName, this.startTime, this.endTime, this.screen);
     this.startTime = null;
   }
 
@@ -21,6 +21,6 @@ export default class OutputFilter {
 
     this.endTime = endTime;
     this.screen = screen;
-    this.timelineController.createCaptionsTrack(this.track);
+    this.timelineController.createCaptionsTrack(this.trackName);
   }
 }


### PR DESCRIPTION
### This PR will...
- Refer to 608/708 captions by name (`textTrack1`) instead of number (`1`)
- Add captions to a new object instead of the timeline-controller prototype

### Why is this Pull Request needed?
- So that the code is simpler to read and modify. It is much more straightfoward to get the label/language of the captions track via property access rather than string concatenation (`captionsProperties.textTrack1.label` vs ` this.config['captionsTextTrack' + track + 'Label']`). 
- It's easier to read (and statically analyze) a class when all properties to be added to the prototype are initialized in the constructor.

### Are there any points in the code the reviewer needs to double check?
Did I miss any number instances?

### Resolves issues:
General tech debt

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
