### PR TITLE
v0.11.0 regression fixes

### DIFF
--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -269,7 +269,7 @@ class AudioTrackController extends TaskLoop {
         }
         // We need to match the (pre-)selected group ID
         // and the NAME of the current track.
-        if ((!this.audioGroupId || track.groupId === this.audioGroupId) &&
+        if ((!this.audioGroupId || track.groupId === this.audioGroupId) &&
           (!name || name === track.name)) {
           // If there was a previous track try to stay with the same `NAME`.
           // It should be unique across tracks of same group, and consistent through redundant track groups.

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -120,6 +120,10 @@ export default class LevelController extends EventHandler {
 
     if (data.audioTracks) {
       audioTracks = data.audioTracks.filter(track => !track.audioCodec || isCodecSupportedInMp4(track.audioCodec, 'audio'));
+      // Reassign id's after filtering since they're used as array indices
+      audioTracks.forEach((track, index) => {
+        track.id = index;
+      });
     }
 
     if (levels.length > 0) {

--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -45,7 +45,7 @@ class AACDemuxer {
     let track = this._audioTrack;
     let id3Data = ID3.getID3Data(data, 0) || [];
     let timestamp = ID3.getTimeStamp(id3Data);
-    let pts = isNaN(timestamp) ? timeOffset * 90000 : timestamp * 90;
+    let pts = Number.isFinite(timestamp) ? timestamp * 90 : timeOffset * 90000;
     let frameIndex = 0;
     let stamp = pts;
     let length = data.length;

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -19,7 +19,7 @@ import { getSelfScope } from '../utils/get-self-scope';
 
 // see https://stackoverflow.com/a/11237259/589493
 const global = getSelfScope(); // safeguard for code that might run both on worker and main thread
-const performance = global;
+const performance = global.performance;
 
 class DemuxerInline {
   constructor (observer, typeSupported, config, vendor) {

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -164,11 +164,11 @@ class PlaylistLoader extends EventHandler {
   }
 
   onAudioTrackLoading (data) {
-    this.load(data.url, { type: ContextType.AUDIO_TRACK, level: 0, id: data.id });
+    this.load(data.url, { type: ContextType.AUDIO_TRACK, level: null, id: data.id });
   }
 
   onSubtitleTrackLoading (data) {
-    this.load(data.url, { type: ContextType.SUBTITLE_TRACK, level: 0, id: data.id });
+    this.load(data.url, { type: ContextType.SUBTITLE_TRACK, level: null, id: data.id });
   }
 
   load (url, context) {


### PR DESCRIPTION
### This PR will...
- Reassign audio track ids after filtering
- Unassign level property from audio tracks and captions
- Fix performance now usage typo

### Why is this Pull Request needed?
- The audio track`id` property is used as an index to the audio track array. If the ID is not reassigned after filtering, it will no longer correspond to the correct array location. This can causes exceptions or the wrong track to be loaded.
- The level property was previously left undefined for audio tracks and captions. This allowed a unique id to be set in https://github.com/video-dev/hls.js/blob/master/src/loader/playlist-loader.js#L343. When changed to 0, it resulted in all audio tracks having the id of 0, which caused the `audioStreamController` to fail to signal the level switch, which caused AAC remuxing to break.
- Trying to access `performance.now()` was always causing an exception

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
