### PR TITLE
Improve stall detection

### DIFF
--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -169,5 +169,11 @@ module.exports = {
   pdtOneValue: {
     url: 'https://playertest.longtailvideo.com/adaptive/aviion/manifest.m3u8',
     description: 'One PDT, no discontinuities'
+  },
+  largeStartGap: {
+    url: 'https://s3.amazonaws.com/bob.jwplayer.com/%7Ealex/123633/new_master.m3u8',
+    description: '10 second start gap',
+    live: false,
+    abr: false
   }
 };


### PR DESCRIPTION
### This PR will...
- Prevent stall warnings from firing while seeking
- Detect when the stream starts or seeks into in an unbuffered region

### Why is this Pull Request needed?
- So that stall events are not fired when the stream is not actually stalling
- So that jump out of gap it has started or seeked into

### Are there any points in the code the reviewer needs to double check?
This PR is a quick fix intended to resolve excessive buffer stall warnings. In the near future I'd like to refactor this logic into a `playhead` class.

### Resolves issues:
Not sure if it was reported

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
