### PR TITLE
Fall back to frag finding by SN if PDT search does not return a good fragment

### DIFF
--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -1,23 +1,22 @@
 import BinarySearch from '../utils/binary-search';
 
 /**
- * Calculates the PDT of the next load position. This calculation is either based on the PDT of the previous frag, or
- * the estimated start PDT of the entire level. Calculating from the previous frag is preferable since it is able to deal
- * with large gaps in PDT following discontinuities.
+ * Calculates the PDT of the next load position.
+ * bufferEnd in this function is usually the position of the playhead.
  * @param {number} [start = 0] - The PTS of the first fragment within the level
  * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
- * @param {*} fragPrevious - The last frag successfully appended
  * @param {*} levelDetails - An object containing the parsed and computed properties of the currently playing level
  * @returns {number} nextPdt - The computed PDT
  */
-export function calculateNextPDT (start = 0, bufferEnd = 0, fragPrevious, levelDetails) {
-  let nextPdt = 0;
-  if (fragPrevious && fragPrevious.pdt) {
-    nextPdt = fragPrevious.pdt + (fragPrevious.duration * 1000);
-  } else if (levelDetails.programDateTime) {
-    nextPdt = (bufferEnd * 1000) + Date.parse(levelDetails.programDateTime) - (1000 * start);
+export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
+  let pdt = 0;
+  if (levelDetails.programDateTime) {
+    const parsedDateInt = Date.parse(levelDetails.programDateTime);
+    if (!isNaN(parsedDateInt)) {
+      pdt = (bufferEnd * 1000) + parsedDateInt - (1000 * start);
+    }
   }
-  return nextPdt;
+  return pdt;
 }
 
 /**

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -26,7 +26,7 @@ export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
  * @returns {*|null} fragment - The best matching fragment
  */
 export function findFragmentByPDT (fragments, PDTValue = null) {
-  if (!Array.isArray(fragments) || PDTValue === null) {
+  if (!Array.isArray(fragments) || !fragments.length || PDTValue === null) {
     return null;
   }
 

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -1,0 +1,116 @@
+import BinarySearch from '../utils/binary-search';
+
+/**
+ * Calculates the PDT of the next load position. This calculation is either based on the PDT of the previous frag, or
+ * the estimated start PDT of the entire level. Calculating from the previous frag is preferable since it is able to deal
+ * with large gaps in PDT following discontinuities.
+ * @param {number} [start = 0] - The PTS of the first fragment within the level
+ * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
+ * @param {*} fragPrevious - The last frag successfully appended
+ * @param {*} levelDetails - An object containing the parsed and computed properties of the currently playing level
+ * @returns {number} nextPdt - The computed PDT
+ */
+export function calculateNextPDT (start = 0, bufferEnd = 0, fragPrevious, levelDetails) {
+  let nextPdt = 0;
+  if (fragPrevious && fragPrevious.pdt) {
+    nextPdt = fragPrevious.pdt + (fragPrevious.duration * 1000);
+  } else if (levelDetails.programDateTime) {
+    nextPdt = (bufferEnd * 1000) + Date.parse(levelDetails.programDateTime) - (1000 * start);
+  }
+  return nextPdt;
+}
+
+/**
+ * Finds the first fragment whose endPDT value exceeds the given PDT.
+ * @param {Array} fragments - The array of candidate fragments
+ * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
+ * @returns {*|null} fragment - The best matching fragment
+ */
+export function findFragmentByPDT (fragments, PDTValue = null) {
+  if (!fragments || !fragments.length || PDTValue === null) {
+    return null;
+  }
+
+  // if less than start
+  let firstSegment = fragments[0];
+
+  if (PDTValue < firstSegment.pdt) {
+    return null;
+  }
+
+  let lastSegment = fragments[fragments.length - 1];
+
+  if (PDTValue >= lastSegment.endPdt) {
+    return null;
+  }
+
+  for (let seg = 0; seg < fragments.length; ++seg) {
+    let frag = fragments[seg];
+    if (PDTValue < frag.endPdt) {
+      return frag;
+    }
+  }
+  return null;
+}
+
+/**
+ * Finds a fragment based on the SN of the previous fragment; or based on the needs of the current buffer.
+ * This method compensates for small buffer gaps by applying a tolerance to the start of any candidate fragment, thus
+ * breaking any traps which would cause the same fragment to be continuously selected within a small range.
+ * @param {*} fragPrevious - The last frag successfully appended
+ * @param {Array} fragments - The array of candidate fragments
+ * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
+ * @param {number} [end = 0] - The computed end time of the stream
+ * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start can be within in order to be considered contiguous
+ * @returns {*} foundFrag - The best matching fragment
+ */
+export function findFragmentBySN (fragPrevious, fragments, bufferEnd = 0, end = 0, maxFragLookUpTolerance = 0) {
+  let foundFrag;
+  const fragNext = fragPrevious ? fragments[fragPrevious.sn - fragments[0].sn + 1] : null;
+  if (bufferEnd < end) {
+    if (bufferEnd > end - maxFragLookUpTolerance) {
+      maxFragLookUpTolerance = 0;
+    }
+
+    // Prefer the next fragment if it's within tolerance
+    if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {
+      foundFrag = fragNext;
+    } else {
+      foundFrag = BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
+    }
+  }
+  return foundFrag;
+}
+
+/**
+ * The test function used by the findFragmentBySn's BinarySearch to look for the best match to the current buffer conditions.
+ * @param {*} candidate - The fragment to test
+ * @param {number} [bufferEnd = 0] - The end of the current buffered range the playhead is currently within
+ * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start can be within in order to be considered contiguous
+ * @returns {number} - 0 if it matches, 1 if too low, -1 if too high
+ */
+export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpTolerance = 0, candidate) {
+  // offset should be within fragment boundary - config.maxFragLookUpTolerance
+  // this is to cope with situations like
+  // bufferEnd = 9.991
+  // frag[Ø] : [0,10]
+  // frag[1] : [10,20]
+  // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
+  //              frag start               frag start+duration
+  //                  |-----------------------------|
+  //              <--->                         <--->
+  //  ...--------><-----------------------------><---------....
+  // previous frag         matching fragment         next frag
+  //  return -1             return 0                 return 1
+  // logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
+  // Set the lookup tolerance to be small enough to detect the current segment - ensures we don't skip over very small segments
+  let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0));
+  if (candidate.start + candidate.duration - candidateLookupTolerance <= bufferEnd) {
+    return 1;
+  } else if (candidate.start - candidateLookupTolerance > bufferEnd && candidate.start) {
+    // if maxFragLookUpTolerance will have negative value then don't return -1 for first element
+    return -1;
+  }
+
+  return 0;
+}

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -26,7 +26,7 @@ export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
  * @returns {*|null} fragment - The best matching fragment
  */
 export function findFragmentByPDT (fragments, PDTValue = null) {
-  if (!fragments || !fragments.length || PDTValue === null) {
+  if (!Array.isArray(fragments) || PDTValue === null) {
     return null;
   }
 

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -21,7 +21,7 @@ export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
 
 /**
  * Finds the first fragment whose endPDT value exceeds the given PDT.
- * @param {Array} fragments - The array of candidate fragments
+ * @param {Array<Fragment>} fragments - The array of candidate fragments
  * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
  * @returns {*|null} fragment - The best matching fragment
  */
@@ -57,7 +57,7 @@ export function findFragmentByPDT (fragments, PDTValue = null) {
  * This method compensates for small buffer gaps by applying a tolerance to the start of any candidate fragment, thus
  * breaking any traps which would cause the same fragment to be continuously selected within a small range.
  * @param {*} fragPrevious - The last frag successfully appended
- * @param {Array} fragments - The array of candidate fragments
+ * @param {Array<Fragment>} fragments - The array of candidate fragments
  * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
  * @param {number} [end = 0] - The computed end time of the stream
  * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start can be within in order to be considered contiguous

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -402,7 +402,7 @@ class StreamController extends TaskLoop {
         foundFrag = findFragmentBySN(fragPrevious, fragments, bufferEnd, end, config.maxFragLookUpTolerance);
       } else {
         // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-        foundFrag = findFragmentByPDT(fragments, calculateNextPDT(start, bufferEnd, fragPrevious, levelDetails));
+        foundFrag = findFragmentByPDT(fragments, calculateNextPDT(start, bufferEnd, levelDetails));
       }
     } else {
       // reach end of playlist

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -15,7 +15,7 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import { alignDiscontinuities } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
-import { calculateNextPDT, findFragmentByPDT, findFragmentBySN } from './fragment-finders';
+import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from './fragment-finders';
 
 export const State = {
   STOPPED: 'STOPPED',
@@ -407,8 +407,8 @@ class StreamController extends TaskLoop {
         if (!foundFrag || fragmentWithinToleranceTest(bufferEnd, config.maxFragLookUpTolerance, foundFrag)) {
           // Fall back to SN order if finding by PDT returns a frag which won't fit within the stream
           // fragmentWithToleranceTest returns 0 if the frag is within tolerance; 1 or -1 otherwise
-          logger.warn(`Frag found by PDT search did not fit within tolerance; falling back to finding by SN`);
-            foundFrag = fragBySN();
+          logger.warn('Frag found by PDT search did not fit within tolerance; falling back to finding by SN');
+          foundFrag = fragBySN();
         }
       }
     } else {

--- a/tests/mocks/data.js
+++ b/tests/mocks/data.js
@@ -1,0 +1,48 @@
+export const mockFragments = [
+  {
+    pdt: 1505502661523,
+    endPdt: 1505502666523,
+    level: 2,
+    duration: 5.000,
+    start: 0,
+    sn: 0,
+    cc: 0
+  },
+  // Discontinuity with PDT 1505502671523 which does not exist in level 1 as per fragPrevious
+  {
+    pdt: 1505502671523,
+    endPdt: 1505502676523,
+    level: 2,
+    duration: 5.000,
+    start: 5.000,
+    sn: 1,
+    cc: 1
+  },
+  {
+    pdt: 1505502676523,
+    endPdt: 1505502681523,
+    level: 2,
+    duration: 5.000,
+    start: 10.000,
+    sn: 2,
+    cc: 1
+  },
+  {
+    pdt: 1505502681523,
+    endPdt: 1505502686523,
+    level: 2,
+    duration: 5.000,
+    start: 15.000,
+    sn: 3,
+    cc: 1
+  },
+  {
+    pdt: 1505502686523,
+    endPdt: 1505502691523,
+    level: 2,
+    duration: 5.000,
+    start: 20.000,
+    sn: 4,
+    cc: 1
+  }
+];

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -169,9 +169,5 @@ module.exports = {
   pdtOneValue: {
     url: 'https://playertest.longtailvideo.com/adaptive/aviion/manifest.m3u8',
     description: 'One PDT, no discontinuities'
-  },
-  pdtDvr: {
-    url: 'https://b028.wpc.azureedge.net/80B028/Samples/a38e6323-95e9-4f1f-9b38-75eba91704e4/5f2ce531-d508-49fb-8152-647eba422aec.ism/Manifest(format=m3u8-aapl-v3)',
-    description: 'DVR stream with PDTs'
   }
 };

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -153,5 +153,25 @@ module.exports = {
     'description': 'Multiple non-alternate audio levels',
     'live': false,
     'abr': false
+  },
+  pdtDuplicate: {
+    url: 'https://playertest.longtailvideo.com/adaptive/artbeats/manifest.m3u8',
+    description: 'Stream with duplicate sequential PDT values'
+  },
+  pdtLargeGap: {
+    url: 'https://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8',
+    description: 'PDTs with large gaps following discontinuities'
+  },
+  pdtBadValues: {
+    url: 'https://playertest.longtailvideo.com/adaptive/progdatime/playlist2.m3u8',
+    description: 'PDTs with bad values'
+  },
+  pdtOneValue: {
+    url: 'https://playertest.longtailvideo.com/adaptive/aviion/manifest.m3u8',
+    description: 'One PDT, no discontinuities'
+  },
+  pdtDvr: {
+    url: 'https://b028.wpc.azureedge.net/80B028/Samples/a38e6323-95e9-4f1f-9b38-75eba91704e4/5f2ce531-d508-49fb-8152-647eba422aec.ism/Manifest(format=m3u8-aapl-v3)',
+    description: 'DVR stream with PDTs'
   }
 };

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -1,0 +1,186 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from '../../../src/controller/fragment-finders';
+import { mockFragments } from '../../mocks/data';
+import BinarySearch from '../../../src/utils/binary-search';
+
+describe('Fragment finders', function () {
+  const sandbox = sinon.sandbox.create();
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  let fragPrevious = {
+    pdt: 1505502671523,
+    endPdt: 1505502676523,
+    duration: 5.000,
+    level: 1,
+    start: 10.000,
+    sn: 2, // Fragment with PDT 1505502671523 in level 1 does not have the same sn as in level 2 where cc is 1
+    cc: 0
+  };
+  const bufferEnd = fragPrevious.start + fragPrevious.duration;
+  const end = mockFragments[mockFragments.length - 1].start + mockFragments[mockFragments.length - 1].duration;
+
+  describe('findFragmentBySN', function () {
+    let tolerance = 0.25;
+    let binarySearchSpy;
+    beforeEach(function () {
+      binarySearchSpy = sandbox.spy(BinarySearch, 'search');
+    });
+
+    it('finds a fragment with SN sequential to the previous fragment', function () {
+      const foundFragment = findFragmentBySN(fragPrevious, mockFragments, bufferEnd, end, tolerance);
+      const resultSN = foundFragment ? foundFragment.sn : -1;
+      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
+      assert(binarySearchSpy.notCalled);
+    });
+
+    it('chooses the fragment with the next SN if its contiguous with the end of the buffer', function () {
+      const actual = findFragmentBySN(mockFragments[0], mockFragments, mockFragments[0].duration, end, tolerance);
+      assert.strictEqual(mockFragments[1], actual, `expected sn ${mockFragments[1].sn}, but got sn ${actual ? actual.sn : null}`);
+      assert(binarySearchSpy.notCalled);
+    });
+
+    it('uses BinarySearch to find a fragment if the subsequent one is not within tolerance', function () {
+      const fragments = [mockFragments[0], mockFragments[(mockFragments.length - 1)]];
+      findFragmentBySN(fragments[0], fragments, bufferEnd, end, tolerance);
+      assert(binarySearchSpy.calledOnce);
+    });
+  });
+
+  describe('fragmentWithinToleranceTest', function () {
+    let tolerance = 0.25;
+    it('returns 0 if the fragment range is equal to the end of the buffer', function () {
+      const frag = {
+        start: 5,
+        duration: 5 - tolerance
+      };
+      const actual = fragmentWithinToleranceTest(5, tolerance, frag);
+      assert.strictEqual(0, actual);
+    });
+
+    it('returns 0 if the fragment range is greater than end of the buffer', function () {
+      const frag = {
+        start: 5,
+        duration: 5
+      };
+      const actual = fragmentWithinToleranceTest(5, tolerance, frag);
+      assert.strictEqual(0, actual);
+    });
+
+    it('returns 1 if the fragment range is less than the end of the buffer', function () {
+      const frag = {
+        start: 0,
+        duration: 5
+      };
+      const actual = fragmentWithinToleranceTest(5, tolerance, frag);
+      assert.strictEqual(1, actual);
+    });
+
+    it('returns -1 if the fragment range is greater than the end of the buffer', function () {
+      const frag = {
+        start: 6,
+        duration: 5
+      };
+      const actual = fragmentWithinToleranceTest(5, tolerance, frag);
+      assert.strictEqual(-1, actual);
+    });
+
+    it('does not skip very small fragments', function () {
+      const frag = {
+        start: 0.2,
+        duration: 0.1,
+        deltaPTS: 0.1
+      };
+      const actual = fragmentWithinToleranceTest(frag, 0, 1);
+      assert.strictEqual(0, actual);
+    });
+  });
+
+  describe('findFragmentByPDT', function () {
+    it('finds a fragment with endPdt greater than the reference PDT', function () {
+      const foundFragment = findFragmentByPDT(mockFragments, fragPrevious.endPdt + 1);
+      const resultSN = foundFragment ? foundFragment.sn : -1;
+      assert.strictEqual(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
+    });
+
+    it('returns null when the reference pdt is outside of the pdt range of the fragment array', function () {
+      let foundFragment = findFragmentByPDT(mockFragments, mockFragments[0].pdt - 1);
+      let resultSN = foundFragment ? foundFragment.sn : -1;
+      assert.strictEqual(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
+
+      foundFragment = findFragmentByPDT(mockFragments, mockFragments[mockFragments.length - 1].endPdt + 1);
+      resultSN = foundFragment ? foundFragment.sn : -1;
+      assert.strictEqual(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
+    });
+
+    it('is able to find the first fragment', function () {
+      const foundFragment = findFragmentByPDT(mockFragments, mockFragments[0].pdt);
+      const resultSN = foundFragment ? foundFragment.sn : -1;
+      assert.strictEqual(foundFragment, mockFragments[0], 'Expected sn 0, found sn segment ' + resultSN);
+    });
+
+    it('is able to find the last fragment', function () {
+      const foundFragment = findFragmentByPDT(mockFragments, mockFragments[mockFragments.length - 1].pdt);
+      const resultSN = foundFragment ? foundFragment.sn : -1;
+      assert.strictEqual(foundFragment, mockFragments[4], 'Expected sn 4, found sn segment ' + resultSN);
+    });
+
+    it('is able to find a fragment if the PDT value is 0', function () {
+      const fragments = [
+        {
+          pdt: 0,
+          endPdt: 1
+        },
+        {
+          pdt: 1,
+          endPdt: 2
+        }
+      ];
+      const actual = findFragmentByPDT(fragments, 0);
+      assert.strictEqual(fragments[0], actual);
+    });
+
+    it('returns null when passed undefined arguments', function () {
+      assert.strictEqual(findFragmentByPDT(mockFragments), null);
+      assert.strictEqual(findFragmentByPDT(undefined, 9001), null);
+      assert.strictEqual(findFragmentByPDT(), null);
+    });
+
+    it('returns null when passed an empty frag array', function () {
+      assert.strictEqual(findFragmentByPDT([], 9001), null);
+    });
+  });
+
+  describe('calculateNextPDT', function () {
+    const levelDetails = {
+      programDateTime: '2012-12-06T19:10:03+00:00'
+    };
+
+    it('calculates based on fragPrevious if available', function () {
+      const expected = 1505502671523 + 5 * 1000;
+      const actual = calculateNextPDT(5, 10, fragPrevious, levelDetails);
+      assert.strictEqual(expected, actual);
+    });
+
+    it('calculates based on levelDetails if fragPrevious does not exist', function () {
+      const expected = 1354821003000 + (10 * 1000) - (1000 * 5);
+      const actual = calculateNextPDT(5, 10, null, levelDetails);
+      assert.strictEqual(expected, actual);
+    });
+
+    it('calculates based on levelDetails if fragPrevious does not have a pdt', function () {
+      const mockFragPrevious = fragPrevious;
+      delete mockFragPrevious.pdt;
+      const expected = 1354821003000 + (10 * 1000) - (1000 * 5);
+      const actual = calculateNextPDT(5, 10, mockFragPrevious, levelDetails);
+      assert.strictEqual(expected, actual);
+    });
+
+    it('returns 0 if there are no PDTs available', function () {
+      const actual = calculateNextPDT(5, 10, {}, {});
+      assert.strictEqual(0, actual);
+    });
+  });
+});

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -158,28 +158,20 @@ describe('Fragment finders', function () {
       programDateTime: '2012-12-06T19:10:03+00:00'
     };
 
-    it('calculates based on fragPrevious if available', function () {
-      const expected = 1505502671523 + 5 * 1000;
-      const actual = calculateNextPDT(5, 10, fragPrevious, levelDetails);
-      assert.strictEqual(expected, actual);
-    });
-
-    it('calculates based on levelDetails if fragPrevious does not exist', function () {
+    it('calculates based on levelDetails', function () {
       const expected = 1354821003000 + (10 * 1000) - (1000 * 5);
-      const actual = calculateNextPDT(5, 10, null, levelDetails);
+      const actual = calculateNextPDT(5, 10, levelDetails);
       assert.strictEqual(expected, actual);
     });
 
-    it('calculates based on levelDetails if fragPrevious does not have a pdt', function () {
-      const mockFragPrevious = fragPrevious;
-      delete mockFragPrevious.pdt;
-      const expected = 1354821003000 + (10 * 1000) - (1000 * 5);
-      const actual = calculateNextPDT(5, 10, mockFragPrevious, levelDetails);
-      assert.strictEqual(expected, actual);
+    it('returns 0 if levelDetails does not have programDateTime', function () {
+      const actual = calculateNextPDT(5, 10, {});
+      assert.strictEqual(0, actual);
     });
 
-    it('returns 0 if there are no PDTs available', function () {
-      const actual = calculateNextPDT(5, 10, {}, {});
+    it('returns 0 if the parsed PDT would be NaN', function () {
+      levelDetails.programDateTime = 'foo';
+      const actual = calculateNextPDT(5, 10, levelDetails);
       assert.strictEqual(0, actual);
     });
   });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -6,6 +6,7 @@ import { FragmentTracker, FragmentState } from '../../../src/controller/fragment
 import StreamController, { State } from '../../../src/controller/stream-controller';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
 import Fragment from '../../../src/loader/fragment';
+import { mockFragments } from '../../mocks/data';
 
 describe('StreamController tests', function () {
   let hls;
@@ -88,63 +89,14 @@ describe('StreamController tests', function () {
       cc: 0
     };
 
-    let fragments = [
-      {
-        pdt: 1505502661523,
-        endPdt: 1505502666523,
-        level: 2,
-        duration: 5.000,
-        start: 0,
-        sn: 0,
-        cc: 0
-      },
-      // Discontinuity with PDT 1505502671523 which does not exist in level 1 as per fragPrevious
-      {
-        pdt: 1505502671523,
-        endPdt: 1505502676523,
-        level: 2,
-        duration: 5.000,
-        start: 5.000,
-        sn: 1,
-        cc: 1
-      },
-      {
-        pdt: 1505502676523,
-        endPdt: 1505502681523,
-        level: 2,
-        duration: 5.000,
-        start: 10.000,
-        sn: 2,
-        cc: 1
-      },
-      {
-        pdt: 1505502681523,
-        endPdt: 1505502686523,
-        level: 2,
-        duration: 5.000,
-        start: 15.000,
-        sn: 3,
-        cc: 1
-      },
-      {
-        pdt: 1505502686523,
-        endPdt: 1505502691523,
-        level: 2,
-        duration: 5.000,
-        start: 20.000,
-        sn: 4,
-        cc: 1
-      }
-    ];
-
-    let fragLen = fragments.length;
+    let fragLen = mockFragments.length;
     let levelDetails = {
-      startSN: fragments[0].sn,
-      endSN: fragments[fragments.length - 1].sn,
-      programDateTime: undefined // If this field is undefined SN search is used by default, if set is PDT
+      startSN: mockFragments[0].sn,
+      endSN: mockFragments[mockFragments.length - 1].sn,
+      programDateTime: null // If this field is null SN search is used by default, if set is PDT
     };
     let bufferEnd = fragPrevious.start + fragPrevious.duration;
-    let end = fragments[fragments.length - 1].start + fragments[fragments.length - 1].duration;
+    let end = mockFragments[mockFragments.length - 1].start + mockFragments[mockFragments.length - 1].duration;
 
     it('SN search choosing wrong fragment (3 instead of 2) after level loaded', function () {
       let config = {};
@@ -152,88 +104,49 @@ describe('StreamController tests', function () {
         config: config,
         on: function () {}
       };
-      levelDetails.programDateTime = undefined;
+      levelDetails.programDateTime = null;
 
       let streamController = new StreamController(hls);
-      let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails);
+      let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, mockFragments, bufferEnd, end, levelDetails);
 
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[3], 'Expected sn 3, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
     // TODO: This test fails if using a real instance of Hls
     it('SN search choosing the right segment if fragPrevious is not available', function () {
-      let config = {};
-      let hls = {
-        config: config,
-        on: function () {}
-      };
-      levelDetails.programDateTime = undefined;
+      levelDetails.programDateTime = null;
 
       let streamController = new StreamController(hls);
-      let foundFragment = streamController._findFragment(0, null, fragLen, fragments, bufferEnd, end, levelDetails);
+      let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[3], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after level loaded', function () {
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
 
-      let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails);
+      let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after starting/seeking to a new position (bufferEnd used)', function () {
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
       let mediaSeekingTime = 17.00;
 
-      let foundFragment = streamController._findFragment(0, null, fragLen, fragments, mediaSeekingTime, end, levelDetails);
+      let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, mediaSeekingTime, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT serch hitting empty discontinuity', function () {
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
       let discontinuityPDTHit = 6.00;
 
-      let foundFragment = streamController._findFragment(0, null, fragLen, fragments, discontinuityPDTHit, end, levelDetails);
+      let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, discontinuityPDTHit, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[1], 'Expected sn 1, found sn segment ' + resultSN);
-    });
-
-    it('Unit test _findFragmentBySN', function () {
-      let foundFragment = streamController._findFragmentBySN(fragPrevious, fragments, bufferEnd, end);
-      let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[3], 'Expected sn 3, found sn segment ' + resultSN);
-    });
-
-    it('Unit test _findFragmentByPDT usual behaviour', function () {
-      let foundFragment = streamController._findFragmentByPDT(fragments, fragPrevious.endPdt + 1);
-      let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[2], 'Expected sn 2, found sn segment ' + resultSN);
-    });
-
-    it('Unit test _findFragmentByPDT beyond limits', function () {
-      let foundFragment = streamController._findFragmentByPDT(fragments, fragments[0].pdt - 1);
-      let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
-
-      foundFragment = streamController._findFragmentByPDT(fragments, fragments[fragments.length - 1].endPdt + 1);
-      resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
-    });
-
-    it('Unit test _findFragmentByPDT at the beginning', function () {
-      let foundFragment = streamController._findFragmentByPDT(fragments, fragments[0].pdt);
-      let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[0], 'Expected sn 0, found sn segment ' + resultSN);
-    });
-
-    it('Unit test _findFragmentByPDT for last segment', function () {
-      let foundFragment = streamController._findFragmentByPDT(fragments, fragments[fragments.length - 1].pdt);
-      let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, fragments[4], 'Expected sn 4, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[1], 'Expected sn 1, found sn segment ' + resultSN);
     });
   });
 

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -2,10 +2,11 @@ import assert from 'assert';
 import sinon from 'sinon';
 import Hls from '../../../src/hls';
 import Event from '../../../src/events';
-import { FragmentTracker } from '../../../src/controller/fragment-tracker';
+import { FragmentTracker, FragmentState } from '../../../src/controller/fragment-tracker';
 import StreamController, { State } from '../../../src/controller/stream-controller';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
 import { mockFragments } from '../../mocks/data';
+import Fragment from '../../../src/loader/fragment';
 
 describe('StreamController tests', function () {
   let hls;
@@ -119,7 +120,7 @@ describe('StreamController tests', function () {
 
       let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after starting/seeking to a new position (bufferEnd used)', function () {
@@ -128,7 +129,7 @@ describe('StreamController tests', function () {
 
       let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, mediaSeekingTime, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
     it('PDT serch hitting empty discontinuity', function () {


### PR DESCRIPTION
### This PR will...
- Fall back to `findFragBySN` if `findFragByPDT` returns a frag which fails the `fragmentWithinToleranceTest`
- Break `findFragmentByPDT` and `findFragmentBySN` into a `fragment-finders.js` module
- Default `bufferEnd` to 0 in `fragmentWithinToleranceTest`
- Unit test & unit test & unit test
- Add 4 functional test streams with different PDT scenarios 

### Why is this Pull Request needed?
So that streams with discontinuities which have huge gaps inbetween PDT values play properly. Test stream: http://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8

```
#EXTM3U
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MEDIA-SEQUENCE:1
#EXT-X-ALLOW-CACHE:YES
#EXT-X-TARGETDURATION:8
#EXT-X-VERSION:3
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:10:03+00:00
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:10:03+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:11:06+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:23:23+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:23:23+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:23:29+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:24:56+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2012-12-06T19:25:03+00:00
#EXTINF:6.006,{}
fragment.ts
#EXT-X-ENDLIST
```

The reason this is a problem is that the next PDT was previously assumed to be the first PDT in the level + the duration of the segment. When PDT values are outside this normal range Hls.js will loop load the same fragment, and eventually stall. This change should ensure we're always calculating the next PDT relative to the last loaded. The former behavior is still used when the previous frag is unknown.

### Are there any points in the code the reviewer needs to double check?
- Does this change make sense in the first place? The spec didn't offer guidelines on how clients should use PDT, but as I interpreted it this method makes more sense.

- Should we use `pdt` or `endPdt`?


### Resolves issues:

From the JW backlog

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
