### PR TITLE
Fix: Select which WebVTT fragment to load based on playhead position

### DIFF
--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -55,16 +55,14 @@ class SubtitleStreamController extends TaskLoop {
     if (this.currentlyProcessing === null && this.currentTrackId > -1 && this.vttFragQueues[this.currentTrackId].length) {
       let queue = this.vttFragQueues[this.currentTrackId];
       let i = this.findQueuedFragmentIndexClosestToPlayhead(queue);
-      let frag;
       if (i >= 0) {
-        frag = queue[i];
-        queue.splice(i, 1);
+        this.fragCurrent = queue.splice(i, 1)[0];
       } else {
-        frag = queue.shift();
+        this.fragCurrent = queue.shift();
       }
 
-      this.fragCurrent = this.currentlyProcessing = frag;
-      this.hls.trigger(Event.FRAG_LOADING, { frag: frag });
+      this.currentlyProcessing = this.fragCurrent;
+      this.hls.trigger(Event.FRAG_LOADING, { frag: this.fragCurrent });
       this.state = State.FRAG_LOADING;
     }
   }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -20,6 +20,7 @@ class SubtitleStreamController extends TaskLoop {
   constructor (hls) {
     super(hls,
       Event.MEDIA_ATTACHED,
+      Event.MEDIA_DETACHING,
       Event.ERROR,
       Event.KEY_LOADED,
       Event.FRAG_LOADED,
@@ -52,11 +53,36 @@ class SubtitleStreamController extends TaskLoop {
   // If no frag is being processed and queue isn't empty, initiate processing of next frag in line.
   nextFrag () {
     if (this.currentlyProcessing === null && this.currentTrackId > -1 && this.vttFragQueues[this.currentTrackId].length) {
-      let frag = this.currentlyProcessing = this.vttFragQueues[this.currentTrackId].shift();
-      this.fragCurrent = frag;
+      let queue = this.vttFragQueues[this.currentTrackId];
+      let i = this.findQueuedFragmentIndexClosestToPlayhead(queue);
+      let frag;
+      if (i >= 0) {
+        frag = queue[i];
+        queue.splice(i, 1);
+      } else {
+        frag = queue.shift();
+      }
+
+      this.fragCurrent = this.currentlyProcessing = frag;
       this.hls.trigger(Event.FRAG_LOADING, { frag: frag });
       this.state = State.FRAG_LOADING;
     }
+  }
+
+  // Try to be smart about choosing the fragment near or just after the current playhead
+  findQueuedFragmentIndexClosestToPlayhead (queue) {
+    let ts = this.media.currentTime;
+    for (let i = 0; i <= queue.length; i++) {
+      let frag = queue[i];
+      if (!frag) {
+        continue;
+      } else if (frag.start <= ts && (frag.start + frag.duration) >= ts) {
+        return i;
+      } else if (frag.start > ts) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   // When fragment has finished processing, add sn to list of completed if successful.
@@ -70,8 +96,13 @@ class SubtitleStreamController extends TaskLoop {
     this.nextFrag();
   }
 
-  onMediaAttached () {
+  onMediaAttached (data) {
     this.state = State.IDLE;
+    this.media = data.media;
+  }
+
+  onMediaDetaching () {
+    this.clearVttFragQueues();
   }
 
   // If something goes wrong, procede to next frag, if we were processing one.

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -1,0 +1,42 @@
+import sinon from 'sinon';
+import SubtitleStreamController from '../../../src/controller/subtitle-stream-controller';
+import Hls from '../../../src/hls';
+
+const assert = require('assert');
+
+describe('SubtitleStreamController', () => {
+  let subtitleStreamController;
+  let videoElement;
+  let queue;
+
+  beforeEach(() => {
+    const hls = new Hls();
+
+    videoElement = document.createElement('video');
+    subtitleStreamController = new SubtitleStreamController(hls);
+
+    subtitleStreamController.media = videoElement;
+    subtitleStreamController.tracks = [{ id: 0, url: 'baz', details: { live: false } }, { id: 1, url: 'bar' }, { id: 2, details: { live: true }, url: 'foo' }];
+
+    queue = [
+      { start: 0, duration: 10 },
+      { start: 10, duration: 10 },
+      { start: 20, duration: 10 },
+      { start: 30, duration: 10 },
+      { start: 40, duration: 10 }
+    ];
+  });
+
+  describe('fragment queue', () => {
+    it('should process the webvtt file closest to the media playhead', () => {
+      videoElement.currentTime = 8;
+      assert.strictEqual(subtitleStreamController.findQueuedFragmentIndexClosestToPlayhead(queue), 0);
+
+      videoElement.currentTime = 25;
+      assert.strictEqual(subtitleStreamController.findQueuedFragmentIndexClosestToPlayhead(queue), 2);
+
+      videoElement.currentTime = 100;
+      assert.strictEqual(subtitleStreamController.findQueuedFragmentIndexClosestToPlayhead(queue), -1);
+    });
+  });
+});

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -5,38 +5,53 @@ import Hls from '../../../src/hls';
 const assert = require('assert');
 
 describe('SubtitleStreamController', () => {
-  let subtitleStreamController;
+  let controller;
   let videoElement;
-  let queue;
 
   beforeEach(() => {
     const hls = new Hls();
 
+    controller = new SubtitleStreamController(hls);
+
     videoElement = document.createElement('video');
-    subtitleStreamController = new SubtitleStreamController(hls);
+    controller.media = videoElement;
 
-    subtitleStreamController.media = videoElement;
-    subtitleStreamController.tracks = [{ id: 0, url: 'baz', details: { live: false } }, { id: 1, url: 'bar' }, { id: 2, details: { live: true }, url: 'foo' }];
-
-    queue = [
-      { start: 0, duration: 10 },
-      { start: 10, duration: 10 },
-      { start: 20, duration: 10 },
-      { start: 30, duration: 10 },
-      { start: 40, duration: 10 }
+    controller.vttFragQueues = [
+      [
+        { start: 0, duration: 10 },
+        { start: 10, duration: 10 },
+        { start: 20, duration: 10 },
+        { start: 30, duration: 10 },
+        { start: 40, duration: 10 }
+      ]
     ];
+    controller.currentTrackId = 0;
   });
 
   describe('fragment queue', () => {
     it('should process the webvtt file closest to the media playhead', () => {
-      videoElement.currentTime = 8;
-      assert.strictEqual(subtitleStreamController.findQueuedFragmentIndexClosestToPlayhead(queue), 0);
+      assert.strictEqual(controller.vttFragQueues[0].length, 5);
 
-      videoElement.currentTime = 25;
-      assert.strictEqual(subtitleStreamController.findQueuedFragmentIndexClosestToPlayhead(queue), 2);
+      // Skip into the 20-30s fragment
+      controller.currentlyProcessing = null;
+      videoElement.currentTime = 28;
+      controller.nextFrag();
+      assert.strictEqual(controller.fragCurrent.start, 20);
+      assert.strictEqual(controller.vttFragQueues[0].length, 4);
 
+      // Skip over into the 40-50s fragment
+      controller.currentlyProcessing = null;
+      videoElement.currentTime = 42;
+      controller.nextFrag();
+      assert.strictEqual(controller.fragCurrent.start, 40);
+      assert.strictEqual(controller.vttFragQueues[0].length, 3);
+
+      // Try a fragment that won't be found; should just resort to processing first one in queue
+      controller.currentlyProcessing = null;
       videoElement.currentTime = 100;
-      assert.strictEqual(subtitleStreamController.findQueuedFragmentIndexClosestToPlayhead(queue), -1);
+      controller.nextFrag();
+      assert.strictEqual(controller.fragCurrent.start, 0);
+      assert.strictEqual(controller.vttFragQueues[0].length, 2);
     });
   });
 });


### PR DESCRIPTION
### This PR will...

Improve closed caption / subtitle display for long videos by more intelligently loading the webvtt fragment based on video.currentTime

### Why is this Pull Request needed?

The existing behavior loads all webvtt fragments serially, so when you seek, it can take a long time before the webvtt caption under the playhead is actually available.  This is especially apparently for multi-hour broadcasts.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

#1680 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
