### PR TITLE
Restore `response` data in playlist loader error events

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -271,11 +271,11 @@ class PlaylistLoader extends EventHandler {
   }
 
   loaderror (response, context, networkDetails = null) {
-    this._handleNetworkError(response, context, networkDetails);
+    this._handleNetworkError(context, networkDetails, false, response);
   }
 
   loadtimeout (stats, context, networkDetails = null) {
-    this._handleNetworkError(null, context, networkDetails, true);
+    this._handleNetworkError(context, networkDetails, true);
   }
 
   _handleMasterPlaylist (response, stats, context, networkDetails) {
@@ -424,7 +424,7 @@ class PlaylistLoader extends EventHandler {
     });
   }
 
-  _handleNetworkError (response, context, networkDetails, timeout = false) {
+  _handleNetworkError (context, networkDetails, timeout = false, response = null) {
     logger.info(`A network error occured while loading a ${context.type}-type playlist`);
 
     let details;

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -271,11 +271,11 @@ class PlaylistLoader extends EventHandler {
   }
 
   loaderror (response, context, networkDetails = null) {
-    this._handleNetworkError(context, networkDetails);
+    this._handleNetworkError(response, context, networkDetails);
   }
 
   loadtimeout (stats, context, networkDetails = null) {
-    this._handleNetworkError(context, networkDetails, true);
+    this._handleNetworkError(null, context, networkDetails, true);
   }
 
   _handleMasterPlaylist (response, stats, context, networkDetails) {
@@ -424,7 +424,7 @@ class PlaylistLoader extends EventHandler {
     });
   }
 
-  _handleNetworkError (context, networkDetails, timeout = false) {
+  _handleNetworkError (response, context, networkDetails, timeout = false) {
     logger.info(`A network error occured while loading a ${context.type}-type playlist`);
 
     let details;
@@ -455,7 +455,7 @@ class PlaylistLoader extends EventHandler {
       this.resetInternalLoader(context.type);
     }
 
-    this.hls.trigger(Event.ERROR, {
+    let errorData = {
       type: ErrorTypes.NETWORK_ERROR,
       details,
       fatal,
@@ -463,7 +463,13 @@ class PlaylistLoader extends EventHandler {
       loader,
       context,
       networkDetails
-    });
+    };
+
+    if (response) {
+      errorData.response = response;
+    }
+
+    this.hls.trigger(Event.ERROR, errorData);
   }
 
   _handlePlaylistLoaded (response, stats, context, networkDetails) {


### PR DESCRIPTION
### This PR will...

Restore `response` in MANIFEST_LOAD_ERROR/LEVEL_LOAD_ERROR/AUDIO_TRACK_LOAD_ERROR event data.

### Why is this Pull Request needed?

`response` was accidentally removed in 5b25906bf7a18ee1df3d6fea3b875e94971b9060. The API docs state that it should contain the status code and status text from the XHR response.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md