### PR TITLE
isCodecSupportedInMp4 test audio codecs as audio

### DIFF
--- a/src/utils/codecs.js
+++ b/src/utils/codecs.js
@@ -69,6 +69,9 @@ function isCodecType (codec, type) {
 }
 
 function isCodecSupportedInMp4 (codec, type) {
+  if (!type && isCodecType(codec, 'audio')) {
+    type = 'audio';
+  }
   return window.MediaSource.isTypeSupported(`${type || 'video'}/mp4;codecs="${codec}"`);
 }
 


### PR DESCRIPTION
Fixes #1824.

### This PR will...

if `src/utils/codecs/sCodecSupportedInMp4(codec, type)` is called without a type, it currently will *always* check if the type is supported using `MediaSource.isTypeSupported(video/mp4;codecs="codec")`. When checking audio codecs, some browsers will respond `false`.

This PR uses `isCodecType()` if there is no type provided, to check if it's an audio type, and so checks for `MediaSource.isTypeSupported(audio/mp4;codecs="codec")` in that case.

### Why is this Pull Request needed?

See #1824.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
