### PR TITLE
fix api link on demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _Note you can access the docs for a particular version using "http://video-dev.g
 ## Demo
 
 ### Latest Release
-[https://video-dev.github.io/hls.js/demo](https://video-dev.github.io/hls.js/demo)
+[https://video-dev.github.io/hls.js/stable/demo](https://video-dev.github.io/hls.js/stable/demo)
 
 ### Master
 [https://video-dev.github.io/hls.js/latest/demo](https://video-dev.github.io/hls.js/latest/demo)

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,7 +31,7 @@
         </h2>
 
         <h3>
-          <a href="../latest/docs/API.html">API docs | usage guide</a>
+          <a href="../docs/API.html">API docs | usage guide</a>
         </h3>
       </header>
     </div>


### PR DESCRIPTION
Follow on from https://github.com/video-dev/hls.js/pull/1940

The change there wouldn't work when the demo was accessed on `/latest`, `/stable`, or `/<commit hash>`

Also `/demo` only existed by mistake. I removed it 37246e6d51eb88a6c91b46aee5c759019d6a5026

If people are actually loading the demo on `/demo` we will need to add a redirect