### PR TITLE
Support universal builds ("SSR")

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -7,6 +7,9 @@ npm install
 if [ "${TRAVIS_MODE}" = "build" ]; then
   npm run lint
   npm run build
+  # check that hls.js doesn't error if requiring in node
+  # see https://github.com/video-dev/hls.js/pull/1642
+  node -e 'require("./" + require("./package.json").main)'
 elif [ "${TRAVIS_MODE}" = "unitTests" ]; then
 	npm run test:unit
 elif [ "${TRAVIS_MODE}" = "funcTests" ]; then

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,7 @@ function getPluginsForConfig(type, minify = false) {
   );
 
   const plugins = [
+    new webpack.BannerPlugin({ entryOnly: true, raw: true, banner: 'typeof window !== "undefined" &&' }), // SSR/Node.js guard
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin(defineConstants)
   ];


### PR DESCRIPTION
### This PR will...

Add a guard against the global `window` object (not present for Node.js), in order to avoid errors when loading hls.js into Node.js with `require()` (including using `import` statements via bundlers or transpilers).

Instead of throwing an error it will export an empty object `{}`. In effect this is making it possible to load the module and not get any error, so the error handling can be deferred, if need be.

The guard can alternatively be added to the hls.js source code, to each file containing references to the DOM. This is less optimal imo. One of the maintainers seems to think the same (see: https://github.com/video-dev/hls.js/pull/1642#discussion_r177874988)

Hls.js doesn't support ES6 modules that can be imported in Node.js (`.mjs`-files), if this is changed in the future, then this fix will not work for them. ES6 module makes this sort of fix impossible 😕 The webpack bundles uses UMD, which doesn't have this problem.

### Resolves issues:
#1813 (unfixed, but closed by author)
#1642 (previous PR attempting to fix this, now reverted)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable) (https://github.com/video-dev/hls.js/pull/1841/commits/8f09e5e7cc436d7baa48f855b8344c59f4d19fc4)
- [ ] API or design changes are documented in API.md
