### PR TITLE
Fixed unsynced subtitles for stream with SSAI

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -59,7 +59,7 @@ const calculateOffset = function (vttCCs, cc, presentationTime) {
 };
 
 const WebVTTParser = {
-  parse: function (vttByteArray, syncPTS, vttCCs, cc, callBack, errorCallBack) {
+  parse: function (vttByteArray, initPTS, vttCCs, cc, callBack, errorCallBack) {
     // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
     let re = /\r\n|\n\r|\n|\r/g;
     // Uint8Array.prototype.reduce is not implemented in IE11
@@ -139,6 +139,17 @@ const WebVTTParser = {
             }
           });
           try {
+            let syncPTS = initPTS;
+            // Set syncPTS to the first mpegTS value available for each discontinuity
+            // or initPTS if mpegTS isn't available
+            let currCC = vttCCs[cc];
+            if (mpegTs && currCC.syncPTS === undefined) {
+              currCC.syncPTS = mpegTs;
+            }
+            if (currCC.syncPTS !== undefined) {
+              syncPTS = currCC.syncPTS;
+            }
+
             // Calculate subtitle offset in milliseconds.
             // If sync PTS is less than zero, we have a 33-bit wraparound, which is fixed by adding 2^33 = 8589934592.
             syncPTS = syncPTS < 0 ? syncPTS + 8589934592 : syncPTS;

--- a/tests/unit/utils/webvtt-parser.js
+++ b/tests/unit/utils/webvtt-parser.js
@@ -1,0 +1,80 @@
+let assert = require('assert');
+import WebVTTParser from '../../../src/utils/webvtt-parser';
+
+const parse = function (webVttString, initPTS, fragStart) {
+  const enc = new TextEncoder('utf-8');
+  let result;
+
+  let vttByteArray = enc.encode(webVttString.split('\n').map(s => s.trim()).join('\n'));
+
+  const vttCCs = { ccOffset: 0, presentationOffset: 0 };
+  const cc = 0;
+  vttCCs[cc] = { start: fragStart || 0, prevCC: -1, new: true };
+
+  WebVTTParser.parse(vttByteArray, initPTS, vttCCs, cc, function (cues) {
+    result = cues;
+  }, function (e) {
+    result = e;
+  });
+
+  return result;
+};
+
+describe('WebVTTParser', function () {
+  it('can parse webvtt without X-TIMESTAMP-MAP', () => {
+    const vtt = `WEBVTT
+
+                 00:01.000 --> 00:04.000
+                 Never drink liquid nitrogen.`;
+
+    const cues = parse(vtt, 0);
+    assert.equal(1, cues.length);
+
+    const cue = cues[0];
+    assert.equal(cue.startTime, 1);
+    assert.equal(cue.endTime, 4);
+    assert.equal(cue.text, 'Never drink liquid nitrogen.');
+  });
+
+  it('can parse webvtt with X-TIMESTAMP-MAP', () => {
+    const vtt = `WEBVTT
+                 X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
+
+                 00:01.000 --> 00:04.000
+                 Never drink liquid nitrogen.`;
+
+    const cues = parse(vtt, 900000);
+    assert.equal(1, cues.length);
+
+    const cue = cues[0];
+    assert.equal(cue.startTime, 1);
+    assert.equal(cue.endTime, 4);
+    assert.equal(cue.text, 'Never drink liquid nitrogen.');
+  });
+
+  it('can handle this webvtt from yospace after ads', () => {
+    const vtt = `WEBVTT
+                 X-TIMESTAMP-MAP=MPEGTS:2250000,LOCAL:00:00:00.000
+
+                 00:00:00.000 --> 00:00:02.080
+                 Här har vi text
+
+                 00:00:02.240 --> 00:00:03.000
+                 –Där någon säger saker
+                 –Men det betyder inget`;
+
+    const initPTS = 126000;
+    const discontinoutyStart = 21;
+
+    const cues = parse(vtt, initPTS, discontinoutyStart);
+    assert.equal(2, cues.length);
+
+    assert.equal(cues[0].startTime, discontinoutyStart);
+    assert.equal(cues[0].endTime, discontinoutyStart + 2.08);
+    assert.equal(cues[0].text, 'Här har vi text');
+
+    assert.equal(cues[1].startTime, discontinoutyStart + 2.240);
+    assert.equal(cues[1].endTime, discontinoutyStart + 3.0);
+    assert.equal(cues[1].text, '–Där någon säger saker\n–Men det betyder inget');
+  });
+});


### PR DESCRIPTION
### This PR will...
If `X-TIMESTAMP-MAP` with `MPEGTS` is provided in webvtts the first available MPEGTS in a discontinuity will be used as syncPTS.

### Why is this Pull Request needed?
For Yospace streams, using SSAI, subtitles did not show correctly due to the webvtt-parser only syncing to the first PTS found which after discontinuities can be very different.

The first webvtt in the stream
```
WEBVTT
X-TIMESTAMP-MAP=MPEGTS:126000, LOCAL:00:00:00.000


1
00:00:00.000 --> 00:00:00.010 line:0%
&nbsp;
```

The first webvtt after ads
```
WEBVTT
X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000

```

### Resolves issues:
I believe it should resolve: https://github.com/video-dev/hls.js/issues/1159 ( but was unable to test their stream )
I also believe it should be more accurate than https://github.com/video-dev/hls.js/pull/1531

### Checklist
- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md

I used @carlanton unit test in https://github.com/video-dev/hls.js/pull/1576 to make my own test, should cause less merge issues than creating my own thing.
The test on line 55 fails without this PR and with this PR it passes.

Teststream can be provided via. PM, if needed we'll try to provide a stream we can make public.
