### PR TITLE
publish canary package on master commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js: node
-# Work-around for https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
-# (Restore `sudo: false` once that is resolved.)
-sudo: required
 # don't connect to sauce labs unless running functional tests
 # before_install: if [ "${TRAVIS_MODE}" != "funcTests" ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 script: ./scripts/travis.sh
@@ -11,12 +8,19 @@ after_success: npm run coverage
 env:
   global:
     - SAUCE_USERNAME=mangui
+stages:
+  - required
+  - optional
 jobs:
   # stage: optional is allowed to be failure
   fast_finish: true
   allow_failures:
     - stage: optional
   include:
+    # publish canary package if on master
+    - stage: required
+      if: branch = master
+      env: TRAVIS_MODE=releaseCanary
     # Required tests
     - stage: required
       env:   TRAVIS_MODE=build
@@ -43,7 +47,6 @@ jobs:
     #  env:   TRAVIS_MODE=funcTests UA=firefox     OS="OS X 10.11"
     - stage: optional
       env:   TRAVIS_MODE=funcTests UA=safari              OS="OS X 10.11" UA_VERSION="9.0"
-
 addons:
   sauce_connect: true
   jwt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js: node
+# so that chrome works
+# see https://github.com/video-dev/hls.js/pull/1710#discussion_r187754754
+sudo: required
 # don't connect to sauce labs unless running functional tests
 # before_install: if [ "${TRAVIS_MODE}" != "funcTests" ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 script: ./scripts/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     # publish canary package if on master
     - stage: required
-      if: branch = master
+      if: branch = master AND type != pull_request
       env: TRAVIS_MODE=releaseCanary
     # Required tests
     - stage: required

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ hls.js is written in [ECMAScript6], and transpiled in ECMAScript5 using [Babel].
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+<!-- Or if you want a more recent version -->
+<!-- <script src="https://cdn.jsdelivr.net/npm/hls.js@canary"></script> -->
 <video id="video"></video>
 <script>
   var video = document.getElementById('video');
@@ -122,6 +124,10 @@ If you want to bundle the application yourself, use node
 
 ```
 npm install hls.js
+```
+or for the lastest version from master
+```
+npm install hls.js@canary
 ```
 
 **NOTE:** `hls.light.*.js` dist files do not include subtitling and alternate-audio features.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ hls.js is written in [ECMAScript6], and transpiled in ECMAScript5 using [Babel].
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
-<!-- Or if you want a more recent version -->
+<!-- Or if you want a more recent canary version -->
 <!-- <script src="https://cdn.jsdelivr.net/npm/hls.js@canary"></script> -->
 <video id="video"></video>
 <script>
@@ -125,7 +125,7 @@ If you want to bundle the application yourself, use node
 ```
 npm install hls.js
 ```
-or for the lastest version from master
+or for the version from master (canary)
 ```
 npm install hls.js@canary
 ```

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "https://github.com/video-dev/hls.js"
   },
-  "publishConfig": {
-    "registry": "http://registry.npmjs.org"
-  },
   "bugs": {
     "url": "https://github.com/video-dev/hls.js/issues"
   },
@@ -23,6 +20,9 @@
     "exclude": [
       "tests"
     ]
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "webpack --progress",

--- a/scripts/check-already-published.js
+++ b/scripts/check-already-published.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const package = require('../package.json');
+
+try {
+  if (versionPublished()) {
+    console.log('published');
+  } else {
+    console.log('not published');
+  }
+} catch(e) {
+  console.error(e);
+  process.exit(1);
+}
+process.exit(0);
+
+function versionPublished() {
+  // npm view returns empty string if package doesn't exist
+  return !!require('child_process').execSync('npm view ' + package.name + '@' + package.version + ' --json').toString().trim();
+}

--- a/scripts/check-already-published.js
+++ b/scripts/check-already-published.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const package = require('../package.json');
 
 try {

--- a/scripts/set-canary-version.js
+++ b/scripts/set-canary-version.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const package = require('../package.json');
+
+try {
+  const version = package.version + '-canary.' + getCommitHash().substr(0, 8);
+  package.version = version;
+  fs.writeFileSync('./package.json', JSON.stringify(package));
+  console.log('Set canary version: ' + version);
+} catch(e) {
+  console.error(e);
+  process.exit(1);
+}
+process.exit(0);
+
+
+function getCommitHash() {
+  return require('child_process').execSync('git rev-parse HEAD').toString().trim();
+}

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,14 +2,18 @@
 # https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
 set -ev
 
+function testNodeRequire {
+  # check that hls.js doesn't error if requiring in node
+  # see https://github.com/video-dev/hls.js/pull/1642
+  node -e 'require("./" + require("./package.json").main)'
+}
+
 npm install
 
 if [ "${TRAVIS_MODE}" = "build" ]; then
   npm run lint
   npm run build
-  # check that hls.js doesn't error if requiring in node
-  # see https://github.com/video-dev/hls.js/pull/1642
-  node -e 'require("./" + require("./package.json").main)'
+  testNodeRequire
 elif [ "${TRAVIS_MODE}" = "unitTests" ]; then
 	npm run test:unit
 elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
@@ -36,6 +40,7 @@ elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
   if [[ $(node ./check-already-published.js) = "not published" ]]; then
     npm run lint
     npm run build
+    testNodeRequire
     # write the token to config
     # see https://docs.npmjs.com/private-modules/ci-server-config
     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -31,7 +31,7 @@ elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 		exit 1
 	fi
 elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
-	npm run lint
+  npm run lint
   npm run build
 
   # update the version

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -5,7 +5,8 @@ set -ev
 npm install
 
 if [ "${TRAVIS_MODE}" = "build" ]; then
-	npm run lint && npm run build
+  npm run lint
+  npm run build
   # check that hls.js doesn't error if requiring in node
   # see https://github.com/video-dev/hls.js/pull/1642
   node -e 'require("./" + require("./package.json").main)'
@@ -29,6 +30,17 @@ elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 	if [ ${n} = ${maxRetries} ]; then
 		exit 1
 	fi
+elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
+	npm run lint
+  npm run build
+
+  # update the version
+  node ./scripts/set-canary-version.js
+  # write the token to config
+  # see https://docs.npmjs.com/private-modules/ci-server-config
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+  npm publish --tag canary
+  echo "Published canary."
 else
 	echo "Unknown travis mode: ${TRAVIS_MODE}" 1>&2
 	exit 1

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -31,12 +31,11 @@ elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 		exit 1
 	fi
 elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
-  npm run lint
-  npm run build
-
   # update the version
   node ./scripts/set-canary-version.js
   if [[ $(node ./check-already-published.js) = "not published" ]]; then
+    npm run lint
+    npm run build
     # write the token to config
     # see https://docs.npmjs.com/private-modules/ci-server-config
     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -41,6 +41,7 @@ elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
     npm run lint
     npm run build
     testNodeRequire
+    npm run test:unit
     # write the token to config
     # see https://docs.npmjs.com/private-modules/ci-server-config
     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -37,7 +37,7 @@ elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
   # update the version
   node ./scripts/set-canary-version.js
-  if [[ $(node ./check-already-published.js) = "not published" ]]; then
+  if [[ $(node ./scripts/check-already-published.js) = "not published" ]]; then
     npm run lint
     npm run build
     testNodeRequire

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -36,11 +36,15 @@ elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
 
   # update the version
   node ./scripts/set-canary-version.js
-  # write the token to config
-  # see https://docs.npmjs.com/private-modules/ci-server-config
-  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-  npm publish --tag canary
-  echo "Published canary."
+  if [[ $(node ./check-already-published.js) = "not published" ]]; then
+    # write the token to config
+    # see https://docs.npmjs.com/private-modules/ci-server-config
+    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+    npm publish --tag canary
+    echo "Published canary."
+  else
+    echo "Canary already published."
+  fi
 else
 	echo "Unknown travis mode: ${TRAVIS_MODE}" 1>&2
 	exit 1


### PR DESCRIPTION
### This PR will...
make travis publish an npm package on every commit merged to master of the form
```
[current version]-canary.[first 8 characters of commit]
```
e.g. 0.9.1-canary.9d7e9af9

### Why is this Pull Request needed?
Because it allows people to easily grab builds of master.

They can:
```
npm install hls.js@canary
```
or use
```
https://cdn.jsdelivr.net/npm/hls.js@canary
```
_which will sometimes be slightly behind due to cdn caching_
or
```
https://cdn.jsdelivr.net/npm/hls.js@0.9.1-canary.9d7e9af9
```

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)

### TODO
- [x] create a separate npm user that is a hls.js contributer, [generate a token](https://docs.npmjs.com/private-modules/ci-server-config), and set as a travis secure env variable `npm_token`