### PR TITLE
Bugfix/1220 cleanup live back buffer

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -545,7 +545,7 @@ If you want to have a native Live UI in environments like iOS Safari, Safari, An
 
 (default: `Infinity`)
 
-Enforce the length (seconds) of the back buffer (`Infinity` means no restriction on back buffer length, `0` - no back buffer is needed).
+Sets the maximum length of the buffer, in seconds, to keep durin a live stream. Any video buffered past this time will be evicted. `Infinity` means no restriction on back buffer length; `0` keeps the minimum amount. The minimum amount is equal to the target duration of a segment to ensure that current playback is not interrupted.
 
 ### `enableWorker`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -540,6 +540,18 @@ Override current Media Source duration to `Infinity` for a live broadcast.
 Useful, if you are building a player which relies on native UI capabilities in modern browsers.
 If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
 
+### `liveMinBackBufferLength`
+
+(default: `4`)
+
+Minimum length (seconds) of the back buffer to be kept during the cleanup.
+
+### `liveMaxBackBufferLength`
+
+(default: `undefined`)
+
+Maximum length (seconds) of the back buffer during live streaming, to explicitly free up memory taken by media buffer.
+
 ### `enableWorker`
 
 (default: `true`)

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,7 @@
   - [`liveSyncDuration`](#livesyncduration)
   - [`liveMaxLatencyDuration`](#livemaxlatencyduration)
   - [`liveDurationInfinity`](#livedurationinfinity)
+  - [`liveBackBufferLength`](#livebackbufferlength)
   - [`enableWorker`](#enableworker)
   - [`enableSoftwareAES`](#enablesoftwareaes)
   - [`startLevel`](#startlevel)
@@ -540,17 +541,11 @@ Override current Media Source duration to `Infinity` for a live broadcast.
 Useful, if you are building a player which relies on native UI capabilities in modern browsers.
 If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
 
-### `liveMinBackBufferLength`
+### `liveBackBufferLength`
 
-(default: `4`)
+(default: `Infinity`)
 
-Minimum length (seconds) of the back buffer to be kept during the cleanup.
-
-### `liveMaxBackBufferLength`
-
-(default: `undefined`)
-
-Maximum length (seconds) of the back buffer during live streaming, to explicitly free up memory taken by media buffer.
+Enforce the length (seconds) of the back buffer (`Infinity` means no restriction on back buffer length, `0` - no back buffer is needed).
 
 ### `enableWorker`
 

--- a/src/config.js
+++ b/src/config.js
@@ -42,8 +42,7 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
-  liveMinBackBufferLength: 4, // used by buffer-controller
-  liveMaxBackBufferLength: undefined, // used by buffer-controller
+  liveBackBufferLength: Infinity, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller
   enableWorker: true, // used by demuxer
   enableSoftwareAES: true, // used by decrypter

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,8 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
+  liveMinBackBufferLength: 4, // used by buffer-controller
+  liveMaxBackBufferLength: undefined, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller
   enableWorker: true, // used by demuxer
   enableSoftwareAES: true, // used by decrypter

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -375,7 +375,7 @@ class BufferController extends EventHandler {
     this.doFlush();
   }
 
-  clearLiveBackBuffer() {
+  clearLiveBackBuffer () {
     // clear back buffer for live only
     if (!this._live) {
       return;
@@ -395,14 +395,14 @@ class BufferController extends EventHandler {
 
           // when back buffer exceeded maximum value
           if (buffered.length > 0 && (currentTime - buffered.start(0) - liveMinBackBufferLength) > liveMaxBackBufferLength) {
-            // remove buffer up until current time minus minimum back buffer length (removing buffer too close to current 
+            // remove buffer up until current time minus minimum back buffer length (removing buffer too close to current
             // time will lead to playback freezing)
             this.removeBufferRange(bufferType, sourceBuffer[bufferType], 0, currentTime - liveMinBackBufferLength);
           }
         }
       }
     } catch (error) {
-      logger.warn("clearLiveBackBuffer failed", error);
+      logger.warn('clearLiveBackBuffer failed', error);
     }
   }
 
@@ -575,7 +575,7 @@ class BufferController extends EventHandler {
     as sourceBuffer.remove() is asynchronous, flushBuffer will be retriggered on sourceBuffer update end
   */
   flushBuffer (startOffset, endOffset, typeIn) {
-    let sb, i, bufStart, bufEnd, flushStart, flushEnd, sourceBuffer = this.sourceBuffer;
+    let sb, sourceBuffer = this.sourceBuffer;
     if (Object.keys(sourceBuffer).length) {
       logger.log(`flushBuffer,pos/start/end: ${this.media.currentTime.toFixed(3)}/${startOffset}/${endOffset}`);
       // safeguard to avoid infinite looping : don't try to flush more than the nb of appended segments
@@ -614,15 +614,15 @@ class BufferController extends EventHandler {
 
   /**
    * Removes first buffered range from provided source buffer that lies within given start and end offsets.
-   * 
+   *
    * @param type Type of the source buffer, logging purposes only.
    * @param sb Target SourceBuffer instance.
    * @param startOffset
    * @param endOffset
-   * 
-   * @returns {boolean} True when source buffer remove requested. 
+   *
+   * @returns {boolean} True when source buffer remove requested.
    */
-  removeBufferRange(type, sb, startOffset, endOffset) {
+  removeBufferRange (type, sb, startOffset, endOffset) {
     try {
       let i, length, bufStart, bufEnd, removeStart, removeEnd;
 
@@ -651,7 +651,7 @@ class BufferController extends EventHandler {
         }
       }
     } catch (error) {
-      logger.warn("removeBufferRange failed", error);
+      logger.warn('removeBufferRange failed', error);
     }
 
     return false;

--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -33,8 +33,7 @@ describe('BufferController tests', function () {
 
     it('should trigger buffer removal with valid range for live', () => {
       bufferController.media = { currentTime: 360 };
-      hls.config.liveMinBackBufferLength = 4;
-      hls.config.liveMaxBackBufferLength = 60;
+      hls.config.liveBackBufferLength = 60;
       bufferController.sourceBuffer = {
         video: {
           buffered: {
@@ -59,9 +58,22 @@ describe('BufferController tests', function () {
           'video',
           bufferController.sourceBuffer.video,
           0,
-          bufferController.media.currentTime - hls.config.liveMinBackBufferLength
+          bufferController.media.currentTime - hls.config.liveBackBufferLength
         ),
-        'remove buffer range was not requested with valid data'
+        'remove buffer range was not requested with valid data from liveBackBufferLength'
+      );
+
+      hls.config.liveBackBufferLength = 0;
+      bufferController._levelTargetDuration = 10;
+      bufferController.clearLiveBackBuffer();
+      assert(
+        removeBufferRangeStub.calledWith(
+          'video',
+          bufferController.sourceBuffer.video,
+          0,
+          bufferController.media.currentTime - bufferController._levelTargetDuration
+        ),
+        'remove buffer range was not requested with valid data from _levelTargetDuration'
       );
     });
   });

--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -1,0 +1,68 @@
+import assert from 'assert';
+import { stub } from 'sinon';
+import Hls from '../../../src/hls';
+import BufferController from '../../../src/controller/buffer-controller';
+
+describe('BufferController tests', function () {
+  let hls;
+  let bufferController;
+
+  beforeEach(function () {
+    hls = new Hls({});
+
+    bufferController = new BufferController(hls);
+  });
+
+  describe('Live back buffer enforcement', () => {
+    it('should trigger clean back buffer when there are no pending appends', () => {
+      bufferController.parent = {};
+      bufferController.segments = [{ parent: bufferController.parent }];
+
+      let clearStub = stub(bufferController, 'clearLiveBackBuffer');
+      stub(bufferController, 'doAppending');
+
+      bufferController.onSBUpdateEnd();
+
+      assert(clearStub.notCalled, 'clear live back buffer was called');
+
+      bufferController.segments = [];
+      bufferController.onSBUpdateEnd();
+
+      assert(clearStub.calledOnce, 'clear live back buffer was not called once');
+    });
+
+    it('should trigger buffer removal with valid range for live', () => {
+      bufferController.media = { currentTime: 360 };
+      hls.config.liveMinBackBufferLength = 4;
+      hls.config.liveMaxBackBufferLength = 60;
+      bufferController.sourceBuffer = {
+        video: {
+          buffered: {
+            start: stub().withArgs(0).returns(120),
+            length: 1
+          }
+        }
+      };
+
+      let removeBufferRangeStub = stub(bufferController, 'removeBufferRange');
+
+      bufferController._live = false;
+      bufferController.clearLiveBackBuffer();
+      assert(removeBufferRangeStub.notCalled, 'remove buffer range was called for non-live');
+
+      bufferController._live = true;
+      bufferController.clearLiveBackBuffer();
+      assert(removeBufferRangeStub.calledOnce, 'remove buffer range was not called once');
+
+      assert(
+        removeBufferRangeStub.calledWith(
+          'video',
+          bufferController.sourceBuffer.video,
+          0,
+          bufferController.media.currentTime - hls.config.liveMinBackBufferLength
+        ),
+        'remove buffer range was not requested with valid data'
+      );
+    });
+  });
+});


### PR DESCRIPTION
### This PR will introduce live streaming back buffer cleanup feature.

### Why is this Pull Request needed?
Address #1220

### Are there any points in the code the reviewer needs to double check?
nope

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md


**Note: Cleanup logic is disabled by default, `liveMaxBackBufferLength` config (value in seconds) was introduced so that cleanup can be manually activated if/when needed. 
Local tests were executed with `liveMaxBackBufferLength=30`**