### PR TITLE
key-loader: set maxRetry to 0

### DIFF
--- a/src/loader/key-loader.js
+++ b/src/loader/key-loader.js
@@ -46,7 +46,7 @@ class KeyLoader extends EventHandler {
 
       let loaderContext, loaderConfig, loaderCallbacks;
       loaderContext = { url: uri, frag: frag, responseType: 'arraybuffer' };
-      loaderConfig = { timeout: config.fragLoadingTimeOut, maxRetry: config.fragLoadingMaxRetry, retryDelay: config.fragLoadingRetryDelay, maxRetryDelay: config.fragLoadingMaxRetryTimeout };
+      loaderConfig = { timeout: config.fragLoadingTimeOut, maxRetry: 0, retryDelay: config.fragLoadingRetryDelay, maxRetryDelay: config.fragLoadingMaxRetryTimeout };
       loaderCallbacks = { onSuccess: this.loadsuccess.bind(this), onError: this.loaderror.bind(this), onTimeout: this.loadtimeout.bind(this) };
       frag.loader.load(loaderContext, loaderConfig, loaderCallbacks);
     } else if (this.decryptkey) {

--- a/src/loader/key-loader.js
+++ b/src/loader/key-loader.js
@@ -46,6 +46,9 @@ class KeyLoader extends EventHandler {
 
       let loaderContext, loaderConfig, loaderCallbacks;
       loaderContext = { url: uri, frag: frag, responseType: 'arraybuffer' };
+      // maxRetry is 0 so that instead of retrying the same key on the same variant multiple times,
+      // key-loader will trigger an error and rely on stream-controller to handle retry logic.
+      // this will also align retry logic with fragment-loader
       loaderConfig = { timeout: config.fragLoadingTimeOut, maxRetry: 0, retryDelay: config.fragLoadingRetryDelay, maxRetryDelay: config.fragLoadingMaxRetryTimeout };
       loaderCallbacks = { onSuccess: this.loadsuccess.bind(this), onError: this.loaderror.bind(this), onTimeout: this.loadtimeout.bind(this) };
       frag.loader.load(loaderContext, loaderConfig, loaderCallbacks);


### PR DESCRIPTION
### This PR will...

Set maxRetry to 0 in `key-loader`.

### Why is this Pull Request needed?

Instead of retrying the same key on the same variant multiple times, key-loader will trigger an error and rely on stream-controller to handle retry logic. This will also align retry logic with `fragment-loader`

### Are there any points in the code the reviewer needs to double check?

If someone can provide a test stream with different keys across variants

### Resolves issues:

Solve #1836.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
