### PR TITLE
Fix Getting Started Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ hls.js is written in [ECMAScript6], and transpiled in ECMAScript5 using [Babel].
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
 <video id="video"></video>
 <script>
+  var video = document.getElementById('video');
   if(Hls.isSupported()) {
-    var video = document.getElementById('video');
     var hls = new Hls();
     hls.loadSource('https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8');
     hls.attachMedia(video);

--- a/docs/API.md
+++ b/docs/API.md
@@ -150,8 +150,8 @@ Let's
 
   <video id="video"></video>
   <script>
+    var video = document.getElementById('video');
     if (Hls.isSupported()) {
-      var video = document.getElementById('video');
       var hls = new Hls();
       // bind them together
       hls.attachMedia(video);

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -149,8 +149,8 @@ hls.js also supports HLS + fmp4, as announced during <a href="https://developer.
 <h2 id="getting-started">Getting Started</h2><pre><code class="lang-html"><code class="source-code prettyprint">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/hls.js@latest&quot;&gt;&lt;/script&gt;
 &lt;video id=&quot;video&quot;&gt;&lt;/video&gt;
 &lt;script&gt;
+  var video = document.getElementById(&apos;video&apos;);
   if(Hls.isSupported()) {
-    var video = document.getElementById(&apos;video&apos;);
     var hls = new Hls();
     hls.loadSource(&apos;https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8&apos;);
     hls.attachMedia(video);


### PR DESCRIPTION
### Closes https://github.com/video-dev/hls.js/issues/1674

<img width="1669" alt="cursor_and_home___hls_js" src="https://user-images.githubusercontent.com/7291189/38950347-cb3a589c-430a-11e8-838a-f36326e0dc92.png">
In the Getting Started documentation, it initializes a `video` variable inside the `if` block then references that variable in the `else if` block. The `video` variable wouldn't be available in the `else if` block.
Move the `video` variable initialization to outside the `if` block so it can be used in both blocks. 