### PR TITLE
Fix setting audio-tracks right after manifest-loaded/parsed

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -29,9 +29,9 @@ const HlsEvents = {
   BUFFER_FLUSHED: 'hlsBufferFlushed',
   // fired to signal that a manifest loading starts - data: { url : manifestURL}
   MANIFEST_LOADING: 'hlsManifestLoading',
-  // fired after manifest has been loaded - data: { levels : [available quality levels], audioTracks : [ available audio tracks], url : manifestURL, stats : { trequest, tfirst, tload, mtime}}
+  // fired after manifest has been loaded - data: { levels : [available quality levels], audioTracks : [available audio tracks], url : manifestURL, stats : {trequest, tfirst, tload, mtime}}
   MANIFEST_LOADED: 'hlsManifestLoaded',
-  // fired after manifest has been parsed - data: { levels : [available quality levels], firstLevel : index of first quality level appearing in Manifest}
+  // fired after manifest has been parsed - data: { levels : [available quality levels], audioTracks : [available audio tracks], firstLevel : index of first quality level appearing in Manifest}
   MANIFEST_PARSED: 'hlsManifestParsed',
   // fired when a level switch is requested - data: { level : id of new level }
   LEVEL_SWITCHING: 'hlsLevelSwitching',


### PR DESCRIPTION
### This PR will...

Attempt to fix the issue described here: https://github.com/video-dev/hls.js/issues/1833

For now we have been able to understand that it is necessary for finally being able to receive audio-track setting in all cases, that we have internally processed the manifest-loaded event, and this only is completely finalized after `AUDIO_TRACKS_UPDATED`.

This may be only about actually updating our API spec and documentation rather than having to change anything about functionality. 

It is clear that manifest-loaded event is an intermediate step, and that as things are, we need to go through several stages internally before being able to accept an audio-track setting.

We may be able to chache values passed to the API and apply them internally once we are ready. This PR can be a platform for suggesting how to deal with this.

### Why is this Pull Request needed?

The result should be that we can set the audio-track as soon as we know about available audio-tracks and hls.js has performed necessary internal initialization so to be ready to receive a setting.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
