### PR TITLE
Fix for issue 1978.  

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1364,6 +1364,12 @@ class StreamController extends TaskLoop {
 
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;
+      // Need to check what the SourceBuffer reports as start time for the first fragment appended.
+      // If within the threshold of maxBufferHole, adjust this.startPosition for _seekToStartPos().
+      var firstbufferedPosition = buffered.start(0);
+      if (Math.abs(this.startPosition - firstbufferedPosition) < this.config.maxBufferHole) {
+        this.startPosition = firstbufferedPosition;
+      }
       this._seekToStartPos();
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -207,6 +207,9 @@ describe('StreamController tests', function () {
       };
       streamController.media = {
         buffered: {
+          start: function () {
+            return 6.014;
+          },
           length: 1
         }
       };
@@ -242,6 +245,15 @@ describe('StreamController tests', function () {
       streamController._checkBuffer();
       assert(seekStub.notCalled);
       assert.strictEqual(streamController.loadedmetadata, undefined);
+    });
+
+    it('should set startPosition to what buffer start reports and seek', function () {
+      const seekStub = sandbox.stub(streamController, '_seekToStartPos');
+      streamController.startPosition = 6;
+      streamController.loadedmetadata = false;
+      streamController._checkBuffer();
+      assert(seekStub.calledOnce);
+      assert.strictEqual(streamController.startPosition, streamController.media.buffered.start());
     });
 
     it('should complete the immediate switch if signalled', function () {


### PR DESCRIPTION
### This PR will...
Check what the SourceBuffer reports as start time for the first fragment appended and If within the threshold of maxBufferHole, adjust this.startPosition for _seekToStartPos. This happens on the first tick in checkBuffer. 

### Why is this Pull Request needed?
Fixes an issue with Edge where it will not start (when autoStartLoad is false) if seek at start position is only set to the value we calculate for the live + latency position. 
E.g.
media seeked to 6.000 VS media seeking to 6.014

In v8.9 and previously, hls.js looked at buffer.start value on first tick in checkBuffer method,  but that was lost in subsequent releases.  

With this PR,  it restores it in the new code base to get live streams on Edge with non zero pts playing again.  

### Are there any points in the code the reviewer needs to double check?
Would like to know if there was a solid reason for removing this in 0.9.0 in order to avoid regressions. 

### Resolves issues:
#1978 

### Checklist

- [ X] changes have been done against master branch, and PR does not conflict
- [X ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
