### PR TITLE
playlist-loader: handle mp4 streams without sidx ranges in map

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -396,16 +396,19 @@ class PlaylistLoader extends EventHandler {
 
   _handleSidxRequest (response, context) {
     const sidxInfo = MP4Demuxer.parseSegmentIndex(new Uint8Array(response.data));
-    sidxInfo.references.forEach((segmentRef, index) => {
-      const segRefInfo = segmentRef.info;
-      const frag = context.levelDetails.fragments[index];
+    const sidxReferences = sidxInfo && sidxInfo.references;
+    if (sidxReferences) {
+      const levelDetails = context.levelDetails;
+      sidxReferences.forEach((segmentRef, index) => {
+        const segRefInfo = segmentRef.info;
+        const frag = levelDetails.fragments[index];
 
-      if (frag.byteRange.length === 0) {
-        frag.rawByteRange = String(1 + segRefInfo.end - segRefInfo.start) + '@' + String(segRefInfo.start);
-      }
-    });
-
-    context.levelDetails.initSegment.rawByteRange = String(sidxInfo.moovEndOffset) + '@0';
+        if (frag.byteRange.length === 0) {
+          frag.rawByteRange = String(1 + segRefInfo.end - segRefInfo.start) + '@' + String(segRefInfo.start);
+        }
+      });
+      levelDetails.initSegment.rawByteRange = String(sidxInfo.moovEndOffset) + '@0';
+    }
   }
 
   _handleManifestParsingError (response, context, reason, networkDetails) {

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -396,19 +396,21 @@ class PlaylistLoader extends EventHandler {
 
   _handleSidxRequest (response, context) {
     const sidxInfo = MP4Demuxer.parseSegmentIndex(new Uint8Array(response.data));
-    const sidxReferences = sidxInfo && sidxInfo.references;
-    if (sidxReferences) {
-      const levelDetails = context.levelDetails;
-      sidxReferences.forEach((segmentRef, index) => {
-        const segRefInfo = segmentRef.info;
-        const frag = levelDetails.fragments[index];
-
-        if (frag.byteRange.length === 0) {
-          frag.rawByteRange = String(1 + segRefInfo.end - segRefInfo.start) + '@' + String(segRefInfo.start);
-        }
-      });
-      levelDetails.initSegment.rawByteRange = String(sidxInfo.moovEndOffset) + '@0';
+    // if provided fragment does not contain sidx, early return
+    if (!sidxInfo) {
+      return;
     }
+    const sidxReferences = sidxInfo.references;
+    const levelDetails = context.levelDetails;
+    sidxReferences.forEach((segmentRef, index) => {
+      const segRefInfo = segmentRef.info;
+      const frag = levelDetails.fragments[index];
+
+      if (frag.byteRange.length === 0) {
+        frag.rawByteRange = String(1 + segRefInfo.end - segRefInfo.start) + '@' + String(segRefInfo.start);
+      }
+    });
+    levelDetails.initSegment.rawByteRange = String(sidxInfo.moovEndOffset) + '@0';
   }
 
   _handleManifestParsingError (response, context, reason, networkDetails) {


### PR DESCRIPTION
### This PR will...

fix playback of streams for which fragment URL looks like mp4 fragment (ie match with this [regex](https://github.com/video-dev/hls.js/blob/d6d83b1066e25c6925bfef308d418bc4beb42a32/src/loader/m3u8-parser.js#L30)), but which are not mp4

related to #1919
regression introduced in [v0.9.0](https://github.com/video-dev/hls.js/releases/tag/v0.9.0)

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
