### PR TITLE
Refactor sourceBuffer estimation to reflect how Hls.js intends to use the parsed manifest

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -90,7 +90,7 @@ class BufferController extends EventHandler {
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
     this.bufferCodecEventsExpected = data.altAudio ? 2 : 1;
-    logger.log(`${this.bufferCodecEventsExpected} bufferCodec(s) expected`);
+    logger.log(`${this.bufferCodecEventsExpected} bufferCodec event(s) expected`);
   }
 
   onMediaAttaching (data) {

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -83,17 +83,12 @@ class BufferController extends EventHandler {
   }
 
   onManifestParsed (data) {
-    const { altAudio, audio, video } = data;
-    let sourceBufferNb = 0;
     // in case of alt audio 2 BUFFER_CODECS events will be triggered, one per stream controller
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
-    if (altAudio && (audio || video)) {
-      sourceBufferNb = (audio ? 1 : 0) + (video ? 1 : 0);
-      logger.log(`${sourceBufferNb} sourceBuffer(s) expected`);
-    }
-    this.sourceBufferNb = sourceBufferNb;
+    this.sourceBufferNb = data.altAudio ? 2 : 1;
+    logger.log(`${this.sourceBufferNb} sourceBuffer(s) expected`);
   }
 
   onMediaAttaching (data) {

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -45,7 +45,7 @@ class CapLevelController extends EventHandler {
     this.restrictedLevels = [];
     this.levels = data.levels;
     this.firstLevel = data.firstLevel;
-    if (hls.config.capLevelToPlayerSize && (data.video || (data.levels.length && data.altAudio))) {
+    if (hls.config.capLevelToPlayerSize && data.video) {
       // Start capping immediately if the manifest has signaled video codecs
       this._startCapping();
     }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -10,6 +10,7 @@ import { isCodecSupportedInMp4 } from '../utils/codecs';
 import { addGroupId } from './level-helper';
 
 const { performance } = window;
+let chromeOrFirefox;
 
 export default class LevelController extends EventHandler {
   constructor (hls) {
@@ -24,6 +25,8 @@ export default class LevelController extends EventHandler {
     this.currentLevelIndex = null;
     this.manualLevelIndex = -1;
     this.timer = null;
+
+    chromeOrFirefox = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
   }
 
   onHandlerDestroying () {
@@ -66,21 +69,21 @@ export default class LevelController extends EventHandler {
 
   onManifestLoaded (data) {
     let levels = [];
+    let audioTracks = [];
     let bitrateStart;
     let levelSet = {};
     let levelFromSet = null;
     let videoCodecFound = false;
     let audioCodecFound = false;
-    let chromeOrFirefox = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
-    let audioTracks = [];
 
     // regroup redundant levels together
     data.levels.forEach(level => {
+      const attributes = level.attrs;
       level.loadError = 0;
       level.fragmentError = false;
 
       videoCodecFound = videoCodecFound || !!level.videoCodec;
-      audioCodecFound = audioCodecFound || !!level.audioCodec || !!(level.attrs && level.attrs.AUDIO);
+      audioCodecFound = audioCodecFound || !!level.audioCodec;
 
       // erase audio codec info if browser does not support mp4a.40.34.
       // demuxer will autodetect codec and fallback to mpeg/audio
@@ -99,12 +102,13 @@ export default class LevelController extends EventHandler {
         levelFromSet.url.push(level.url);
       }
 
-      if (level.attrs) {
-        if (level.attrs.AUDIO) {
-          addGroupId(levelFromSet || level, 'audio', level.attrs.AUDIO);
+      if (attributes) {
+        if (attributes.AUDIO) {
+            audioCodecFound = true;
+            addGroupId(levelFromSet || level, 'audio', attributes.AUDIO);
         }
-        if (level.attrs.SUBTITLES) {
-          addGroupId(levelFromSet || level, 'text', level.attrs.SUBTITLES);
+        if (attributes.SUBTITLES) {
+          addGroupId(levelFromSet || level, 'text', attributes.SUBTITLES);
         }
       }
     });
@@ -131,9 +135,7 @@ export default class LevelController extends EventHandler {
       // start bitrate is the first bitrate of the manifest
       bitrateStart = levels[0].bitrate;
       // sort level on bitrate
-      levels.sort(function (a, b) {
-        return a.bitrate - b.bitrate;
-      });
+      levels.sort((a, b) => a.bitrate - b.bitrate);
       this._levels = levels;
       // find index of first level in sorted levels
       for (let i = 0; i < levels.length; i++) {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -144,15 +144,15 @@ export default class LevelController extends EventHandler {
         }
       }
 
-      const hasVideo = !!levels.length;
+      // Audio is only alternate if manifest include a URI along with the audio group tag
       this.hls.trigger(Event.MANIFEST_PARSED, {
         levels,
         audioTracks,
         firstLevel: this._firstLevel,
         stats: data.stats,
         audio: audioCodecFound,
-        video: hasVideo,
-        altAudio: !!(audioTracks.length && hasVideo) // Audio is only alternate if there is a video track; otherwise, it's an audio-only stream
+        video: videoCodecFound,
+        altAudio: audioTracks.some(t => !!t.url)
       });
     } else {
       this.hls.trigger(Event.ERROR, {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -99,12 +99,13 @@ export default class LevelController extends EventHandler {
         levelFromSet.url.push(level.url);
       }
 
-      if (level.attrs && level.attrs.AUDIO) {
-        addGroupId(levelFromSet || level, 'audio', level.attrs.AUDIO);
-      }
-
-      if (level.attrs && level.attrs.SUBTITLES) {
-        addGroupId(levelFromSet || level, 'text', level.attrs.SUBTITLES);
+      if (level.attrs) {
+        if (level.attrs.AUDIO) {
+          addGroupId(levelFromSet || level, 'audio', level.attrs.AUDIO);
+        }
+        if (level.attrs.SUBTITLES) {
+          addGroupId(levelFromSet || level, 'text', level.attrs.SUBTITLES);
+        }
       }
     });
 
@@ -142,14 +143,16 @@ export default class LevelController extends EventHandler {
           break;
         }
       }
+
+      const hasVideo = !!levels.length;
       this.hls.trigger(Event.MANIFEST_PARSED, {
         levels,
         audioTracks,
         firstLevel: this._firstLevel,
         stats: data.stats,
         audio: audioCodecFound,
-        video: videoCodecFound,
-        altAudio: audioTracks.length > 0 && videoCodecFound
+        video: hasVideo,
+        altAudio: !!(audioTracks.length && hasVideo) // Audio is only alternate if there is a video track; otherwise, it's an audio-only stream
       });
     } else {
       this.hls.trigger(Event.ERROR, {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -104,8 +104,8 @@ export default class LevelController extends EventHandler {
 
       if (attributes) {
         if (attributes.AUDIO) {
-            audioCodecFound = true;
-            addGroupId(levelFromSet || level, 'audio', attributes.AUDIO);
+          audioCodecFound = true;
+          addGroupId(levelFromSet || level, 'audio', attributes.AUDIO);
         }
         if (attributes.SUBTITLES) {
           addGroupId(levelFromSet || level, 'text', attributes.SUBTITLES);

--- a/tests/mocks/hls.mock.js
+++ b/tests/mocks/hls.mock.js
@@ -32,6 +32,11 @@ export default class HlsMock {
     });
   }
 
+  getEventData (n) {
+    const event = this.trigger.getCall(n).args;
+    return { name: event[0], payload: event[1] };
+  }
+
   /**
    * Reset all spies
    */

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -179,5 +179,13 @@ module.exports = {
   noTrackIntersection: {
     url: 'https://s3.amazonaws.com/bob.jwplayer.com/%7Ealex/123633/new_master.m3u8',
     description: 'Audio/video track PTS values do not intersect; 10 second start gap'
+  },
+  altAudioNoVideoCodecSignaled: {
+    url: 'https://d35u71x3nb8v2y.cloudfront.net/4b711b97-513c-4d36-ad29-298ab23a2e5e/3cbf1114-b2f4-4320-afb3-f0f7eeeb8630/playlist.m3u8',
+    description: 'Alternate audio track, but no video codec is signaled in the master manifest'
+  },
+  altAudioAndTracks: {
+    url: 'https://wowzaec2demo.streamlock.net/vod-multitrack/_definst_/smil:ElephantsDream/elephantsdream2.smil/playlist.m3u',
+    description: 'Alternate audio tracks, and multiple VTT tracks'
   }
 };

--- a/tests/unit/controller/cap-level-controller.js
+++ b/tests/unit/controller/cap-level-controller.js
@@ -130,14 +130,14 @@ describe('CapLevelController', function () {
       assert.strictEqual(capLevelController.restrictedLevels.length, 0);
     });
 
-    it('should start capping in MANIFEST_PARSED if a video codec was signaled', function () {
+    it('should start capping in MANIFEST_PARSED if a video codec was signaled in the manifest', function () {
       capLevelController.onManifestParsed({ video: {} });
       assert(startCappingSpy.calledOnce);
     });
 
-    it('should start capping in MANIFEST_PARSED if a levels and altAudio were signaled', function () {
+    it('does not start capping on MANIFEST_PARSED if no video codec was signaled in the manifest', function () {
       capLevelController.onManifestParsed({ levels: [{}], altAudio: true });
-      assert(startCappingSpy.calledOnce);
+      assert(startCappingSpy.notCalled);
     });
   });
 });

--- a/tests/unit/controller/level-controller.js
+++ b/tests/unit/controller/level-controller.js
@@ -1,10 +1,9 @@
 import LevelController from '../../../src/controller/level-controller';
 import HlsMock from '../../mocks/hls.mock';
 import Event from '../../../src/events';
-import { ErrorTypes, ErrorDetails } from '../../../src/errors';
+import { ErrorDetails } from '../../../src/errors';
 
 const assert = require('assert');
-const sinon = require('sinon');
 
 describe('LevelController', () => {
   let hls, levelController;
@@ -78,5 +77,120 @@ describe('LevelController', () => {
 
     assert.equal(levelController.hls.trigger.args[1][0], Event.LEVEL_SWITCHING);
     assert.equal(levelController.hls.trigger.args[1][1].level, nextLevel);
+  });
+
+  describe('manifest parsing', function () {
+    let data;
+    beforeEach(function () {
+      data = {
+        audioTracks: [],
+        levels: [{ bitrate: 105000, name: '144', details: { totalduration: 10, fragments: [{}] } }],
+        networkDetails: '',
+        subtitles: [],
+        url: 'foo'
+      };
+    });
+
+    it('signals video if there is a videoCodec signaled', function () {
+      data.levels[0].videoCodec = 'avc1.42e01e';
+      levelController.onManifestLoaded(data);
+
+      const { name, payload } = hls.getEventData(0);
+      assert.strictEqual(name, Event.MANIFEST_PARSED);
+      assert.strictEqual(payload.video, true);
+      assert.strictEqual(payload.audio, false);
+      assert.strictEqual(payload.altAudio, false);
+    });
+
+    it('signals audio if there is an audioCodec signaled', function () {
+      data.levels[0].audioCodec = 'mp4a.40.5';
+      levelController.onManifestLoaded(data);
+
+      const { name, payload } = hls.getEventData(0);
+      assert.strictEqual(name, Event.MANIFEST_PARSED);
+      assert.strictEqual(payload.video, false);
+      assert.strictEqual(payload.audio, true);
+      assert.strictEqual(payload.altAudio, false);
+    });
+
+    it('signals audio if the level is part of an audio group', function () {
+      data.levels = [{
+        attrs: {
+          AUDIO: true
+        }
+      }];
+      levelController.onManifestLoaded(data);
+
+      const { name, payload } = hls.getEventData(0);
+      assert.strictEqual(name, Event.MANIFEST_PARSED);
+      assert.strictEqual(payload.video, false);
+      assert.strictEqual(payload.audio, true);
+      assert.strictEqual(payload.altAudio, false);
+    });
+
+    it('signals altAudio if there is are audioTracks containing URIs', function () {
+      data.levels[0].videoCodec = 'avc1.42e01e';
+      data.audioTracks = [
+        {
+          groupId: 'audio',
+          name: 'Audio',
+          type: 'AUDIO',
+          default: true,
+          autoselect: true,
+          forced: false,
+          url: 'https://d35u71x3nb8v2y.cloudfront.net/4b711b97-513c-4d36-ad29-298ab23a2e5e/05845f51-c319-41ca-8e84-b84299925a0c/playlist.m3u8',
+          id: 0
+        },
+        {
+          groupId: 'audio',
+          name: 'Audio',
+          type: 'AUDIO',
+          default: true,
+          autoselect: true,
+          forced: false,
+          id: 0
+        }
+      ];
+
+      levelController.onManifestLoaded(data);
+
+      const { name, payload } = hls.getEventData(0);
+      assert.strictEqual(name, Event.MANIFEST_PARSED);
+      assert.strictEqual(payload.video, true);
+      assert.strictEqual(payload.audio, false);
+      assert.strictEqual(payload.altAudio, true);
+    });
+
+    it('does not signal altAudio if the audioTracks do no not contain any URIs', function () {
+      data.levels[0].videoCodec = 'avc1.42e01e';
+      data.audioTracks = [
+        {
+          groupId: 'audio',
+          name: 'Audio',
+          type: 'AUDIO',
+          default: true,
+          autoselect: true,
+          forced: false,
+          id: 0
+        },
+        {
+          groupId: 'audio',
+          name: 'Audio',
+          type: 'AUDIO',
+          default: true,
+          autoselect: true,
+          forced: false,
+          id: 0
+        }
+      ];
+
+      levelController.onManifestLoaded(data);
+
+      const { name, payload } = hls.getEventData(0);
+      assert.strictEqual(name, Event.MANIFEST_PARSED);
+      assert.strictEqual(payload.video, true);
+      assert.strictEqual(payload.audio, false);
+      assert.strictEqual(payload.altAudio, false);
+    });
   });
 });

--- a/tests/unit/controller/level-controller.js
+++ b/tests/unit/controller/level-controller.js
@@ -128,7 +128,7 @@ describe('LevelController', () => {
       assert.strictEqual(payload.altAudio, false);
     });
 
-    it('signals altAudio if there is are audioTracks containing URIs', function () {
+    it('signals altAudio if there are audioTracks containing URIs', function () {
       data.levels[0].videoCodec = 'avc1.42e01e';
       data.audioTracks = [
         {


### PR DESCRIPTION
### This PR will...
- Change the definition of `altAudio` in the `MANIFEST_PARSED` event to reflect whether any audioTracks contain a URI
- Calculate the number of sourceBuffers based solely on whether altAudio is signaled or not. There are two expected sourceBuffers with altAudio, and 1 otherwise
- Remove assumption in `cap-level-controller` which starts capping if levels and altAudio are signaled
- Refactor, add unit tests, and test streams


### Why is this Pull Request needed?
- This reflects how Hls.js actually determines whether to load a track via the `stream-controller`. https://github.com/video-dev/hls.js/blob/master/src/controller/stream-controller.js#L1161-L1162
- Even if there are levels and alt audio signaled, the stream can still be audio-only. Hls.js must not cap if there is no video. If video *is* signaled, capping will start in `onBufferCodecs`.

Simply put, codec presence in the manifest does not provide a reliable estimate for the number of sourceBuffers needed. By aligning the estimation with how Hls.js actually behaves (i.e. whether it chooses to download & demux an alt-audio track), our sourceBuffer calculation should always be correct (barring any stream problems).

### Are there any points in the code the reviewer needs to double check?
@mangui Is it possible for Hls.js to create two sourceBuffers if there is no alt audio?

### Resolves issues:
#1909 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
