### PR TITLE
redirect to /stable instead of /latest

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <script type="text/javascript">
-    window.location.replace(window.location.href + "/latest");
-  </script>
- </head>
- <body>
- Redirecting...
- </body>
- </html>
+  <head>
+    <meta charset="utf-8">
+    <script type="text/javascript">
+      window.location.replace(window.location.href + "/stable");
+    </script>
+  </head>
+  <body>
+    Redirecting...
+  </body>
+</html>


### PR DESCRIPTION
^

so that by default people see the docs for the latest stable release