### PR TITLE
fix chrome stream hang up when seeking

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -67,7 +67,6 @@ class BufferController extends EventHandler {
         try {
           audioBuffer.abort();
         } catch (err) {
-          updating = true;
           logger.warn('can not abort audio buffer: ' + err);
         }
 
@@ -198,16 +197,15 @@ class BufferController extends EventHandler {
     logger.log('media source ended');
   }
 
-  updateTimestampOffset () {
+  onSBUpdateEnd () {
+    // update timestampOffset
     if (this.audioTimestampOffset) {
       let audioBuffer = this.sourceBuffer.audio;
       logger.warn('change mpeg audio timestamp offset from ' + audioBuffer.timestampOffset + ' to ' + this.audioTimestampOffset);
       audioBuffer.timestampOffset = this.audioTimestampOffset;
       delete this.audioTimestampOffset;
     }
-  }
 
-  onSBUpdateEnd () {
     if (this._needsFlush) {
       this.doFlush();
     }
@@ -476,9 +474,6 @@ class BufferController extends EventHandler {
         let segment = segments.shift();
         try {
           let type = segment.type, sb = sourceBuffer[type];
-
-          this.updateTimestampOffset();
-
           if (sb) {
             if (!sb.updating) {
               // reset sourceBuffer ended flag before appending segment

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -198,15 +198,16 @@ class BufferController extends EventHandler {
     logger.log('media source ended');
   }
 
-  onSBUpdateEnd () {
-    // update timestampOffset
+  updateTimestampOffset () {
     if (this.audioTimestampOffset) {
       let audioBuffer = this.sourceBuffer.audio;
       logger.warn('change mpeg audio timestamp offset from ' + audioBuffer.timestampOffset + ' to ' + this.audioTimestampOffset);
       audioBuffer.timestampOffset = this.audioTimestampOffset;
       delete this.audioTimestampOffset;
     }
+  }
 
+  onSBUpdateEnd () {
     if (this._needsFlush) {
       this.doFlush();
     }
@@ -475,6 +476,9 @@ class BufferController extends EventHandler {
         let segment = segments.shift();
         try {
           let type = segment.type, sb = sourceBuffer[type];
+
+          this.updateTimestampOffset();
+
           if (sb) {
             if (!sb.updating) {
               // reset sourceBuffer ended flag before appending segment


### PR DESCRIPTION
### This PR will...
Fix the issue with stuck stream on chrome while seeking. This fix augments this commit https://github.com/nochev/hls.js/commit/2737c71b8bf7377f01be69cce14c5594de6e8e2d. Essentially, player gets stuck when it goes not to the `onSBUpdateEnd` method but to the first branch in `if` statement (https://github.com/video-dev/hls.js/blob/master/src/controller/buffer-controller.js#L478) when an abort error happens in chrome (https://github.com/video-dev/hls.js/blob/master/src/controller/buffer-controller.js#L70). As a result it doesn't pickup `this.audioTimestampOffset` and gets stuck

### Why is this Pull Request needed?
We are using hls.js and cannot ship features in production without chrome working with `audio/mpeg` streams while seeking. Also there are issues related to this problem

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#1924 also some issues with seeking opened may be fixed

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
