### PR TITLE
Fix: don't try to load embedded audio tracks

### DIFF
--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -323,13 +323,14 @@ class AudioTrackController extends TaskLoop {
    * @returns {boolean}
    */
   _needsTrackLoading (audioTrack) {
-    const { details } = audioTrack;
+    const { details, url } = audioTrack;
 
-    if (!details) {
-      return true;
-    } else if (details.live) {
-      return true;
+    if (!details || details.live) {
+      // check if we face an audio track embedded in main playlist (audio track without URI attribute)
+      return !!url;
     }
+
+    return false;
   }
 
   /**

--- a/tests/unit/controller/audio-track-controller.js
+++ b/tests/unit/controller/audio-track-controller.js
@@ -81,6 +81,18 @@ describe('AudioTrackController', () => {
     });
   });
 
+  describe('_needsTrackLoading', () => {
+    it('should not need loading because the audioTrack is embedded in the main playlist', () => {
+      assert.strictEqual(audioTrackController._needsTrackLoading({ details: { live: true } }), false);
+      assert.strictEqual(audioTrackController._needsTrackLoading({ details: null }), false);
+    });
+
+    it('should need loading because the track has not been loaded yet', () => {
+      assert.strictEqual(audioTrackController._needsTrackLoading({ details: { live: true }, url: 'http://example.com/manifest.m3u8' }), true);
+      assert.strictEqual(audioTrackController._needsTrackLoading({ details: null, url: 'http://example.com/manifest.m3u8' }), true);
+    });
+  });
+
   describe('onAudioTrackLoaded', () => {
     it('should set the track details from the event data but not set the interval for a non-live track', () => {
       const details = {


### PR DESCRIPTION
Hi 

### This PR will...

Fix an issue introduced since version 0.10.0 that was trying to fetch an embedded audioTrack in the main playlist.
As it doesn't have an URI tag, that embedded track had an `undefined` url, which means the audioTrack controller was trying to fetch the `${hostname}/undefined`

### Why is this Pull Request needed?

Because it makes a 404 request on our platform at each video loading

### Are there any points in the code the reviewer needs to double check?

Here is a manifest with an embedded audioTrack in the main playlist: https://cdn-rtlhu.akamaized.net/videos/rtlhu/usp/mb_sd3/9/e/1/Survivor_c12058981_Survivor-A-sziget-2-/Survivor_c12058981_Survivor-A-sziget-2-_unpnp.ism/Manifest.m3u8

A multiple languages manifest still works fine: https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
