### PR TITLE
Stop level capping on media detaching

### DIFF
--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -11,7 +11,8 @@ class CapLevelController extends EventHandler {
       Event.FPS_DROP_LEVEL_CAPPING,
       Event.MEDIA_ATTACHING,
       Event.MANIFEST_PARSED,
-      Event.BUFFER_CODECS);
+      Event.BUFFER_CODECS,
+      Event.MEDIA_DETACHING);
 
     this.autoLevelCapping = Number.POSITIVE_INFINITY;
     this.firstLevel = null;
@@ -62,6 +63,10 @@ class CapLevelController extends EventHandler {
 
   onLevelsUpdated (data) {
     this.levels = data.levels;
+  }
+
+  onMediaDetaching () {
+    this._stopCapping();
   }
 
   detectPlayerSize () {


### PR DESCRIPTION
### Why is this Pull Request needed?
So that when the current media is detached, and new media with fewer levels is attached, `maxAutoLevel` does not represent an index out-of-bounds with respect to the new array of levels.

From the reported issue:

1. load a source with multiple levels with large video tag size to make `autoLevelCapping` > 0, let say `autoLevelCapping = 1`
2. detach (`autoLevelCapping  = 1`)
3. load source with a single level (`autoLevelCapping  = 1`)
4. ABR controller reads `maxAutoLevel` (which equals `autoLevelCapping = 1`) and traverses all levels from `minAutoLevel` to `maxAutoLevel` and breaks up because `minAutoLevel = 0`, `maxAutoLevel = 1` and `levels.length === 1` (we are getting out of range error)

### Are there any points in the code the reviewer needs to double check?
Does re-attaching guarantee that `onManifestParsed` will be called again? I'm wondering if it could be the case that we detach & re-attach the same media but capping is not resumed.

### Resolves issues:
https://github.com/video-dev/hls.js/issues/1757#issuecomment-394738123

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
