### PR TITLE
Resolve partial frag loop loading

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -34,6 +34,7 @@ class AbrController extends EventHandler {
     let frag = data.frag;
     if (frag.type === 'main') {
       if (!this.timer) {
+        this.fragCurrent = frag;
         this.timer = setInterval(this.onCheck, 100);
       }
 
@@ -55,7 +56,6 @@ class AbrController extends EventHandler {
         }
         this._bwEstimator = new EwmaBandWidthEstimator(hls, ewmaSlow, ewmaFast, config.abrEwmaDefaultEstimate);
       }
-      this.fragCurrent = frag;
     }
   }
 
@@ -65,7 +65,11 @@ class AbrController extends EventHandler {
       we compute expected time of arrival of the complete fragment.
       we compare it to expected time of buffer starvation
     */
-    let hls = this.hls, v = hls.media, frag = this.fragCurrent, loader = frag.loader, minAutoLevel = hls.minAutoLevel;
+    const hls = this.hls;
+    const v = hls.media;
+    const frag = this.fragCurrent;
+    const minAutoLevel = hls.minAutoLevel;
+    const loader = frag.loader;
 
     // if loader has been destroyed or loading has been aborted, stop timer and return
     if (!loader || (loader.stats && loader.stats.aborted)) {

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -324,7 +324,7 @@ class AudioStreamController extends TaskLoop {
         }
         if (frag) {
           // logger.log('      loading frag ' + i +',pos/bufEnd:' + pos.toFixed(3) + '/' + bufferEnd.toFixed(3));
-          if (frag.decryptdata && (frag.decryptdata.uri != null) && (frag.decryptdata.key == null)) {
+          if (frag.encrypted) {
             logger.log(`Loading key for ${frag.sn} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}`);
             this.state = State.KEY_LOADING;
             hls.trigger(Event.KEY_LOADING, { frag: frag });

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -542,7 +542,7 @@ class StreamController extends TaskLoop {
       }
 
       // Allow backtracked fragments to load
-      if (frag.backtracked || fragState === FragmentState.NOT_LOADED) {
+      if (frag.backtracked || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
         frag.autoLevel = this.hls.autoLevelEnabled;
         frag.bitrateTest = this.bitrateTest;
 
@@ -1167,9 +1167,9 @@ class StreamController extends TaskLoop {
           if (!frag.backtracked) {
             const levelDetails = level.details;
             if (levelDetails && frag.sn === levelDetails.startSN) {
-              logger.warn('missing video frame(s) on first frag, appending with gap');
+              logger.warn('missing video frame(s) on first frag, appending with gap', frag.sn);
             } else {
-              logger.warn('missing video frame(s), backtracking fragment');
+              logger.warn('missing video frame(s), backtracking fragment', frag.sn);
               // Return back to the IDLE state without appending to buffer
               // Causes findFragments to backtrack a segment and find the keyframe
               // Audio fragments arriving before video sets the nextLoadPosition, causing _findFragments to skip the backtracked fragment
@@ -1182,7 +1182,7 @@ class StreamController extends TaskLoop {
               return;
             }
           } else {
-            logger.warn('Already backtracked on this fragment, appending with the gap');
+            logger.warn('Already backtracked on this fragment, appending with the gap', frag.sn);
           }
         } else {
           // Only reset the backtracked flag if we've loaded the frag without any dropped frames

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -307,7 +307,7 @@ class StreamController extends TaskLoop {
     }
 
     if (frag) {
-      if (frag.keyLoadNeeded) {
+      if (frag.encrypted) {
         logger.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}`);
         this._loadKey(frag);
       } else {

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -125,7 +125,7 @@ class SubtitleStreamController extends TaskLoop {
       trackDetails.fragments.forEach(frag => {
         if (!(alreadyProcessed(frag) || frag.sn === currentFragSN || alreadyInQueue(frag))) {
           // Load key if subtitles are encrypted
-          if ((frag.decryptdata && frag.decryptdata.uri != null) && (frag.decryptdata.key == null)) {
+          if (frag.encrypted) {
             logger.log(`Loading key for ${frag.sn}`);
             this.state = State.KEY_LOADING;
             this.hls.trigger(Event.KEY_LOADING, { frag: frag });

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -92,8 +92,8 @@ export default class Fragment {
     return this._decryptdata;
   }
 
-  get keyLoadNeeded() {
-    return (this.decryptdata && this.decryptdata.uri != null) && (this.decryptdata.key == null);
+  get encrypted () {
+    return !!((this.decryptdata && this.decryptdata.uri !== null) && (this.decryptdata.key === null));
   }
 
   /**

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -92,6 +92,10 @@ export default class Fragment {
     return this._decryptdata;
   }
 
+  get keyLoadNeeded() {
+    return (this.decryptdata && this.decryptdata.uri != null) && (this.decryptdata.key == null);
+  }
+
   /**
    * @param {ElementaryStreamType} type
    */

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -2,23 +2,20 @@ import assert from 'assert';
 import sinon from 'sinon';
 import Hls from '../../../src/hls';
 import Event from '../../../src/events';
-import { FragmentTracker } from '../../../src/controller/fragment-tracker';
+import { FragmentTracker, FragmentState } from '../../../src/controller/fragment-tracker';
 import StreamController, { State } from '../../../src/controller/stream-controller';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
+import Fragment from '../../../src/loader/fragment';
 
 describe('StreamController tests', function () {
-  /**
-   * Create StreamController instance with initial setting
-   * @returns {{hls: Hls, streamController: StreamController}}
-   */
-  const createStreamController = () => {
-    const hls = new Hls({});
-    const fragmentTracker = new FragmentTracker(hls);
-    return {
-      hls,
-      streamController: new StreamController(hls, fragmentTracker)
-    };
-  };
+  let hls;
+  let fragmentTracker;
+  let streamController;
+  beforeEach(function () {
+    hls = new Hls({});
+    fragmentTracker = new FragmentTracker(hls);
+    streamController = new StreamController(hls, fragmentTracker);
+  });
 
   /**
    * Assert: streamController should be started
@@ -40,12 +37,10 @@ describe('StreamController tests', function () {
 
   describe('StreamController', function () {
     it('should be STOPPED when it is initialized', function () {
-      const { streamController } = createStreamController();
       assertStreamControllerStopped(streamController);
     });
 
     it('should trigger STREAM_STATE_TRANSITION when state is updated', function () {
-      const { hls, streamController } = createStreamController();
       const spy = sinon.spy();
       hls.on(Event.STREAM_STATE_TRANSITION, spy);
       streamController.state = State.ENDED;
@@ -53,7 +48,6 @@ describe('StreamController tests', function () {
     });
 
     it('should not trigger STREAM_STATE_TRANSITION when state is not updated', function () {
-      const { hls, streamController } = createStreamController();
       const spy = sinon.spy();
       hls.on(Event.STREAM_STATE_TRANSITION, spy);
       // no update
@@ -62,13 +56,11 @@ describe('StreamController tests', function () {
     });
 
     it('should not start when controller have not levels data', function () {
-      const { streamController } = createStreamController();
       streamController.startLoad(1);
       assertStreamControllerStopped(streamController);
     });
 
     it('should start when controller have levels data', function () {
-      const { streamController } = createStreamController();
       const manifest = `#EXTM3U
   #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=836280,RESOLUTION=848x360,NAME="480"
   http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core`;
@@ -169,6 +161,7 @@ describe('StreamController tests', function () {
       assert.equal(foundFragment, fragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
+    // TODO: This test fails if using a real instance of Hls
     it('SN search choosing the right segment if fragPrevious is not available', function () {
       let config = {};
       let hls = {
@@ -179,91 +172,49 @@ describe('StreamController tests', function () {
 
       let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragment(0, null, fragLen, fragments, bufferEnd, end, levelDetails);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after level loaded', function () {
-      let config = {};
-      let hls = {
-        config: config,
-        on: function () {}
-      };
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
 
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after starting/seeking to a new position (bufferEnd used)', function () {
-      let config = {};
-      let hls = {
-        config: config,
-        on: function () {}
-      };
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
       let mediaSeekingTime = 17.00;
 
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragment(0, null, fragLen, fragments, mediaSeekingTime, end, levelDetails);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT serch hitting empty discontinuity', function () {
-      let config = {};
-      let hls = {
-        config: config,
-        on: function () {}
-      };
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
       let discontinuityPDTHit = 6.00;
 
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragment(0, null, fragLen, fragments, discontinuityPDTHit, end, levelDetails);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[1], 'Expected sn 1, found sn segment ' + resultSN);
     });
 
     it('Unit test _findFragmentBySN', function () {
-      let config = { };
-      let hls = {
-        config: config,
-        on: function () {}
-      };
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragmentBySN(fragPrevious, fragments, bufferEnd, end);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
     it('Unit test _findFragmentByPDT usual behaviour', function () {
-      let config = { };
-      let hls = {
-        config: config,
-        on: function () {}
-      };
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragmentByPDT(fragments, fragPrevious.endPdt + 1);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('Unit test _findFragmentByPDT beyond limits', function () {
-      let config = { };
-      let hls = {
-        config: config,
-        on: function () {}
-      };
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragmentByPDT(fragments, fragments[0].pdt - 1);
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
@@ -274,29 +225,70 @@ describe('StreamController tests', function () {
     });
 
     it('Unit test _findFragmentByPDT at the beginning', function () {
-      let config = { };
-      let hls = {
-        config: config,
-        on: function () {}
-      };
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragmentByPDT(fragments, fragments[0].pdt);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[0], 'Expected sn 0, found sn segment ' + resultSN);
     });
 
     it('Unit test _findFragmentByPDT for last segment', function () {
-      let config = { };
-      let hls = {
-        config: config,
-        on: function () {}
-      };
-      let streamController = new StreamController(hls);
       let foundFragment = streamController._findFragmentByPDT(fragments, fragments[fragments.length - 1].pdt);
-
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, fragments[4], 'Expected sn 4, found sn segment ' + resultSN);
+    });
+  });
+
+  describe('fragment loading', function () {
+    function fragStateStub (state) {
+      return sinon.stub(fragmentTracker, 'getState').callsFake(() => state);
+    }
+
+    let triggerSpy;
+    let frag;
+    beforeEach(function () {
+      triggerSpy = sinon.spy(hls, 'trigger');
+      frag = new Fragment();
+    });
+
+    function assertLoadingState (frag) {
+      assert(triggerSpy.calledWith(Event.FRAG_LOADING, { frag }),
+        `Was expecting trigger to be called with FRAG_LOADING, but received ${triggerSpy.notCalled ? 'no calls' : triggerSpy.getCalls()}`);
+      assert.strictEqual(streamController.state, State.FRAG_LOADING);
+    }
+
+    function assertNotLoadingState() {
+      assert(triggerSpy.notCalled);
+      assert(hls.state !== State.FRAG_LOADING);
+    }
+
+    it('should load a complete fragment which has not been previously appended', function () {
+      fragStateStub(FragmentState.NOT_LOADED);
+      streamController._loadFragment(frag);
+      assertLoadingState(frag);
+    });
+
+    it('should load a partial fragment', function () {
+      fragStateStub(FragmentState.PARTIAL);
+      streamController._loadFragment(frag);
+      assertLoadingState(frag);
+    });
+
+    it('should load a frag which has backtracked', function () {
+      fragStateStub(FragmentState.OK);
+      frag.backtracked = true;
+      streamController._loadFragment(frag);
+      assertLoadingState(frag);
+    });
+
+    it('should not load a fragment which has completely & successfully loaded', function () {
+      fragStateStub(FragmentState.OK);
+      streamController._loadFragment(frag);
+      assertNotLoadingState();
+    });
+
+    it('should not load a fragment while it is appending', function () {
+      fragStateStub(FragmentState.APPENDING);
+      streamController._loadFragment(frag);
+      assertNotLoadingState();
     });
   });
 });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -255,7 +255,7 @@ describe('StreamController tests', function () {
       assert.strictEqual(streamController.state, State.FRAG_LOADING);
     }
 
-    function assertNotLoadingState() {
+    function assertNotLoadingState () {
       assert(triggerSpy.notCalled);
       assert(hls.state !== State.FRAG_LOADING);
     }

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -1,0 +1,41 @@
+import Fragment from '../../../src/loader/fragment';
+import assert from 'assert';
+
+describe('Fragment tests', function () {
+  describe('get keyLoadNeeded', function () {
+    it('returns true if the fragment needs to be decrypted', function () {
+      const frag = new Fragment();
+      frag._decryptdata = {
+        uri: 'foo.bar',
+        key: null
+      };
+
+      assert(frag.encrypted);
+    });
+
+    it('returns false if the key uri is null', function () {
+      const frag = new Fragment();
+      frag._decryptdata = {
+        uri: null,
+        key: null
+      };
+
+      assert.strictEqual(frag.encrypted, false);
+    });
+
+    it('returns false if the frag has already been decrypted', function () {
+      const frag = new Fragment();
+      frag._decryptdata = {
+        uri: 'foo.bar',
+        key: 'foo'
+      };
+
+      assert.strictEqual(frag.encrypted, false);
+    });
+
+    it('returns false if the frag does not need decryption', function () {
+      const frag = new Fragment();
+      assert.strictEqual(frag.encrypted, false);
+    });
+  });
+});


### PR DESCRIPTION
### This PR will...
- Load partial frags which have already been loaded once before
- Set currentFrag before arming abr check timer
- Implement `frag.encrypted` getter
- Add unit tests

### Why is this Pull Request needed?
- So that partial frags which have been loaded once are allowed to load again. This can happen when seeking backwards into a region which requires that fragment to be loaded again. Without this change, that fragment continuously loads until `checkBuffer()` intervenes by nudging `currentTime`.

For example:

1) The stream begins loading in order: `1506, 1507, 1508, 1509, 1510`
2) `1509` is a partial fragment. After backtracking it appends with the gap
3) For whatever reason (in this case seeking or a forced reparse from the demuxer), Hls.js wants to load `1509` again
4) `1509` is selected but not loaded because it's fragState is `PARTIAL`
5) Hls.js loop loads `1509` until the buffer stalls; `checkBuffer` may skip this gap


- The ABR controller change is so that slow code execution does not cause `onCheck` to fire before `this.currentFrag` has been set.

### Are there any points in the code the reviewer needs to double check?
Not too familiar with the fragment tracker, can you give this a check @azu?


### Test Stream
http://bob.jwplayer.com/~alex/110131/new_master.m3u8


### To-Do
- Unit tests
