### PR TITLE
Fixed FragmentTracker causing endless loading

### DIFF
--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -232,8 +232,9 @@ export class FragmentTracker extends EventHandler {
    */
   onFragLoaded (e) {
     let fragment = e.frag;
-    // dont track initsegment (for which sn is not a number)
-    if (!isNaN(fragment.sn)) {
+    // don't track initsegment (for which sn is not a number)
+    // don't track frags used for bitrateTest, they're irrelevant.
+    if (!isNaN(fragment.sn) && !fragment.bitrateTest) {
       let fragKey = this.getFragmentKey(fragment);
       let fragmentEntity = {
         body: fragment,


### PR DESCRIPTION
### This PR will...
Prevent FragmentTracker from tracking a fragment that was used for bitrate testing
### Why is this Pull Request needed?
The bug caused the StreamController to go into an endless loading loop because
the bitrateTest fragment was being treated by the FragmentTracker as buffered
when it wasn't and thus if the StreamController tried to fetch that fragment
again it was blocked because the FragmentTracker told the StreamController
it was already loaded.

This worked fine in 0.8.9.

### Are there any points in the code the reviewer needs to double check?
No
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
