### PR TITLE
XHR timeout fix

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -55,6 +55,7 @@ export var hlsDefaultConfig = {
   levelLoadingRetryDelay: 1000, // used by playlist-loader
   levelLoadingMaxRetryTimeout: 64000, // used by playlist-loader
   fragLoadingTimeOut: 20000, // used by fragment-loader
+  fragLoadDoneTimeOut: 0, // used by fragment-loader
   fragLoadingMaxRetry: 6, // used by fragment-loader
   fragLoadingRetryDelay: 1000, // used by fragment-loader
   fragLoadingMaxRetryTimeout: 64000, // used by fragment-loader

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -60,6 +60,7 @@ class FragmentLoader extends EventHandler {
 
     loaderConfig = {
       timeout: config.fragLoadingTimeOut,
+      doneTimeout: config.fragLoadDoneTimeOut,
       maxRetry: 0,
       retryDelay: 0,
       maxRetryDelay: config.fragLoadingMaxRetryTimeout

--- a/src/loader/key-loader.js
+++ b/src/loader/key-loader.js
@@ -49,7 +49,7 @@ class KeyLoader extends EventHandler {
       // maxRetry is 0 so that instead of retrying the same key on the same variant multiple times,
       // key-loader will trigger an error and rely on stream-controller to handle retry logic.
       // this will also align retry logic with fragment-loader
-      loaderConfig = { timeout: config.fragLoadingTimeOut, maxRetry: 0, retryDelay: config.fragLoadingRetryDelay, maxRetryDelay: config.fragLoadingMaxRetryTimeout };
+      loaderConfig = { timeout: config.fragLoadingTimeOut, doneTimeout: config.fragLoadDoneTimeOut, maxRetry: 0, retryDelay: config.fragLoadingRetryDelay, maxRetryDelay: config.fragLoadingMaxRetryTimeout };
       loaderCallbacks = { onSuccess: this.loadsuccess.bind(this), onError: this.loaderror.bind(this), onTimeout: this.loadtimeout.bind(this) };
       frag.loader.load(loaderContext, loaderConfig, loaderCallbacks);
     } else if (this.decryptkey) {


### PR DESCRIPTION
### This PR will...

Fix the issue when you setup fragLoadingTimeOut, but real xhr request time increases it. It add new parameter _fragLoadDoneTimeOut_ which specify timeout for complete fragment download.

### Why is this Pull Request needed?

Issue appears because in according to XMLHttpRequest spec _readystatechange_ event with _readyState_ 3 could be emmited more than once during receiving data. This leads to that _readystatechange_ method of _XhrLoader_ could be called more than once and _requestTimeout_ would be cleared and then again placed with the same _config.timeout_ parameter.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

No

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md