### PR TITLE
Fix: AV out of sync on fMP4 streams with alternate fMP4 audio playlist

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -585,7 +585,7 @@ class AudioStreamController extends TaskLoop {
         // If not we need to wait for it
         let initPTS = this.initPTS[cc];
         let initSegmentData = details.initSegment ? details.initSegment.data : [];
-        if (details.initSegment || initPTS !== undefined) {
+        if (initPTS !== undefined) {
           this.pendingBuffering = true;
           logger.log(`Demuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
           // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)


### PR DESCRIPTION
seems to help synchronizing, but only seems to synchronize on the 2nd audio segment and beyond.

### This PR will... help with ticket #1733 but only solves the issue once the playback hits the audio of the 2nd segment.


### Why is this Pull Request needed? To improve the AV sync on fMP4 streams.

### Are there any points in the code the reviewer needs to double check? 
Everything!  I'm sure there might be a better way of solving this, but this seems to at least work starting from the 2nd segment, instead of having the whole content out of sync.

### Resolves issues: #1733  partially

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
