### PR TITLE
Fix ewma-bandwidth-estimator.js link in design doc

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -52,13 +52,6 @@ design idea is pretty simple :
         - trigger BUFFER_FLUSHED event upon successful buffer flushing
   - [src/controller/cap-level-controller.js][]
     - in charge of determining best quality level to actual size (dimensions: width and height) of the player
-  - [src/controller/ewma-bandwidth-estimator.js][]
-    - Exponential Weighted Moving Average bandwidth estimator, heavily inspired from shaka-player
-      - Tracks bandwidth samples and estimates available bandwidth, based on the minimum of two exponentially-weighted moving averages with different half-lives.
-      - one fast average with a short half-life: useful to quickly react to bandwidth drop and switch rendition down quickly
-      - one slow average with a long half-life: useful to slowly react to bandwidth increase and avoid switching up rendition to quickly
-      - bandwidth estimate is Math.min(fast average,slow average)
-      - average half-life are configurable , refer to abrEwma* config params
   - [src/controller/fps-controller.js][]
     - in charge of monitoring frame rate, and fire FPS_DROP event in case FPS drop exceeds configured threshold. disabled for now.
   - [src/controller/id3-track-controller.js](../src/controller/id3-track-controller.js)
@@ -202,6 +195,13 @@ design idea is pretty simple :
     - Default CC renderer. Translates Screen objects from cea-608-parser into HTML5 VTTCue objects, rendered by the video tag
   - [src/utils/ewma.js][]
     - compute [exponential weighted moving average](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average)
+  - [src/utils/ewma-bandwidth-estimator.js][]
+    - Exponential Weighted Moving Average bandwidth estimator, heavily inspired from shaka-player
+      - Tracks bandwidth samples and estimates available bandwidth, based on the minimum of two exponentially-weighted moving averages with different half-lives.
+      - one fast average with a short half-life: useful to quickly react to bandwidth drop and switch rendition down quickly
+      - one slow average with a long half-life: useful to slowly react to bandwidth increase and avoid switching up rendition to quickly
+      - bandwidth estimate is Math.min(fast average,slow average)
+      - average half-life are configurable , refer to abrEwma* config params
   - [src/utils/hex.js][]
     - Hex dump utils, useful for debug
   - [src/utils/logger.js][]


### PR DESCRIPTION
### This PR will fix ewma-bandwidth-estimator.js link in design doc

### Why is this Pull Request needed?

ewma-bandwidth-estimator.js is moved to utils folder, the current link is broken.

### Are there any points in the code the reviewer needs to double check?

no.

### Resolves issues:

no.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
