### PR TITLE
Fix RemuxerTrackIdConfig as per iso/iec 14496-12 spec

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -27,10 +27,10 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 // With MSE currently one can only have one track of each, and we are muxing
 // whatever video/audio rendition in them.
 const RemuxerTrackIdConfig = {
-  video: 0,
-  audio: 1,
-  id3: 2,
-  text: 3
+  video: 1,
+  audio: 2,
+  id3: 3,
+  text: 4
 };
 
 class TSDemuxer {


### PR DESCRIPTION
### This PR will...
Fix RemuxerTrackIdConfig as per iso/iec 14496-12 spec

### Why is this Pull Request needed?
ISO/IEC 14496-12 (ISO base media file format)
"track_ID is an integer that uniquely identifies this track over the entire life-time of this presentation.
Track IDs are never re-used and cannot be zero. "
But RemuxerTrackIdConfig.video is 0. So we should use properly track Id.

### Are there any points in the code the reviewer needs to double check?
I'm not sure, but I think it will be reviewed by developers involved in remux.

### Resolves issues:
https://github.com/video-dev/hls.js/issues/1687

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
