### PR TITLE
Fix memory leak

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -62,11 +62,13 @@ class AudioStreamController extends TaskLoop {
 
   onHandlerDestroying () {
     this.stopLoad();
+    super.onHandlerDestroying();
   }
 
   onHandlerDestroyed () {
     this.state = State.STOPPED;
     this.fragmentTracker = null;
+    super.onHandlerDestroyed();
   }
 
   // Signal that video PTS was found

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -61,11 +61,13 @@ class StreamController extends TaskLoop {
 
   onHandlerDestroying () {
     this.stopLoad();
+    super.onHandlerDestroying();
   }
 
   onHandlerDestroyed () {
     this.state = State.STOPPED;
     this.fragmentTracker = null;
+    super.onHandlerDestroyed();
   }
 
   startLoad (startPosition) {


### PR DESCRIPTION
### This PR will...
Fixed `AudioStreamController` & `StreamController` not being cleaned up
- `onHandlerDestroying()` is overriden by said controllers but doesn't call
`super.onHandlerDestroying()` which cases the tick interval to never stop

### Why is this Pull Request needed?
Because hls.js is leaking memory after `destroy()`
### Are there any points in the code the reviewer needs to double check?
no
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
