### PR TITLE
Add WebPack entry for separate is-supported bundle.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -205,7 +205,36 @@ const multiConfig = [
   }
 ].map(config => clone(baseConfig, config));
 
+const isSupportedConfig = {
+  name: 'is-supported',
+  mode: 'production',
+  entry: './src/is-supported.js',
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    strictExportPresence: true,
+    rules: [
+      { test: /\.ts?$/, loader: 'ts-loader' },
+      { test: /\.js?$/, exclude: [/node_modules/], loader: 'ts-loader' }
+    ]
+  },
+  output: {
+    filename: 'is-supported.js',
+    chunkFilename: 'is-supported.js',
+    path: path.resolve(__dirname),
+    publicPath: '/',
+    library: 'Hls',
+    libraryTarget: 'umd',
+    libraryExport: 'default',
+    globalObject: 'this'
+  },
+  plugins: getPluginsForConfig('main', true)
+};
+
 multiConfig.push(demoConfig);
+
+multiConfig.push(isSupportedConfig);
 
 // webpack matches the --env arguments to a string; for example, --env.debug.min translates to { debug: true, min: true }
 module.exports = (envArgs) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -232,9 +232,8 @@ const isSupportedConfig = {
   plugins: getPluginsForConfig('main', true)
 };
 
-multiConfig.push(demoConfig);
-
 multiConfig.push(isSupportedConfig);
+multiConfig.push(demoConfig);
 
 // webpack matches the --env arguments to a string; for example, --env.debug.min translates to { debug: true, min: true }
 module.exports = (envArgs) => {


### PR DESCRIPTION
### This PR will...

...add a new entry to the WebPack config, for creating a separate bundle of `src/is-supported.js` (like mentioned here: https://github.com/video-dev/hls.js/pull/1454#issuecomment-347878876)

### Why is this Pull Request needed?

This allows isSupported to be consumed independently of hls.js, without having to build it in the consuming project.

I stumbled upon this when loading `hls.js/src/is-supported` in a module that is covered by my Mocha unit tests running in a Node.js context. As `hls.js/src/is-supported` uses `import` (which is not supported by Node.js), the test runner crashed.

### Are there any points in the code the reviewer needs to double check?

* That my additions to the WebPack config is correct and does not cause any trouble.
* That the bundle is built with the right properties.
* Where should the bundle be placed? It currently goes to the project root; this makes it easy to find. `dist` is an option, but will make it a bit more cumbersome to consume.
* It should be documented that `isSupported` can be used independently.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
