### PR TITLE
Fix: XHR loader timeout for fragments doesn't work

### DIFF
--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -79,6 +79,7 @@ class XhrLoader {
 
     // setup timeout before we perform request
     this.requestTimeout = window.setTimeout(this.loadtimeout.bind(this), this.config.timeout);
+    this.startRequestTime = Date.now();
     xhr.send();
   }
 
@@ -137,7 +138,11 @@ class XhrLoader {
         }
       } else {
         // readyState >= 2 AND readyState !==4 (readyState = HEADERS_RECEIVED || LOADING) rearm timeout as xhr not finished yet
-        this.requestTimeout = window.setTimeout(this.loadtimeout.bind(this), config.timeout);
+        let timeElapsed = Date.now() - this.startRequestTime;
+        if (timeElapsed > config.timeout) {
+          return this.loadtimeout();
+        }
+        this.requestTimeout = window.setTimeout(this.loadtimeout.bind(this), config.timeout - timeElapsed);
       }
     }
   }


### PR DESCRIPTION
### This PR will...

Fix the issue when you setup fragLoadingTimeOut, but real xhr request time increases it.

### Why is this Pull Request needed?

Issue appears because in according to XMLHttpRequest spec _readystatechange_ event with _readyState_ 3 could be emmited more than once during receiving data. This leads to that _readystatechange_ method of _XhrLoader_ could be called more than once and _requestTimeout_ would be cleared and then again placed with the same _config.timeout_ parameter.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

No

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md