### PR TITLE
Change example to use 'loadedmetadata' event rather than 'canplay' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ hls.js is written in [ECMAScript6], and transpiled in ECMAScript5 using [Babel].
  // hls.js is not supported on platforms that do not have Media Source Extensions (MSE) enabled.
  // When the browser has built-in HLS support (check using `canPlayType`), we can provide an HLS manifest (i.e. .m3u8 URL) directly to the video element throught the `src` property.
  // This is using the built-in support of the plain video element, without using hls.js.
+ // Note: it would be more normal to wait on the 'canplay' event below however on Safari (where you are most likely to find built-in HLS support) the video.src URL must be on the user-driven
+ // white-list before a 'canplay' event will be emitted; the last video event that can be reliably listened-for when the URL is not on the white-list is 'loadedmetadata'.
   else if (video.canPlayType('application/vnd.apple.mpegurl')) {
     video.src = 'https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8';
-    video.addEventListener('canplay',function() {
+    video.addEventListener('loadedmetadata',function() {
       video.play();
     });
   }


### PR DESCRIPTION
### This PR will...
Change the example code for the case where MSE is not supported to use the `loadedmetadata` event rather than the `canplay` event.

### Why is this Pull Request needed?
The most likely situation where MSE is not supported but HLS is natively supported is with Safari and, since September 17, Safari only emits the `canplay` event if the URL is in the user-controlled white-list, hence the example code as it stands would not work.

### Are there any points in the code the reviewer needs to double check?
Use of English.

### Resolves issues:
#1686 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
