### PR TITLE
Progressive subtitle download

### DIFF
--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -4,6 +4,7 @@
 
 import Event from '../events';
 import { logger } from '../utils/logger';
+import { BufferHelper } from '../utils/buffer-helper';
 import Decrypter from '../crypt/decrypter';
 import TaskLoop from '../task-loop';
 
@@ -23,6 +24,7 @@ class SubtitleStreamController extends TaskLoop {
       Event.ERROR,
       Event.KEY_LOADED,
       Event.FRAG_LOADED,
+      Event.FRAG_BUFFERED,
       Event.SUBTITLE_TRACKS_UPDATED,
       Event.SUBTITLE_TRACK_SWITCH,
       Event.SUBTITLE_TRACK_LOADED,
@@ -30,7 +32,7 @@ class SubtitleStreamController extends TaskLoop {
 
     this.config = hls.config;
     this.vttFragSNsProcessed = {};
-    this.vttFragQueues = undefined;
+    this.vttFragQueues = null;
     this.currentlyProcessing = null;
     this.state = State.STOPPED;
     this.currentTrackId = -1;
@@ -70,8 +72,15 @@ class SubtitleStreamController extends TaskLoop {
     this.nextFrag();
   }
 
-  onMediaAttached () {
+  onMediaAttached (data) {
     this.state = State.IDLE;
+    this.media = data.media;
+  }
+
+  onFragBuffered (data) {
+    if (data.id === 'main') {
+      this.tick();
+    }
   }
 
   // If something goes wrong, procede to next frag, if we were processing one.
@@ -90,42 +99,42 @@ class SubtitleStreamController extends TaskLoop {
 
   doTick () {
     switch (this.state) {
-    case State.IDLE:
-      const tracks = this.tracks;
-      let trackId = this.currentTrackId;
+    case State.IDLE: {
+      const tracks = this.tracks || [];
+      const trackId = this.currentTrackId;
+      const trackDetails = tracks[trackId] ? tracks[trackId].details : null;
 
-      const processedFragSNs = this.vttFragSNsProcessed[trackId],
-        fragQueue = this.vttFragQueues[trackId],
-        currentFragSN = this.currentlyProcessing ? this.currentlyProcessing.sn : -1;
+      // exit if track details don't exist or if there is no active textTrack
+      if (trackId === -1 || !trackDetails) break;
 
-      const alreadyProcessed = function (frag) {
-        return processedFragSNs.indexOf(frag.sn) > -1;
-      };
+      const { config } = this.hls;
+      const media = this.media;
+      const processedFragSNs = this.vttFragSNsProcessed[trackId];
+      const fragQueue = this.vttFragQueues[trackId];
+      const currentFragSN = this.currentlyProcessing ? this.currentlyProcessing.sn : -1;
+      const { start: bufferStart, len } = BufferHelper.bufferInfo(media, this.media.currentTime, config.maxBufferHole);
 
-      const alreadyInQueue = function (frag) {
-        return fragQueue.some(fragInQueue => {
-          return fragInQueue.sn === frag.sn;
-        });
-      };
+      // for low buffer conditions :
+      // ensure that the buffer range we're mapping the subtitles over is >= than maxConfigBuffer
+      const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
+      const minBufferEnd = bufferStart + Math.max(maxConfigBuffer, len);
 
-        // exit if tracks don't exist
-      if (!tracks) {
-        break;
-      }
+      const alreadyProcessed = frag => processedFragSNs.indexOf(frag.sn) > -1;
+      const alreadyInQueue = frag => fragQueue.some(fragInQueue => fragInQueue.sn === frag.sn);
 
-      var trackDetails;
+      // function to check if bufferStart < frag.start < minBufferEnd to enable progressive subtitle download.
+      // + handle the case for fragments starting before the current buffer start time but long enough to cover
+      // the buffered region, ie: case where there is only one fragment for the whole video
+      const inBufferRange = frag =>
+        (frag.start < minBufferEnd && frag.start >= bufferStart - 1) ||
+        (frag.start <= bufferStart && frag.start + frag.duration >= bufferStart);
 
-      if (trackId < tracks.length) {
-        trackDetails = tracks[trackId].details;
-      }
-
-      if (typeof trackDetails === 'undefined') {
-        break;
-      }
-
+      // Filter out fragments out of buffer range to enable progressive download
       // Add all fragments that haven't been, aren't currently being and aren't waiting to be processed, to queue.
-      trackDetails.fragments.forEach(frag => {
-        if (!(alreadyProcessed(frag) || frag.sn === currentFragSN || alreadyInQueue(frag))) {
+      trackDetails.fragments
+        .filter(frag =>
+          inBufferRange(frag) && !(alreadyProcessed(frag) || frag.sn === currentFragSN || alreadyInQueue(frag)))
+        .forEach(frag => {
           // Load key if subtitles are encrypted
           if (frag.encrypted) {
             logger.log(`Loading key for ${frag.sn}`);
@@ -137,8 +146,8 @@ class SubtitleStreamController extends TaskLoop {
             fragQueue.push(frag);
             this.nextFrag();
           }
-        }
-      });
+        });
+    }
     }
   }
 
@@ -180,10 +189,11 @@ class SubtitleStreamController extends TaskLoop {
   }
 
   onFragLoaded (data) {
-    let fragCurrent = this.fragCurrent,
-      decryptData = data.frag.decryptdata;
-    let fragLoaded = data.frag,
-      hls = this.hls;
+    const fragCurrent = this.fragCurrent;
+    const fragLoaded = data.frag;
+    const decryptData = data.frag.decryptdata;
+    const hls = this.hls;
+
     if (this.state === State.FRAG_LOADING &&
         fragCurrent &&
         data.frag.type === 'subtitle' &&


### PR DESCRIPTION
### This PR will...
attempt to fix #1645 #1303 by enabling subtitles to be loaded progressively by watching `BUFFER_APPENDED` events.

### Why is this Pull Request needed?
Currently hls.js will try to load every vtt fragment: 

- it may cause a slow down if the number of vtt fragments is too big
- it may trigger unnecessary network requests (ie: user accidentally clicks on the wrong subtitle track or user stops playback before the end of the video, both cases will trigger a full download of the whole fragments)
- it may help to pull some pressure off on the media server (reduces the number of sequential incoming requests)

### Are there any points in the code the reviewer needs to double check?
Double check the mapping between the frag loading and the buffer events. 

I've tested the changes on our live and VOD streams at France Télévisions + on some hls test streams.
It's working as expected but I may have missed some edge cases.

Oh, and I did a bit of linting.

### Resolves issues:
#1645 #1303

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
