### PR TITLE
Updated LEVEL_PLAYLIST_REGEX_SLOW in m3u8-parser.js to use first colon as tag end

### DIFF
--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -25,7 +25,7 @@ const LEVEL_PLAYLIST_REGEX_FAST = new RegExp([
   /|#.*/.source // All other non-segment oriented tags will match with all groups empty
 ].join(''), 'g');
 
-const LEVEL_PLAYLIST_REGEX_SLOW = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DISCONTINUITY-SEQ)UENCE:(\d+))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(VERSION):(\d+))|(?:#EXT-X-(MAP):(.+))|(?:(#)(.*):(.*))|(?:(#)(.*))(?:.*)\r?\n?/;
+const LEVEL_PLAYLIST_REGEX_SLOW = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DISCONTINUITY-SEQ)UENCE:(\d+))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(VERSION):(\d+))|(?:#EXT-X-(MAP):(.+))|(?:(#)([^:]*):(.*))|(?:(#)(.*))(?:.*)\r?\n?/;
 
 const MP4_REGEX_SUFFIX = /\.(mp4|m4s|m4v|m4a)$/i;
 

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -693,7 +693,7 @@ Rollover38803/20160525T064049-01-69844069.ts
     let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
     assert.strictEqual(result.programDateTime, undefined);
   });
-  
+
   it('tests : at end of tag name is used to divide custom tags', () => {
     let level = `#EXTM3U
 #EXT-X-VERSION:2

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -694,7 +694,7 @@ Rollover38803/20160525T064049-01-69844069.ts
     assert.strictEqual(result.programDateTime, undefined);
   });
   
-  it('ensures first : is used for cusomt tags', () => {
+  it('tests : at end of tag name is used to divide custom tags', () => {
     let level = `#EXTM3U
 #EXT-X-VERSION:2
 #EXT-X-TARGETDURATION:10


### PR DESCRIPTION
### This PR will...

Updated regular expression to use first colon as tag name divider, rather than last.

### Why is this Pull Request needed?

If passing a JSON object in a custom tag, the tag name contains part of json object, and value is broken.

### Are there any points in the code the reviewer needs to double check?

The regex could be validated.

### Resolves issues:
#1814

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
