### PR TITLE
Fix/1770 playback wont start preaudio

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -469,7 +469,6 @@ class MP4Remuxer {
     );
 
     // compute normalized PTS
-    let lastSample;
     inputSamples.forEach(function (sample) {
       sample.pts = sample.dts = ptsNormalize(sample.pts - initDTS, timeOffset * inputTimeScale);
       lastSample = sample;
@@ -478,16 +477,13 @@ class MP4Remuxer {
     // filter out sample with negative PTS that are not playable anyway
     // if we don't remove these negative samples, they will shift all audio samples forward.
     // leading to audio overlap between current / next fragment
-    inputSamples = inputSamples.filter(function (sample) {
-      return sample.pts >= 0;
-    });
+    // inputSamples = inputSamples.filter(function (sample) {
+    //   return sample.pts >= 0;
+    // });
 
     // in case all samples have negative PTS, and have been filtered out, return now
     if (inputSamples.length === 0) {
-      if(!lastSample) {
-        return;
-      }
-      inputSamples = [lastSample];
+      return;
     }
 
     if (!contiguous) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -469,8 +469,10 @@ class MP4Remuxer {
     );
 
     // compute normalized PTS
+    let lastSample;
     inputSamples.forEach(function (sample) {
       sample.pts = sample.dts = ptsNormalize(sample.pts - initDTS, timeOffset * inputTimeScale);
+      lastSample = sample;
     });
 
     // filter out sample with negative PTS that are not playable anyway
@@ -482,7 +484,10 @@ class MP4Remuxer {
 
     // in case all samples have negative PTS, and have been filtered out, return now
     if (inputSamples.length === 0) {
-      return;
+      if(!lastSample) {
+        return;
+      }
+      inputSamples = [lastSample];
     }
 
     if (!contiguous) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -471,7 +471,6 @@ class MP4Remuxer {
     // compute normalized PTS
     inputSamples.forEach(function (sample) {
       sample.pts = sample.dts = ptsNormalize(sample.pts - initDTS, timeOffset * inputTimeScale);
-      lastSample = sample;
     });
 
     // filter out sample with negative PTS that are not playable anyway


### PR DESCRIPTION
### This PR will... kinda fix the issue. It unblocks the audio controller to start loading the next segment.

### Why is this Pull Request needed? To fix #1770 

### Are there any points in the code the reviewer needs to double check? 
I believe there is probably a much nicer way to make the audio controller pass on to the next segment.
Obviously, i should also just remove the 3 commented lines, but yeah.. Just wanted to share what seemed to work for me.

### Resolves issues: Yeah, kinda does, but probably not the right way of doing it.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
