### PR TITLE
Update readme and demo for gh pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ _Note you can access the docs for a particular version using "http://video-dev.g
 
 ## Demo
 
-### Latest Release
+### Master
 [https://video-dev.github.io/hls.js/demo](https://video-dev.github.io/hls.js/demo)
 
 ### Canary
-[https://video-dev.github.io/hls.js/demo?version=canary](https://video-dev.github.io/hls.js/demo?version=canary)
+[https://video-dev.github.io/hls.js/latest/demo](https://video-dev.github.io/hls.js/latest/demo)
 
-### Local
-[https://video-dev.github.io/hls.js/demo?version=local](https://video-dev.github.io/hls.js/demo?version=local)
+### Specific Version
+"http://video-dev.github.io/hls.js/v[x.y.z]/demo"
+
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build our distro bundle and serve our development environment we use [Webpack
 
 ## API docs and usage guide
 
-* [API and usage docs, with code examples](https://github.com/video-dev/hls.js/blob/master/docs/API.md)
+* [API and usage docs, with code examples](./docs/API.md)
 
 * [Auto-Generated Docs (Latest Release)](http://video-dev.github.io/hls.js/stable/api-docs)
 * [Auto-Generated Docs (Master)](http://video-dev.github.io/hls.js/latest/api-docs)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ _Note you can access the docs for a particular version using "http://video-dev.g
 
 ## Demo
 
-### Master
+### Latest Release
 [https://video-dev.github.io/hls.js/demo](https://video-dev.github.io/hls.js/demo)
 
-### Canary
+### Master
 [https://video-dev.github.io/hls.js/latest/demo](https://video-dev.github.io/hls.js/latest/demo)
 
 ### Specific Version

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ To build our distro bundle and serve our development environment we use [Webpack
 
 * [API and usage docs, with code examples](https://github.com/video-dev/hls.js/blob/master/docs/API.md)
 
-* [Auto-Generated Docs](http://video-dev.github.io/hls.js/docs/html)
+* [Auto-Generated Docs (Latest Release)](http://video-dev.github.io/hls.js/stable/api-docs)
+* [Auto-Generated Docs (Master)](http://video-dev.github.io/hls.js/latest/api-docs)
+
+_Note you can access the docs for a particular version using "http://video-dev.github.io/hls.js/v[x.y.z]/api-docs"_
 
 ## Demo
 

--- a/demo/basic-usage.html
+++ b/demo/basic-usage.html
@@ -5,7 +5,7 @@
   </head>
 
   <body>
-      <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+      <script src="../dist/hls.js"></script>
 
       <center>
           <h1>Hls.js demo - basic usage</h1>

--- a/demo/index.html
+++ b/demo/index.html
@@ -288,51 +288,8 @@
     <script src="metrics.js"></script>
     <script src="jsonpack.js"></script>
 
-    <script>
-      (function() {
-        function loadScript(url, onLoad) {
-          var s = document.createElement("script");
-          s.setAttribute('src', url);
-          if (onLoad) {
-            s.onload = onLoad;
-          }
-          document.body.appendChild(s);
-        }
-
-        var LOCAL_DIST_SRC = '../dist/hls.js';
-        var LATEST_DIST_SRC = 'https://cdn.jsdelivr.net/npm/hls.js@latest';
-        var LOCAL_DEMO_SRC = '../dist/hls-demo.js';
-        var CANARY_DEMO_SRC = 'https://cdn.jsdelivr.net/npm/hls.js@canary/dist/hls-demo.js';
-
-        var queryParts = window.location.search.substring(1).split('&');
-        var src = null;
-        var demoSrc = null;
-        if (queryParts.indexOf('version=latest') >= 0) {
-          src = LATEST_DIST_SRC;
-          demoSrc = CANARY_DEMO_SRC;
-        } else if (queryParts.indexOf('version=canary') >= 0 || queryParts.indexOf('canary=true') >= 0) {
-          src = 'https://cdn.jsdelivr.net/npm/hls.js@canary';
-          demoSrc = CANARY_DEMO_SRC;
-        } else if (queryParts.indexOf('version=local') >= 0) {
-          src = LOCAL_DIST_SRC;
-          demoSrc = LOCAL_DEMO_SRC;
-        }
-        if (!src) {
-          if (window.location.port) {
-            // we are not on port 80/443. Probably running locally. default to local
-            src = LOCAL_DIST_SRC;
-            demoSrc = LOCAL_DEMO_SRC;
-          } else {
-            src = LATEST_DIST_SRC;
-            demoSrc = CANARY_DEMO_SRC;
-          }
-        }
-
-        loadScript(src, function() {
-          // load compiled demo main
-          loadScript(demoSrc);
-        });
-      })();
-    </script>
+    <!-- demo build -->
+    <script src="../dist/hls.js"></script>
+    <script src="../dist/hls-demo.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### This PR will...
Update the links in the readme to the new location of hosted api docs and update the demo to use the build from the repo instead of the cdn.

The one breaking thing in here is that `?canary=true` no longer works on the demo, which instead will be located at "http://video-dev.github.io/hls.js/latest/demo". "http://video-dev.github.io/hls.js/latest/demo" will still exist and point to the demo for the latest tag.

Also the api docs will now be at http://video-dev.github.io/hls.js/latest/api-docs instead of http://video-dev.github.io/hls.js/docs/html

## TODO
- [x] before this is merged I need to manually add the previous tag build to gh-pages
- [ ] after this is merged we should change the settings so that github pages uses the gh-pages branch