### PR TITLE
Improve EME Controller: parse PSSH box in manifest

### DIFF
--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -7,7 +7,7 @@
 import EventHandler from '../event-handler';
 import Event from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
-
+import { base64ToArrayBuffer } from '../utils/base64toArrayBuffer';
 import { logger } from '../utils/logger';
 
 const { XMLHttpRequest } = window;
@@ -72,18 +72,6 @@ const getSupportedMediaKeySystemConfigurations = function (keySystem, audioCodec
     throw Error('Unknown key-system: ' + keySystem);
   }
 };
-
-function base64ToArrayBuffer (base64String) {
-  let binaryString = window.atob(base64String);
-  let len = binaryString.length;
-  let bytes = new Uint8Array(len);
-
-  for (let i = 0; i < len; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-
-  return bytes;
-}
 
 /**
  * Controller to deal with encrypted media extensions (EME)

--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -495,7 +495,7 @@ class EMEController extends EventHandler {
       return;
     }
 
-    // add initData and type if they are not included in playlist
+    // add initData and type if they are included in playlist
     if (this._initData && !this._hasSetMediaKeys) {
       this._onMediaEncrypted(this._initDataType, this._initData);
     }

--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -106,6 +106,9 @@ class EMEController extends EventHandler {
     this._isMediaEncrypted = false;
 
     this._requestLicenseFailureCount = 0;
+
+    this._initData = null;
+    this._initDataType = '';
   }
 
   /**
@@ -487,17 +490,20 @@ class EMEController extends EventHandler {
     this._attemptKeySystemAccess(KeySystems.WIDEVINE, audioCodecs, videoCodecs);
   }
 
-  onFragLoaded (data) {
+  onFragLoaded () {
     if (!this._emeEnabled) {
       return;
     }
 
     // add initData and type if they are not included in playlist
-    if (this.initData && !this._hasSetMediaKeys) {
-      this._onMediaEncrypted(this.initDataType, this.initData);
+    if (this._initData && !this._hasSetMediaKeys) {
+      this._onMediaEncrypted(this._initDataType, this._initData);
     }
   }
 
+  /**
+   * @param {object} data
+   */
   onLevelLoaded (data) {
     if (!this._emeEnabled) {
       return;
@@ -510,8 +516,8 @@ class EMEController extends EventHandler {
       const pssh = details[1];
 
       if (encoding.includes('base64')) {
-        this.initDataType = 'cenc';
-        this.initData = base64ToArrayBuffer(pssh);
+        this._initDataType = 'cenc';
+        this._initData = base64ToArrayBuffer(pssh);
       }
     }
   }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -166,7 +166,7 @@ export default class M3U8Parser {
         // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
         const title = (' ' + result[2]).slice(1);
         frag.title = title || null;
-        frag.tagList.push(title ? [ 'INF', duration, title ] : [ 'INF', duration ]);
+        frag.tagList.push(title ? ['INF', duration, title] : ['INF', duration]);
       } else if (result[3]) { // url
         if (Number.isFinite(frag.duration)) {
           const sn = currentSN++;
@@ -217,7 +217,7 @@ export default class M3U8Parser {
 
         switch (result[i]) {
         case '#':
-          frag.tagList.push(value2 ? [ value1, value2 ] : [ value1 ]);
+          frag.tagList.push(value2 ? [value1, value2] : [value1]);
           break;
         case 'PLAYLIST-TYPE':
           level.type = value1.toUpperCase();
@@ -252,7 +252,7 @@ export default class M3U8Parser {
             decryptiv = keyAttrs.hexadecimalInteger('IV');
           if (decryptmethod) {
             levelkey = new LevelKey();
-            if ((decrypturi) && (['AES-128', 'SAMPLE-AES', 'SAMPLE-AES-CENC'].indexOf(decryptmethod) >= 0)) {
+            if ((decrypturi) && (['AES-128', 'SAMPLE-AES', 'SAMPLE-AES-CENC', 'SAMPLE-AES-CTR'].indexOf(decryptmethod) >= 0)) {
               levelkey.method = decryptmethod;
               // URI to get the key
               levelkey.baseuri = baseurl;
@@ -302,6 +302,7 @@ export default class M3U8Parser {
     level.endSN = currentSN - 1;
     level.startCC = level.fragments[0] ? level.fragments[0].cc : 0;
     level.endCC = cc;
+    level.levelkey = levelkey;
 
     if (!level.initSegment && level.fragments.length) {
       // this is a bit lurky but HLS really has no other way to tell us

--- a/src/utils/base64toArrayBuffer.js
+++ b/src/utils/base64toArrayBuffer.js
@@ -1,3 +1,7 @@
+/**
+ * @param {string} base64String base64 encoded string
+ * @returns {ArrayBuffer}
+ */
 export function base64ToArrayBuffer (base64String) {
   let binaryString = window.atob(base64String);
   let len = binaryString.length;

--- a/src/utils/base64toArrayBuffer.js
+++ b/src/utils/base64toArrayBuffer.js
@@ -1,0 +1,11 @@
+export function base64ToArrayBuffer (base64String) {
+  let binaryString = window.atob(base64String);
+  let len = binaryString.length;
+  let bytes = new Uint8Array(len);
+
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  return bytes;
+}

--- a/tests/unit/utils/base64toArrayBuffer.js
+++ b/tests/unit/utils/base64toArrayBuffer.js
@@ -1,0 +1,11 @@
+import { base64ToArrayBuffer } from '../../../src/utils/base64toArrayBuffer';
+import assert from 'assert';
+
+describe('base64 to arraybuffer util', function () {
+  let base64String = 'AAAA';
+  it('converts base 64 encoded string to arraybuffer', function () {
+    let bytes = base64ToArrayBuffer(base64String);
+    assert(Object.prototype.toString.call(bytes), '[object Uint8Array]');
+    assert(bytes.toString(), '0,0,0');
+  });
+});


### PR DESCRIPTION
### This PR will...

Add support for parsing PSSH element from manifest rather than relying on embedded in the init segment. 

### Why is this Pull Request needed?


**Background**

According to the [`"cenc" Initialization Data` spec](https://www.w3.org/TR/eme-initdata-cenc/), it "...also specifies storage of a 'pssh' box base64-encoded in an XML element of the form <cenc:pssh (base64 'pssh')>." In our case it's in the hls manfiest which according to the [Widevine with DRM doc](https://storage.googleapis.com/wvdocs/Widevine_DRM_HLS.pdf), it should be in the URI like so: ```URI=”data:text/plain;base64,<base64 encoded PSSH box>”``` 


**Current Widevine Sample Stream**

In the case of this sample widevine stream: https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine-hls/hls.m3u8, the init.mp4 has the necessary pssh information for the `encrypted` event to be triggered. 

```
          ---pssh
                  size: 62
                  version: 0
                  flags: 0x000000
                  System ID: 0xedef8ba979d64acea3c827dcd51d21ed
                  Data Size: 30
```


But that information is also in the manifest:

```
#EXT-X-KEY:METHOD=SAMPLE-AES-CTR,URI="data:text/plain;base64,AAAAPnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB4iFnNoYWthX2NlYzJmNjRhYTc4OTBhMTFI49yVmwY=",KEYID=0x800AACAA522958AE888062B5695DB6BF,KEYFORMATVERSIONS="1",KEYFORMAT="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
```

### Are there any points in the code the reviewer needs to double check?

1) Should `base64ToArrayBuffer` be in it's own file? 
2) I attached `levelKey` to the level but we may need to think about situations where there are multi-drm streams with more than one key tag. ( I have a separate WIP branch which I'm looking into this )
3) Do we have a sample stream where there isn't a PSSH box in the stream itself? The way I tested that scenario was the simply comment out the following line and play the widevine test stream.

https://github.com/video-dev/hls.js/pull/1915/files#diff-66dbb17319c4f0d5f009baca4e3ecf36R484

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
