### PR TITLE
Remove playbackRate factor for setting lastCurrentTime

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -565,7 +565,7 @@ class StreamController extends TaskLoop {
         media decode error, check this, to avoid seeking back to
         wrong position after a media decode error
       */
-      if (currentTime > video.playbackRate * this.lastCurrentTime) {
+      if (currentTime > this.lastCurrentTime) {
         this.lastCurrentTime = currentTime;
       }
 


### PR DESCRIPTION
### Why is this Pull Request needed?
So that `lastCurrentTime` is updated frequently enough to avoid stalls. If the playback rate is set > 1, a small gap can causes this check never to pass:

```
      if (currentTime !== this.lastCurrentTime) {
        // The playhead is now moving, but was previously stalled
        if (this.stallReported) {
          logger.warn(`playback not stuck anymore @${currentTime}, after ${Math.round(tnow - this.stalled)}ms`);
          this.stallReported = false;
        }
```

Because the difference between `currentTime` and `lastCurrentTime` is not large enough to re-set `lastCurrentTime`.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
https://github.com/video-dev/hls.js/issues/1505

From https://github.com/jwplayer/hls.js/pull/118

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
