### PR TITLE
Refactor checkbuffer

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1362,7 +1362,7 @@ class StreamController extends TaskLoop {
    */
   _checkBuffer () {
     const { config, media } = this;
-    if (!media || !media.readyState) {
+    if (!media || media.readyState === 0) {
       // Exit early if we don't have media or if the media hasn't bufferd anything yet (readyState 0)
       return;
     }
@@ -1526,8 +1526,8 @@ class StreamController extends TaskLoop {
   _tryNudgeBuffer () {
     const { config, hls, media } = this;
     const currentTime = media.currentTime;
-    let nudgeRetry = this.nudgeRetry || 0;
-    this.nudgeRetry = ++nudgeRetry;
+    const nudgeRetry = (this.nudgeRetry || 0) + 1;
+    this.nudgeRetry = nudgeRetry;
 
     if (nudgeRetry < config.nudgeMaxRetry) {
       const targetTime = currentTime + nudgeRetry * config.nudgeOffset;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1395,7 +1395,6 @@ class StreamController extends TaskLoop {
         // Allow some slack time to for small stalls to resolve themselves
         if (!this.stalled) {
           this.stalled = tnow;
-          this.stallReported = true;
           return;
         }
 
@@ -1452,16 +1451,15 @@ class StreamController extends TaskLoop {
     const currentTime = media.currentTime;
     const jumpThreshold = 0.5; // tolerance needed as some browsers stalls playback before reaching buffered range end
 
+    this._reportStall(bufferInfo.len);
     const partial = this.fragmentTracker.getPartialFragment(currentTime);
     if (partial) {
-      this._reportStall(bufferInfo.len);
       // Try to skip over the buffer hole caused by a partial fragment
       // This method isn't limited by the size of the gap between buffered ranges
       this._trySkipBufferHole(partial);
     }
 
     if (bufferInfo.len > jumpThreshold && stalledDuration > config.highBufferWatchdogPeriod * 1000) {
-      this._reportStall(bufferInfo.len);
       // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds
       // We only try to jump the hole if it's under the configured size
       // Reset stalled so to rearm watchdog timer

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1357,102 +1357,47 @@ class StreamController extends TaskLoop {
   }
 
   _checkBuffer () {
-    let media = this.media,
-      config = this.config;
-    // if ready state different from HAVE_NOTHING (numeric value 0), we are allowed to seek
-    if (media && media.readyState) {
-      let currentTime = media.currentTime,
-        mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media,
-        buffered = mediaBuffer.buffered;
-      // adjust currentTime to start position on loaded metadata
-      if (!this.loadedmetadata && buffered.length) {
-        this.loadedmetadata = true;
-        // only adjust currentTime if different from startPosition or if startPosition not buffered
-        // at that stage, there should be only one buffered range, as we reach that code after first fragment has been buffered
-        const startPosition = media.seeking ? currentTime : this.startPosition;
-        // if currentTime not matching with expected startPosition or startPosition not buffered but close to first buffered
-        if (currentTime !== startPosition) {
-          // if startPosition not buffered, let's seek to buffered.start(0)
+    const { config, media } = this;
+    if (!media || !media.readyState) {
+      // Exit early if we don't have media or if the media hasn't bufferd anything yet (readyState 0)
+      return;
+    }
 
-          logger.log(`target start position not buffered, seek to buffered.start(0) ${startPosition} from current time${currentTime} `);
-          media.currentTime = startPosition;
-        }
-      } else if (this.immediateSwitch) {
-        this.immediateLevelSwitchEnd();
-      } else {
-        let bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole),
-          expectedPlaying = !((media.paused && media.readyState > 1) || // not playing when media is paused and sufficiently buffered
-                                media.ended || // not playing when media is ended
-                                media.buffered.length === 0), // not playing if nothing buffered
-          jumpThreshold = 0.5, // tolerance needed as some browsers stalls playback before reaching buffered range end
-          playheadMoving = currentTime !== this.lastCurrentTime;
+    const currentTime = media.currentTime;
+    const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
+    const buffered = mediaBuffer.buffered;
 
-        if (playheadMoving) {
-          // played moving, but was previously stalled => now not stuck anymore
-          if (this.stallReported) {
-            logger.warn(`playback not stuck anymore @${currentTime}, after ${Math.round(performance.now() - this.stalled)}ms`);
-            this.stallReported = false;
-          }
-          this.stalled = undefined;
-          this.nudgeRetry = 0;
-        } else {
-          // playhead not moving
-          if (expectedPlaying) {
-            // playhead not moving BUT media expected to play
-            const tnow = performance.now();
-            const hls = this.hls;
-            if (!this.stalled) {
-              // stall just detected, store current time
-              this.stalled = tnow;
-              this.stallReported = false;
-            } else {
-              // playback already stalled, check stalling duration
-              // if stalling for more than a given threshold, let's try to recover
-              const stalledDuration = tnow - this.stalled;
-              const bufferLen = bufferInfo.len;
-              let nudgeRetry = this.nudgeRetry || 0;
-              // Check if fragment is broken
-              let partial = this.fragmentTracker.getPartialFragment(currentTime);
-              if (partial !== null) {
-                let lastEndTime = 0;
-                // Check if currentTime is between unbuffered regions of partial fragments
-                for (let i = 0; i < media.buffered.length; i++) {
-                  let startTime = media.buffered.start(i);
-                  if (currentTime >= lastEndTime && currentTime < startTime) {
-                    media.currentTime = Math.max(startTime, media.currentTime + 0.1);
-                    logger.warn(`skipping hole, adjusting currentTime from ${currentTime} to ${media.currentTime}`);
-                    this.stalled = undefined;
-                    hls.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.BUFFER_SEEK_OVER_HOLE, fatal: false, reason: `fragment loaded with buffer holes, seeking from ${currentTime} to ${media.currentTime}`, frag: partial });
-                    return;
-                  }
-                  lastEndTime = media.buffered.end(i);
-                }
-              }
-              if (bufferLen > jumpThreshold && stalledDuration > config.highBufferWatchdogPeriod * 1000) {
-                // report stalled error once
-                if (!this.stallReported) {
-                  this.stallReported = true;
-                  logger.warn(`playback stalling in high buffer @${currentTime}`);
-                  hls.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.BUFFER_STALLED_ERROR, fatal: false, buffer: bufferLen });
-                }
-                // reset stalled so to rearm watchdog timer
-                this.stalled = undefined;
-                this.nudgeRetry = ++nudgeRetry;
-                if (nudgeRetry < config.nudgeMaxRetry) {
-                  const currentTime = media.currentTime;
-                  const targetTime = currentTime + nudgeRetry * config.nudgeOffset;
-                  logger.log(`adjust currentTime from ${currentTime} to ${targetTime}`);
-                  // playback stalled in buffered area ... let's nudge currentTime to try to overcome this
-                  media.currentTime = targetTime;
-                  hls.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.BUFFER_NUDGE_ON_STALL, fatal: false });
-                } else {
-                  logger.error(`still stuck in high buffer @${currentTime} after ${config.nudgeMaxRetry}, raise fatal error`);
-                  hls.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.BUFFER_STALLED_ERROR, fatal: true });
-                }
-              }
-            }
-          }
+    if (!this.loadedmetadata && buffered.length) {
+      this.loadedmetadata = true;
+      this._seekToStartPos();
+    } else if (this.immediateSwitch) {
+      this.immediateLevelSwitchEnd();
+    } else {
+      const expectedPlaying = !((media.paused && media.readyState > 1) || // not playing when media is paused and sufficiently buffered
+        media.ended || // not playing when media is ended
+        media.buffered.length === 0); // not playing if nothing buffered
+      const tnow = performance.now();
+
+      if (currentTime !== this.lastCurrentTime) {
+        // The playhead is now moving, but was previously stalled
+        if (this.stallReported) {
+          logger.warn(`playback not stuck anymore @${currentTime}, after ${Math.round(tnow - this.stalled)}ms`);
+          this.stallReported = false;
         }
+        this.stalled = null;
+        this.nudgeRetry = 0;
+      } else if (expectedPlaying) {
+        // The playhead isn't moving but it should be
+        // Allow some slack time to for small stalls to resolve themselves
+        if (!this.stalled) {
+          this.stalled = tnow;
+          this.stallReported = true;
+          return;
+        }
+
+        const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
+        const stalledDuration = tnow - this.stalled;
+        this._tryFixBufferStall(bufferInfo, stalledDuration);
       }
     }
   }
@@ -1490,6 +1435,108 @@ class StreamController extends TaskLoop {
   computeLivePosition (sliding, levelDetails) {
     let targetLatency = this.config.liveSyncDuration !== undefined ? this.config.liveSyncDuration : this.config.liveSyncDurationCount * levelDetails.targetduration;
     return sliding + Math.max(0, levelDetails.totalduration - targetLatency);
+  }
+
+  _tryFixBufferStall (bufferInfo, stalledDuration) {
+    const { config, media } = this;
+    const currentTime = media.currentTime;
+    const jumpThreshold = 0.5; // tolerance needed as some browsers stalls playback before reaching buffered range end
+
+    const partial = this.fragmentTracker.getPartialFragment(currentTime);
+    if (partial) {
+      this._reportStall(bufferInfo.len);
+      // Try to skip over the buffer hole caused by a partial fragment
+      // This method isn't limited by the size of the gap between buffered ranges
+      this._trySkipBufferHole(partial);
+    }
+
+    if (bufferInfo.len > jumpThreshold && stalledDuration > config.highBufferWatchdogPeriod * 1000) {
+      this._reportStall(bufferInfo.len);
+      // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds
+      // We only try to jump the hole if it's under the configured size
+      // Reset stalled so to rearm watchdog timer
+      this.stalled = null;
+      this._tryNudgeBuffer();
+    }
+  }
+
+  _reportStall (bufferLen) {
+    const { hls, media, stallReported } = this;
+    if (!stallReported) {
+      // Report stalled error once
+      this.stallReported = true;
+      logger.warn(`Playback stalling at @${media.currentTime} due to low buffer`);
+      hls.trigger(Event.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_STALLED_ERROR,
+        fatal: false,
+        buffer: bufferLen
+      });
+    }
+  }
+
+  _trySkipBufferHole (partial) {
+    const { hls, media } = this;
+    const currentTime = media.currentTime;
+    let lastEndTime = 0;
+    // Check if currentTime is between unbuffered regions of partial fragments
+    for (let i = 0; i < media.buffered.length; i++) {
+      let startTime = media.buffered.start(i);
+      if (currentTime >= lastEndTime && currentTime < startTime) {
+        media.currentTime = Math.max(startTime, media.currentTime + 0.1);
+        logger.warn(`skipping hole, adjusting currentTime from ${currentTime} to ${media.currentTime}`);
+        this.stalled = null;
+        hls.trigger(Event.ERROR, {
+          type: ErrorTypes.MEDIA_ERROR,
+          details: ErrorDetails.BUFFER_SEEK_OVER_HOLE,
+          fatal: false,
+          reason: `fragment loaded with buffer holes, seeking from ${currentTime} to ${media.currentTime}`,
+          frag: partial
+        });
+        return;
+      }
+      lastEndTime = media.buffered.end(i);
+    }
+  }
+
+  _tryNudgeBuffer () {
+    const { config, hls, media } = this;
+    const currentTime = media.currentTime;
+    let nudgeRetry = this.nudgeRetry || 0;
+    this.nudgeRetry = ++nudgeRetry;
+
+    if (nudgeRetry < config.nudgeMaxRetry) {
+      const targetTime = currentTime + nudgeRetry * config.nudgeOffset;
+      logger.log(`adjust currentTime from ${currentTime} to ${targetTime}`);
+      // playback stalled in buffered area ... let's nudge currentTime to try to overcome this
+      media.currentTime = targetTime;
+      hls.trigger(Event.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_NUDGE_ON_STALL,
+        fatal: false
+      });
+    } else {
+      logger.error(`still stuck in high buffer @${currentTime} after ${config.nudgeMaxRetry}, raise fatal error`);
+      hls.trigger(Event.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_STALLED_ERROR,
+        fatal: true
+      });
+    }
+  }
+
+  _seekToStartPos () {
+    const { media } = this;
+    const currentTime = media.currentTime;
+    // only adjust currentTime if different from startPosition or if startPosition not buffered
+    // at that stage, there should be only one buffered range, as we reach that code after first fragment has been buffered
+    const startPosition = media.seeking ? currentTime : this.startPosition;
+    // if currentTime not matching with expected startPosition or startPosition not buffered but close to first buffered
+    if (currentTime !== startPosition) {
+      // if startPosition not buffered, let's seek to buffered.start(0)
+      logger.log(`target start position not buffered, seek to buffered.start(0) ${startPosition} from current time ${currentTime} `);
+      media.currentTime = startPosition;
+    }
   }
 
   get liveSyncPosition () {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -55,6 +55,7 @@ class StreamController extends TaskLoop {
     this.config = hls.config;
     this.audioCodecSwap = false;
     this._state = State.STOPPED;
+    this.stallReported = false;
   }
 
   onHandlerDestroying () {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1356,6 +1356,10 @@ class StreamController extends TaskLoop {
     return false;
   }
 
+  /**
+   * Checks the health of the buffer and attempts to resolve playback stalls.
+   * @private
+   */
   _checkBuffer () {
     const { config, media } = this;
     if (!media || !media.readyState) {
@@ -1437,6 +1441,12 @@ class StreamController extends TaskLoop {
     return sliding + Math.max(0, levelDetails.totalduration - targetLatency);
   }
 
+  /**
+   * Detects and attempts to fix known buffer stalling issues.
+   * @param bufferInfo - The properties of the current buffer.
+   * @param stalledDuration - The amount of time Hls.js has been stalling for.
+   * @private
+   */
   _tryFixBufferStall (bufferInfo, stalledDuration) {
     const { config, media } = this;
     const currentTime = media.currentTime;
@@ -1460,6 +1470,11 @@ class StreamController extends TaskLoop {
     }
   }
 
+  /**
+   * Triggers a BUFFER_STALLED_ERROR event, but only once per stall period.
+   * @param bufferLen - The playhead distance from the end of the current buffer segment.
+   * @private
+   */
   _reportStall (bufferLen) {
     const { hls, media, stallReported } = this;
     if (!stallReported) {
@@ -1475,6 +1490,11 @@ class StreamController extends TaskLoop {
     }
   }
 
+  /**
+   * Attempts to fix buffer stalls by jumping over known gaps caused by partial fragments
+   * @param partial - The partial fragment found at the current time (where playback is stalling).
+   * @private
+   */
   _trySkipBufferHole (partial) {
     const { hls, media } = this;
     const currentTime = media.currentTime;
@@ -1499,6 +1519,10 @@ class StreamController extends TaskLoop {
     }
   }
 
+  /**
+   * Attempts to fix buffer stalls by advancing the mediaElement's current time by a small amount.
+   * @private
+   */
   _tryNudgeBuffer () {
     const { config, hls, media } = this;
     const currentTime = media.currentTime;
@@ -1525,6 +1549,10 @@ class StreamController extends TaskLoop {
     }
   }
 
+  /**
+   * Seeks to the set startPosition if not equal to the mediaElement's current time.
+   * @private
+   */
   _seekToStartPos () {
     const { media } = this;
     const currentTime = media.currentTime;

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import StreamController from "../../../src/controller/stream-controller";
-import {FragmentTracker} from "../../../src/helper/fragment-tracker";
-import Hls from "../../../src/hls";
+import StreamController from '../../../src/controller/stream-controller';
+import { FragmentTracker } from '../../../src/helper/fragment-tracker';
+import Hls from '../../../src/hls';
 import Event from '../../../src/events';
 import { ErrorTypes, ErrorDetails } from '../../../src/errors';
 

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -1,0 +1,218 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import StreamController from "../../../src/controller/stream-controller";
+import {FragmentTracker} from "../../../src/helper/fragment-tracker";
+import Hls from "../../../src/hls";
+import Event from '../../../src/events';
+import { ErrorTypes, ErrorDetails } from '../../../src/errors';
+
+describe('checkBuffer', function () {
+  let streamController;
+  let config;
+  let media;
+  let triggerSpy;
+  beforeEach(function () {
+    media = document.createElement('video');
+    const hls = new Hls({});
+    const fragmentTracker = new FragmentTracker(hls);
+    streamController = new StreamController(hls, fragmentTracker);
+    streamController.media = media;
+    config = hls.config;
+    triggerSpy = sinon.spy(hls, 'trigger');
+  });
+
+  describe('_tryNudgeBuffer', function () {
+    it('should increment the currentTime by a multiple of nudgeRetry and the configured nudge amount', function () {
+      for (let i = 1; i < config.nudgeMaxRetry; i++) {
+        let expected = media.currentTime + (i * config.nudgeOffset);
+        streamController._tryNudgeBuffer();
+        assert.equal(expected, media.currentTime);
+      }
+      assert(triggerSpy.alwaysCalledWith(Event.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_NUDGE_ON_STALL,
+        fatal: false
+      }));
+    });
+
+    it('should not increment the currentTime if the max amount of nudges has been attempted', function () {
+      config.nudgeMaxRetry = 0;
+      streamController._tryNudgeBuffer();
+      assert.equal(0, media.currentTime);
+      assert(triggerSpy.calledWith(Event.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_STALLED_ERROR,
+        fatal: true
+      }));
+    });
+  });
+
+  describe('_reportStall', function () {
+    it('should report a stall with the current buffer length if it has not already been reported', function () {
+      streamController._reportStall(42);
+      assert(triggerSpy.calledWith(Event.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_STALLED_ERROR,
+        fatal: false,
+        buffer: 42
+      }));
+    });
+
+    it('should not report a stall if it was already reported', function () {
+      streamController.stallReported = true;
+      streamController._reportStall(42);
+      assert(triggerSpy.notCalled);
+    });
+  });
+
+  describe('_tryFixBufferStall', function () {
+    let reportStallSpy;
+    beforeEach(function () {
+      reportStallSpy = sinon.spy(streamController, '_reportStall');
+    });
+
+    it('should nudge when stalling close to the buffer end', function () {
+      const mockBufferInfo = { len: 1 };
+      const mockStallDuration = (config.highBufferWatchdogPeriod + 1) * 1000;
+      const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
+      streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
+      assert(nudgeStub.calledOnce);
+      assert(reportStallSpy.calledOnce);
+    });
+
+    it('should not nudge when briefly stalling close to the buffer end', function () {
+      const mockBufferInfo = { len: 1 };
+      const mockStallDuration = (config.highBufferWatchdogPeriod / 2) * 1000;
+      const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
+      streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
+      assert(nudgeStub.notCalled);
+      assert(reportStallSpy.notCalled);
+    });
+
+    it('should not nudge when too far from the buffer end', function () {
+      const mockBufferInfo = { len: 0.25 };
+      const mockStallDuration = (config.highBufferWatchdogPeriod + 1) * 1000;
+      const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
+      streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
+      assert(nudgeStub.notCalled);
+      assert(reportStallSpy.notCalled);
+    });
+
+    it('should try to jump partial fragments when detected', function () {
+      sinon.stub(streamController.fragmentTracker, 'getPartialFragment').returns({});
+      const skipHoleStub = sinon.stub(streamController, '_trySkipBufferHole');
+      streamController._tryFixBufferStall({ len: 0 });
+      assert(skipHoleStub.calledOnce);
+      assert(reportStallSpy.calledOnce);
+    });
+
+    it('should not try to jump partial fragments when none are detected', function () {
+      sinon.stub(streamController.fragmentTracker, 'getPartialFragment').returns(null);
+      const skipHoleStub = sinon.stub(streamController, '_trySkipBufferHole');
+      streamController._tryFixBufferStall({ len: 0 });
+      assert(skipHoleStub.notCalled);
+      assert(reportStallSpy.notCalled);
+    });
+  });
+
+  describe('_seekToStartPos', function () {
+    it('should seek to startPosition when startPosition is not buffered & the media is not seeking', function () {
+      streamController.startPosition = 5;
+      streamController._seekToStartPos();
+      assert(5, media.currentTime);
+    });
+
+    it('should not seek to startPosition when it is buffered', function () {
+      streamController.startPosition = 5;
+      media.currentTime = 5;
+      streamController._seekToStartPos();
+      assert(5, media.currentTime);
+    });
+  });
+
+  describe('_checkBuffer', function () {
+    let mockMedia;
+    beforeEach(function () {
+      mockMedia = {
+        readyState: 1,
+        buffered: {
+          length: 1
+        }
+      };
+      streamController.media = mockMedia;
+    });
+
+    function setExpectedPlaying () {
+      mockMedia.paused = false;
+      mockMedia.readyState = 4;
+      mockMedia.currentTime = 4;
+      streamController.lastCurrentTime = 4;
+    }
+
+    it('should not throw when media is undefined', function () {
+      streamController.media = null;
+      streamController._checkBuffer();
+    });
+
+    it('should seek to start pos when metadata has not yet been loaded', function () {
+      const seekStub = sinon.stub(streamController, '_seekToStartPos');
+      streamController._checkBuffer();
+      assert(seekStub.calledOnce);
+      assert(streamController.loadedmetadata);
+    });
+
+    it('should not seek to start pos when metadata has been loaded', function () {
+      const seekStub = sinon.stub(streamController, '_seekToStartPos');
+      streamController.loadedmetadata = true;
+      streamController._checkBuffer();
+      assert(seekStub.notCalled);
+      assert(streamController.loadedmetadata);
+    });
+
+    it('should not seek to start pos when nothing has been buffered', function () {
+      const seekStub = sinon.stub(streamController, '_seekToStartPos');
+      mockMedia.buffered.length = 0;
+      streamController._checkBuffer();
+      assert(seekStub.notCalled);
+      assert.equal(streamController.loadedmetadata, undefined);
+    });
+
+    it('should complete the immediate switch if signalled', function () {
+      const levelSwitchStub = sinon.stub(streamController, 'immediateLevelSwitchEnd');
+      streamController.loadedmetadata = true;
+      streamController.immediateSwitch = true;
+      streamController._checkBuffer();
+      assert(levelSwitchStub.called);
+    });
+
+    it('should try to fix a stall if expected to be playing', function () {
+      streamController.loadedmetadata = true;
+      streamController.immediateSwitch = false;
+      const fixStallStub = sinon.stub(streamController, '_tryFixBufferStall');
+      setExpectedPlaying();
+      streamController._checkBuffer();
+
+      // The first _checkBuffer call made while stalling just sets stall flags
+      assert.equal(typeof streamController.stalled, 'number');
+      assert(streamController.stallReported);
+
+      streamController._checkBuffer();
+      assert(fixStallStub.calledOnce);
+    });
+
+    it('should reset stall flags when no longer stalling', function () {
+      streamController.loadedmetadata = true;
+      streamController.stallReported = true;
+      streamController.nudgeRetry = 1;
+      streamController.stalled = 4200;
+      streamController.lastCurrentTime = 1;
+      const fixStallStub = sinon.stub(streamController, '_tryFixBufferStall');
+      streamController._checkBuffer();
+
+      assert.equal(streamController.stalled, null);
+      assert.equal(streamController.nudgeRetry, 0);
+      assert.equal(streamController.stallReported, false);
+      assert(fixStallStub.notCalled);
+    });
+  });
+});

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -119,14 +119,14 @@ describe('checkBuffer', function () {
     it('should seek to startPosition when startPosition is not buffered & the media is not seeking', function () {
       streamController.startPosition = 5;
       streamController._seekToStartPos();
-      assert(5, media.currentTime);
+      assert.equal(5, media.currentTime);
     });
 
     it('should not seek to startPosition when it is buffered', function () {
       streamController.startPosition = 5;
       media.currentTime = 5;
       streamController._seekToStartPos();
-      assert(5, media.currentTime);
+      assert.equal(5, media.currentTime);
     });
   });
 

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -26,7 +26,7 @@ describe('checkBuffer', function () {
       for (let i = 1; i < config.nudgeMaxRetry; i++) {
         let expected = media.currentTime + (i * config.nudgeOffset);
         streamController._tryNudgeBuffer();
-        assert.equal(expected, media.currentTime);
+        assert.strictEqual(expected, media.currentTime);
       }
       assert(triggerSpy.alwaysCalledWith(Event.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
@@ -38,7 +38,7 @@ describe('checkBuffer', function () {
     it('should not increment the currentTime if the max amount of nudges has been attempted', function () {
       config.nudgeMaxRetry = 0;
       streamController._tryNudgeBuffer();
-      assert.equal(0, media.currentTime);
+      assert.strictEqual(0, media.currentTime);
       assert(triggerSpy.calledWith(Event.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_STALLED_ERROR,
@@ -119,14 +119,14 @@ describe('checkBuffer', function () {
     it('should seek to startPosition when startPosition is not buffered & the media is not seeking', function () {
       streamController.startPosition = 5;
       streamController._seekToStartPos();
-      assert.equal(5, media.currentTime);
+      assert.strictEqual(5, media.currentTime);
     });
 
     it('should not seek to startPosition when it is buffered', function () {
       streamController.startPosition = 5;
       media.currentTime = 5;
       streamController._seekToStartPos();
-      assert.equal(5, media.currentTime);
+      assert.strictEqual(5, media.currentTime);
     });
   });
 
@@ -174,7 +174,7 @@ describe('checkBuffer', function () {
       mockMedia.buffered.length = 0;
       streamController._checkBuffer();
       assert(seekStub.notCalled);
-      assert.equal(streamController.loadedmetadata, undefined);
+      assert.strictEqual(streamController.loadedmetadata, undefined);
     });
 
     it('should complete the immediate switch if signalled', function () {
@@ -193,7 +193,7 @@ describe('checkBuffer', function () {
       streamController._checkBuffer();
 
       // The first _checkBuffer call made while stalling just sets stall flags
-      assert.equal(typeof streamController.stalled, 'number');
+      assert.strictEqual(typeof streamController.stalled, 'number');
       assert(streamController.stallReported);
 
       streamController._checkBuffer();
@@ -209,9 +209,9 @@ describe('checkBuffer', function () {
       const fixStallStub = sinon.stub(streamController, '_tryFixBufferStall');
       streamController._checkBuffer();
 
-      assert.equal(streamController.stalled, null);
-      assert.equal(streamController.nudgeRetry, 0);
-      assert.equal(streamController.stallReported, false);
+      assert.strictEqual(streamController.stalled, null);
+      assert.strictEqual(streamController.nudgeRetry, 0);
+      assert.strictEqual(streamController.stallReported, false);
       assert(fixStallStub.notCalled);
     });
   });

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -86,7 +86,7 @@ describe('checkBuffer', function () {
       const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
       streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
       assert(nudgeStub.notCalled);
-      assert(reportStallSpy.notCalled);
+      assert(reportStallSpy.calledOnce);
     });
 
     it('should not nudge when too far from the buffer end', function () {
@@ -95,7 +95,7 @@ describe('checkBuffer', function () {
       const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
       streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
       assert(nudgeStub.notCalled);
-      assert(reportStallSpy.notCalled);
+      assert(reportStallSpy.calledOnce);
     });
 
     it('should try to jump partial fragments when detected', function () {
@@ -111,7 +111,7 @@ describe('checkBuffer', function () {
       const skipHoleStub = sinon.stub(streamController, '_trySkipBufferHole');
       streamController._tryFixBufferStall({ len: 0 });
       assert(skipHoleStub.notCalled);
-      assert(reportStallSpy.notCalled);
+      assert(reportStallSpy.calledOnce);
     });
   });
 
@@ -194,7 +194,7 @@ describe('checkBuffer', function () {
 
       // The first _checkBuffer call made while stalling just sets stall flags
       assert.strictEqual(typeof streamController.stalled, 'number');
-      assert(streamController.stallReported);
+      assert.equal(streamController.stallReported, false);
 
       streamController._checkBuffer();
       assert(fixStallStub.calledOnce);


### PR DESCRIPTION
### This PR will...
- Break some `_checkBuffer()` functionality into 4 new functions: `_tryFixStall()`, `_reportStall()`, `_tryNudgeBuffer()`, and `_trySkipBufferHole` 
- Unit test each component & control flow through `checkBuffer()` itself
- **Change**: Always emit a stall event when stalling (this was the behavior before fragment tracker; was changed to only trigger on high buffer stalling afterwards)

### Why is this Pull Request needed?
- `checkBuffer()` is currently large, hard to understand, and not well tested. Refactoring helps readability and allows us to unit test the individual functionality it comprises. Test coverage is up a few percentage points with this PR.
- Not always emitting a stalling event breaks JW's integration. But I think this is also a wider regression. If you hit the edge of a live stream no stall event will be emitted.

### Are there any points in the code the reviewer needs to double check?
Did I break any existing functionality in my refactor?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
