### PR TITLE
Clear stall values when paused to avoid unnecessary nudge.

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1376,12 +1376,13 @@ class StreamController extends TaskLoop {
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();
     } else {
-      const expectedPlaying = !((media.paused && media.readyState > 1) || // not playing when media is paused and sufficiently buffered
+      const purposefullyPaused = media.paused && media.readyState > 1;
+      const expectedPlaying = !(purposefullyPaused || // not playing when media is paused and sufficiently buffered
         media.ended || // not playing when media is ended
         media.buffered.length === 0); // not playing if nothing buffered
       const tnow = window.performance.now();
 
-      if (currentTime !== this.lastCurrentTime) {
+      if (currentTime !== this.lastCurrentTime || purposefullyPaused) {
         // The playhead is now moving, but was previously stalled
         if (this.stallReported) {
           logger.warn(`playback not stuck anymore @${currentTime}, after ${Math.round(tnow - this.stalled)}ms`);

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -217,6 +217,22 @@ describe('checkBuffer', function () {
       assert(fixStallStub.notCalled);
     });
 
+    it('should reset stall flags when no longer stalling and paused', function () {
+      streamController.loadedmetadata = true;
+      streamController.stallReported = true;
+      streamController.nudgeRetry = 1;
+      streamController.stalled = 4200;
+      mockMedia.paused = true;
+      mockMedia.readyState = 4;
+      const fixStallStub = sandbox.stub(streamController, '_tryFixBufferStall');
+      streamController._checkBuffer();
+
+      assert.strictEqual(streamController.stalled, null);
+      assert.strictEqual(streamController.nudgeRetry, 0);
+      assert.strictEqual(streamController.stallReported, false);
+      assert(fixStallStub.notCalled);
+    });
+
     it('should trigger reportStall when stalling for 1 second or longer', function () {
       setExpectedPlaying();
       const clock = sandbox.useFakeTimers(0);


### PR DESCRIPTION
Without this fix there is a problem where a stall is 'detected'
if you pause the video, seek (within the buffer), wait for nudge threshold seconds,
seek again (within the buffer). This would trigger a stall since the
stalled variable was never cleared.

### This PR will...
Ensure that stall trackers are cleared once the video recovers even if the video is paused.

### Why is this Pull Request needed?
Without this we were experiencing an issue, the repro for which is essentially:

1. Load a video
2. Pause the video or leave it paused
3. Seek - this will result in `this.stalled` in stream-controller being set
4. Wait `highBufferWatchdogPeriod` seconds - in our use case users were frequently seeking (we have a frame-by-frame seek option when paused)
5. Seek again - since `this.stalled` has never been cleared the brief time that `readyState` drops to `1` will appear to be a long stall and hls.js runs the nudge code.

### Are there any points in the code the reviewer needs to double check?
Are there cases where `purposefullyPaused` would be true, but we are actually stalled?

### Resolves issues:
I believe this is the first report of the issue I've seen

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [X] new unit / functional tests have been added (whenever applicable)
- [X] API or design changes are documented in API.md
