### PR TITLE
Fix slight time offset on video element after mp4 remuxing

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -191,6 +191,7 @@ class MP4Remuxer {
       outputSamples = [],
       nbSamples = inputSamples.length,
       ptsNormalize = this._PTSNormalize,
+      initPTS = this._initPTS,
       initDTS = this._initDTS;
 
     // for (let i = 0; i < track.samples.length; i++) {
@@ -234,10 +235,10 @@ class MP4Remuxer {
     }
 
     // PTS is coded on 33bits, and can loop from -2^32 to 2^32
-    // ptsNormalize will make PTS/DTS value monotonic, we use last known DTS value as reference value
+    // ptsNormalize will make PTS/DTS value monotonic, we use last known PTS value as reference value
     inputSamples.forEach(function (sample) {
-      sample.pts = ptsNormalize(sample.pts - initDTS, nextAvcDts);
-      sample.dts = ptsNormalize(sample.dts - initDTS, nextAvcDts);
+      sample.pts = ptsNormalize(sample.pts - initPTS, nextAvcDts);
+      sample.dts = ptsNormalize(sample.dts - initPTS, nextAvcDts);
     });
 
     // sort video samples by DTS then PTS then demux id order
@@ -444,6 +445,7 @@ class MP4Remuxer {
       inputSampleDuration = mp4SampleDuration * scaleFactor,
       ptsNormalize = this._PTSNormalize,
       initDTS = this._initDTS,
+      initPTS = this._initPTS,
       rawMPEG = !track.isAAC && this.typeSupported.mpeg;
 
     let offset,
@@ -470,7 +472,7 @@ class MP4Remuxer {
 
     // compute normalized PTS
     inputSamples.forEach(function (sample) {
-      sample.pts = sample.dts = ptsNormalize(sample.pts - initDTS, timeOffset * inputTimeScale);
+      sample.pts = sample.dts = ptsNormalize(sample.pts - initPTS, timeOffset * inputTimeScale);
     });
 
     // filter out sample with negative PTS that are not playable anyway


### PR DESCRIPTION
### This PR will...

Fixes inaccurate current time. This problem can also be seen on the demo page where the video and current time is always off by `0.033322`. This PR fixes that.

### Why is this Pull Request needed?

Currently, HLS.js will not show nor seek 100% accurate currentTime, even with the demo file. The reason is that we normalize pts to 0 based on `initDTS` which will almost never make the first frame have pts==0, i.e. currentTime==0.

mpegts cannot start with `first_pts==0 && first_dts>=0` without disabling B frames. We should be normalizing based on initPTS instead of initDTS to make sure pts starts at zero and is in sync with `currentTime`.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/1708

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)