### PR TITLE
Add `detachMedia` to `attachMedia` (#1942)

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -242,6 +242,10 @@ export default class Hls extends Observer {
    */
   attachMedia (media) {
     logger.log('attachMedia');
+    if (this.media !== null) {
+      this.detachMedia();
+    }
+
     this.media = media;
     this.trigger(HlsEvents.MEDIA_ATTACHING, { media: media });
   }


### PR DESCRIPTION
### This PR will...

This PR will add `detachMedia` to `attachMedia`.

### Why is this Pull Request needed?

This PR is needed to create a new `SourceBuffer` after deleting `SourceBuffer` from `MediaSource`. By this, the error (`Uncaught DOMException: Failed to read the 'buffered' property from 'SourceBuffer': This SourceBuffer has been removed from the parent media source. at checkBuffer`) dose not occur.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/1942

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
