### PR TITLE
Add ability to load demo page with canary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ hls.js is written in [ECMAScript6], and transpiled in ECMAScript5 using [Babel].
 ## Demo
 
 ### Latest Release
-[http://video-dev.github.io/hls.js/demo](http://video-dev.github.io/hls.js/demo)
+[https://video-dev.github.io/hls.js/demo](https://video-dev.github.io/hls.js/demo)
 
 ### Canary
-[http://video-dev.github.io/hls.js/demo?canary=true](http://video-dev.github.io/hls.js/demo?canary=true)
+[https://video-dev.github.io/hls.js/demo?canary=true](https://video-dev.github.io/hls.js/demo?canary=true)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ hls.js is written in [ECMAScript6], and transpiled in ECMAScript5 using [Babel].
 
 ## Demo
 
+### Latest Release
 [http://video-dev.github.io/hls.js/demo](http://video-dev.github.io/hls.js/demo)
+
+### Canary
+[http://video-dev.github.io/hls.js/demo?canary=true](http://video-dev.github.io/hls.js/demo?canary=true)
 
 ## Getting Started
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -300,7 +300,7 @@
         }
 
         // load compiled lib dist, or latest canary from jsdelivr (?canary=true)
-        var src = window.location.search.indexOf('canary=true') >= 0
+        var src = window.location.search.substring(1).split('&').indexOf('canary=true') >= 0
           ? 'https://cdn.jsdelivr.net/npm/hls.js@canary'
           : '../dist/hls.js';
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,7 +15,6 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.min.js"></script>
-
   </head>
 
   <body>
@@ -135,7 +134,7 @@
 
       <label class="center">Error:</label>
       <pre id="errorOut" class="center" style="white-space: pre-wrap;"></pre>
-      
+
       <div class="center" style="text-align: center;" id="toggleButtons">
         <button type="button" class="btn btn-sm" onclick="toggleTab('playbackControlTab');">Playback</button>
         <button type="button" class="btn btn-sm" onclick="toggleTab('qualityLevelControlTab');">Quality-levels</button>
@@ -289,10 +288,27 @@
     <script src="metrics.js"></script>
     <script src="jsonpack.js"></script>
 
-    <!-- Compiled lib dist -->
-    <script src="../dist/hls.js"></script>
-    <!-- Compiled demo main -->
-    <script src="../dist/hls-demo.js"></script>
+    <script>
+      (function() {
+        function loadScript(url, onLoad) {
+          var s = document.createElement("script");
+          s.setAttribute('src', url);
+          if (onLoad) {
+            s.onLoad = onLoad;
+          }
+          document.body.appendChild(s);
+        }
 
+        // load compiled lib dist, or latest canary from jsdelivr (?canary=true)
+        var src = window.location.search.indexOf('canary=true') >= 0
+          ? 'https://cdn.jsdelivr.net/npm/hls.js@canary'
+          : '../dist/hls.js';
+
+        loadScript(src, function() {
+          // load compiled demo main
+          loadScript('../dist/hls-demo.js');
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -49,6 +49,8 @@ elif [ "${TRAVIS_MODE}" = "releaseCanary" ]; then
     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
     npm publish --tag canary
     echo "Published canary."
+    curl https://purge.jsdelivr.net/npm/hls.js@canary
+    echo "Cleared jsdelivr cache."
   else
     echo "Canary already published."
   fi


### PR DESCRIPTION
### This PR will...
Allow people to access the demo page with the canary build of hls.js at http://video-dev.github.io/hls.js/demo?canary=true

It also clears the jsdelivr cache after a new canary release is publishes, so that new requests should get the new version immediately.

### Why is this Pull Request needed?
So that people can easily test the canary version.