### PR TITLE
Calculate fragment start/end based on the intersection of audio/video PTS

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1365,11 +1365,7 @@ class StreamController extends TaskLoop {
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;
       // Need to check what the SourceBuffer reports as start time for the first fragment appended.
-      // If within the threshold of maxBufferHole, adjust this.startPosition for _seekToStartPos().
-      var firstbufferedPosition = buffered.start(0);
-      if (Math.abs(this.startPosition - firstbufferedPosition) < this.config.maxBufferHole) {
-        this.startPosition = firstbufferedPosition;
-      }
+      this.startPosition = buffered.start(0);
       this._seekToStartPos();
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1124,7 +1124,7 @@ class StreamController extends TaskLoop {
         }
       }
 
-      let drift = LevelHelper.updateFragPTSDTS(level.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS, data.type),
+      let drift = LevelHelper.updateFragPTSDTS(level.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS),
         hls = this.hls;
       hls.trigger(Event.LEVEL_PTS_UPDATED, { details: level.details, level: this.level, drift: drift, type: data.type, start: data.startPTS, end: data.endPTS });
       // has remuxer dropped video frames located before first keyframe ?

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1124,7 +1124,7 @@ class StreamController extends TaskLoop {
         }
       }
 
-      let drift = LevelHelper.updateFragPTSDTS(level.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS),
+      let drift = LevelHelper.updateFragPTSDTS(level.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS, data.type),
         hls = this.hls;
       hls.trigger(Event.LEVEL_PTS_UPDATED, { details: level.details, level: this.level, drift: drift, type: data.type, start: data.startPTS, end: data.endPTS });
       // has remuxer dropped video frames located before first keyframe ?

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -261,7 +261,7 @@ class MP4Remuxer {
     firstDTS = Math.max(sample.dts, 0);
     firstPTS = Math.max(sample.pts, 0);
 
-    // check timestamp continuity accross consecutive fragments (this is to remove inter-fragment gap/hole)
+    // check timestamp continuity across consecutive fragments (this is to remove inter-fragment gap/hole)
     let delta = Math.round((firstDTS - nextAvcDts) / 90);
     // if fragment are contiguous, detect hole/overlapping between fragments
     if (contiguous) {

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -175,5 +175,9 @@ module.exports = {
   differentPTSDTSWithSmallSubsequentSegment: {
     url: 'https://9secfail-tepnrytnng.now.sh/index.m3u8',
     description: 'Audio/video has different PTS; the following segment is very small (0.04s) and tests buffer intersection'
+  },
+  noTrackIntersection: {
+    url: 'https://s3.amazonaws.com/bob.jwplayer.com/%7Ealex/123633/new_master.m3u8',
+    description: 'Audio/video track PTS values do not intersect; 10 second start gap'
   }
 };

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -171,5 +171,9 @@ module.exports = {
   pdtOneValue: {
     url: 'https://playertest.longtailvideo.com/adaptive/aviion/manifest.m3u8',
     description: 'One PDT, no discontinuities'
+  },
+  differentPTSDTSWithSmallSubsequentSegment: {
+    url: 'https://9secfail-tepnrytnng.now.sh/index.m3u8',
+    description: 'Audio/video has different PTS; the following segment is very small (0.04s) and tests buffer intersection'
   }
 };

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -1,0 +1,90 @@
+import * as LevelHelper from '../../../src/controller/level-helper';
+const assert = require('assert');
+
+describe('level-helper', function () {
+  describe('updateFragPTSDTS', function () {
+    let details;
+    let frag;
+    beforeEach(function () {
+      details = {
+        fragments: []
+      };
+      frag = {
+        sn: 0
+      };
+    });
+
+    describe('PTS/DTS updating', function () {
+      function checkFragProperties (frag, startPTS, endPTS, startDTS, endDTS) {
+        assert.strictEqual(frag.start, startPTS);
+        assert.strictEqual(frag.startPTS, startPTS);
+        assert.strictEqual(frag.maxStartPTS, startPTS);
+        assert.strictEqual(frag.endPTS, endPTS);
+        assert.strictEqual(frag.startDTS, startDTS);
+        assert.strictEqual(frag.endDTS, endDTS);
+        assert.strictEqual(frag.duration, endPTS - startPTS);
+      }
+
+      it('updates frag properties based on the provided PTS/DTS', function () {
+        const startPTS = 2;
+        const endPTS = 12;
+        const startDTS = 1;
+        const endDTS = 11;
+
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        checkFragProperties(frag, 2, 12, 1, 11);
+      });
+
+      it('updates frag properties based on the intersection of existing frag PTS/DTS and provided frag PTS/DTS', function () {
+        const startPTS = 2;
+        const endPTS = 12;
+        const startDTS = 1;
+        const endDTS = 11;
+
+        frag.startPTS = 3;
+        frag.endPTS = 13;
+        frag.startDTS = 2;
+        frag.endDTS = 12;
+
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        checkFragProperties(frag, 3, 12, 2, 11);
+        assert.strictEqual(frag.deltaPTS, 1);
+
+        frag.startPTS = 0;
+        frag.endPTS = 10;
+        frag.startDTS = 0;
+        frag.endDTS = 10;
+
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        checkFragProperties(frag, 2, 10, 1, 10);
+        assert.strictEqual(frag.deltaPTS, 2);
+      });
+    });
+
+    describe('drift calculation', function () {
+      let startPTS;
+      let endPTS;
+      let startDTS;
+      let endDTS;
+      beforeEach(function () {
+        startPTS = 2;
+        endPTS = 12;
+        startDTS = 1;
+        endDTS = 11;
+        details.startSN = 0;
+        details.endSN = 10;
+      });
+
+      it('returns a drift of 0 if the fragment is out of the sequence range of its level', function () {
+        frag.sn = 50;
+        assert.strictEqual(LevelHelper.updateFragPTSDTS(details, frag, startPTS, endPTS, startDTS, endDTS), 0);
+      });
+
+      it('returns the drift between startPTS and fragStart if the fragment is within the sequence range', function () {
+        frag.sn = 0;
+        frag.start = 0;
+        assert.strictEqual(LevelHelper.updateFragPTSDTS(details, frag, startPTS, endPTS, startDTS, endDTS), 2);
+      });
+    });
+  });
+});

--- a/tests/unit/utils/discontinuities.js
+++ b/tests/unit/utils/discontinuities.js
@@ -1,4 +1,4 @@
-import { shouldAlignOnDiscontinuities, findDiscontinuousReferenceFrag, adjustPts, alignDiscontinuities, alignPDT } from '../../../src/utils/discontinuities';
+import { shouldAlignOnDiscontinuities, findDiscontinuousReferenceFrag, adjustPts, alignPDT } from '../../../src/utils/discontinuities';
 
 const assert = require('assert');
 
@@ -34,7 +34,7 @@ const mockFrags = [
   }
 ];
 
-describe('level-helper', function () {
+describe('discontinuities', function () {
   it('adjusts level fragments with overlapping CC range using a reference fragment', function () {
     const details = {
       fragments: mockFrags.slice(0),


### PR DESCRIPTION
### This PR will...
- In the case that a/v PTS values intersect:
    - Set frag.startPTS to the min of audio/video startPTS values
    - Set frag.endPTS to the max of audio/video endPTS values
    - If the frag is the last of a VOD stream, set the end PTS/DTS to the max end PTS/DTS
- Otherwise, the start/end PTS values will be determined by the existing behavior (min start/max end)
- Always skip startup gaps, regardless of size @dsparacio 
- Add tests and comments

### Why is this Pull Request needed?
According to the MSE spec, the start/end time for a buffered range is the intersection of the sourceBuffer start/end times for that range (https://www.w3.org/TR/media-source/#htmlmediaelement-extensions), and not the min of the starts and max of the ends as we have previously assumed. This assumption causes Hls.js' internal representation of a fragments start/end time to not match what MSE will actually buffer it as. As a result, Hls.js can sometimes fail to find the correct fragment to buffer in `findFragmentByPTS`:

`  if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) { `
```
  if (candidate.start + candidate.duration - candidateLookupTolerance <= bufferEnd) {
    return 1;
  } else if (candidate.start - candidateLookupTolerance > bufferEnd && candidate.start) {
    // if maxFragLookUpTolerance will have negative value then don't return -1 for first element
    return -1;
  }
```

In this case, `candidate.start` should be equal to the `endPTS` of the previously muxed fragment, which should be equal to the end of the buffer (`bufferEnd`). However, since we incorrectly computed `endPTS`, `candidate.start` will be incorrect, and in the case that it's greater than `bufferEnd`, the fragment will not be selected to buffer. This error is apparent in the following test stream:

https://9secfail-tepnrytnng.now.sh/index.m3u8

As for the gap skipping, we're marking frags a partial less frequently now. Streams which previously had start gaps and worked had their first frag marked as partial and jumped; however, these frags in reality are not partial. I don't think there's any harm in skipping an arbitrarily sized gap at startup. I think a better long-term solution is to re-evaulate partial gap jumping - it may be the case that the `PARTIAL` state will never apply to a fragment anymore. It seems that we caused (and fixed) our own problem by not adhering to the MSE spec.

### Are there any points in the code the reviewer needs to double check?
Everything 😅

### Resolves issues:
#1880 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
