### PR TITLE
fix-1439: allow spaces in fragment files

### DIFF
--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -19,7 +19,7 @@ const MASTER_PLAYLIST_MEDIA_REGEX = /#EXT-X-MEDIA:(.*)/g;
 
 const LEVEL_PLAYLIST_REGEX_FAST = new RegExp([
   /#EXTINF:\s*(\d*(?:\.\d+)?)(?:,(.*)\s+)?/.source, // duration (#EXTINF:<duration>,<title>), group 1 => duration, group 2 => title
-  /|(?!#)(\S+)/.source, // segment URI, group 3 => the URI (note newline is not eaten)
+  /|(?!#)([\S+ ?]+)/.source, // segment URI, group 3 => the URI (note newline is not eaten)
   /|#EXT-X-BYTERANGE:*(.+)/.source, // next segment's byterange, group 4 => range spec (x@y)
   /|#EXT-X-PROGRAM-DATE-TIME:(.+)/.source, // next segment's program date/time group 5 => the datetime spec
   /|#.*/.source // All other non-segment oriented tags will match with all groups empty

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -809,4 +809,45 @@ http://dummy.url.com/hls/live/segment/segment_022916_164500865_719928.ts
     assert.strictEqual(result.fragments[2].tagList[2][0], 'EXT-X-CUSTOM-URI');
     assert.strictEqual(result.fragments[2].tagList[2][1], 'http://dummy.url.com/hls/moreinfo.json');
   });
+
+  it('allows spaces in the fragment files', () => {
+    const level = `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-TARGETDURATION:7
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXTINF:6.006,
+180724_Allison VLOG-v3_00001.ts
+#EXTINF:6.006,
+180724_Allison VLOG-v3_00002.ts
+#EXT-X-ENDLIST
+    `;
+    const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
+    assert.strictEqual(result.fragments.length, 2);
+    assert.strictEqual(result.totalduration, 12.012);
+    assert.strictEqual(result.targetduration, 7);
+    assert.strictEqual(result.fragments[0].url, 'http://dummy.url.com/180724_Allison VLOG-v3_00001.ts');
+    assert.strictEqual(result.fragments[1].url, 'http://dummy.url.com/180724_Allison VLOG-v3_00002.ts');
+  });
+
+  it('deals with spaces after fragment files', () => {
+    // You can't see them, but there should be spaces directly after the .ts
+    const level = `#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-TARGETDURATION:7
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXTINF:6.006,
+180724_Allison VLOG v3_00001.ts 
+#EXTINF:6.006,
+180724_Allison VLOG v3_00002.ts 
+#EXT-X-ENDLIST
+    `;
+    const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
+    assert.strictEqual(result.fragments.length, 2);
+    assert.strictEqual(result.totalduration, 12.012);
+    assert.strictEqual(result.targetduration, 7);
+    assert.strictEqual(result.fragments[0].url, 'http://dummy.url.com/180724_Allison VLOG v3_00001.ts');
+    assert.strictEqual(result.fragments[1].url, 'http://dummy.url.com/180724_Allison VLOG v3_00002.ts');
+  });
 });


### PR DESCRIPTION
### This PR will...
Allow fragment files to contain spaces

### Why is this Pull Request needed?
Safari allows spaces in their fragment files, many encoders all them. They are expected to work.

### Are there any points in the code the reviewer needs to double check?
Perhaps if there is a space at the end of the .ts fragment, it would be included. I'm not certain if that is handled.

### Resolves issues:
#1439 

### Checklist

- [x ] changes have been done against master branch, and PR does not conflict
- [x ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
