### PR TITLE
Remove es6 set to fix compatibility issues in old browsers

### DIFF
--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -8,11 +8,11 @@ import { logger } from './utils/logger';
 import { ErrorTypes, ErrorDetails } from './errors';
 import Event from './events';
 
-const FORBIDDEN_EVENT_NAMES = new Set([
-  'hlsEventGeneric',
-  'hlsHandlerDestroying',
-  'hlsHandlerDestroyed'
-]);
+const FORBIDDEN_EVENT_NAMES = {
+  'hlsEventGeneric': true,
+  'hlsHandlerDestroying': true,
+  'hlsHandlerDestroyed': true
+};
 
 class EventHandler {
   constructor (hls, ...events) {
@@ -40,7 +40,7 @@ class EventHandler {
   registerListeners () {
     if (this.isEventHandler()) {
       this.handledEvents.forEach(function (event) {
-        if (FORBIDDEN_EVENT_NAMES.has(event)) {
+        if (FORBIDDEN_EVENT_NAMES[event]) {
           throw new Error('Forbidden event-name: ' + event);
         }
 


### PR DESCRIPTION
### Why is this Pull Request needed?

So that browsers which do not support Sets (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#Browser_compatibility) do not throw an exception & prevent Hls.js from functioning. Converting Set to a plain object is preferable to a polyfill because it results in less code - polyfills have a price.

### Are there any points in the code the reviewer needs to double check?

No

### Resolves issues:

https://github.com/video-dev/hls.js/issues/1859

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
