### PR TITLE
Apply search tolerances to finding frags via PDT

### DIFF
--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -114,12 +114,5 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
  */
 export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
   let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
-
-  if (candidate.endPdt - candidateLookupTolerance <= pdtBufferEnd) {
-    return false;
-  } else if (candidate.pdt && candidate.pdt - candidateLookupTolerance > pdtBufferEnd) {
-    return false;
-  }
-
-  return true;
+  return candidate.endPdt - candidateLookupTolerance > pdtBufferEnd;
 }

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -23,9 +23,10 @@ export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
  * Finds the first fragment whose endPDT value exceeds the given PDT.
  * @param {Array<Fragment>} fragments - The array of candidate fragments
  * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
+ * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start/end can be within in order to be considered contiguous
  * @returns {*|null} fragment - The best matching fragment
  */
-export function findFragmentByPDT (fragments, PDTValue = null) {
+export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTolerance = 0) {
   if (!Array.isArray(fragments) || !fragments.length || PDTValue === null) {
     return null;
   }
@@ -43,13 +44,7 @@ export function findFragmentByPDT (fragments, PDTValue = null) {
     return null;
   }
 
-  for (let seg = 0; seg < fragments.length; ++seg) {
-    let frag = fragments[seg];
-    if (PDTValue < frag.endPdt) {
-      return frag;
-    }
-  }
-  return null;
+  return BinarySearch.search(fragments, pdtWithinToleranceTest.bind(null, PDTValue, maxFragLookUpTolerance));
 }
 
 /**
@@ -59,26 +54,16 @@ export function findFragmentByPDT (fragments, PDTValue = null) {
  * @param {*} fragPrevious - The last frag successfully appended
  * @param {Array<Fragment>} fragments - The array of candidate fragments
  * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
- * @param {number} [end = 0] - The computed end time of the stream
- * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start can be within in order to be considered contiguous
+ * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start/end can be within in order to be considered contiguous
  * @returns {*} foundFrag - The best matching fragment
  */
-export function findFragmentBySN (fragPrevious, fragments, bufferEnd = 0, end = 0, maxFragLookUpTolerance = 0) {
-  let foundFrag;
+export function findFragmentBySN (fragPrevious, fragments, bufferEnd = 0, maxFragLookUpTolerance = 0) {
   const fragNext = fragPrevious ? fragments[fragPrevious.sn - fragments[0].sn + 1] : null;
-  if (bufferEnd < end) {
-    if (bufferEnd > end - maxFragLookUpTolerance) {
-      maxFragLookUpTolerance = 0;
-    }
-
-    // Prefer the next fragment if it's within tolerance
-    if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {
-      foundFrag = fragNext;
-    } else {
-      foundFrag = BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
-    }
+  // Prefer the next fragment if it's within tolerance
+  if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {
+    return fragNext;
   }
-  return foundFrag;
+  return BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
 }
 
 /**
@@ -108,6 +93,26 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
     return 1;
   } else if (candidate.start - candidateLookupTolerance > bufferEnd && candidate.start) {
     // if maxFragLookUpTolerance will have negative value then don't return -1 for first element
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * The test function used by the findFragmentByPdt's BinarySearch to look for the best match to the current buffer conditions.
+ * This function tests the candidate's program date time values, as represented in Unix time
+ * @param {*} candidate - The fragment to test
+ * @param {number} [pdtBufferEnd = 0] - The Unix time representing the end of the current buffered range
+ * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start can be within in order to be considered contiguous
+ * @returns {number} - 0 if it matches, 1 if too low, -1 if too high
+ */
+export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
+  let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
+
+  if (candidate.endPdt - candidateLookupTolerance <= pdtBufferEnd) {
+    return 1;
+  } else if (candidate.pdt && candidate.pdt - candidateLookupTolerance > pdtBufferEnd) {
     return -1;
   }
 

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -44,7 +44,12 @@ export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTole
     return null;
   }
 
-  return BinarySearch.search(fragments, pdtWithinToleranceTest.bind(null, PDTValue, maxFragLookUpTolerance));
+  for (let seg = 0; seg < fragments.length; ++seg) {
+    let frag = fragments[seg];
+    if (pdtWithinToleranceTest(PDTValue, maxFragLookUpTolerance, frag)) {
+      return frag;
+    }
+  }
 }
 
 /**
@@ -105,16 +110,16 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
  * @param {*} candidate - The fragment to test
  * @param {number} [pdtBufferEnd = 0] - The Unix time representing the end of the current buffered range
  * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start can be within in order to be considered contiguous
- * @returns {number} - 0 if it matches, 1 if too low, -1 if too high
+ * @returns {boolean} True if contiguous, false otherwise
  */
 export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
   let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
 
   if (candidate.endPdt - candidateLookupTolerance <= pdtBufferEnd) {
-    return 1;
+    return false;
   } else if (candidate.pdt && candidate.pdt - candidateLookupTolerance > pdtBufferEnd) {
-    return -1;
+    return false;
   }
 
-  return 0;
+  return true;
 }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -404,7 +404,7 @@ class StreamController extends TaskLoop {
       const fragBySN = () => findFragmentBySN(fragPrevious, fragments, bufferEnd, lookupTolerance);
       if (!levelDetails.programDateTime) {
         // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-        frag = findFragmentBySN(fragPrevious, fragments, bufferEnd, end, config.maxFragLookUpTolerance);
+        frag = findFragmentBySN(fragPrevious, fragments, bufferEnd, config.maxFragLookUpTolerance);
       } else {
         // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
         frag = findFragmentByPDT(fragments, calculateNextPDT(start, bufferEnd, levelDetails), lookupTolerance);

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -216,7 +216,7 @@ export default class M3U8Parser {
         frag.rawProgramDateTime = (' ' + result[5]).slice(1);
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
         if (!level.programDateTime) {
-          const pdt = new Date(new Date(Date.parse(result[5])) - 1000 * totalduration);
+          const pdt = new Date(Date.parse(result[5]) - 1000 * totalduration);
           if (!isNaN(pdt)) {
             level.programDateTime = pdt;
           }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -192,6 +192,11 @@ export default class M3U8Parser {
             frag.endPdt = frag.pdt + (frag.duration * 1000);
           }
 
+          if (isNaN(frag.pdt)) {
+            frag.pdt = null;
+            frag.endPdt = null;
+          }
+
           level.fragments.push(frag);
           prevFrag = frag;
           totalduration += frag.duration;
@@ -210,8 +215,11 @@ export default class M3U8Parser {
         // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
         frag.rawProgramDateTime = (' ' + result[5]).slice(1);
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
-        if (level.programDateTime === undefined) {
-          level.programDateTime = new Date(new Date(Date.parse(result[5])) - 1000 * totalduration);
+        if (!level.programDateTime) {
+          const pdt = new Date(new Date(Date.parse(result[5])) - 1000 * totalduration);
+          if (!isNaN(pdt)) {
+            level.programDateTime = pdt;
+          }
         }
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -130,11 +130,13 @@ describe('Fragment finders', function () {
       const fragments = [
         {
           pdt: 0,
-          endPdt: 1
+          endPdt: 1,
+          duration: 0.001
         },
         {
           pdt: 1,
-          endPdt: 2
+          endPdt: 2,
+          duration: 0.001
         }
       ];
       const actual = findFragmentByPDT(fragments, 0);
@@ -149,10 +151,6 @@ describe('Fragment finders', function () {
 
     it('returns null when passed an empty frag array', function () {
       assert.strictEqual(findFragmentByPDT([], 9001), null);
-    });
-
-    it('accounts for tolerances', function () {
-
     });
   });
 
@@ -202,16 +200,6 @@ describe('Fragment finders', function () {
       assert.strictEqual(false, actual);
     });
 
-    it('returns false if the fragment range is greater than the end of the buffer', function () {
-      const frag = {
-        pdt: pdtBufferEnd + 5000,
-        endPdt: pdtBufferEnd + 10000,
-        duration: 5
-      };
-      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(false, actual);
-    });
-
     it('does not skip very small fragments', function () {
       const frag = {
         pdt: pdtBufferEnd + 200,
@@ -231,16 +219,6 @@ describe('Fragment finders', function () {
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
       assert.strictEqual(false, actual);
-    });
-
-    it('accounts for tolerance when checking the pdt of the fragment', function () {
-      const frag = {
-        pdt: pdtBufferEnd + 1,
-        endPdt: pdtBufferEnd + 5000,
-        duration: 5
-      };
-      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(true, actual);
     });
   });
 });

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -182,34 +182,34 @@ describe('Fragment finders', function () {
   describe('pdtWithinToleranceTest', function () {
     let tolerance = 0.25;
     let pdtBufferEnd = 1505502678523; // Fri Sep 15 2017 15:11:18 GMT-0400 (Eastern Daylight Time)
-    it('returns 0 if the fragment range is equal to the end of the buffer', function () {
+    it('returns true if the fragment range is equal to the end of the buffer', function () {
       const frag = {
         pdt: pdtBufferEnd,
         endPdt: pdtBufferEnd + 5000 - (tolerance * 1000),
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(0, actual);
+      assert.strictEqual(true, actual);
     });
 
-    it('returns 1 if the fragment range is less than the end of the buffer', function () {
+    it('returns false if the fragment range is less than the end of the buffer', function () {
       const frag = {
         pdt: pdtBufferEnd - 10000,
         endPdt: pdtBufferEnd - 5000,
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(1, actual);
+      assert.strictEqual(false, actual);
     });
 
-    it('returns -1 if the fragment range is greater than the end of the buffer', function () {
+    it('returns false if the fragment range is greater than the end of the buffer', function () {
       const frag = {
         pdt: pdtBufferEnd + 5000,
         endPdt: pdtBufferEnd + 10000,
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(-1, actual);
+      assert.strictEqual(false, actual);
     });
 
     it('does not skip very small fragments', function () {
@@ -220,7 +220,7 @@ describe('Fragment finders', function () {
         deltaPTS: 0.1
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(0, actual);
+      assert.strictEqual(true, actual);
     });
 
     it('accounts for tolerance when checking the endPdt of the fragment', function () {
@@ -230,7 +230,7 @@ describe('Fragment finders', function () {
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(1, actual);
+      assert.strictEqual(false, actual);
     });
 
     it('accounts for tolerance when checking the pdt of the fragment', function () {
@@ -240,7 +240,7 @@ describe('Fragment finders', function () {
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(0, actual);
+      assert.strictEqual(true, actual);
     });
   });
 });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -120,16 +120,16 @@ describe('StreamController tests', function () {
 
       let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after starting/seeking to a new position (bufferEnd used)', function () {
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
       let mediaSeekingTime = 17.00;
-
       let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, mediaSeekingTime, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
+      // Fragment 2 starts at 15:11:16 and ends at 15:11:21, which is the best candidate for buffering at the seeked-to PDT of 15:11:18
+      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT serch hitting empty discontinuity', function () {
@@ -150,6 +150,11 @@ describe('StreamController tests', function () {
       const expected = fragments[2];
       const actual = streamController._findFragment(0, fragments[1], fragments.length, fragments, bufferEnd, end, levelDetails);
       assert.strictEqual(expected, actual);
+    });
+
+    it('returns the last fragment if the stream is fully buffered', function () {
+      const actual = streamController._findFragment(0, null, mockFragments.length, mockFragments, end, end, levelDetails);
+      assert.strictEqual(actual, mockFragments[mockFragments.length - 1]);
     });
   });
 


### PR DESCRIPTION
### This PR will...
- Apply search tolerances to finding frags via PDT 
- Clean up redundant code
- Add tests
- Avoid assigning pdt to the level or frag if it is NaN

### Why is this Pull Request needed?
So that searching for the next fragment via SN/Buffer or PDT follows the same rules. Without applying the tolerances small discrepancies in PDT cause fragments to loop load or be missed. And in the case of bad PDT values (non-date), NaN values cause the wrong fragment to be selected.

### Are there any points in the code the reviewer needs to double check?
Sure. Any more unit tests to add?

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
