### PR TITLE
fix(timeline-controller): reuse text tracks when not in same order

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -190,9 +190,9 @@ class TimelineController extends EventHandler {
       this.tracks.forEach((track, index) => {
         let textTrack;
         if (index < inUseTracks.length) {
-          const inUseTrack = inUseTracks[index];
+          const inUseTrack = Object.values(inUseTracks).find(inUseTrack => reuseVttTextTrack(inUseTrack, track));
           // Reuse tracks with the same label, but do not reuse 608/708 tracks
-          if (reuseVttTextTrack(inUseTrack, track)) {
+          if (inUseTrack) {
             textTrack = inUseTrack;
           }
         }

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -10,7 +10,7 @@ import WebVTTParser from '../utils/webvtt-parser';
 import { logger } from '../utils/logger';
 import { sendAddTrackEvent, clearCurrentCues } from '../utils/texttrack-utils';
 
-function reuseVttTextTrack (inUseTrack, manifestTrack) {
+function canReuseVttTextTrack (inUseTrack, manifestTrack) {
   return inUseTrack && inUseTrack.label === manifestTrack.name && !(inUseTrack.textTrack1 || inUseTrack.textTrack2);
 }
 
@@ -190,7 +190,7 @@ class TimelineController extends EventHandler {
       this.tracks.forEach((track, index) => {
         let textTrack;
         if (index < inUseTracks.length) {
-          const inUseTrack = Object.values(inUseTracks).find(inUseTrack => reuseVttTextTrack(inUseTrack, track));
+          const inUseTrack = Object.values(inUseTracks).find(inUseTrack => canReuseVttTextTrack(inUseTrack, track));
           // Reuse tracks with the same label, but do not reuse 608/708 tracks
           if (inUseTrack) {
             textTrack = inUseTrack;

--- a/tests/unit/controller/timeline-controller.js
+++ b/tests/unit/controller/timeline-controller.js
@@ -35,4 +35,66 @@ describe('TimelineController', () => {
     assert.strictEqual(timelineController.textTracks[0].mode, 'disabled');
     assert.strictEqual(timelineController.textTracks[1].mode, 'hidden');
   });
+
+  describe('reuse text track', () => {
+    it('should reuse text track when track order is same between manifests', () => {
+      hls.subtitleTrackController = { subtitleDisplay: false };
+
+      timelineController.onManifestLoaded({
+        subtitles: [{ id: 0, name: 'en' }, { id: 1, name: 'ru' }]
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order as in manifest
+      assert.strictEqual(timelineController.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.textTracks.length, 2);
+      // text tracks of the media contain the newly added text tracks
+      assert.strictEqual(timelineController.media.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.media.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.media.textTracks.length, 2);
+
+      timelineController.onManifestLoaded({
+        subtitles: [{ id: 0, name: 'en' }, { id: 1, name: 'ru' }]
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order
+      assert.strictEqual(timelineController.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.textTracks.length, 2);
+      // text tracks of the media contain the previously added text tracks, in same order as the manifest order
+      assert.strictEqual(timelineController.media.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.media.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.media.textTracks.length, 2);
+    });
+
+    it('should reuse text track when track order is not same between manifests', () => {
+      hls.subtitleTrackController = { subtitleDisplay: false };
+
+      timelineController.onManifestLoaded({
+        subtitles: [{ id: 0, name: 'en' }, { id: 1, name: 'ru' }]
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order as in manifest
+      assert.strictEqual(timelineController.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.textTracks.length, 2);
+      // text tracks of the media contain the newly added text tracks
+      assert.strictEqual(timelineController.media.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.media.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.media.textTracks.length, 2);
+
+      timelineController.onManifestLoaded({
+        subtitles: [{ id: 0, name: 'ru' }, { id: 1, name: 'en' }]
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order
+      assert.strictEqual(timelineController.textTracks[0].label, 'ru');
+      assert.strictEqual(timelineController.textTracks[1].label, 'en');
+      assert.strictEqual(timelineController.textTracks.length, 2);
+      // text tracks of the media contain the previously added text tracks, in opposite order to the manifest order
+      assert.strictEqual(timelineController.media.textTracks[0].label, 'en');
+      assert.strictEqual(timelineController.media.textTracks[1].label, 'ru');
+      assert.strictEqual(timelineController.media.textTracks.length, 2);
+    });
+  });
 });


### PR DESCRIPTION
### This PR will...

enable reusing text tracks even if they are not in same order between manifests

### Why is this Pull Request needed?

If two manifests have same text tracks in different order then the current logic, which is index based, will not be able to reuse the text tracks

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
closes #1868 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
