### PR TITLE
Fixed stalled playback when audio/video CC gets out of sync

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -267,6 +267,9 @@ class AudioStreamController extends TaskLoop {
             this.media.currentTime = nextBuffered + 0.05;
             return;
           }
+        } else if (this.resyncWithVideoCC && this.videoTrackCC !== null) {
+          this.resyncWithVideoCC = false;
+          frag = findFragWithCC(fragments, this.videoTrackCC);
         } else {
           let foundFrag;
           let maxFragLookUpTolerance = config.maxFragLookUpTolerance;
@@ -383,6 +386,12 @@ class AudioStreamController extends TaskLoop {
           track = this.tracks[this.trackId];
           if (track.details && track.details.live) {
             logger.warn(`Waiting fragment CC (${waitingFragCC}) does not match video track CC (${videoTrackCC})`);
+            this.waitingFragment = null;
+            this.state = State.IDLE;
+          } else if (videoTrackCC > waitingFragCC) {
+            logger.warn(`Waiting fragment CC (${waitingFragCC}) is lower than video track CC (${videoTrackCC}), resyncing based on video CC`);
+            this.fragmentTracker.removeFragment(this.waitingFragment.frag);
+            this.resyncWithVideoCC = true;
             this.waitingFragment = null;
             this.state = State.IDLE;
           }


### PR DESCRIPTION
### This PR will...
When `audio-stream-controller` is in state: `WAITING_INIT_PTS`, check if the the new initPTS CC is higher than the `waitingFragment` CC, if it is force the `audio-stream-controller` to get the first fragment matching the video CC.
### Why is this Pull Request needed?
There is an edge-case where the `audio-stream-controllers` can load an earlier discontinuity than the `stream-controller`, when seeking, and thus gets stuck in an endless state `WAITING_INIT_PTS`. This happens when the accumulated  audio playlist`#EXTINF` duration of a discontinuity is longer than that of the video equivalent.
Eg.
The first video fragment of CC 30 has a start time of 2338
The first audio fragment of CC 30 has a start time of 2340.16

CC 30 ends at 2340 according to the video playlist but at 2342.16 according to the audio playlist ( according to the #EXTINF that is ) so if you seek to 2340.16 `audio-stream-controller` will want to load CC 30 but `stream-controller` will want to load CC 31

I can provide a stream for testing, please contact me on the video-dev slack ( bwallberg ).

### Are there any points in the code the reviewer needs to double check?
No
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md

### Other
In addition to this there is an additional edge case here, if `audio-stream-controller` is trying to load a CC larger than the `stream-controller` and the `stream-controller` isn't forthcoming then you'll get an endless loop as well, but I don't have a test-case for that. But it might make sense to add.