### PR TITLE
Bugfix/buffer stalls on segment boundary lookup tolerance

### DIFF
--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -67,6 +67,10 @@ export default class Fragment {
     return byteRange;
   }
 
+  get end () {
+    return this.start + this.duration;
+  }
+
   /**
    * @type {number}
    */
@@ -98,6 +102,21 @@ export default class Fragment {
 
   get encrypted () {
     return !!((this.decryptdata && this.decryptdata.uri !== null) && (this.decryptdata.key === null));
+  }
+
+  /**
+   * Compares a time value with the time-range of the fragment
+   * @param {number} timeSeconds
+   * @returns {number} 0 when inside time-range of fragment, negative when before, positive when after
+   */
+  compareTimeInterval (timeSeconds) {
+    if (timeSeconds < this.start) {
+      return timeSeconds - this.start;
+    } else if (timeSeconds > this.end) {
+      return this.end + timeSeconds;
+    } else {
+      return 0;
+    }
   }
 
   /**


### PR DESCRIPTION
### This PR will...

... fix buffer-stalls occuring when seeking to segment boundaries when lookup tolerance is applied.

Currently these stalls are handled via gap-controller doing a playhead nudge after a timeout as this may appear as an unpredictable gap.

However, this is a completely predictable stall that simply has to be addresses before we even do the request to the segment, since we know beforehand that we are not getting the data with the timestamps at which the media position currently is (since we applied the lookup tolerance and use a fragment after the boundary).

### Why is this Pull Request needed?

Currently the performance in terms of seeking time is impaired severely through this bug, since with small enough segments the probability to hit a boundary is relatively high. At the moment the gap-controller avoids the stall but it takes as much time as the watchdog period is set. That is unnecessarilly suboptimal and also doesn't make sense, since the functionnality is rather thought to be like we have fixed it here.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
