### PR TITLE
Refactor backbuffer cleanup PR

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -545,7 +545,7 @@ If you want to have a native Live UI in environments like iOS Safari, Safari, An
 
 (default: `Infinity`)
 
-Sets the maximum length of the buffer, in seconds, to keep durin a live stream. Any video buffered past this time will be evicted. `Infinity` means no restriction on back buffer length; `0` keeps the minimum amount. The minimum amount is equal to the target duration of a segment to ensure that current playback is not interrupted.
+Sets the maximum length of the buffer, in seconds, to keep during a live stream. Any video buffered past this time will be evicted. `Infinity` means no restriction on back buffer length; `0` keeps the minimum amount. The minimum amount is equal to the target duration of a segment to ensure that current playback is not interrupted.
 
 ### `enableWorker`
 

--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -1,80 +1,120 @@
 import assert from 'assert';
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import Hls from '../../../src/hls';
 import BufferController from '../../../src/controller/buffer-controller';
 
 describe('BufferController tests', function () {
   let hls;
   let bufferController;
+  let flushSpy;
+  let removeStub;
+  const sandbox = sinon.sandbox.create();
 
   beforeEach(function () {
     hls = new Hls({});
-
     bufferController = new BufferController(hls);
+    flushSpy = sandbox.spy(bufferController, 'flushLiveBackBuffer');
+    removeStub = sandbox.stub(bufferController, 'removeBufferRange');
   });
 
-  describe('Live back buffer enforcement', () => {
-    it('should trigger clean back buffer when there are no pending appends', () => {
-      bufferController.parent = {};
-      bufferController.segments = [{ parent: bufferController.parent }];
+  afterEach(function () {
+    sandbox.restore();
+  });
 
-      let clearStub = stub(bufferController, 'clearLiveBackBuffer');
-      stub(bufferController, 'doAppending');
+  describe('Live back buffer enforcement', function () {
+    let mockMedia;
+    let mockSourceBuffer;
+    let bufStart;
 
-      bufferController.onSBUpdateEnd();
-
-      assert(clearStub.notCalled, 'clear live back buffer was called');
-
-      bufferController.segments = [];
-      bufferController.onSBUpdateEnd();
-
-      assert(clearStub.calledOnce, 'clear live back buffer was not called once');
-    });
-
-    it('should trigger buffer removal with valid range for live', () => {
-      bufferController.media = { currentTime: 360 };
-      hls.config.liveBackBufferLength = 60;
-      bufferController.sourceBuffer = {
+    beforeEach(function () {
+      bufStart = 0;
+      bufferController._levelTargetDuration = 10;
+      bufferController.media = mockMedia = {
+        currentTime: 0
+      };
+      bufferController.sourceBuffer = mockSourceBuffer = {
         video: {
           buffered: {
-            start: stub().withArgs(0).returns(120),
+            start () {
+              return bufStart;
+            },
             length: 1
           }
         }
       };
-
-      let removeBufferRangeStub = stub(bufferController, 'removeBufferRange');
-
-      bufferController._live = false;
-      bufferController.clearLiveBackBuffer();
-      assert(removeBufferRangeStub.notCalled, 'remove buffer range was called for non-live');
-
       bufferController._live = true;
-      bufferController.clearLiveBackBuffer();
-      assert(removeBufferRangeStub.calledOnce, 'remove buffer range was not called once');
+      hls.config.liveBackBufferLength = 10;
+    });
 
-      assert(
-        removeBufferRangeStub.calledWith(
-          'video',
-          bufferController.sourceBuffer.video,
-          0,
-          bufferController.media.currentTime - hls.config.liveBackBufferLength
-        ),
-        'remove buffer range was not requested with valid data from liveBackBufferLength'
-      );
+    it('exits early if not live', function () {
+      bufferController.flushLiveBackBuffer();
+      assert(removeStub.notCalled);
+    });
 
+    it('exits early if liveBackBufferLength is not a finite number, or is less than 0', function () {
+      hls.config.liveBackBufferLength = 'foo';
+      bufferController.flushLiveBackBuffer();
+
+      hls.config.liveBackBufferLength = -1;
+      bufferController.flushLiveBackBuffer();
+
+      assert(removeStub.notCalled);
+    });
+
+    it('does not flush if nothing is buffered', function () {
+      delete mockSourceBuffer.buffered;
+      bufferController.flushLiveBackBuffer();
+
+      mockSourceBuffer = null;
+      bufferController.flushLiveBackBuffer();
+
+      assert(removeStub.notCalled);
+    });
+
+    it('does not flush if no buffered range intersects with back buffer limit', function () {
+      bufStart = 5;
+      mockMedia.currentTime = 10;
+      bufferController.flushLiveBackBuffer();
+      assert(removeStub.notCalled);
+    });
+
+    it('does not flush if the liveBackBufferLength is Infinity', function () {
+      hls.config.liveBackBufferLength = Infinity;
+      mockMedia.currentTime = 15;
+      bufferController.flushLiveBackBuffer();
+      assert(removeStub.notCalled);
+    });
+
+    it('flushes up to the back buffer limit if the buffer intersects with that point', function () {
+      mockMedia.currentTime = 15;
+      bufferController.flushLiveBackBuffer();
+      assert(removeStub.calledOnce);
+      assert(!bufferController.flushBufferCounter, 'Should reset the flushBufferCounter');
+      assert(removeStub.calledWith('video', mockSourceBuffer.video, 0, 5));
+    });
+
+    it('flushes to a max of one targetDuration from currentTime, regardless of liveBackBufferLength', function () {
+      mockMedia.currentTime = 15;
+      bufferController._levelTargetDuration = 5;
       hls.config.liveBackBufferLength = 0;
-      bufferController._levelTargetDuration = 10;
-      bufferController.clearLiveBackBuffer();
-      assert(
-        removeBufferRangeStub.calledWith(
-          'video',
-          bufferController.sourceBuffer.video,
-          0,
-          bufferController.media.currentTime - bufferController._levelTargetDuration
-        ),
-        'remove buffer range was not requested with valid data from _levelTargetDuration'
-      );
+      bufferController.flushLiveBackBuffer();
+      assert(removeStub.calledWith('video', mockSourceBuffer.video, 0, 10));
+    });
+
+    it('should trigger clean back buffer when there are no pending appends', function () {
+      bufferController.parent = {};
+      bufferController.segments = [{ parent: bufferController.parent }];
+
+      sandbox.stub(bufferController, 'doAppending');
+
+      bufferController.onSBUpdateEnd();
+
+      assert(flushSpy.notCalled, 'clear live back buffer was called');
+
+      bufferController.segments = [];
+      bufferController.onSBUpdateEnd();
+
+      assert(flushSpy.calledOnce, 'clear live back buffer was not called once');
     });
   });
 });


### PR DESCRIPTION
### This PR will...
- Only schedule flushes on `LEVEL_UPDATED` events
- Refactor
- Improve unit tests

### Why is this Pull Request needed?
In the interest of time (and better code) I refactored https://github.com/video-dev/hls.js/pull/1845 to match Hls.js' design patterns.

* There already exists code to flush arbitrary buffer ranges. It is preferable to use this code because it handles edge cases around flushing sourcebuffers, and ensures that flushes are scheduled for the future if blocked by a current append operation.

* Always flushing on sourcebuffer update end harms performance - that event can be triggered several times per second. It's not critical to *immediately* clear the back buffer on append; the `LEVEL_UPDATED` event triggers frequently enough for this use case.

* There were some minor nitpicks over code style. In the interest of time I've addressed them here.

* Unit tests coverage has been reworked to focus on the `flushLiveBackBuffer` method and not the actual act of flushing.

### Are there any points in the code the reviewer needs to double check?
Do the docs make sense? Are there any more unit tests to add? Should we gate this just to live, or allow VOD backbuffer to be cleaned too?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
