### PR TITLE
gap-controller: fix false positive buffer-stall errors when seeking

### DIFF
--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -16,14 +16,16 @@ export default class GapController {
 
     this._seeking = media.seeking;
 
-    this.media.addEventListener('seeking', () => this._onMediaSeek(false));
-    this.media.addEventListener('seeked', () => this._onMediaSeek(false));
+    this._onMediaSeeking = () => this._onMediaSeek(false);
+    this._onMediaSeeked = () => this._onMediaSeek(true);
 
-    // Problem: We have to take care of media attaching/detaching, which is not handled at all yet
+    this.media.addEventListener('seeking', this._onMediaSeeking);
+    this.media.addEventListener('seeked', this._onMediaSeeked);
   }
 
   destroy () {
-    // TODO deregister event listeners on media
+    this.media.removeEventListener('seeking', this._onMediaSeeking);
+    this.media.removeEventListener('seeked', this._onMediaSeeked);
   }
 
   _onMediaSeek (done) {
@@ -61,7 +63,7 @@ export default class GapController {
     }
 
     // we are seeking or waiting for parsed data to get buffered. it's ok to stall.
-    if (this._seeking || !BufferHelper.isBuffered(media, currentTime)) {
+    if (media.seeking || this._seeking || !BufferHelper.isBuffered(media, currentTime)) {
       return;
     }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -743,6 +743,7 @@ class StreamController extends TaskLoop {
       media.removeEventListener('ended', this.onvended);
       this.onvseeking = this.onvseeked = this.onvended = null;
     }
+    this.gapController.destroy();
     this.media = this.mediaBuffer = null;
     this.loadedmetadata = false;
     this.stopLoad();


### PR DESCRIPTION
### This PR will...

Fix the false positive buffer stall errors.

### Why is this Pull Request needed?

Why would we trigger an error when it is expected that the playhead waits for data to continue :) it's not causing any critical failures, but it should still be fixed.

### Are there any points in the code the reviewer needs to double check?

I would like to understand how the previous logic was supposed to make sense actually. Maybe I am missing something? But afaics it makes more sense like this and also does what is expected now. 

It also seems that the current unit tests did not cover the bugs fixed here.

We also added listeners to detect the media seeking state independently of the media element `seeking` property, as that may not be consistent across browsers. 

### Resolves issues:

Probably some tickets already mention this problem. 

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
