### PR TITLE
Improve fragment searching via PDT

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -142,7 +142,7 @@ class AbrController extends EventHandler {
 
   onFragLoaded (data) {
     const frag = data.frag;
-    if (frag.type === 'main' && !isNaN(frag.sn)) {
+    if (frag.type === 'main' && Number.isFinite(frag.sn)) {
       // stop monitoring bw once frag loaded
       this.clearTimer();
       // store level id after successful fragment load
@@ -174,7 +174,7 @@ class AbrController extends EventHandler {
     // if same frag is loaded multiple times, it might be in browser cache, and loaded quickly
     // and leading to wrong bw estimation
     // on bitrate test, also only update stats once (if tload = tbuffered == on FRAG_LOADED)
-    if (stats.aborted !== true && frag.type === 'main' && !isNaN(frag.sn) && ((!frag.bitrateTest || stats.tload === stats.tbuffered))) {
+    if (stats.aborted !== true && frag.type === 'main' && Number.isFinite(frag.sn) && ((!frag.bitrateTest || stats.tload === stats.tbuffered))) {
       // use tparsed-trequest instead of tbuffered-trequest to compute fragLoadingProcessing; rationale is that  buffer appending only happens once media is attached
       // in case we use config.startFragPrefetch while media is not attached yet, fragment might be parsed while media not attached yet, but it will only be buffered on media attached
       // as a consequence it could happen really late in the process. meaning that appending duration might appears huge ... leading to underestimated throughput estimation

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -339,7 +339,7 @@ class AudioStreamController extends TaskLoop {
             if (audioSwitch || this.fragmentTracker.getState(frag) === FragmentState.NOT_LOADED) {
               this.fragCurrent = frag;
               this.startFragRequested = true;
-              if (!isNaN(frag.sn)) {
+              if (Number.isFinite(frag.sn)) {
                 this.nextLoadPosition = frag.start + frag.duration;
               }
 
@@ -525,7 +525,7 @@ class AudioStreamController extends TaskLoop {
       if (this.startPosition === -1) {
         // first, check if start time offset has been set in playlist, if yes, use this value
         let startTimeOffset = newDetails.startTimeOffset;
-        if (!isNaN(startTimeOffset)) {
+        if (Number.isFinite(startTimeOffset)) {
           logger.log(`start time offset found in playlist, adjust startPosition to ${startTimeOffset}`);
           this.startPosition = startTimeOffset;
         } else {
@@ -654,7 +654,7 @@ class AudioStreamController extends TaskLoop {
         track = this.tracks[trackId],
         hls = this.hls;
 
-      if (isNaN(data.endPTS)) {
+      if (!Number.isFinite(data.endPTS)) {
         data.endPTS = data.startPTS + fragCurrent.duration;
         data.endDTS = data.startDTS + fragCurrent.duration;
       }

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -413,8 +413,7 @@ class BufferController extends EventHandler {
       // Override duration to Infinity
       logger.log('Media Source duration is set to Infinity');
       this._msDuration = this.mediaSource.duration = Infinity;
-    } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration) ||
-      (duration === Infinity || isNaN(duration))) {
+    } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration) || !Number.isFinite(duration)) {
       // levelDuration was the last value we set.
       // not using mediaSource.duration as the browser may tweak this value
       // only update Media Source duration if its value increase, this is to avoid

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -13,11 +13,11 @@ export function findFragmentByPDT (fragments, PDTValue, maxFragLookUpTolerance) 
   }
 
   // if less than start
-  if (PDTValue < fragments[0].pdt) {
+  if (PDTValue < fragments[0].programDateTime) {
     return null;
   }
 
-  if (PDTValue >= fragments[fragments.length - 1].endPdt) {
+  if (PDTValue >= fragments[fragments.length - 1].endProgramDateTime) {
     return null;
   }
 
@@ -28,6 +28,8 @@ export function findFragmentByPDT (fragments, PDTValue, maxFragLookUpTolerance) 
       return frag;
     }
   }
+
+  return null;
 }
 
 /**
@@ -92,5 +94,5 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
  */
 export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
   let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
-  return candidate.endPdt - candidateLookupTolerance > pdtBufferEnd;
+  return candidate.endProgramDateTime - candidateLookupTolerance > pdtBufferEnd;
 }

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -1,55 +1,33 @@
 import BinarySearch from '../utils/binary-search';
 
 /**
- * Calculates the PDT of the next load position.
- * bufferEnd in this function is usually the position of the playhead.
- * @param {number} [start = 0] - The PTS of the first fragment within the level
- * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
- * @param {*} levelDetails - An object containing the parsed and computed properties of the currently playing level
- * @returns {number} nextPdt - The computed PDT
- */
-export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
-  let pdt = 0;
-  if (levelDetails.programDateTime) {
-    const parsedDateInt = Date.parse(levelDetails.programDateTime);
-    if (!isNaN(parsedDateInt)) {
-      pdt = (bufferEnd * 1000) + parsedDateInt - (1000 * start);
-    }
-  }
-  return pdt;
-}
-
-/**
- * Finds the first fragment whose endPDT value exceeds the given PDT.
+ * Returns first fragment whose endPdt value exceeds the given PDT.
  * @param {Array<Fragment>} fragments - The array of candidate fragments
  * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
+ * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start/end can be within in order to be considered contiguous
  * @returns {*|null} fragment - The best matching fragment
  */
-export function findFragmentByPDT (fragments, PDTValue = null) {
-  if (!Array.isArray(fragments) || !fragments.length || PDTValue === null) {
+export function findFragmentByPDT (fragments, PDTValue, maxFragLookUpTolerance) {
+  if (!Array.isArray(fragments) || !fragments.length || !Number.isFinite(PDTValue)) {
     return null;
   }
 
   // if less than start
-  let firstSegment = fragments[0];
-
-  if (PDTValue < firstSegment.pdt) {
+  if (PDTValue < fragments[0].pdt) {
     return null;
   }
 
-  let lastSegment = fragments[fragments.length - 1];
-
-  if (PDTValue >= lastSegment.endPdt) {
+  if (PDTValue >= fragments[fragments.length - 1].endPdt) {
     return null;
   }
 
+  maxFragLookUpTolerance = maxFragLookUpTolerance || 0;
   for (let seg = 0; seg < fragments.length; ++seg) {
     let frag = fragments[seg];
-    if (PDTValue < frag.endPdt) {
+    if (pdtWithinToleranceTest(PDTValue, maxFragLookUpTolerance, frag)) {
       return frag;
     }
   }
-  return null;
 }
 
 /**
@@ -59,26 +37,16 @@ export function findFragmentByPDT (fragments, PDTValue = null) {
  * @param {*} fragPrevious - The last frag successfully appended
  * @param {Array<Fragment>} fragments - The array of candidate fragments
  * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
- * @param {number} [end = 0] - The computed end time of the stream
- * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start can be within in order to be considered contiguous
+ * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start/end can be within in order to be considered contiguous
  * @returns {*} foundFrag - The best matching fragment
  */
-export function findFragmentBySN (fragPrevious, fragments, bufferEnd = 0, end = 0, maxFragLookUpTolerance = 0) {
-  let foundFrag;
+export function findFragmentByPTS (fragPrevious, fragments, bufferEnd = 0, maxFragLookUpTolerance = 0) {
   const fragNext = fragPrevious ? fragments[fragPrevious.sn - fragments[0].sn + 1] : null;
-  if (bufferEnd < end) {
-    if (bufferEnd > end - maxFragLookUpTolerance) {
-      maxFragLookUpTolerance = 0;
-    }
-
-    // Prefer the next fragment if it's within tolerance
-    if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {
-      foundFrag = fragNext;
-    } else {
-      foundFrag = BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
-    }
+  // Prefer the next fragment if it's within tolerance
+  if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {
+    return fragNext;
   }
-  return foundFrag;
+  return BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
 }
 
 /**
@@ -112,4 +80,17 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
   }
 
   return 0;
+}
+
+/**
+ * The test function used by the findFragmentByPdt's BinarySearch to look for the best match to the current buffer conditions.
+ * This function tests the candidate's program date time values, as represented in Unix time
+ * @param {*} candidate - The fragment to test
+ * @param {number} [pdtBufferEnd = 0] - The Unix time representing the end of the current buffered range
+ * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start can be within in order to be considered contiguous
+ * @returns {boolean} True if contiguous, false otherwise
+ */
+export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
+  let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
+  return candidate.endPdt - candidateLookupTolerance > pdtBufferEnd;
 }

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -105,7 +105,7 @@ export class FragmentTracker extends EventHandler {
       fragmentEntity.buffered = true;
 
       Object.keys(this.timeRanges).forEach(elementaryStream => {
-        if (fragment.hasElementaryStream(elementaryStream) === true) {
+        if (fragment.hasElementaryStream(elementaryStream)) {
           let timeRange = this.timeRanges[elementaryStream];
           // Check for malformed fragments
           // Gaps need to be calculated for each elementaryStream
@@ -234,7 +234,7 @@ export class FragmentTracker extends EventHandler {
     let fragment = e.frag;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
-    if (!isNaN(fragment.sn) && !fragment.bitrateTest) {
+    if (Number.isFinite(fragment.sn) && !fragment.bitrateTest) {
       let fragKey = this.getFragmentKey(fragment);
       let fragmentEntity = {
         body: fragment,

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -106,8 +106,6 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
   }
 
   details.PTSKnown = true;
-  // logger.log(`frag start/end:${startPTS.toFixed(3)}/${endPTS.toFixed(3)}`);
-
   return drift;
 }
 

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -29,7 +29,7 @@ export function addGroupId (level, type, id) {
 export function updatePTS (fragments, fromIdx, toIdx) {
   let fragFrom = fragments[fromIdx], fragTo = fragments[toIdx], fragToPTS = fragTo.startPTS;
   // if we know startPTS[toIdx]
-  if (!isNaN(fragToPTS)) {
+  if (Number.isFinite(fragToPTS)) {
     // update fragment duration.
     // it helps to fix drifts between playlist reported duration and fragment real duration
     if (toIdx > fromIdx) {
@@ -56,10 +56,10 @@ export function updatePTS (fragments, fromIdx, toIdx) {
 export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, endDTS) {
   // update frag PTS/DTS
   let maxStartPTS = startPTS;
-  if (!isNaN(frag.startPTS)) {
+  if (Number.isFinite(frag.startPTS)) {
     // delta PTS between audio and video
     let deltaPTS = Math.abs(frag.startPTS - startPTS);
-    if (isNaN(frag.deltaPTS)) {
+    if (!Number.isFinite(frag.deltaPTS)) {
       frag.deltaPTS = deltaPTS;
     } else {
       frag.deltaPTS = Math.max(deltaPTS, frag.deltaPTS);
@@ -91,7 +91,7 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
   fragments = details.fragments;
   // update frag reference in fragments array
   // rationale is that fragments array might not contain this frag object.
-  // this will happpen if playlist has been refreshed between frag loading and call to updateFragPTSDTS()
+  // this will happen if playlist has been refreshed between frag loading and call to updateFragPTSDTS()
   // if we don't update frag, we won't be able to propagate PTS info on the playlist
   // resulting in invalid sliding computation
   fragments[fragIdx] = frag;
@@ -106,7 +106,7 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
   }
 
   details.PTSKnown = true;
-  // logger.log(`                                            frag start/end:${startPTS.toFixed(3)}/${endPTS.toFixed(3)}`);
+  // logger.log(`frag start/end:${startPTS.toFixed(3)}/${endPTS.toFixed(3)}`);
 
   return drift;
 }
@@ -136,7 +136,7 @@ export function mergeDetails (oldDetails, newDetails) {
       newFrag = newfragments[i];
     if (newFrag && oldFrag) {
       ccOffset = oldFrag.cc - newFrag.cc;
-      if (!isNaN(oldFrag.startPTS)) {
+      if (Number.isFinite(oldFrag.startPTS)) {
         newFrag.start = newFrag.startPTS = oldFrag.startPTS;
         newFrag.endPTS = oldFrag.endPTS;
         newFrag.duration = oldFrag.duration;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -364,8 +364,8 @@ class StreamController extends TaskLoop {
       if (fragPrevious) {
         if (levelDetails.hasProgramDateTime) {
           // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-          logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
-          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
+          logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.programDateTime}`);
+          frag = findFragmentByPDT(fragments, fragPrevious.endProgramDateTime, config.maxFragLookUpTolerance);
         } else {
           // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
           const targetSN = fragPrevious.sn + 1;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -13,9 +13,9 @@ import * as LevelHelper from './level-helper';
 import TimeRanges from '../utils/time-ranges';
 import { ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
-import { alignDiscontinuities } from '../utils/discontinuities';
+import { alignStream } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
-import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from './fragment-finders';
+import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import GapController from './gap-controller';
 
 export const State = {
@@ -362,7 +362,12 @@ class StreamController extends TaskLoop {
          even if SN are not synchronized between playlists, loading this frag will help us
          compute playlist sliding and find the right one after in case it was not the right consecutive one */
       if (fragPrevious) {
-        if (!levelDetails.programDateTime) { // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
+        if (levelDetails.hasProgramDateTime) {
+          // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
+          logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
+          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
+        } else {
+          // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
           const targetSN = fragPrevious.sn + 1;
           if (targetSN >= levelDetails.startSN && targetSN <= levelDetails.endSN) {
             const fragNext = fragments[targetSN - levelDetails.startSN];
@@ -381,8 +386,6 @@ class StreamController extends TaskLoop {
               logger.log(`live playlist, switching playlist, load frag with same CC: ${frag.sn}`);
             }
           }
-        } else { // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-          frag = findFragmentByPDT(fragments, fragPrevious.endPdt + 1);
         }
       }
       if (!frag) {
@@ -393,34 +396,24 @@ class StreamController extends TaskLoop {
         logger.log(`live playlist, switching playlist, unknown, load middle frag : ${frag.sn}`);
       }
     }
+
     return frag;
   }
 
   _findFragment (start, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails) {
     const config = this.hls.config;
-    const fragBySN = () => findFragmentBySN(fragPrevious, fragments, bufferEnd, end, config.maxFragLookUpTolerance);
     let frag;
-    let foundFrag;
 
     if (bufferEnd < end) {
-      if (!levelDetails.programDateTime) { // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-        foundFrag = findFragmentBySN(fragPrevious, fragments, bufferEnd, end, config.maxFragLookUpTolerance);
-      } else {
-        // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-        foundFrag = findFragmentByPDT(fragments, calculateNextPDT(start, bufferEnd, levelDetails));
-        if (!foundFrag || fragmentWithinToleranceTest(bufferEnd, config.maxFragLookUpTolerance, foundFrag)) {
-          // Fall back to SN order if finding by PDT returns a frag which won't fit within the stream
-          // fragmentWithToleranceTest returns 0 if the frag is within tolerance; 1 or -1 otherwise
-          logger.warn('Frag found by PDT search did not fit within tolerance; falling back to finding by SN');
-          foundFrag = fragBySN();
-        }
-      }
+      const lookupTolerance = (bufferEnd > end - config.maxFragLookUpTolerance) ? 0 : config.maxFragLookUpTolerance;
+      // Remove the tolerance if it would put the bufferEnd past the actual end of stream
+      // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
+      frag = findFragmentByPTS(fragPrevious, fragments, bufferEnd, lookupTolerance);
     } else {
       // reach end of playlist
-      foundFrag = fragments[fragLen - 1];
+      frag = fragments[fragLen - 1];
     }
-    if (foundFrag) {
-      frag = foundFrag;
+    if (frag) {
       const curSNIdx = frag.sn - levelDetails.startSN;
       const sameLevel = fragPrevious && frag.level === fragPrevious.level;
       const prevFrag = fragments[curSNIdx - 1];
@@ -439,7 +432,7 @@ class StreamController extends TaskLoop {
               logger.warn('SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this');
             } else {
               frag = nextFrag;
-              logger.log(`SN just loaded, load next one: ${frag.sn}`);
+              logger.log(`SN just loaded, load next one: ${frag.sn}`, frag);
             }
           } else {
             frag = null;
@@ -480,7 +473,7 @@ class StreamController extends TaskLoop {
     this.fragCurrent = frag;
     this.startFragRequested = true;
     // Don't update nextLoadPosition for fragments which are not buffered
-    if (!isNaN(frag.sn) && !frag.bitrateTest) {
+    if (Number.isFinite(frag.sn) && !frag.bitrateTest) {
       this.nextLoadPosition = frag.start + frag.duration;
     }
 
@@ -757,7 +750,7 @@ class StreamController extends TaskLoop {
 
   onMediaSeeking () {
     let media = this.media, currentTime = media ? media.currentTime : undefined, config = this.config;
-    if (!isNaN(currentTime)) {
+    if (Number.isFinite(currentTime)) {
       logger.log(`media seeking to ${currentTime.toFixed(3)}`);
     }
 
@@ -808,7 +801,7 @@ class StreamController extends TaskLoop {
 
   onMediaSeeked () {
     const media = this.media, currentTime = media ? media.currentTime : undefined;
-    if (!isNaN(currentTime)) {
+    if (Number.isFinite(currentTime)) {
       logger.log(`media seeked to ${currentTime.toFixed(3)}`);
     }
 
@@ -876,16 +869,16 @@ class StreamController extends TaskLoop {
         LevelHelper.mergeDetails(curDetails, newDetails);
         sliding = newDetails.fragments[0].start;
         this.liveSyncPosition = this.computeLivePosition(sliding, curDetails);
-        if (newDetails.PTSKnown && !isNaN(sliding)) {
+        if (newDetails.PTSKnown && Number.isFinite(sliding)) {
           logger.log(`live playlist sliding:${sliding.toFixed(3)}`);
         } else {
           logger.log('live playlist - outdated PTS, unknown sliding');
-          alignDiscontinuities(this.fragPrevious, lastLevel, newDetails);
+          alignStream(this.fragPrevious, lastLevel, newDetails);
         }
       } else {
         logger.log('live playlist - first load, unknown sliding');
         newDetails.PTSKnown = false;
-        alignDiscontinuities(this.fragPrevious, lastLevel, newDetails);
+        alignStream(this.fragPrevious, lastLevel, newDetails);
       }
     } else {
       newDetails.PTSKnown = false;
@@ -897,10 +890,10 @@ class StreamController extends TaskLoop {
 
     if (this.startFragRequested === false) {
     // compute start position if set to -1. use it straight away if value is defined
-      if (this.startPosition === -1 || this.lastCurrentTime === -1) {
+      if (this.startPosition === -1 || this.lastCurrentTime === -1) {
         // first, check if start time offset has been set in playlist, if yes, use this value
         let startTimeOffset = newDetails.startTimeOffset;
-        if (!isNaN(startTimeOffset)) {
+        if (Number.isFinite(startTimeOffset)) {
           if (startTimeOffset < 0) {
             logger.log(`negative start time offset ${startTimeOffset}, count from end of last fragment`);
             startTimeOffset = sliding + duration + startTimeOffset;
@@ -975,10 +968,6 @@ class StreamController extends TaskLoop {
           audioCodec = this.config.defaultAudioCodec || currentLevel.audioCodec;
         if (this.audioCodecSwap) {
           logger.log('swapping playlist audio codec');
-          if (audioCodec === undefined) {
-            audioCodec = this.lastAudioCodec;
-          }
-
           if (audioCodec) {
             if (audioCodec.indexOf('mp4a.40.5') !== -1) {
               audioCodec = 'mp4a.40.2';
@@ -1089,7 +1078,7 @@ class StreamController extends TaskLoop {
         this.state === State.PARSING) {
       let level = this.levels[this.level],
         frag = fragCurrent;
-      if (isNaN(data.endPTS)) {
+      if (!Number.isFinite(data.endPTS)) {
         data.endPTS = data.startPTS + fragCurrent.duration;
         data.endDTS = data.startDTS + fragCurrent.duration;
       }

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -99,7 +99,7 @@ class Demuxer {
 
   push (data, initSegment, audioCodec, videoCodec, frag, duration, accurateTimeOffset, defaultInitPTS) {
     const w = this.w;
-    const timeOffset = !isNaN(frag.startDTS) ? frag.startDTS : frag.start;
+    const timeOffset = Number.isFinite(frag.startDTS) ? frag.startDTS : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
     const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -53,7 +53,7 @@ class FragmentLoader extends EventHandler {
     let start = frag.byteRangeStartOffset,
       end = frag.byteRangeEndOffset;
 
-    if (!isNaN(start) && !isNaN(end)) {
+    if (Number.isFinite(start) && Number.isFinite(end)) {
       loaderContext.rangeStart = start;
       loaderContext.rangeEnd = end;
     }

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -9,7 +9,7 @@ export default class Fragment {
     this._byteRange = null;
     this._decryptdata = null;
     this.tagList = [];
-    this.pdt = null;
+    this.programDateTime = null;
     this.rawProgramDateTime = null;
 
     // Holds the types of data this fragment supports
@@ -86,14 +86,14 @@ export default class Fragment {
     return this._decryptdata;
   }
 
-  get endPdt () {
-    if (!Number.isFinite(this.pdt)) {
+  get endProgramDateTime () {
+    if (!Number.isFinite(this.programDateTime)) {
       return null;
     }
 
     let duration = !Number.isFinite(this.duration) ? 0 : this.duration;
 
-    return this.pdt + (duration * 1000);
+    return this.programDateTime + (duration * 1000);
   }
 
   get encrypted () {

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -87,8 +87,9 @@ export default class Fragment {
   }
 
   get endPdt () {
-    if (!Number.isFinite(this.pdt))
+    if (!Number.isFinite(this.pdt)) {
       return null;
+    }
 
     let duration = !Number.isFinite(this.duration) ? 0 : this.duration;
 

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -9,6 +9,8 @@ export default class Fragment {
     this._byteRange = null;
     this._decryptdata = null;
     this.tagList = [];
+    this.pdt = null;
+    this.rawProgramDateTime = null;
 
     // Holds the types of data this fragment supports
     this._elementaryStreams = {
@@ -39,14 +41,6 @@ export default class Fragment {
 
   set url (value) {
     this._url = value;
-  }
-
-  get programDateTime () {
-    if (!this._programDateTime && this.rawProgramDateTime) {
-      this._programDateTime = new Date(Date.parse(this.rawProgramDateTime));
-    }
-
-    return this._programDateTime;
   }
 
   get byteRange () {
@@ -90,6 +84,15 @@ export default class Fragment {
     }
 
     return this._decryptdata;
+  }
+
+  get endPdt () {
+    if (!Number.isFinite(this.pdt))
+      return null;
+
+    let duration = !Number.isFinite(this.duration) ? 0 : this.duration;
+
+    return this.pdt + (duration * 1000);
   }
 
   get encrypted () {

--- a/src/loader/level.js
+++ b/src/loader/level.js
@@ -18,6 +18,6 @@ export default class Level {
   }
 
   get hasProgramDateTime () {
-    return !!(this.fragments[0] && Number.isFinite(this.fragments[0].pdt));
+    return !!(this.fragments[0] && Number.isFinite(this.fragments[0].programDateTime));
   }
 }

--- a/src/loader/level.js
+++ b/src/loader/level.js
@@ -1,0 +1,23 @@
+export default class Level {
+  constructor (baseUrl) {
+    // Please keep properties in alphabetical order
+    this.endCC = 0;
+    this.endSN = 0;
+    this.fragments = [];
+    this.initSegment = null;
+    this.live = true;
+    this.needSidxRanges = false;
+    this.startCC = 0;
+    this.startSN = 0;
+    this.startTimeOffset = null;
+    this.targetduration = 0;
+    this.totalduration = 0;
+    this.type = null;
+    this.url = baseUrl;
+    this.version = null;
+  }
+
+  get hasProgramDateTime () {
+    return !!(this.fragments[0] && Number.isFinite(this.fragments[0].pdt));
+  }
+}

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -344,20 +344,20 @@ function backfillProgramDateTimes (fragments, startIndex) {
   let fragPrev = fragments[startIndex];
   for (let i = startIndex - 1; i >= 0; i--) {
     const frag = fragments[i];
-    frag.pdt = fragPrev.pdt - (frag.duration * 1000);
+    frag.programDateTime = fragPrev.programDateTime - (frag.duration * 1000);
     fragPrev = frag;
   }
 }
 
 function assignProgramDateTime (frag, prevFrag) {
   if (frag.rawProgramDateTime) {
-    frag.pdt = Date.parse(frag.rawProgramDateTime);
-  } else if (prevFrag && prevFrag.pdt) {
-    frag.pdt = prevFrag.endPdt;
+    frag.programDateTime = Date.parse(frag.rawProgramDateTime);
+  } else if (prevFrag && prevFrag.programDateTime) {
+    frag.programDateTime = prevFrag.endProgramDateTime;
   }
 
-  if (!Number.isFinite(frag.pdt)) {
-    frag.pdt = null;
+  if (!Number.isFinite(frag.programDateTime)) {
+    frag.programDateTime = null;
     frag.rawProgramDateTime = null;
   }
 }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -332,8 +332,9 @@ export default class M3U8Parser {
      * We have already extrapolated forward, but all fragments up to the first instance of PDT do not have their PDTs
      * computed.
      */
-    if (firstPdtIndex)
+    if (firstPdtIndex) {
       backfillProgramDateTimes(level.fragments, firstPdtIndex);
+    }
 
     return level;
   }
@@ -353,10 +354,11 @@ function backfillProgramDateTimes (fragments, startIndex) {
 }
 
 function assignProgramDateTime (frag, prevFrag) {
-  if (frag.rawProgramDateTime)
+  if (frag.rawProgramDateTime) {
     frag.pdt = Date.parse(frag.rawProgramDateTime);
-  else if (prevFrag && prevFrag.pdt)
+  } else if (prevFrag && prevFrag.pdt) {
     frag.pdt = prevFrag.endPdt;
+  }
 
   if (!Number.isFinite(frag.pdt)) {
     frag.pdt = null;

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -2,6 +2,7 @@
 import URLToolkit from 'url-toolkit';
 
 import Fragment from './fragment';
+import Level from './level';
 import LevelKey from './level-key';
 
 import AttrList from '../utils/attr-list';
@@ -145,15 +146,17 @@ export default class M3U8Parser {
   }
 
   static parseLevelPlaylist (string, baseurl, id, type, levelUrlId) {
-    let currentSN = 0,
-      totalduration = 0,
-      level = { type: null, version: null, url: baseurl, fragments: [], live: true, startSN: 0 },
-      levelkey = new LevelKey(),
-      cc = 0,
-      prevFrag = null,
-      frag = new Fragment(),
-      result,
-      i;
+    let currentSN = 0;
+    let totalduration = 0;
+    let level = new Level(baseurl);
+    let levelkey = new LevelKey();
+    let cc = 0;
+    let prevFrag = null;
+    let frag = new Fragment();
+    let result;
+    let i;
+
+    let firstPdtIndex = null;
 
     LEVEL_PLAYLIST_REGEX_FAST.lastIndex = 0;
 
@@ -166,7 +169,7 @@ export default class M3U8Parser {
         frag.title = title || null;
         frag.tagList.push(title ? [ 'INF', duration, title ] : [ 'INF', duration ]);
       } else if (result[3]) { // url
-        if (!isNaN(frag.duration)) {
+        if (Number.isFinite(frag.duration)) {
           const sn = currentSN++;
           frag.type = type;
           frag.start = totalduration;
@@ -178,19 +181,7 @@ export default class M3U8Parser {
           frag.baseurl = baseurl;
           // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
           frag.relurl = (' ' + result[3]).slice(1);
-
-          if (level.programDateTime) {
-            if (prevFrag) {
-              if (frag.rawProgramDateTime) { // PDT discontinuity found
-                frag.pdt = Date.parse(frag.rawProgramDateTime);
-              } else { // Contiguous fragment
-                frag.pdt = prevFrag.pdt + (prevFrag.duration * 1000);
-              }
-            } else { // First fragment
-              frag.pdt = Date.parse(level.programDateTime);
-            }
-            frag.endPdt = frag.pdt + (frag.duration * 1000);
-          }
+          assignProgramDateTime(frag, prevFrag);
 
           level.fragments.push(frag);
           prevFrag = frag;
@@ -210,8 +201,8 @@ export default class M3U8Parser {
         // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
         frag.rawProgramDateTime = (' ' + result[5]).slice(1);
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
-        if (level.programDateTime === undefined) {
-          level.programDateTime = new Date(new Date(Date.parse(result[5])) - 1000 * totalduration);
+        if (firstPdtIndex === null) {
+          firstPdtIndex = level.fragments.length;
         }
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);
@@ -278,7 +269,7 @@ export default class M3U8Parser {
           let startAttrs = new AttrList(startParams);
           let startTimeOffset = startAttrs.decimalFloatingPoint('TIME-OFFSET');
           // TIME-OFFSET can be 0
-          if (!isNaN(startTimeOffset)) {
+          if (Number.isFinite(startTimeOffset)) {
             level.startTimeOffset = startTimeOffset;
           }
 
@@ -293,6 +284,7 @@ export default class M3U8Parser {
           frag.sn = 'initSegment';
           level.initSegment = frag;
           frag = new Fragment();
+          frag.rawProgramDateTime = level.initSegment.rawProgramDateTime;
           break;
         default:
           logger.warn(`line parsed but not handled: ${result}`);
@@ -331,6 +323,43 @@ export default class M3U8Parser {
       }
     }
 
+    /**
+     * Backfill any missing PDT values
+       "If the first EXT-X-PROGRAM-DATE-TIME tag in a Playlist appears after
+       one or more Media Segment URIs, the client SHOULD extrapolate
+       backward from that tag (using EXTINF durations and/or media
+       timestamps) to associate dates with those segments."
+     * We have already extrapolated forward, but all fragments up to the first instance of PDT do not have their PDTs
+     * computed.
+     */
+    if (firstPdtIndex)
+      backfillProgramDateTimes(level.fragments, firstPdtIndex);
+
     return level;
+  }
+}
+
+function endsWith (str, search) {
+  return str.substring(str.length - search.length, str.length) === search;
+}
+
+function backfillProgramDateTimes (fragments, startIndex) {
+  let fragPrev = fragments[startIndex];
+  for (let i = startIndex - 1; i >= 0; i--) {
+    const frag = fragments[i];
+    frag.pdt = fragPrev.pdt - (frag.duration * 1000);
+    fragPrev = frag;
+  }
+}
+
+function assignProgramDateTime (frag, prevFrag) {
+  if (frag.rawProgramDateTime)
+    frag.pdt = Date.parse(frag.rawProgramDateTime);
+  else if (prevFrag && prevFrag.pdt)
+    frag.pdt = prevFrag.endPdt;
+
+  if (!Number.isFinite(frag.pdt)) {
+    frag.pdt = null;
+    frag.rawProgramDateTime = null;
   }
 }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -340,10 +340,6 @@ export default class M3U8Parser {
   }
 }
 
-function endsWith (str, search) {
-  return str.substring(str.length - search.length, str.length) === search;
-}
-
 function backfillProgramDateTimes (fragments, startIndex) {
   let fragPrev = fragments[startIndex];
   for (let i = startIndex - 1; i >= 0; i--) {

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -339,6 +339,7 @@ class PlaylistLoader extends EventHandler {
 
     const url = PlaylistLoader.getResponseUrl(response, context);
 
+    const levelUrlId = Number.isFinite(id) ? 0 : id;
     const levelId = Number.isFinite(level) ? level : Number.isFinite(id) ? id : 0; // level -> id -> 0
     const levelType = PlaylistLoader.mapContextToLevelType(context);
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -339,8 +339,7 @@ class PlaylistLoader extends EventHandler {
 
     const url = PlaylistLoader.getResponseUrl(response, context);
 
-    const levelUrlId = isNaN(id) ? 0 : id;
-    const levelId = isNaN(level) ? levelUrlId : level; // level -> id -> 0
+    const levelId = Number.isFinite(level) ? level : Number.isFinite(id) ? id : 0; // level -> id -> 0
     const levelType = PlaylistLoader.mapContextToLevelType(context);
 
     const levelDetails = M3U8Parser.parseLevelPlaylist(response.data, url, levelId, levelType, levelUrlId);

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -339,8 +339,8 @@ class PlaylistLoader extends EventHandler {
 
     const url = PlaylistLoader.getResponseUrl(response, context);
 
-    const levelUrlId = Number.isFinite(id) ? 0 : id;
-    const levelId = Number.isFinite(level) ? level : Number.isFinite(id) ? id : 0; // level -> id -> 0
+    const levelUrlId = Number.isFinite(id) ? id : 0;
+    const levelId = Number.isFinite(level) ? level : levelUrlId;
     const levelType = PlaylistLoader.mapContextToLevelType(context);
 
     const levelDetails = M3U8Parser.parseLevelPlaylist(response.data, url, levelId, levelType, levelUrlId);

--- a/src/polyfills/number-isFinite.js
+++ b/src/polyfills/number-isFinite.js
@@ -1,0 +1,3 @@
+export const isFiniteNumber = Number.isFinite || function (value) {
+  return typeof value === 'number' && isFinite(value);
+};

--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -68,10 +68,33 @@ export function adjustPts (sliding, details) {
   details.PTSKnown = true;
 }
 
-// If a change in CC is detected, the PTS can no longer be relied upon
-// Attempt to align the level by using the last level - find the last frag matching the current CC and use it's PTS
-// as a reference
-export function alignDiscontinuities (lastFrag, lastLevel, details) {
+/**
+ * Using the parameters of the last level, this function computes PTS' of the new fragments so that they form a
+ * contiguous stream with the last fragments.
+ * The PTS of a fragment lets Hls.js know where it fits into a stream - by knowing every PTS, we know which fragment to
+ * download at any given time. PTS is normally computed when the fragment is demuxed, so taking this step saves us time
+ * and an extra download.
+ * @param lastFrag
+ * @param lastLevel
+ * @param details
+ */
+export function alignStream (lastFrag, lastLevel, details) {
+  alignDiscontinuities(lastFrag, details, lastLevel);
+  if (!details.PTSKnown && lastLevel) {
+    // If the PTS wasn't figured out via discontinuity sequence that means there was no CC increase within the level.
+    // Aligning via Program Date Time should therefore be reliable, since PDT should be the same within the same
+    // discontinuity sequence.
+    alignPDT(details, lastLevel.details);
+  }
+}
+
+/**
+ * Computes the PTS if a new level's fragments using the PTS of a fragment in the last level which shares the same
+ * discontinuity sequence.
+ * @param lastLevel - The details of the last loaded level
+ * @param details - The details of the new level
+ */
+export function alignDiscontinuities (lastFrag, details, lastLevel) {
   if (shouldAlignOnDiscontinuities(lastFrag, lastLevel, details)) {
     const referenceFrag = findDiscontinuousReferenceFrag(lastLevel.details, details);
     if (referenceFrag) {
@@ -79,16 +102,26 @@ export function alignDiscontinuities (lastFrag, lastLevel, details) {
       adjustPts(referenceFrag.start, details);
     }
   }
-  // try to align using programDateTime attribute (if available)
-  if (details.PTSKnown === false && lastLevel && lastLevel.details && lastLevel.details.fragments && lastLevel.details.fragments.length) {
+}
+
+/**
+ * Computes the PTS of a new level's fragments using the difference in Program Date Time from the last level.
+ * @param details - The details of the new level
+ * @param lastDetails - The details of the last loaded level
+ */
+export function alignPDT (details, lastDetails) {
+  if (lastDetails && lastDetails.fragments.length) {
+    if (!details.hasProgramDateTime || !lastDetails.hasProgramDateTime) {
+      return;
+    }
     // if last level sliding is 1000 and its first frag PROGRAM-DATE-TIME is 2017-08-20 1:10:00 AM
     // and if new details first frag PROGRAM DATE-TIME is 2017-08-20 1:10:08 AM
     // then we can deduce that playlist B sliding is 1000+8 = 1008s
-    let lastPDT = lastLevel.details.programDateTime;
-    let newPDT = details.programDateTime;
+    let lastPDT = lastDetails.fragments[0].pdt;
+    let newPDT = details.fragments[0].pdt;
     // date diff is in ms. frag.start is in seconds
-    let sliding = (newPDT - lastPDT) / 1000 + lastLevel.details.fragments[0].start;
-    if (!isNaN(sliding)) {
+    let sliding = (newPDT - lastPDT) / 1000 + lastDetails.fragments[0].start;
+    if (Number.isFinite(sliding)) {
       logger.log(`adjusting PTS using programDateTime delta, sliding:${sliding.toFixed(3)}`);
       adjustPts(sliding, details);
     }

--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -117,8 +117,8 @@ export function alignPDT (details, lastDetails) {
     // if last level sliding is 1000 and its first frag PROGRAM-DATE-TIME is 2017-08-20 1:10:00 AM
     // and if new details first frag PROGRAM DATE-TIME is 2017-08-20 1:10:08 AM
     // then we can deduce that playlist B sliding is 1000+8 = 1008s
-    let lastPDT = lastDetails.fragments[0].pdt;
-    let newPDT = details.fragments[0].pdt;
+    let lastPDT = lastDetails.fragments[0].programDateTime;
+    let newPDT = details.fragments[0].programDateTime;
     // date diff is in ms. frag.start is in seconds
     let sliding = (newPDT - lastPDT) / 1000 + lastDetails.fragments[0].start;
     if (Number.isFinite(sliding)) {

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -12,7 +12,7 @@ const cueString2millis = function (timeString) {
   let mins = parseInt(timeString.substr(-9, 2));
   let hours = timeString.length > 9 ? parseInt(timeString.substr(0, timeString.indexOf(':'))) : 0;
 
-  if (isNaN(ts) || isNaN(secs) || isNaN(mins) || isNaN(hours)) {
+  if (!Number.isFinite(ts) || !Number.isFinite(secs) || !Number.isFinite(mins) || !Number.isFinite(hours)) {
     return -1;
   }
 

--- a/tests/mocks/data.js
+++ b/tests/mocks/data.js
@@ -1,7 +1,7 @@
 export const mockFragments = [
   {
-    pdt: 1505502661523,
-    endPdt: 1505502666523,
+    programDateTime: 1505502661523,
+    endProgramDateTime: 1505502666523,
     level: 2,
     duration: 5.000,
     start: 0,
@@ -10,8 +10,8 @@ export const mockFragments = [
   },
   // Discontinuity with PDT 1505502671523 which does not exist in level 1 as per fragPrevious
   {
-    pdt: 1505502671523,
-    endPdt: 1505502676523,
+    programDateTime: 1505502671523,
+    endProgramDateTime: 1505502676523,
     level: 2,
     duration: 5.000,
     start: 5.000,
@@ -19,8 +19,8 @@ export const mockFragments = [
     cc: 1
   },
   {
-    pdt: 1505502676523,
-    endPdt: 1505502681523,
+    programDateTime: 1505502676523,
+    endProgramDateTime: 1505502681523,
     level: 2,
     duration: 5.000,
     start: 10.000,
@@ -28,8 +28,8 @@ export const mockFragments = [
     cc: 1
   },
   {
-    pdt: 1505502681523,
-    endPdt: 1505502686523,
+    programDateTime: 1505502681523,
+    endProgramDateTime: 1505502686523,
     level: 2,
     duration: 5.000,
     start: 15.000,
@@ -37,8 +37,8 @@ export const mockFragments = [
     cc: 1
   },
   {
-    pdt: 1505502686523,
-    endPdt: 1505502691523,
+    programDateTime: 1505502686523,
+    endProgramDateTime: 1505502691523,
     level: 2,
     duration: 5.000,
     start: 20.000,

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -11,8 +11,8 @@ describe('Fragment finders', function () {
   });
 
   let fragPrevious = {
-    pdt: 1505502671523,
-    endPdt: 1505502676523,
+    programDateTime: 1505502671523,
+    endProgramDateTime: 1505502676523,
     duration: 5.000,
     level: 1,
     start: 10.000,
@@ -98,30 +98,30 @@ describe('Fragment finders', function () {
   });
 
   describe('findFragmentByPDT', function () {
-    it('finds a fragment with endPdt greater than the reference PDT', function () {
-      const foundFragment = findFragmentByPDT(mockFragments, fragPrevious.endPdt + 1);
+    it('finds a fragment with endProgramDateTime greater than the reference PDT', function () {
+      const foundFragment = findFragmentByPDT(mockFragments, fragPrevious.endProgramDateTime + 1);
       const resultSN = foundFragment ? foundFragment.sn : -1;
       assert.strictEqual(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('returns null when the reference pdt is outside of the pdt range of the fragment array', function () {
-      let foundFragment = findFragmentByPDT(mockFragments, mockFragments[0].pdt - 1);
+      let foundFragment = findFragmentByPDT(mockFragments, mockFragments[0].programDateTime - 1);
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.strictEqual(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
 
-      foundFragment = findFragmentByPDT(mockFragments, mockFragments[mockFragments.length - 1].endPdt + 1);
+      foundFragment = findFragmentByPDT(mockFragments, mockFragments[mockFragments.length - 1].endProgramDateTime + 1);
       resultSN = foundFragment ? foundFragment.sn : -1;
       assert.strictEqual(foundFragment, null, 'Expected sn -1, found sn segment ' + resultSN);
     });
 
     it('is able to find the first fragment', function () {
-      const foundFragment = findFragmentByPDT(mockFragments, mockFragments[0].pdt);
+      const foundFragment = findFragmentByPDT(mockFragments, mockFragments[0].programDateTime);
       const resultSN = foundFragment ? foundFragment.sn : -1;
       assert.strictEqual(foundFragment, mockFragments[0], 'Expected sn 0, found sn segment ' + resultSN);
     });
 
     it('is able to find the last fragment', function () {
-      const foundFragment = findFragmentByPDT(mockFragments, mockFragments[mockFragments.length - 1].pdt);
+      const foundFragment = findFragmentByPDT(mockFragments, mockFragments[mockFragments.length - 1].programDateTime);
       const resultSN = foundFragment ? foundFragment.sn : -1;
       assert.strictEqual(foundFragment, mockFragments[4], 'Expected sn 4, found sn segment ' + resultSN);
     });
@@ -129,13 +129,13 @@ describe('Fragment finders', function () {
     it('is able to find a fragment if the PDT value is 0', function () {
       const fragments = [
         {
-          pdt: 0,
-          endPdt: 1,
+          programDateTime: 0,
+          endProgramDateTime: 1,
           duration: 0.001
         },
         {
-          pdt: 1,
-          endPdt: 2,
+          programDateTime: 1,
+          endProgramDateTime: 2,
           duration: 0.001
         }
       ];
@@ -159,8 +159,8 @@ describe('Fragment finders', function () {
     let pdtBufferEnd = 1505502678523; // Fri Sep 15 2017 15:11:18 GMT-0400 (Eastern Daylight Time)
     it('returns true if the fragment range is equal to the end of the buffer', function () {
       const frag = {
-        pdt: pdtBufferEnd,
-        endPdt: pdtBufferEnd + 5000 - (tolerance * 1000),
+        programDateTime: pdtBufferEnd,
+        endProgramDateTime: pdtBufferEnd + 5000 - (tolerance * 1000),
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
@@ -169,8 +169,8 @@ describe('Fragment finders', function () {
 
     it('returns false if the fragment range is less than the end of the buffer', function () {
       const frag = {
-        pdt: pdtBufferEnd - 10000,
-        endPdt: pdtBufferEnd - 5000,
+        programDateTime: pdtBufferEnd - 10000,
+        endProgramDateTime: pdtBufferEnd - 5000,
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
@@ -179,8 +179,8 @@ describe('Fragment finders', function () {
 
     it('does not skip very small fragments', function () {
       const frag = {
-        pdt: pdtBufferEnd + 200,
-        endPdt: pdtBufferEnd + 300,
+        programDateTime: pdtBufferEnd + 200,
+        endProgramDateTime: pdtBufferEnd + 300,
         duration: 0.1,
         deltaPTS: 0.1
       };
@@ -188,10 +188,10 @@ describe('Fragment finders', function () {
       assert.strictEqual(true, actual);
     });
 
-    it('accounts for tolerance when checking the endPdt of the fragment', function () {
+    it('accounts for tolerance when checking the endProgramDateTime of the fragment', function () {
       const frag = {
-        pdt: pdtBufferEnd,
-        endPdt: pdtBufferEnd + (tolerance * 1000),
+        programDateTime: pdtBufferEnd,
+        endProgramDateTime: pdtBufferEnd + (tolerance * 1000),
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from '../../../src/controller/fragment-finders';
+import { findFragmentByPDT, findFragmentByPTS, fragmentWithinToleranceTest, pdtWithinToleranceTest } from '../../../src/controller/fragment-finders';
 import { mockFragments } from '../../mocks/data';
 import BinarySearch from '../../../src/utils/binary-search';
 
@@ -20,9 +20,8 @@ describe('Fragment finders', function () {
     cc: 0
   };
   const bufferEnd = fragPrevious.start + fragPrevious.duration;
-  const end = mockFragments[mockFragments.length - 1].start + mockFragments[mockFragments.length - 1].duration;
 
-  describe('findFragmentBySN', function () {
+  describe('findFragmentByPTS', function () {
     let tolerance = 0.25;
     let binarySearchSpy;
     beforeEach(function () {
@@ -30,21 +29,21 @@ describe('Fragment finders', function () {
     });
 
     it('finds a fragment with SN sequential to the previous fragment', function () {
-      const foundFragment = findFragmentBySN(fragPrevious, mockFragments, bufferEnd, end, tolerance);
+      const foundFragment = findFragmentByPTS(fragPrevious, mockFragments, bufferEnd, tolerance);
       const resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
       assert(binarySearchSpy.notCalled);
     });
 
     it('chooses the fragment with the next SN if its contiguous with the end of the buffer', function () {
-      const actual = findFragmentBySN(mockFragments[0], mockFragments, mockFragments[0].duration, end, tolerance);
+      const actual = findFragmentByPTS(mockFragments[0], mockFragments, mockFragments[0].duration, tolerance);
       assert.strictEqual(mockFragments[1], actual, `expected sn ${mockFragments[1].sn}, but got sn ${actual ? actual.sn : null}`);
       assert(binarySearchSpy.notCalled);
     });
 
     it('uses BinarySearch to find a fragment if the subsequent one is not within tolerance', function () {
       const fragments = [mockFragments[0], mockFragments[(mockFragments.length - 1)]];
-      findFragmentBySN(fragments[0], fragments, bufferEnd, end, tolerance);
+      findFragmentByPTS(fragments[0], fragments, bufferEnd, tolerance);
       assert(binarySearchSpy.calledOnce);
     });
   });
@@ -93,7 +92,7 @@ describe('Fragment finders', function () {
         duration: 0.1,
         deltaPTS: 0.1
       };
-      const actual = fragmentWithinToleranceTest(frag, 0, 1);
+      const actual = fragmentWithinToleranceTest(0, tolerance, frag);
       assert.strictEqual(0, actual);
     });
   });
@@ -131,11 +130,13 @@ describe('Fragment finders', function () {
       const fragments = [
         {
           pdt: 0,
-          endPdt: 1
+          endPdt: 1,
+          duration: 0.001
         },
         {
           pdt: 1,
-          endPdt: 2
+          endPdt: 2,
+          duration: 0.001
         }
       ];
       const actual = findFragmentByPDT(fragments, 0);
@@ -153,26 +154,48 @@ describe('Fragment finders', function () {
     });
   });
 
-  describe('calculateNextPDT', function () {
-    const levelDetails = {
-      programDateTime: '2012-12-06T19:10:03+00:00'
-    };
-
-    it('calculates based on levelDetails', function () {
-      const expected = 1354821003000 + (10 * 1000) - (1000 * 5);
-      const actual = calculateNextPDT(5, 10, levelDetails);
-      assert.strictEqual(expected, actual);
+  describe('pdtWithinToleranceTest', function () {
+    let tolerance = 0.25;
+    let pdtBufferEnd = 1505502678523; // Fri Sep 15 2017 15:11:18 GMT-0400 (Eastern Daylight Time)
+    it('returns true if the fragment range is equal to the end of the buffer', function () {
+      const frag = {
+        pdt: pdtBufferEnd,
+        endPdt: pdtBufferEnd + 5000 - (tolerance * 1000),
+        duration: 5
+      };
+      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
+      assert.strictEqual(true, actual);
     });
 
-    it('returns 0 if levelDetails does not have programDateTime', function () {
-      const actual = calculateNextPDT(5, 10, {});
-      assert.strictEqual(0, actual);
+    it('returns false if the fragment range is less than the end of the buffer', function () {
+      const frag = {
+        pdt: pdtBufferEnd - 10000,
+        endPdt: pdtBufferEnd - 5000,
+        duration: 5
+      };
+      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
+      assert.strictEqual(false, actual);
     });
 
-    it('returns 0 if the parsed PDT would be NaN', function () {
-      levelDetails.programDateTime = 'foo';
-      const actual = calculateNextPDT(5, 10, levelDetails);
-      assert.strictEqual(0, actual);
+    it('does not skip very small fragments', function () {
+      const frag = {
+        pdt: pdtBufferEnd + 200,
+        endPdt: pdtBufferEnd + 300,
+        duration: 0.1,
+        deltaPTS: 0.1
+      };
+      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
+      assert.strictEqual(true, actual);
+    });
+
+    it('accounts for tolerance when checking the endPdt of the fragment', function () {
+      const frag = {
+        pdt: pdtBufferEnd,
+        endPdt: pdtBufferEnd + (tolerance * 1000),
+        duration: 5
+      };
+      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
+      assert.strictEqual(false, actual);
     });
   });
 });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -80,8 +80,8 @@ describe('StreamController tests', function () {
 
   describe('SN Searching', function () {
     let fragPrevious = {
-      pdt: 1505502671523,
-      endPdt: 1505502676523,
+      programDateTime: 1505502671523,
+      endProgramDateTime: 1505502676523,
       duration: 5.000,
       level: 1,
       start: 10.000,

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -3,33 +3,33 @@ import Fragment from '../../../src/loader/fragment';
 
 describe('Fragment class tests', function () {
   let frag;
-  describe('endPdt getter', function () {
+  describe('endProgramDateTime getter', function () {
     beforeEach(function () {
       frag = new Fragment();
     });
 
     it('computes endPdt when pdt and duration are valid', function () {
-      frag.pdt = 1000;
+      frag.programDateTime = 1000;
       frag.duration = 1;
-      assert.strictEqual(frag.endPdt, 2000);
+      assert.strictEqual(frag.endProgramDateTime, 2000);
     });
 
     it('considers 0 a valid pdt', function () {
-      frag.pdt = 0;
+      frag.programDateTime = 0;
       frag.duration = 1;
-      assert.strictEqual(frag.endPdt, 1000);
+      assert.strictEqual(frag.endProgramDateTime, 1000);
     });
 
     it('returns null if pdt is NaN', function () {
-      frag.pdt = 'foo';
+      frag.programDateTime = 'foo';
       frag.duration = 1;
-      assert.strictEqual(frag.endPdt, null);
+      assert.strictEqual(frag.endProgramDateTime, null);
     });
 
     it('defaults duration to 0 if duration is NaN', function () {
-      frag.pdt = 1000;
+      frag.programDateTime = 1000;
       frag.duration = 'foo';
-      assert.strictEqual(frag.endPdt, 1000);
+      assert.strictEqual(frag.endProgramDateTime, 1000);
     });
   });
 });

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -1,41 +1,35 @@
+const assert = require('assert');
 import Fragment from '../../../src/loader/fragment';
-import assert from 'assert';
 
-describe('Fragment tests', function () {
-  describe('get keyLoadNeeded', function () {
-    it('returns true if the fragment needs to be decrypted', function () {
-      const frag = new Fragment();
-      frag._decryptdata = {
-        uri: 'foo.bar',
-        key: null
-      };
-
-      assert(frag.encrypted);
+describe('Fragment class tests', function () {
+  let frag;
+  describe('endPdt getter', function () {
+    beforeEach(function () {
+      frag = new Fragment();
     });
 
-    it('returns false if the key uri is null', function () {
-      const frag = new Fragment();
-      frag._decryptdata = {
-        uri: null,
-        key: null
-      };
-
-      assert.strictEqual(frag.encrypted, false);
+    it('computes endPdt when pdt and duration are valid', function () {
+      frag.pdt = 1000;
+      frag.duration = 1;
+      assert.strictEqual(frag.endPdt, 2000);
     });
 
-    it('returns false if the frag has already been decrypted', function () {
-      const frag = new Fragment();
-      frag._decryptdata = {
-        uri: 'foo.bar',
-        key: 'foo'
-      };
-
-      assert.strictEqual(frag.encrypted, false);
+    it('considers 0 a valid pdt', function () {
+      frag.pdt = 0;
+      frag.duration = 1;
+      assert.strictEqual(frag.endPdt, 1000);
     });
 
-    it('returns false if the frag does not need decryption', function () {
-      const frag = new Fragment();
-      assert.strictEqual(frag.encrypted, false);
+    it('returns null if pdt is NaN', function () {
+      frag.pdt = 'foo';
+      frag.duration = 1;
+      assert.strictEqual(frag.endPdt, null);
+    });
+
+    it('defaults duration to 0 if duration is NaN', function () {
+      frag.pdt = 1000;
+      frag.duration = 'foo';
+      assert.strictEqual(frag.endPdt, 1000);
     });
   });
 });

--- a/tests/unit/loader/level.js
+++ b/tests/unit/loader/level.js
@@ -4,7 +4,7 @@ import Level from '../../../src/loader/level';
 describe('Level Class tests', function () {
   it('sets programDateTime to true when the first fragment has valid pdt', function () {
     const level = new Level();
-    level.fragments = [{ pdt: 1 }];
+    level.fragments = [{ programDateTime: 1 }];
     assert.strictEqual(level.hasProgramDateTime, true);
   });
 
@@ -15,7 +15,7 @@ describe('Level Class tests', function () {
 
   it('sets programDateTime to false when the first fragment has an invalid pdt', function () {
     const level = new Level();
-    level.fragments = [{ pdt: 'foo' }];
+    level.fragments = [{ programDateTime: 'foo' }];
     assert.strictEqual(level.hasProgramDateTime, false);
   });
 });

--- a/tests/unit/loader/level.js
+++ b/tests/unit/loader/level.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+import Level from '../../../src/loader/level';
+
+describe('Level Class tests', function () {
+  it('sets programDateTime to true when the first fragment has valid pdt', function () {
+    const level = new Level();
+    level.fragments = [{ pdt: 1 }];
+    assert.strictEqual(level.hasProgramDateTime, true);
+  });
+
+  it('sets programDateTime to false when no fragments is empty', function () {
+    const level = new Level();
+    assert.strictEqual(level.hasProgramDateTime, false);
+  });
+
+  it('sets programDateTime to false when the first fragment has an invalid pdt', function () {
+    const level = new Level();
+    level.fragments = [{ pdt: 'foo' }];
+    assert.strictEqual(level.hasProgramDateTime, false);
+  });
+});

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -619,11 +619,11 @@ Rollover38803/20160525T064049-01-69844069.ts
     assert.strictEqual(result.hasProgramDateTime, true);
     assert.strictEqual(result.totalduration, 30);
     assert.strictEqual(result.fragments[0].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844067.ts');
-    assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+    assert.strictEqual(result.fragments[0].programDateTime, 1464366884000);
     assert.strictEqual(result.fragments[1].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844068.ts');
-    assert.strictEqual(result.fragments[1].pdt, 1464366894000);
+    assert.strictEqual(result.fragments[1].programDateTime, 1464366894000);
     assert.strictEqual(result.fragments[2].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844069.ts');
-    assert.strictEqual(result.fragments[2].pdt, 1464366904000);
+    assert.strictEqual(result.fragments[2].programDateTime, 1464366904000);
   });
 
   it('parses #EXTINF without a leading digit', () => {
@@ -676,11 +676,11 @@ Rollover38803/20160525T064049-01-69844069.ts
       let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
       assert.strictEqual(result.hasProgramDateTime, true);
       assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:34:44Z');
-      assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+      assert.strictEqual(result.fragments[0].programDateTime, 1464366884000);
       assert.strictEqual(result.fragments[1].rawProgramDateTime, '2016-05-27T16:34:54Z');
-      assert.strictEqual(result.fragments[1].pdt, 1464366894000);
+      assert.strictEqual(result.fragments[1].programDateTime, 1464366894000);
       assert.strictEqual(result.fragments[2].rawProgramDateTime, '2016-05-27T16:35:04Z');
-      assert.strictEqual(result.fragments[2].pdt, 1464366904000);
+      assert.strictEqual(result.fragments[2].programDateTime, 1464366904000);
     });
 
     it('backfills PDT values if the first segment does not start with PDT', function () {
@@ -697,8 +697,8 @@ frag2.ts
       const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
       assert.strictEqual(result.hasProgramDateTime, true);
       assert.strictEqual(result.fragments[2].rawProgramDateTime, '2016-05-27T16:35:04Z');
-      assert.strictEqual(result.fragments[1].pdt, 1464366894000);
-      assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+      assert.strictEqual(result.fragments[1].programDateTime, 1464366894000);
+      assert.strictEqual(result.fragments[0].programDateTime, 1464366884000);
     });
 
     it('extrapolates PDT forward when subsequent fragments do not have a raw programDateTime', function () {
@@ -715,8 +715,8 @@ frag2.ts
       const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
       assert.strictEqual(result.hasProgramDateTime, true);
       assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
-      assert.strictEqual(result.fragments[1].pdt, 1464366914000);
-      assert.strictEqual(result.fragments[2].pdt, 1464366924000);
+      assert.strictEqual(result.fragments[1].programDateTime, 1464366914000);
+      assert.strictEqual(result.fragments[2].programDateTime, 1464366924000);
     });
 
     it('recomputes PDT extrapolation whenever a new raw programDateTime is hit', function () {
@@ -744,15 +744,15 @@ frag5.ts
 
       const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
       assert.strictEqual(result.hasProgramDateTime, true);
-      assert.strictEqual(result.fragments[0].pdt, 1464366904000);
+      assert.strictEqual(result.fragments[0].programDateTime, 1464366904000);
       assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
-      assert.strictEqual(result.fragments[1].pdt, 1464366914000);
-      assert.strictEqual(result.fragments[2].pdt, 1495902904000);
+      assert.strictEqual(result.fragments[1].programDateTime, 1464366914000);
+      assert.strictEqual(result.fragments[2].programDateTime, 1495902904000);
       assert.strictEqual(result.fragments[2].rawProgramDateTime, '2017-05-27T16:35:04Z');
-      assert.strictEqual(result.fragments[3].pdt, 1495902914000);
-      assert.strictEqual(result.fragments[4].pdt, 1432726923000);
+      assert.strictEqual(result.fragments[3].programDateTime, 1495902914000);
+      assert.strictEqual(result.fragments[4].programDateTime, 1432726923000);
       assert.strictEqual(result.fragments[4].rawProgramDateTime, '2015-05-27T11:42:03Z');
-      assert.strictEqual(result.fragments[5].pdt, 1432726933000);
+      assert.strictEqual(result.fragments[5].programDateTime, 1432726933000);
     });
 
     it('propagates the raw programDateTime to the fragment following the init segment', function () {
@@ -768,7 +768,7 @@ frag1.ts
       assert.strictEqual(result.hasProgramDateTime, true);
       assert.strictEqual(result.sn === 'initSegment', false);
       assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
-      assert.strictEqual(result.fragments[0].pdt, 1464366904000);
+      assert.strictEqual(result.fragments[0].programDateTime, 1464366904000);
     });
 
     it('ignores bad PDT values', function () {
@@ -782,7 +782,7 @@ frag1.ts
       const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
       assert.strictEqual(result.hasProgramDateTime, false);
       assert.strictEqual(result.fragments[0].rawProgramDateTime, null);
-      assert.strictEqual(result.fragments[0].pdt, null);
+      assert.strictEqual(result.fragments[0].programDateTime, null);
     });
   });
 

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -616,14 +616,14 @@ Rollover38803/20160525T064049-01-69844069.ts
     `;
     let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
     assert.strictEqual(result.fragments.length, 3);
-    assert.strictEqual(result.programDateTime.getTime(), 1464366884000);
+    assert.strictEqual(result.hasProgramDateTime, true);
     assert.strictEqual(result.totalduration, 30);
     assert.strictEqual(result.fragments[0].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844067.ts');
-    assert.strictEqual(result.fragments[0].programDateTime.getTime(), 1464366884000);
+    assert.strictEqual(result.fragments[0].pdt, 1464366884000);
     assert.strictEqual(result.fragments[1].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844068.ts');
-    assert.strictEqual(result.fragments[1].programDateTime.getTime(), 1464366894000);
+    assert.strictEqual(result.fragments[1].pdt, 1464366894000);
     assert.strictEqual(result.fragments[2].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844069.ts');
-    assert.strictEqual(result.fragments[2].programDateTime.getTime(), 1464366904000);
+    assert.strictEqual(result.fragments[2].pdt, 1464366904000);
   });
 
   it('parses #EXTINF without a leading digit', () => {
@@ -657,8 +657,9 @@ main.mp4`;
     assert.strictEqual(result.initSegment.sn, 'initSegment');
   });
 
-  it('if playlists contains #EXT-X-PROGRAM-DATE-TIME switching will be applied by PDT', () => {
-    let level = `#EXTM3U
+  describe('PDT calculations', function () {
+    it('if playlists contains #EXT-X-PROGRAM-DATE-TIME switching will be applied by PDT', () => {
+      let level = `#EXTM3U
 #EXT-X-VERSION:2
 #EXT-X-TARGETDURATION:10
 #EXT-X-MEDIA-SEQUENCE:69844067
@@ -672,26 +673,117 @@ Rollover38803/20160525T064049-01-69844068.ts
 #EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
 Rollover38803/20160525T064049-01-69844069.ts
     `;
-    let hls = { config: { }, on: function () { } };
-    let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
-    assert.ok(result.programDateTime);
-  });
+      let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:34:44Z');
+      assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+      assert.strictEqual(result.fragments[1].rawProgramDateTime, '2016-05-27T16:34:54Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366894000);
+      assert.strictEqual(result.fragments[2].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[2].pdt, 1464366904000);
+    });
 
-  it('if playlists does NOT contain #EXT-X-PROGRAM-DATE-TIME switching will be applied by CC count', () => {
-    let level = `#EXTM3U
-#EXT-X-VERSION:2
-#EXT-X-TARGETDURATION:10
-#EXT-X-MEDIA-SEQUENCE:69844067
-#EXTINF:10, no desc
-Rollover38803/20160525T064049-01-69844067.ts
-#EXTINF:10, no desc
-Rollover38803/20160525T064049-01-69844068.ts
-#EXTINF:10, no desc
-Rollover38803/20160525T064049-01-69844069.ts
+    it('backfills PDT values if the first segment does not start with PDT', function () {
+      const level = `
+#EXTINF:10
+frag0.ts
+#EXTINF:10
+frag1.ts
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+frag2.ts
     `;
-    let hls = { config: { }, on: function () { } };
-    let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
-    assert.strictEqual(result.programDateTime, undefined);
+
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[2].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366894000);
+      assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+    });
+
+    it('extrapolates PDT forward when subsequent fragments do not have a raw programDateTime', function () {
+      const level = `
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+frag0.ts
+#EXTINF:10
+frag1.ts
+#EXTINF:10
+frag2.ts
+    `;
+
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366914000);
+      assert.strictEqual(result.fragments[2].pdt, 1464366924000);
+    });
+
+    it('recomputes PDT extrapolation whenever a new raw programDateTime is hit', function () {
+      const level = `
+#EXTM3U
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+#EXTINF:10
+frag0.ts
+#EXTINF:10
+frag1.ts
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2017-05-27T16:35:04Z
+#EXTINF:10
+frag2.ts
+#EXTINF:10
+frag3.ts
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2015-05-27T11:42:03Z
+#EXTINF:10
+frag4.ts
+#EXTINF:10
+frag5.ts
+    `;
+
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[0].pdt, 1464366904000);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366914000);
+      assert.strictEqual(result.fragments[2].pdt, 1495902904000);
+      assert.strictEqual(result.fragments[2].rawProgramDateTime, '2017-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[3].pdt, 1495902914000);
+      assert.strictEqual(result.fragments[4].pdt, 1432726923000);
+      assert.strictEqual(result.fragments[4].rawProgramDateTime, '2015-05-27T11:42:03Z');
+      assert.strictEqual(result.fragments[5].pdt, 1432726933000);
+    });
+
+    it('propagates the raw programDateTime to the fragment following the init segment', function () {
+      const level = `
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+#EXT-X-MAP
+frag0.ts
+#EXTINF:10
+frag1.ts
+    `;
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.sn === 'initSegment', false);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[0].pdt, 1464366904000);
+    });
+
+    it('ignores bad PDT values', function () {
+      const level = `
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:foo
+frag0.ts
+#EXTINF:10
+frag1.ts
+    `;
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, false);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, null);
+      assert.strictEqual(result.fragments[0].pdt, null);
+    });
   });
 
   it('tests : at end of tag name is used to divide custom tags', () => {

--- a/tests/unit/utils/discontinuities.js
+++ b/tests/unit/utils/discontinuities.js
@@ -81,7 +81,7 @@ describe('level-helper', function () {
             endPTS: 24,
             duration: 4,
             cc: 0,
-            pdt: 1503892800000
+            programDateTime: 1503892800000
           },
           {
             start: 24,
@@ -109,7 +109,7 @@ describe('level-helper', function () {
           endPTS: 4,
           duration: 4,
           cc: 2,
-          pdt: 1503892850000
+          programDateTime: 1503892850000
         },
         {
           start: 4,
@@ -140,7 +140,7 @@ describe('level-helper', function () {
           endPTS: 74,
           duration: 4,
           cc: 2,
-          pdt: 1503892850000
+          programDateTime: 1503892850000
         },
         {
           start: 74,

--- a/tests/unit/utils/discontinuities.js
+++ b/tests/unit/utils/discontinuities.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-import { shouldAlignOnDiscontinuities, findDiscontinuousReferenceFrag, adjustPts, alignDiscontinuities } from '../../../src/utils/discontinuities';
+import { shouldAlignOnDiscontinuities, findDiscontinuousReferenceFrag, adjustPts, alignDiscontinuities, alignPDT } from '../../../src/utils/discontinuities';
 
 const mockReferenceFrag = {
   start: 20,
@@ -70,18 +70,18 @@ describe('level-helper', function () {
   });
 
   it('adjusts level fragments without overlapping CC range but with programDateTime info', function () {
-    const lastFrag = { cc: 0 };
     const lastLevel = {
       details: {
         PTSKnown: true,
-        programDateTime: new Date('2017-08-28 00:00:00'),
+        hasProgramDateTime: true,
         fragments: [
           {
             start: 20,
             startPTS: 20,
             endPTS: 24,
             duration: 4,
-            cc: 0
+            cc: 0,
+            pdt: 1503892800000
           },
           {
             start: 24,
@@ -108,7 +108,8 @@ describe('level-helper', function () {
           startPTS: 0,
           endPTS: 4,
           duration: 4,
-          cc: 2
+          cc: 2,
+          pdt: 1503892850000
         },
         {
           start: 4,
@@ -126,9 +127,9 @@ describe('level-helper', function () {
         }
       ],
       PTSKnown: false,
-      programDateTime: new Date('2017-08-28 00:00:50'),
       startCC: 2,
-      endCC: 3
+      endCC: 3,
+      hasProgramDateTime: true
     };
 
     let detailsExpected = {
@@ -138,7 +139,8 @@ describe('level-helper', function () {
           startPTS: 70,
           endPTS: 74,
           duration: 4,
-          cc: 2
+          cc: 2,
+          pdt: 1503892850000
         },
         {
           start: 74,
@@ -156,11 +158,11 @@ describe('level-helper', function () {
         }
       ],
       PTSKnown: true,
-      programDateTime: new Date('2017-08-28 00:00:50'),
       startCC: 2,
-      endCC: 3
+      endCC: 3,
+      hasProgramDateTime: true
     };
-    alignDiscontinuities(lastFrag, lastLevel, details);
+    alignPDT(details, lastLevel.details);
     assert.deepEqual(detailsExpected, details);
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const clone = (...args) => Object.assign({}, ...args);
 /* Allow to customise builds through env-vars */
 const env = process.env;
 
-const addSubtitleSupport = !!env.SUBTITLE || !!env.USE_SUBTITLES ;
+const addSubtitleSupport = !!env.SUBTITLE || !!env.USE_SUBTITLES;
 const addAltAudioSupport = !!env.ALT_AUDIO || !!env.USE_ALT_AUDIO;
 const addEMESupport = !!env.EME_DRM || !!env.USE_EME_DRM;
 const runAnalyzer = !!env.ANALYZE;
@@ -30,14 +30,25 @@ const uglifyJsOptions = {
 const baseConfig = {
   entry: './src/hls.js',
   module: {
+    strictExportPresence: true,
     rules: [
       {
         test: /\.js$/,
         exclude: [
           path.resolve(__dirname, 'node_modules')
         ],
-        use: {
-          loader: 'babel-loader'
+        loader: 'babel-loader',
+        options: {
+          plugins: [
+            {
+              visitor: {
+                CallExpression: function (espath, file) {
+                  if (espath.get('callee').matchesPattern('Number.isFinite'))
+                    espath.node.callee = file.addImport(path.resolve('src/polyfills/number-isFinite'), 'isFiniteNumber');
+                }
+              }
+            }
+          ]
         }
       }
     ]
@@ -62,13 +73,13 @@ const demoConfig = clone(baseConfig, {
 });
 
 
-function getPluginsForConfig(type, minify = false) {
+function getPluginsForConfig (type, minify = false) {
   // common plugins.
 
   const defineConstants = getConstantsForConfig(type);
 
   console.log(
-    `Building <${ minify ? 'minified' : 'non-minified / debug' }> distro-type "${type}" with compile-time defined constants:`,
+    `Building <${minify ? 'minified' : 'non-minified / debug'}> distro-type "${type}" with compile-time defined constants:`,
     JSON.stringify(defineConstants, null, 4),
     '\n'
   );
@@ -96,13 +107,13 @@ function getPluginsForConfig(type, minify = false) {
     }));
   } else {
     // https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/115
-    plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
+    plugins.push(new webpack.optimize.ModuleConcatenationPlugin());
   }
 
   return plugins;
 }
 
-function getConstantsForConfig(type) {
+function getConstantsForConfig (type) {
   // By default the "main" dists (hls.js & hls.min.js) are full-featured.
   return {
     __VERSION__: JSON.stringify(pkgJson.version),
@@ -112,7 +123,7 @@ function getConstantsForConfig(type) {
   };
 }
 
-function getAliasesForLightDist() {
+function getAliasesForLightDist () {
   let aliases = {};
 
   if (!addEMESupport) {
@@ -154,7 +165,7 @@ const multiConfig = [
       libraryExport: 'default'
     },
     plugins: getPluginsForConfig('main'),
-    devtool: 'source-map',
+    devtool: 'source-map'
   },
   {
     name: 'dist',


### PR DESCRIPTION
### This PR will...
- Stop searching for fragments via PDT when PTS is known
- Backfill PDT values in cases when the first PDT tag does not correspond to the first fragment
- Remove `programDateTime` property from `level.details`; PDT can change between discontinuities within a level. `hasProgramDateTime` has been added to `details` so that code can easily infer if PDT is available for use; if true, all fragments will have `pdt` set.
- Lazy compute `endPdt` since it changes based on duration; duration may change after frags are demuxed
- Avoid assigning pdt to the level or frag if it is NaN
- Apply search tolerances to finding frags via PDT 
- Replace `isNaN` with `Number.isFinite`
- Polyfill `Number.isFinite` via webpack replacement
- Clean up redundant code
- Add tests


### Why is this Pull Request needed?
- Searching for fragments via PDT when PTS is known is useless. When the PTS of each fragment is known, Hls.js knows which fragment to choose at any given time. PTS is more reliable and robust than PDT. PDT will now only be used for live streams when the PTS is unknown, which is typical when switching renditions.
- Backfilling PDT values is conformant to the spec. The original implementation was not correct.
- Without applying the tolerances small discrepancies in PDT cause fragments to loop load or be missed
- Bad PDT values (non-date, NaN) cause the wrong fragment to be selected.


This fix greatly improves performance. There are 50% less javascript calls per-period compared to current master.

### Are there any points in the code the reviewer needs to double check?
Sure. This has already been reviewed, tested, and merged on the JW fork so I'm pretty sure it's functionally sound. There may be style things code improvements or merge errors to fix.


### Resolves Issue
https://github.com/video-dev/hls.js/issues/1805