### PR TITLE
Trigger BUFFER_NUDGE_ON_STALL before updating currentTime

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1532,12 +1532,12 @@ class StreamController extends TaskLoop {
       const targetTime = currentTime + nudgeRetry * config.nudgeOffset;
       logger.log(`adjust currentTime from ${currentTime} to ${targetTime}`);
       // playback stalled in buffered area ... let's nudge currentTime to try to overcome this
-      media.currentTime = targetTime;
       hls.trigger(Event.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_NUDGE_ON_STALL,
         fatal: false
       });
+      media.currentTime = targetTime;
     } else {
       logger.error(`still stuck in high buffer @${currentTime} after ${config.nudgeMaxRetry}, raise fatal error`);
       hls.trigger(Event.ERROR, {


### PR DESCRIPTION
### This PR will...
Trigger BUFFER_NUDGE_ON_STALL error first before updating the currentTime of the video tag.

### Why is this Pull Request needed?
Anytime we set the video tag's currentTime value, it triggers a pair of 'seek' and 'seeked' events. By triggering the error first, users of HLSjs can better decide how to deal with these events.

### Are there any points in the code the reviewer needs to double check?
None.

### Resolves issues:
Buffering on slower internet connections. (100kbps or less)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
