### PR TITLE
Fix for accurate seeking into unbuffered region at segment boundary (without nudging playhead)

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -210,6 +210,7 @@ function loadSelectedStream() {
     debug            : true,
     enableWorker     : enableWorker,
     defaultAudioCodec: defaultAudioCodec,
+    highBufferWatchdogPeriod: 300,
     widevineLicenseUrl: widevineLicenseUrl
   };
 
@@ -229,6 +230,8 @@ function loadSelectedStream() {
 
   onDemoConfigChanged();
   console.log('Using Hls.js config:', hlsConfig);
+
+  video.currentTime = 129.9
 
   window.hls = hls = new Hls(hlsConfig);
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1361,7 +1361,7 @@ class StreamController extends TaskLoop {
         this.bufferStallCorrection = MIN_FRAGMENT_DURATION;
       }
       this.fragPrevious = null;
-      this.startLoad(this.media.currentTime - this.bufferStallCorrection);
+      this.startLoad(this.media.currentTime);
       break;
     default:
       break;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -320,7 +320,6 @@ class StreamController extends TaskLoop {
       }
 
       logger.log(`stream-controller: _findFragment at ${fragmentFindPosition}, buffer-end ${bufferEnd}, position ${pos}`, fragPrevious);
-      // this.bufferStallCorrection = 0;
       frag = this._findFragment(fragPrevious, fragments, fragmentFindPosition, end, levelDetails);
     }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -60,7 +60,7 @@ class StreamController extends TaskLoop {
     this.stallReported = false;
     this.gapController = null;
 
-    this.bufferStallCorrection = 0;
+    // this._bufferStallCorrection = 0;
   }
 
   onHandlerDestroying () {
@@ -311,15 +311,22 @@ class StreamController extends TaskLoop {
     }
     if (!frag) {
       let fragmentFindPosition;
-      if (this.bufferStallCorrection !== 0) {
-        fragmentFindPosition = pos - this.bufferStallCorrection;
-        logger.debug('Applying fragment-finder correction:', this.bufferStallCorrection);
-        this.bufferStallCorrection = 0;
+
+      /*
+      if (this._bufferStallCorrection !== 0) {
+        fragmentFindPosition = pos - this._bufferStallCorrection;
+        logger.debug('Applying fragment-finder correction:', this._bufferStallCorrection);
+        this._bufferStallCorrection = 0;
       } else {
         fragmentFindPosition = bufferEnd;
       }
+      */
 
-      logger.log(`stream-controller: _findFragment at ${fragmentFindPosition}, buffer-end ${bufferEnd}, position ${pos}`, fragPrevious);
+      fragmentFindPosition = bufferEnd;
+
+      logger.debug(`stream-controller: _findFragment at ${fragmentFindPosition},
+          buffer-end ${bufferEnd}, position ${pos}`, fragPrevious);
+
       frag = this._findFragment(fragPrevious, fragments, fragmentFindPosition, end, levelDetails);
     }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -270,10 +270,10 @@ class StreamController extends TaskLoop {
   }
 
   _fetchPayloadOrEos (pos, bufferInfo, levelDetails) {
-    const fragPrevious = this.fragPrevious,
-      level = this.level,
-      fragments = levelDetails.fragments,
-      fragLen = fragments.length;
+    const fragPrevious = this.fragPrevious;
+    const level = this.level;
+    const fragments = levelDetails.fragments;
+    const fragLen = fragments.length;
 
     // empty playlist
     if (fragLen === 0) {
@@ -281,10 +281,10 @@ class StreamController extends TaskLoop {
     }
 
     // find fragment index, contiguous with end of buffer position
-    let start = fragments[0].start,
-      end = fragments[fragLen - 1].start + fragments[fragLen - 1].duration,
-      bufferEnd = bufferInfo.end,
-      frag;
+    let start = fragments[0].start;
+    let end = fragments[fragLen - 1].start + fragments[fragLen - 1].duration;
+    let bufferEnd = bufferInfo.end;
+    let frag;
 
     if (levelDetails.initSegment && !levelDetails.initSegment.data) {
       frag = levelDetails.initSegment;
@@ -329,7 +329,7 @@ class StreamController extends TaskLoop {
         logger.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}`);
         this._loadKey(frag);
       } else {
-        logger.log(`Loading ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos.toFixed(3)},bufferEnd:${bufferEnd.toFixed(3)}`);
+        logger.log(`Loading ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos.toFixed(3)}, bufferEnd:${bufferEnd.toFixed(3)}`);
         this._loadFragment(frag);
       }
     }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -405,7 +405,15 @@ class StreamController extends TaskLoop {
     return frag;
   }
 
-  _findFragment (start, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails) {
+  /**
+   *
+   * @param {Fragment} fragPrevious Previous fragment
+   * @param {Fragment[]} fragments List of current level
+   * @param {number} bufferEnd Last timestamp of buffered time-range
+   * @param {number} end Last timestamp of current level fragment list
+   * @param {*} levelDetails Current level details object
+   */
+  _findFragment (fragPrevious, fragments, bufferEnd, end, levelDetails) {
     const config = this.hls.config;
     let frag;
 
@@ -416,7 +424,7 @@ class StreamController extends TaskLoop {
       frag = findFragmentByPTS(fragPrevious, fragments, bufferEnd, lookupTolerance);
     } else {
       // reach end of playlist
-      frag = fragments[fragLen - 1];
+      frag = fragments[fragments.length - 1];
     }
     if (frag) {
       const curSNIdx = frag.sn - levelDetails.startSN;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1360,14 +1360,16 @@ class StreamController extends TaskLoop {
       }
       break;
     case ErrorDetails.BUFFER_STALLED_ERROR:
+      /*
       logger.log('attempting buffer stall correction on load position');
       const MIN_FRAGMENT_DURATION = 0.5;
       const currentFragment = this.fragCurrent;
       if (this.media.currentTime < currentFragment.start) {
-        this.bufferStallCorrection = MIN_FRAGMENT_DURATION;
+        this._bufferStallCorrection = MIN_FRAGMENT_DURATION;
       }
       this.fragPrevious = null;
       this.startLoad(this.media.currentTime);
+      */
       break;
     default:
       break;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -767,7 +767,7 @@ class StreamController extends TaskLoop {
       logger.log(`media seeking to ${currentTime.toFixed(3)}`);
     }
 
-    let mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
+    let mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media; // FIXME: why do we have to do this?
     let bufferInfo = BufferHelper.bufferInfo(mediaBuffer, currentTime, this.config.maxBufferHole);
     if (this.state === State.FRAG_LOADING) {
       let fragCurrent = this.fragCurrent;

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -100,6 +100,24 @@ export default class Fragment {
     return !!((this.decryptdata && this.decryptdata.uri !== null) && (this.decryptdata.key === null));
   }
 
+  get end () {
+    return this.start + this.duration;
+  }
+
+  /**
+   *
+   * @param {number} timeSeconds 0 when inside, negative when before, positive when after
+   */
+  compareTimeInterval (timeSeconds) {
+    if (timeSeconds < this.start) {
+      return timeSeconds - this.start;
+    } else if (timeSeconds > this.end) {
+      return this.end + timeSeconds;
+    } else {
+      return 0;
+    }
+  }
+
   /**
    * @param {ElementaryStreamType} type
    */

--- a/src/utils/buffer-helper.js
+++ b/src/utils/buffer-helper.js
@@ -33,6 +33,13 @@ export class BufferHelper {
     return false;
   }
 
+  /**
+   *
+   * @param {HTMLMediaElement} media
+   * @param {number} pos
+   * @param {number} maxHoleDuration
+   * @returns {*}
+   */
   static bufferInfo (media, pos, maxHoleDuration) {
     try {
       if (media) {
@@ -41,7 +48,7 @@ export class BufferHelper {
           buffered.push({ start: vbuffered.start(i), end: vbuffered.end(i) });
         }
 
-        return this.bufferedInfo(buffered, pos, maxHoleDuration);
+        return BufferHelper.bufferedInfo(buffered, pos, maxHoleDuration);
       }
     } catch (error) {
       // this is to catch


### PR DESCRIPTION
### This PR will...

Introduce a more accurate and correct way to handle buffer-stalls on seeking.

The problem:

- seek is done to a position X
- fragment-finder is resolving to fragment N
- fragment N doesn't contain position X (timestamps shifted for some reason or another)
- Playback stalls at seek target with data buffered in time-range very near (but not at target)

Reproduce:

- Use our default BigBuckBunny test video
- Set `highBufferWatchdogPeriod` to 300
- Before loading data, set media currentTime to 129.9
- Playback will stall

Current behavior:

- Gap-controller detects the stall, and after the configurable time `highBufferWatchdogPeriod` we attempt a "nudge", which means we actually seek into the buffered range.

Issues: 
* We actually don't seek accurately to the initially requested position
* There is a delay in seeking depending on `highBufferWatchdogPeriod`, and the whole process is fuzzy, as the watchdog time has to be balanced against normally expectable seek latencies, which are in principle not predictable.

Our solution:

- Actually attempt load the correct fragment! Thus we manage to optimize seek-time to best-effort in any case, as we are trying to resolve the correct fragment with normal means, and when this fails handle it by the following method.
(- We are estimating the shift in timestamps that occured so that our initial seek went wrong) -> using a constant with minimal expected segment duration for now, as we need some buffer state evaluation for the first one
- With this value, we are resetting the load position of the next fragment (we re-init loading with startLoad) and actually get the correct fragment to be loaded

Notes:

* The gap-controller based handling would still have grip if after the watchdog-time the buffer is still stalling. This isn't a replacement but more-off a better first way to handle this. The gap-controller nudge-method is still there in case of emergency.

* The default watch-dog period should be raised probably.

* Afaics there is no case where this shouldn't work, except if there are very weird gaps in the stream and we don't manage to resolve the seek-time with straight-forward logic (but this is also then a missing information in the stream, like PDT stamps e.g).

=> This is surely not perfect yet, but an approach to a better solution that the current "nudge method". 

Happy to get feedback on this and get it to something real-life ready.

### Are there any points in the code the reviewer needs to double check?

Yes, but I'd like it to be plainly reviewed first, and then we get into the tricky considerations of this solution.

### Resolves issues:

Yes.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
