### PR TITLE
Ensure canary version is higher than stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/video-dev/hls.js.svg?branch=master)](https://travis-ci.org/video-dev/hls.js)
-[![npm][npm-image]][npm-url]
+[![npm](https://img.shields.io/npm/v/hls.js.svg?style=flat)](https://npmjs.org/package/hls.js)
+[![npm](https://img.shields.io/npm/v/hls.js/canary.svg?style=flat)](https://www.npmjs.com/package/hls.js/v/canary)
 [![Greenkeeper badge](https://badges.greenkeeper.io/video-dev/hls.js.svg)](https://greenkeeper.io/)
 [![](https://data.jsdelivr.com/v1/package/npm/hls.js/badge?style=rounded)](https://www.jsdelivr.com/package/npm/hls.js)
 
@@ -260,6 +261,3 @@ Click [here](/docs/design.md) for details.
 ### Tested With
 
 [<img src="https://cloud.githubusercontent.com/assets/7864462/12837037/452a17c6-cb73-11e5-9f39-fc96893bc9bf.png" alt="Browser Stack Logo" width="300">](https://www.browserstack.com/)
-
-[npm-image]: https://img.shields.io/npm/v/hls.js.svg?style=flat
-[npm-url]: https://npmjs.org/package/hls.js

--- a/scripts/set-canary-version.js
+++ b/scripts/set-canary-version.js
@@ -2,10 +2,20 @@ const fs = require('fs');
 const package = require('../package.json');
 
 try {
-  const version = package.version + '-canary.' + getCommitHash().substr(0, 8);
-  package.version = version;
+  // bump patch
+  let matched = false;
+  let newVersion = package.version.replace(/^(\d+)\.(\d+)\.(\d+).*$/, function(_, major, minor, patch) {
+    matched = true;
+    return major + '.' + minor + '.' + (parseInt(patch) + 1);
+  });
+  if (!matched) {
+    throw new Error('Error calculating version.');
+  }
+  newVersion += '-canary.' + getCommitNum();
+
+  package.version = newVersion;
   fs.writeFileSync('./package.json', JSON.stringify(package));
-  console.log('Set canary version: ' + version);
+  console.log('Set canary version: ' + newVersion);
 } catch(e) {
   console.error(e);
   process.exit(1);
@@ -13,6 +23,6 @@ try {
 process.exit(0);
 
 
-function getCommitHash() {
-  return require('child_process').execSync('git rev-parse HEAD').toString().trim();
+function getCommitNum() {
+  return parseInt(require('child_process').execSync('git rev-list --count HEAD').toString());
 }

--- a/scripts/set-canary-version.js
+++ b/scripts/set-canary-version.js
@@ -6,7 +6,7 @@ try {
   let matched = false;
   let newVersion = package.version.replace(/^(\d+)\.(\d+)\.(\d+).*$/, function(_, major, minor, patch) {
     matched = true;
-    return major + '.' + minor + '.' + (parseInt(patch) + 1);
+    return major + '.' + minor + '.' + (parseInt(patch, 10) + 1);
   });
   if (!matched) {
     throw new Error('Error calculating version.');
@@ -24,5 +24,5 @@ process.exit(0);
 
 
 function getCommitNum() {
-  return parseInt(require('child_process').execSync('git rev-list --count HEAD').toString());
+  return parseInt(require('child_process').execSync('git rev-list --count HEAD').toString(), 10);
 }


### PR DESCRIPTION
### This PR will...
bump the patch version for canary releases, and use the commit number as the prerelease string instead of commit hash.

### Why is this Pull Request needed?
I did some more reading around npm/semver and the current canary version is incorrect. The canary version should be higher than the current stable version. Also the prerelease string should ascend between versions.

This allows someone to specify
```
^0.9.5-canary.3810
```
in their package.json, which will always resolve to the latest canary, until >= 0.9.5 has been released, at which point they will automatically switch to the stable releases.