### PR TITLE
Inject polyfills via webpack provide (not modifying global env)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "events": "^3.0.0",
-    "string.prototype.endswith": "^0.2.0",
     "url-toolkit": "^2.1.2"
   },
   "devDependencies": {

--- a/src/hls.js
+++ b/src/hls.js
@@ -22,9 +22,6 @@ import HlsEvents from './events';
 
 import { EventEmitter } from 'events';
 
-// polyfill for IE11
-require('string.prototype.endswith');
-
 /**
  * @module Hls
  * @class

--- a/src/hls.js
+++ b/src/hls.js
@@ -24,7 +24,6 @@ import { EventEmitter } from 'events';
 
 // polyfill for IE11
 require('string.prototype.endswith');
-require('./polyfills/number-is-finite');
 
 /**
  * @module Hls

--- a/src/polyfills/number.js
+++ b/src/polyfills/number.js
@@ -1,4 +1,11 @@
+import { getSelfScope } from "../utils/get-self-scope";
+
+const self = getSelfScope();
+const Number = self.Number;
+
 // TODO: get rid of global polyfills and replace them with wrappers ("ponyfills")
 Number.isFinite = Number.isFinite || function (value) {
   return typeof value === 'number' && isFinite(value);
 };
+
+export {Number};

--- a/src/polyfills/number.js
+++ b/src/polyfills/number.js
@@ -1,4 +1,4 @@
-import { getSelfScope } from "../utils/get-self-scope";
+import { getSelfScope } from '../utils/get-self-scope';
 
 const self = getSelfScope();
 const Number = self.Number;
@@ -8,4 +8,4 @@ Number.isFinite = Number.isFinite || function (value) {
   return typeof value === 'number' && isFinite(value);
 };
 
-export {Number};
+export { Number };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,10 @@ function getPluginsForConfig(type, minify = false) {
   const plugins = [
     new webpack.BannerPlugin({ entryOnly: true, raw: true, banner: 'typeof window !== "undefined" &&' }), // SSR/Node.js guard
     new webpack.optimize.OccurrenceOrderPlugin(),
-    new webpack.DefinePlugin(defineConstants)
+    new webpack.DefinePlugin(defineConstants),
+    new webpack.ProvidePlugin({
+      Number: [path.resolve('./src/polyfills/number'), 'Number']
+    })
   ];
 
   if (runAnalyzer && !minify) {


### PR DESCRIPTION
### This PR will...

* Make the Number.isFinite polyfill be injected in local scopes where it is used (or where Number is used in fact)
* The polyfill adresses Number as a whole (but that is just a conceptual detail, doesn't change the result)
* Remove the String endsWith polyfill that was modifying globals (we don't need it anywhere)

### Why is this Pull Request needed?

We don't want to touch global env with our bundle

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
