### PR TITLE
replace window with 'self' in workers automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5143,6 +5143,24 @@
         "resolve-cwd": "2.0.0"
       }
     },
+    "imports-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.8.0.tgz",
+      "integrity": "sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "http-server": "^0.11.0",
     "husky": "^0.14.3",
+    "imports-loader": "^0.8.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jshint": "^2.9.4",
     "karma": "^2.0.0",

--- a/src/crypt/decrypter.js
+++ b/src/crypt/decrypter.js
@@ -7,12 +7,6 @@ import { logger } from '../utils/logger';
 
 import Event from '../events';
 
-import { getSelfScope } from '../utils/get-self-scope';
-
-// see https://stackoverflow.com/a/11237259/589493
-/* eslint-disable-next-line no-undef */
-const window = getSelfScope(); // safeguard for code that might run both on worker and main thread
-
 const { performance, crypto } = window;
 
 class Decrypter {

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -6,8 +6,6 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 
 import Event from '../events';
 
-import { getSelfScope } from '../utils/get-self-scope';
-
 export function getAudioConfig (observer, data, offset, audioCodec) {
   let adtsObjectType, // :int
     adtsSampleingIndex, // :int

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -15,12 +15,6 @@ import MP3Demuxer from '../demux/mp3demuxer';
 import MP4Remuxer from '../remux/mp4-remuxer';
 import PassThroughRemuxer from '../remux/passthrough-remuxer';
 
-import { getSelfScope } from '../utils/get-self-scope';
-
-// see https://stackoverflow.com/a/11237259/589493
-/* eslint-disable-next-line no-undef */
-const window = getSelfScope(); // safeguard for code that might run both on worker and main thread
-
 const { performance } = window;
 
 class DemuxerInline {

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -6,11 +6,6 @@ import DemuxerInline from '../demux/demuxer-inline';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { getMediaSource } from '../utils/mediasource-helper';
-import { getSelfScope } from '../utils/get-self-scope';
-
-// see https://stackoverflow.com/a/11237259/589493
-/* eslint-disable-next-line no-undef */
-const window = getSelfScope(); // safeguard for code that might run both on worker and main thread
 
 const MediaSource = getMediaSource();
 

--- a/src/utils/get-self-scope.js
+++ b/src/utils/get-self-scope.js
@@ -1,9 +1,3 @@
-export function getSelfScope () {
-  // see https://stackoverflow.com/a/11237259/589493
-  if (typeof window === 'undefined') {
-    /* eslint-disable-next-line no-undef */
-    return self;
-  } else {
-    return window;
-  }
-}
+// see https://stackoverflow.com/a/11237259/589493
+/* eslint-disable-next-line no-undef */
+export default typeof window === 'undefined' ? self : window;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,5 +1,3 @@
-import { getSelfScope } from './get-self-scope';
-
 function noop () {}
 
 const fakeLogger = {
@@ -26,9 +24,6 @@ function formatMsg (type, msg) {
   msg = '[' + type + '] > ' + msg;
   return msg;
 }
-
-/* eslint-disable-next-line no-undef */
-const window = getSelfScope();
 
 function consolePrintFn (type) {
   const func = window.console[type];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ const uglifyJsOptions = {
   sourceMap: true
 };
 
+const getSelfScopePath = path.resolve(__dirname, 'src', 'utils', 'get-self-scope');
 const baseConfig = {
   entry: './src/hls.js',
   module: {
@@ -39,6 +40,13 @@ const baseConfig = {
         use: {
           loader: 'babel-loader'
         }
+      },
+      {
+        include: [ path.resolve(__dirname, 'src') ],
+        exclude: [ getSelfScopePath ],
+        test: /\.js$/,
+        // replace `window` with `self` if we are in a worker
+        use: `imports-loader?window=>require('${getSelfScopePath}')`
       }
     ]
   }


### PR DESCRIPTION
### This PR will...

use the webpack imports loader to automatically replace `window` with `self` when running in a worker.

### Why is this Pull Request needed?
It removes some duplicated code, and also caches `window` or `self`, so might have slightly better performance.


E.g in the build
```js
/*** IMPORTS FROM imports-loader ***/
var demuxer_window = __webpack_require__(0);
```
is injected at the top of each module, and in this built module `window` has been rewritten as `demuxer_window`.