### PR TITLE
add work around tagging issue in Travis CI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
         file_glob: true
         file: dist/*
         draft: true
+        tag_name: $TRAVIS_TAG
+        target_commitish: $TRAVIS_COMMIT
         skip_cleanup: true
         on:
           tags: true


### PR DESCRIPTION
When `draft: true` is set, incorrect commit/tag information is sent to
Github. Override tag/target fields for correct behavior.

Ref. travis-ci/travis-ci#9852

### This PR will...
workaround a travis bug so that when the release is created it is assigned to the tag.
