### PR TITLE
expose observer.once to public api

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1103,12 +1103,18 @@ get : position of live sync point (ie edge of live position minus safety delay d
 
 ## Runtime Events
 
-Hls.js fires a bunch of events, that could be registered as below:
+Hls.js fires a bunch of events, that could be registered and unregistered as below:
 
 ```js
-hls.on(Hls.Events.LEVEL_LOADED,function(event,data) {
+function onLevelLoaded (event, data) {
   var level_duration = data.details.totalduration;
-});
+}
+// subscribe event
+hls.on(Hls.Events.LEVEL_LOADED, onLevelLoaded);
+// unsubscribe event
+hls.off(Hls.Events.LEVEL_LOADED, onLevelLoaded);
+// subscribe for a single event call only
+hls.once(Hls.Events.LEVEL_LOADED, onLevelLoaded);
 ```
 Full list of Events is available below:
 

--- a/src/hls.js
+++ b/src/hls.js
@@ -123,6 +123,7 @@ export default class Hls {
     };
     this.on = observer.on.bind(observer);
     this.off = observer.off.bind(observer);
+    this.once = observer.once.bind(observer);
     this.trigger = observer.trigger.bind(observer);
 
     // core controllers and network loaders


### PR DESCRIPTION
### This PR will...
Expose observer.once to public API.

### Why is this Pull Request needed?
It simplifies hls.js events subscription code in some cases - instead of writing something like
```js
function onManifestParsedOnce() {
  hls.off(Hls.Events.MANIFEST_PARSED, onManifestParsedOnce);
  video.play();
})

hls.on(Hls.Events.MANIFEST_PARSED, onManifestParsedOnce);
```
you can just do
```js
hls.once(Hls.Events.MANIFEST_PARSED, function () {
  video.play();
}));
```
if you need a single event call subscription.
### Are there any points in the code the reviewer needs to double check?
no
### Resolves issues:
no
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
I could not find any tests for on/off API, please point if I should add some.
- [x] API or design changes are documented in API.md
