### PR TITLE
Fix DOM `Event` lint global false positive and access all window props explicitely

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,19 +1,11 @@
 module.exports = {
   'env': {
-    'browser': true,
     'commonjs': true,
     'es6': true
   },
   'globals': {
     // Allowed globals
     'console': true,
-    // "MediaSource": true,
-    'performance': true,
-    'crypto': true,
-    'fetch': true,
-    'Request': true,
-    'Headers': true,
-    'escape': true,
 
     // Compile-time defines
     '__VERSION__': true,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "docs:release": "npm run docs:clean && npm run docs:generate && npm run docs:update",
     "lint": "npm run lint:src && npm run lint:tests",
     "lint:fix": "eslint src/ tests/ --fix",
+    "lint:quiet": "eslint src/ tests/ --quiet",
     "lint:src": "eslint src/",
     "lint:tests": "eslint tests/",
     "lint:demo": "eslint demo/",

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,18 +2,11 @@
 # https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
 set -ev
 
-function testNodeRequire {
-  # check that hls.js doesn't error if requiring in node
-  # see https://github.com/video-dev/hls.js/pull/1642
-  node -e 'require("./" + require("./package.json").main)'
-}
-
 npm install
 
 if [ "${TRAVIS_MODE}" = "build" ]; then
   npm run lint
   npm run build
-  testNodeRequire
 elif [ "${TRAVIS_MODE}" = "unitTests" ]; then
 	npm run test:unit
 elif [ "${TRAVIS_MODE}" = "funcTests" ]; then

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -11,6 +11,8 @@ import { ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import EwmaBandWidthEstimator from '../utils/ewma-bandwidth-estimator';
 
+const { performance } = window;
+
 class AbrController extends EventHandler {
   constructor (hls) {
     super(hls, Event.FRAG_LOADING,

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -15,6 +15,8 @@ import TaskLoop from '../task-loop';
 import { FragmentState } from './fragment-tracker';
 import Fragment from '../loader/fragment';
 
+const { performance } = window;
+
 const State = {
   STOPPED: 'STOPPED',
   STARTING: 'STARTING',

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -109,7 +109,7 @@ class BufferController extends EventHandler {
       ms.addEventListener('sourceended', this.onmse);
       ms.addEventListener('sourceclose', this.onmsc);
       // link video and media Source
-      media.src = URL.createObjectURL(ms);
+      media.src = window.URL.createObjectURL(ms);
       // cache the locally generated object url
       this._objectUrl = media.src;
     }
@@ -137,7 +137,7 @@ class BufferController extends EventHandler {
       // Detach properly the MediaSource from the HTMLMediaElement as
       // suggested in https://github.com/w3c/media-source/issues/53.
       if (this.media) {
-        URL.revokeObjectURL(this._objectUrl);
+        window.URL.revokeObjectURL(this._objectUrl);
 
         // clean up video tag src only if it's our own url. some external libraries might
         // hijack the video tag and change its 'src' without destroying the Hls instance first

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -36,7 +36,7 @@ class CapLevelController extends EventHandler {
   }
 
   onMediaAttaching (data) {
-    this.media = data.media instanceof HTMLVideoElement ? data.media : null;
+    this.media = data.media instanceof window.HTMLVideoElement ? data.media : null;
   }
 
   onManifestParsed (data) {

--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -10,6 +10,8 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 
 import { logger } from '../utils/logger';
 
+const { XMLHttpRequest } = window;
+
 const MAX_LICENSE_REQUEST_FAILURES = 3;
 
 /**

--- a/src/controller/fps-controller.js
+++ b/src/controller/fps-controller.js
@@ -6,6 +6,8 @@ import Event from '../events';
 import EventHandler from '../event-handler';
 import { logger } from '../utils/logger';
 
+const { performance } = window;
+
 class FPSController extends EventHandler {
   constructor (hls) {
     super(hls, Event.MEDIA_ATTACHING);
@@ -22,7 +24,7 @@ class FPSController extends EventHandler {
   onMediaAttaching (data) {
     const config = this.hls.config;
     if (config.capLevelOnFPSDrop) {
-      const video = this.video = data.media instanceof HTMLVideoElement ? data.media : null;
+      const video = this.video = data.media instanceof window.HTMLVideoElement ? data.media : null;
       if (typeof video.getVideoPlaybackQuality === 'function') {
         this.isVideoPlaybackQualityAvailable = true;
       }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -8,6 +8,8 @@ import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { isCodecSupportedInMp4 } from '../utils/codecs';
 
+const { performance } = window;
+
 export default class LevelController extends EventHandler {
   constructor (hls) {
     super(hls,

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -17,6 +17,8 @@ import { alignDiscontinuities } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
 import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from './fragment-finders';
 
+const { performance } = window;
+
 export const State = {
   STOPPED: 'STOPPED',
   IDLE: 'IDLE',

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -17,8 +17,6 @@ import { alignDiscontinuities } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
 import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from './fragment-finders';
 
-const { performance } = window;
-
 export const State = {
   STOPPED: 'STOPPED',
   IDLE: 'IDLE',
@@ -144,7 +142,7 @@ class StreamController extends TaskLoop {
 
       break;
     case State.FRAG_LOADING_WAITING_RETRY:
-      var now = performance.now();
+      var now = window.performance.now();
       var retryDate = this.retryDate;
       // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
       if (!retryDate || (now >= retryDate) || (this.media && this.media.seeking)) {
@@ -955,12 +953,12 @@ class StreamController extends TaskLoop {
         // switch back to IDLE state ... we just loaded a fragment to determine adequate start bitrate and initialize autoswitch algo
         this.state = State.IDLE;
         this.startFragRequested = false;
-        stats.tparsed = stats.tbuffered = performance.now();
+        stats.tparsed = stats.tbuffered = window.performance.now();
         this.hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: fragCurrent, id: 'main' });
         this.tick();
       } else if (fragLoaded.sn === 'initSegment') {
         this.state = State.IDLE;
-        stats.tparsed = stats.tbuffered = performance.now();
+        stats.tparsed = stats.tbuffered = window.performance.now();
         details.initSegment.data = data.payload;
         this.hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: fragCurrent, id: 'main' });
         this.tick();
@@ -1159,7 +1157,7 @@ class StreamController extends TaskLoop {
         fragNew.sn === fragCurrent.sn &&
         fragNew.level === fragCurrent.level &&
         this.state === State.PARSING) {
-      this.stats.tparsed = performance.now();
+      this.stats.tparsed = window.performance.now();
       this.state = State.PARSED;
       this._checkAppendedParsed();
     }
@@ -1258,7 +1256,7 @@ class StreamController extends TaskLoop {
         logger.log(`main buffered : ${TimeRanges.toString(media.buffered)}`);
         this.fragPrevious = frag;
         const stats = this.stats;
-        stats.tbuffered = performance.now();
+        stats.tbuffered = window.performance.now();
         // we should get rid of this.fragLastKbps
         this.fragLastKbps = Math.round(8 * stats.total / (stats.tbuffered - stats.tfirst));
         this.hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: frag, id: 'main' });
@@ -1289,7 +1287,7 @@ class StreamController extends TaskLoop {
           // exponential backoff capped to config.fragLoadingMaxRetryTimeout
           let delay = Math.min(Math.pow(2, this.fragLoadError) * this.config.fragLoadingRetryDelay, this.config.fragLoadingMaxRetryTimeout);
           logger.warn(`mediaController: frag loading failed, retry in ${delay} ms`);
-          this.retryDate = performance.now() + delay;
+          this.retryDate = window.performance.now() + delay;
           // retry loading state
           // if loadedmetadata is not set, it means that we are emergency switch down on first frag
           // in that case, reset startFragRequested flag
@@ -1381,7 +1379,7 @@ class StreamController extends TaskLoop {
       const expectedPlaying = !((media.paused && media.readyState > 1) || // not playing when media is paused and sufficiently buffered
         media.ended || // not playing when media is ended
         media.buffered.length === 0); // not playing if nothing buffered
-      const tnow = performance.now();
+      const tnow = window.performance.now();
 
       if (currentTime !== this.lastCurrentTime) {
         // The playhead is now moving, but was previously stalled

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -7,6 +7,8 @@ import { logger } from '../utils/logger';
 import Decrypter from '../crypt/decrypter';
 import TaskLoop from '../task-loop';
 
+const { performance } = window;
+
 const State = {
   STOPPED: 'STOPPED',
   IDLE: 'IDLE',

--- a/src/crypt/decrypter.js
+++ b/src/crypt/decrypter.js
@@ -7,9 +7,11 @@ import { logger } from '../utils/logger';
 
 import Event from '../events';
 
-const { performance, crypto } = window;
+// see https://stackoverflow.com/a/11237259/589493
+/* eslint-disable-next-line no-undef */
+const window = self; // safeguard for code that might run both on worker and main thread
 
-/* globals self: false */
+const { performance, crypto } = window;
 
 class Decrypter {
   constructor (observer, config, { removePKCS7Padding = true } = {}) {
@@ -20,7 +22,7 @@ class Decrypter {
     // built in decryptor expects PKCS7 padding
     if (removePKCS7Padding) {
       try {
-        const browserCrypto = crypto || self.crypto;
+        const browserCrypto = crypto || window.crypto;
         this.subtle = browserCrypto.subtle || browserCrypto.webkitSubtle;
       } catch (e) {}
     }

--- a/src/crypt/decrypter.js
+++ b/src/crypt/decrypter.js
@@ -7,9 +7,11 @@ import { logger } from '../utils/logger';
 
 import Event from '../events';
 
+import { getSelfScope } from '../utils/get-self-scope';
+
 // see https://stackoverflow.com/a/11237259/589493
 /* eslint-disable-next-line no-undef */
-const window = self; // safeguard for code that might run both on worker and main thread
+const window = getSelfScope();  // safeguard for code that might run both on worker and main thread
 
 const { performance, crypto } = window;
 

--- a/src/crypt/decrypter.js
+++ b/src/crypt/decrypter.js
@@ -11,7 +11,7 @@ import { getSelfScope } from '../utils/get-self-scope';
 
 // see https://stackoverflow.com/a/11237259/589493
 /* eslint-disable-next-line no-undef */
-const window = getSelfScope();  // safeguard for code that might run both on worker and main thread
+const window = getSelfScope(); // safeguard for code that might run both on worker and main thread
 
 const { performance, crypto } = window;
 

--- a/src/crypt/decrypter.js
+++ b/src/crypt/decrypter.js
@@ -5,6 +5,10 @@ import AESDecryptor from './aes-decryptor';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 
+import Event from '../events';
+
+const { performance, crypto } = window;
+
 /* globals self: false */
 
 class Decrypter {

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -6,6 +6,8 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 
 import Event from '../events';
 
+import { getSelfScope } from '../utils/get-self-scope';
+
 export function getAudioConfig (observer, data, offset, audioCodec) {
   let adtsObjectType, // :int
     adtsSampleingIndex, // :int

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -5,6 +5,8 @@ import { logger } from '../utils/logger';
 import Event from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 
+import Event from '../events';
+
 export function getAudioConfig (observer, data, offset, audioCodec) {
   let adtsObjectType, // :int
     adtsSampleingIndex, // :int

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -2,7 +2,6 @@
  *  ADTS parser helper
  */
 import { logger } from '../utils/logger';
-import Event from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 
 import Event from '../events';

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -1,5 +1,8 @@
-/*  inline demuxer.
- *   probe fragments and instantiate appropriate demuxer depending on content type (TSDemuxer, AACDemuxer, ...)
+/**
+ *
+ * inline demuxer: probe fragments and instantiate
+ * appropriate demuxer depending on content type (TSDemuxer, AACDemuxer, ...)
+ *
  */
 
 import Event from '../events';
@@ -11,6 +14,10 @@ import TSDemuxer from '../demux/tsdemuxer';
 import MP3Demuxer from '../demux/mp3demuxer';
 import MP4Remuxer from '../remux/mp4-remuxer';
 import PassThroughRemuxer from '../remux/passthrough-remuxer';
+
+// see https://stackoverflow.com/a/11237259/589493
+/* eslint-disable-next-line no-undef */
+const window = self; // safeguard for code that might run both on worker and main thread
 
 const { performance } = window;
 

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -12,6 +12,8 @@ import MP3Demuxer from '../demux/mp3demuxer';
 import MP4Remuxer from '../remux/mp4-remuxer';
 import PassThroughRemuxer from '../remux/passthrough-remuxer';
 
+const { performance } = window;
+
 class DemuxerInline {
   constructor (observer, typeSupported, config, vendor) {
     this.observer = observer;

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -15,9 +15,11 @@ import MP3Demuxer from '../demux/mp3demuxer';
 import MP4Remuxer from '../remux/mp4-remuxer';
 import PassThroughRemuxer from '../remux/passthrough-remuxer';
 
+import { getSelfScope } from '../utils/get-self-scope';
+
 // see https://stackoverflow.com/a/11237259/589493
 /* eslint-disable-next-line no-undef */
-const window = self; // safeguard for code that might run both on worker and main thread
+const window = getSelfScope(); // safeguard for code that might run both on worker and main thread
 
 const { performance } = window;
 

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -6,10 +6,11 @@ import DemuxerInline from '../demux/demuxer-inline';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { getMediaSource } from '../utils/mediasource-helper';
+import { getSelfScope } from '../utils/get-self-scope';
 
 // see https://stackoverflow.com/a/11237259/589493
 /* eslint-disable-next-line no-undef */
-const window = self; // safeguard for code that might run both on worker and main thread
+const window = getSelfScope(); // safeguard for code that might run both on worker and main thread
 
 const MediaSource = getMediaSource();
 

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -64,7 +64,7 @@ class Demuxer {
         logger.error('error while initializing DemuxerWorker, fallback on DemuxerInline');
         if (w) {
           // revoke the Object URL that was used to create demuxer worker, so as not to leak it
-          URL.revokeObjectURL(w.objectURL);
+          window.URL.revokeObjectURL(w.objectURL);
         }
         this.demuxer = new DemuxerInline(observer, typeSupported, config, vendor);
         this.w = undefined;
@@ -129,7 +129,7 @@ class Demuxer {
     switch (data.event) {
     case 'init':
       // revoke the Object URL that was used to create demuxer worker, so as not to leak it
-      URL.revokeObjectURL(this.w.objectURL);
+      window.URL.revokeObjectURL(this.w.objectURL);
       break;
       // special case for FRAG_PARSING_DATA: data1 and data2 are transferable objects
     case Event.FRAG_PARSING_DATA:

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -7,6 +7,10 @@ import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { getMediaSource } from '../utils/mediasource-helper';
 
+// see https://stackoverflow.com/a/11237259/589493
+/* eslint-disable-next-line no-undef */
+const window = self; // safeguard for code that might run both on worker and main thread
+
 const MediaSource = getMediaSource();
 
 class Demuxer {

--- a/src/events.js
+++ b/src/events.js
@@ -106,4 +106,5 @@ const HlsEvents = {
   // fired upon stream controller state transitions - data: { previousState, nextState }
   STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
 };
+
 export default HlsEvents;

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -18,6 +18,8 @@ import { logger } from '../utils/logger';
 import MP4Demuxer from '../demux/mp4demuxer';
 import M3U8Parser from './m3u8-parser';
 
+const { performance } = window;
+
 /**
  * `type` property values for this loaders' context object
  * @enum

--- a/src/utils/codecs.js
+++ b/src/utils/codecs.js
@@ -69,7 +69,7 @@ function isCodecType (codec, type) {
 }
 
 function isCodecSupportedInMp4 (codec, type) {
-  return MediaSource.isTypeSupported(`${type || 'video'}/mp4;codecs="${codec}"`);
+  return window.MediaSource.isTypeSupported(`${type || 'video'}/mp4;codecs="${codec}"`);
 }
 
 export { isCodecType, isCodecSupportedInMp4 };

--- a/src/utils/fetch-loader.js
+++ b/src/utils/fetch-loader.js
@@ -5,6 +5,8 @@
  * but still it is not bullet proof as it fails to avoid data waste....
 */
 
+const { Request, Headers, fetch, performance } = window;
+
 class FetchLoader {
   constructor (config) {
     this.fetchSetup = config.fetchSetup;

--- a/src/utils/get-self-scope.js
+++ b/src/utils/get-self-scope.js
@@ -1,0 +1,14 @@
+export function getSelfScope () {
+  let window;
+  if (typeof self === 'undefined') {
+    // workaround for Node.js bundling apps
+    // @see https://github.com/video-dev/hls.js/pull/1642
+    window = {}; // a Node app can not expect any DOM features if it doesn't define `self`
+    // as common scope for Window and Worker.
+  } else {
+    // see https://stackoverflow.com/a/11237259/589493
+    /* eslint-disable-next-line no-undef */
+    window = self; // safeguard for code that might run both on worker and main thread
+  }
+  return window;
+}

--- a/src/utils/get-self-scope.js
+++ b/src/utils/get-self-scope.js
@@ -1,14 +1,9 @@
 export function getSelfScope () {
-  let window;
-  if (typeof self === 'undefined') {
-    // workaround for Node.js bundling apps
-    // @see https://github.com/video-dev/hls.js/pull/1642
-    window = {}; // a Node app can not expect any DOM features if it doesn't define `self`
-    // as common scope for Window and Worker.
-  } else {
-    // see https://stackoverflow.com/a/11237259/589493
+  // see https://stackoverflow.com/a/11237259/589493
+  if (typeof window === 'undefined') {
     /* eslint-disable-next-line no-undef */
-    window = self; // safeguard for code that might run both on worker and main thread
+    return self;
+  } else {
+    return window;
   }
-  return window;
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,3 +1,5 @@
+import { getSelfScope } from './get-self-scope';
+
 function noop () {}
 
 const fakeLogger = {
@@ -26,7 +28,7 @@ function formatMsg (type, msg) {
 }
 
 /* eslint-disable-next-line no-undef */
-const window = self;
+const window = getSelfScope();
 
 function consolePrintFn (type) {
   const func = window.console[type];

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -11,8 +11,6 @@ const fakeLogger = {
 
 let exportedLogger = fakeLogger;
 
-/* globals self: false */
-
 // let lastCallTime;
 // function formatMsgWithTimeInfo(type, msg) {
 //   const now = Date.now();
@@ -27,15 +25,18 @@ function formatMsg (type, msg) {
   return msg;
 }
 
+/* eslint-disable-next-line no-undef */
+const window = self;
+
 function consolePrintFn (type) {
-  const func = self.console[type];
+  const func = window.console[type];
   if (func) {
     return function (...args) {
       if (args[0]) {
         args[0] = formatMsg(type, args[0]);
       }
 
-      func.apply(self.console, args);
+      func.apply(window.console, args);
     };
   }
   return noop;

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -4,6 +4,8 @@
 
 import { logger } from '../utils/logger';
 
+const { performance, XMLHttpRequest } = window;
+
 class XhrLoader {
   constructor (config) {
     if (config && config.xhrSetup) {

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -1,9 +1,13 @@
 import assert from 'assert';
 import sinon from 'sinon';
+
+import Hls from '../../../src/hls';
+
 import StreamController from '../../../src/controller/stream-controller';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
-import Hls from '../../../src/hls';
+
 import Event from '../../../src/events';
+
 import { ErrorTypes, ErrorDetails } from '../../../src/errors';
 
 describe('checkBuffer', function () {

--- a/tests/unit/demuxer/demuxer.js
+++ b/tests/unit/demuxer/demuxer.js
@@ -217,7 +217,7 @@ describe('Demuxer tests', function () {
       }
     };
 
-    let spy = sinon.spy(URL, 'revokeObjectURL');
+    let spy = sinon.spy(window.URL, 'revokeObjectURL');
 
     demux.onWorkerMessage(evt);
 


### PR DESCRIPTION
### This PR will...

Acknowledged the issue that was addressed here: https://github.com/video-dev/hls.js/pull/1755 ...

* Fix a few false positives of linter browser-env globals for `Event`, which is supposed to be our event enum, but linter thought was the DOM Event constructor.

* For code safety measure, remove all preset and custom globals from our eslint config

* Only access window globals explicitely everyhwere (yes), since this is the only way to write (almost) safe code in the end

* Add a `lint:quiet` script to only show fatal errors in eslint output 

* Mask the `window` global explicitely with self for transparent use of that scope in modules that are imported by both worker and main threads.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

`Event` not defined in `decryptor` and `adts` demuxer, which was causing error events not to be triggered in effect. 

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
