### PR TITLE
Live vtt cues cleanup

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,7 +40,7 @@
   - [`liveSyncDuration`](#livesyncduration)
   - [`liveMaxLatencyDuration`](#livemaxlatencyduration)
   - [`liveDurationInfinity`](#livedurationinfinity)
-  - [`livePastVTTCuesLength` / `livePastID3CuesLength`](#livepastvttcueslength--livepastid3cueslength)
+  - [`livePastCEA708CuesLength` / `livePastID3CuesLength`](#livepastcea708cueslength--livepastid3cueslength)
   - [`enableWorker`](#enableworker)
   - [`enableSoftwareAES`](#enablesoftwareaes)
   - [`startLevel`](#startlevel)
@@ -541,7 +541,7 @@ Override current Media Source duration to `Infinity` for a live broadcast.
 Useful, if you are building a player which relies on native UI capabilities in modern browsers.
 If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
 
-### `livePastVTTCuesLength` / `livePastID3CuesLength`
+### `livePastCEA708CuesLength` / `livePastID3CuesLength`
 
 (default: `Infinity`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,7 @@
   - [`liveSyncDuration`](#livesyncduration)
   - [`liveMaxLatencyDuration`](#livemaxlatencyduration)
   - [`liveDurationInfinity`](#livedurationinfinity)
+  - [`liveCleanupPastVTTCues` / `liveCleanupPastID3Cues`](#livecleanuppastvttcues--livecleanuppastid3cues)
   - [`enableWorker`](#enableworker)
   - [`enableSoftwareAES`](#enablesoftwareaes)
   - [`startLevel`](#startlevel)
@@ -539,6 +540,13 @@ A value too close from `liveSyncDuration` is likely to cause playback stalls.
 Override current Media Source duration to `Infinity` for a live broadcast.
 Useful, if you are building a player which relies on native UI capabilities in modern browsers.
 If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
+
+### `liveCleanupPastVTTCues` / `liveCleanupPastID3Cues`
+
+(default: `undefined`)
+
+Positive finite number value of seconds behind the current live stream playback time in order to cleanup past text track/ID3 cues (e.g. = 30 seconds
+will cleanup cues with end time less than `current time - 30` and will basically do that in 30 seconds intervals).
 
 ### `enableWorker`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,7 +40,7 @@
   - [`liveSyncDuration`](#livesyncduration)
   - [`liveMaxLatencyDuration`](#livemaxlatencyduration)
   - [`liveDurationInfinity`](#livedurationinfinity)
-  - [`liveCleanupPastVTTCues` / `liveCleanupPastID3Cues`](#livecleanuppastvttcues--livecleanuppastid3cues)
+  - [`livePastVTTCuesLength` / `livePastID3CuesLength`](#livepastvttcueslength--livepastid3cueslength)
   - [`enableWorker`](#enableworker)
   - [`enableSoftwareAES`](#enablesoftwareaes)
   - [`startLevel`](#startlevel)
@@ -541,12 +541,11 @@ Override current Media Source duration to `Infinity` for a live broadcast.
 Useful, if you are building a player which relies on native UI capabilities in modern browsers.
 If you want to have a native Live UI in environments like iOS Safari, Safari, Android Google Chrome, etc. set this value to `true`.
 
-### `liveCleanupPastVTTCues` / `liveCleanupPastID3Cues`
+### `livePastVTTCuesLength` / `livePastID3CuesLength`
 
-(default: `undefined`)
+(default: `Infinity`)
 
-Positive finite number value of seconds behind the current live stream playback time in order to cleanup past text track/ID3 cues (e.g. = 30 seconds
-will cleanup cues with end time less than `current time - 30` and will basically do that in 30 seconds intervals).
+Number of seconds behind the current live stream playback time in order to cleanup past text track/ID3 cues (e.g. = 30 seconds will cleanup cues with end time less than `current time - 30`).
 
 ### `enableWorker`
 

--- a/src/config.js
+++ b/src/config.js
@@ -42,8 +42,8 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
-  liveCleanupPastVTTCues: undefined, // used by timeline-controller
-  liveCleanupPastID3Cues: undefined, // used by id3-track-controller
+  livePastVTTCuesLength: Infinity, // used by timeline-controller
+  livePastID3CuesLength: Infinity, // used by id3-track-controller
   maxMaxBufferLength: 600, // used by stream-controller
   enableWorker: true, // used by demuxer
   enableSoftwareAES: true, // used by decrypter

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,8 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
+  liveCleanupPastVTTCues: undefined, // used by timeline-controller
+  liveCleanupPastID3Cues: undefined, // used by id3-track-controller
   maxMaxBufferLength: 600, // used by stream-controller
   enableWorker: true, // used by demuxer
   enableSoftwareAES: true, // used by decrypter

--- a/src/config.js
+++ b/src/config.js
@@ -42,7 +42,6 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
-  livePastVTTCuesLength: Infinity, // used by timeline-controller
   livePastID3CuesLength: Infinity, // used by id3-track-controller
   maxMaxBufferLength: 600, // used by stream-controller
   enableWorker: true, // used by demuxer
@@ -100,6 +99,7 @@ if (__USE_SUBTITLES__) {
   hlsDefaultConfig.subtitleTrackController = SubtitleTrackController;
   hlsDefaultConfig.timelineController = TimelineController;
   hlsDefaultConfig.cueHandler = Cues; // used by timeline-controller
+  hlsDefaultConfig.livePastCEA708CuesLength = Infinity; // used by timeline-controller
   hlsDefaultConfig.enableCEA708Captions = true; // used by timeline-controller
   hlsDefaultConfig.enableWebVTT = true; // used by timeline-controller
   hlsDefaultConfig.captionsTextTrack1Label = 'English'; // used by timeline-controller

--- a/src/controller/id3-track-controller.js
+++ b/src/controller/id3-track-controller.js
@@ -55,7 +55,7 @@ class ID3TrackController extends EventHandler {
     }
   }
 
-  cleanupPastCues() {
+  cleanupPastCues () {
     const liveCleanupPastID3Cues = this.hls.config.liveCleanupPastID3Cues;
 
     if (this._live && liveCleanupPastID3Cues > 0) {

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -309,7 +309,7 @@ class TimelineController extends EventHandler {
     this._live = details && details.live;
   }
 
-  cleanupPastCues(textTrack) {
+  cleanupPastCues (textTrack) {
     const liveCleanupPastVTTCues = this.hls.config.liveCleanupPastVTTCues;
 
     if (this._live && liveCleanupPastVTTCues > 0) {

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -314,9 +314,9 @@ class TimelineController extends EventHandler {
       return;
     }
 
-    const livePastVTTCuesLength = this.hls.config.livePastVTTCuesLength;
+    const livePastCEA708CuesLength = this.hls.config.livePastCEA708CuesLength;
 
-    clearPastCuesThrottled(textTrack, this.media.currentTime, livePastVTTCuesLength);
+    clearPastCuesThrottled(textTrack, this.media.currentTime, livePastCEA708CuesLength);
   }
 
   onFragDecrypted (data) {

--- a/src/utils/texttrack-utils.js
+++ b/src/utils/texttrack-utils.js
@@ -1,3 +1,4 @@
+import { logger } from './logger';
 
 export function sendAddTrackEvent (track, videoEl) {
   let event = null;
@@ -12,10 +13,33 @@ export function sendAddTrackEvent (track, videoEl) {
   videoEl.dispatchEvent(event);
 }
 
+function canManageCues(track) {
+  return track && track.cues;
+}
+
 export function clearCurrentCues (track) {
-  if (track && track.cues) {
+  if (canManageCues(track)) {
     while (track.cues.length > 0) {
       track.removeCue(track.cues[0]);
+    }
+  }
+}
+
+/**
+ * Removes cues past the given playback time (Cue's end time is less
+ * than time value) from a given track.
+ *
+ * @param {TextTrack} track         Text track to remove cues from.
+ * @param {Number}    playheadTime  Playhead time anchor for past cue decision.
+ */
+export function clearPastCues (track, playheadTime) {
+  if (canManageCues(track) && playheadTime > 0) {
+    try {
+      while (track.cues.length > 0 && track.cues[0].endTime < playheadTime) {
+        track.removeCue(track.cues[0]);
+      }
+    } catch (error) {
+      logger.warn('failed to remove cues', error);
     }
   }
 }

--- a/src/utils/texttrack-utils.js
+++ b/src/utils/texttrack-utils.js
@@ -13,7 +13,7 @@ export function sendAddTrackEvent (track, videoEl) {
   videoEl.dispatchEvent(event);
 }
 
-function canManageCues(track) {
+function canManageCues (track) {
   return track && track.cues;
 }
 

--- a/src/utils/texttrack-utils.js
+++ b/src/utils/texttrack-utils.js
@@ -13,12 +13,8 @@ export function sendAddTrackEvent (track, videoEl) {
   videoEl.dispatchEvent(event);
 }
 
-function canManageCues (track) {
-  return track && track.cues;
-}
-
 export function clearCurrentCues (track) {
-  if (canManageCues(track)) {
+  if (track && track.cues) {
     while (track.cues.length > 0) {
       track.removeCue(track.cues[0]);
     }
@@ -33,7 +29,7 @@ export function clearCurrentCues (track) {
  * @param {Number}    playheadTime  Playhead time anchor for past cue decision.
  */
 export function clearPastCues (track, playheadTime) {
-  if (canManageCues(track) && playheadTime > 0) {
+  if (track && track.cues && playheadTime > 0) {
     try {
       while (track.cues.length > 0 && track.cues[0].endTime < playheadTime) {
         track.removeCue(track.cues[0]);

--- a/tests/unit/utils/texttrack-utils.js
+++ b/tests/unit/utils/texttrack-utils.js
@@ -1,0 +1,28 @@
+import { spy, stub } from 'sinon';
+import { clearPastCues } from '../../../src/utils/texttrack-utils';
+
+const assert = require('assert');
+
+describe('Texttrack utils', () => {
+  describe('clearPastCues', () => {
+    it ('should remove cue past current time', () => {
+      const cues = [
+        {startTime: 1, endTime: 5},
+        {startTime: 5, endTime: 7},
+        {startTime: 7, endTime: 9},
+        {startTime: 9, endTime: 13}
+      ];
+
+      const trackStub = {
+        cues: cues.concat(),
+        removeCue: stub().callsFake((cue) => trackStub.cues.splice(trackStub.cues.indexOf(cue), 1))
+      };
+
+      clearPastCues(trackStub, 8);
+
+      assert(trackStub.removeCue.calledTwice, 'proper cues count not removed');
+      assert(trackStub.removeCue.calledWith(cues[0]));
+      assert(trackStub.removeCue.calledWith(cues[1]));
+    });
+  });
+});

--- a/tests/unit/utils/texttrack-utils.js
+++ b/tests/unit/utils/texttrack-utils.js
@@ -1,16 +1,16 @@
-import { spy, stub } from 'sinon';
+import { stub } from 'sinon';
 import { clearPastCues } from '../../../src/utils/texttrack-utils';
 
 const assert = require('assert');
 
 describe('Texttrack utils', () => {
   describe('clearPastCues', () => {
-    it ('should remove cue past current time', () => {
+    it('should remove cue past current time', () => {
       const cues = [
-        {startTime: 1, endTime: 5},
-        {startTime: 5, endTime: 7},
-        {startTime: 7, endTime: 9},
-        {startTime: 9, endTime: 13}
+        { startTime: 1, endTime: 5 },
+        { startTime: 5, endTime: 7 },
+        { startTime: 7, endTime: 9 },
+        { startTime: 9, endTime: 13 }
       ];
 
       const trackStub = {

--- a/tests/unit/utils/texttrack-utils.js
+++ b/tests/unit/utils/texttrack-utils.js
@@ -3,6 +3,15 @@ import { clearPastCues } from '../../../src/utils/texttrack-utils';
 
 const assert = require('assert');
 
+function getTextTrackStub (cues) {
+  const trackStub = {
+    cues: cues.concat(),
+    removeCue: stub().callsFake((cue) => trackStub.cues.splice(trackStub.cues.indexOf(cue), 1))
+  };
+
+  return trackStub;
+}
+
 describe('Texttrack utils', () => {
   describe('clearPastCues', () => {
     it('should remove cue past current time', () => {
@@ -13,10 +22,7 @@ describe('Texttrack utils', () => {
         { startTime: 9, endTime: 13 }
       ];
 
-      const trackStub = {
-        cues: cues.concat(),
-        removeCue: stub().callsFake((cue) => trackStub.cues.splice(trackStub.cues.indexOf(cue), 1))
-      };
+      const trackStub = getTextTrackStub(cues);
 
       clearPastCues(trackStub, 8);
 


### PR DESCRIPTION
### PR introduces 
`livePastCEA708CuesLength` and `livePastID3CuesLength` config options to only keep the past text and metadata (id3) cues within a given length of seconds. Default values for both options is `Infinity`, i.e. cues are never removed.

### Why is this Pull Request needed?
Part of ongoing effort to address live streaming memory leaks, see [PR comment](https://github.com/video-dev/hls.js/pull/1845#pullrequestreview-153382728)

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
Contributes to the fix effort of #1220 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
