### PR TITLE
Fix 0.11.1 Regressions

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -176,7 +176,9 @@ class BufferController extends EventHandler {
     // Check if we've received all of the expected bufferCodec events. When none remain, create all the sourceBuffers at once.
     // This is important because the MSE spec allows implementations to throw QuotaExceededErrors if creating new sourceBuffers after
     // data has been appended to existing ones.
-    if (Object.keys(pendingTracks).length && !bufferCodecEventsExpected) {
+    // 2 tracks is the max (one for audio, one for video). If we've reach this max go ahead and create the buffers.
+    const pendingTracksCount = Object.keys(pendingTracks).length;
+    if ((pendingTracksCount && !bufferCodecEventsExpected) || pendingTracksCount === 2) {
       // ok, let's create them now !
       this.createSourceBuffers(pendingTracks);
       this.pendingTracks = {};
@@ -275,8 +277,7 @@ class BufferController extends EventHandler {
 
     const { mediaSource } = this;
     this.bufferCodecEventsExpected = Math.max(this.bufferCodecEventsExpected - 1, 0);
-    if (mediaSource && mediaSource.readyState === 'open' && !this.bufferCodecEventsExpected) {
-      // try to create sourcebuffers if mediasource opened, and all expected bufferCodec events have been received
+    if (mediaSource && mediaSource.readyState === 'open') {
       this.checkPendingTracks();
     }
   }

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -191,7 +191,7 @@ class TimelineController extends EventHandler {
       this.tracks.forEach((track, index) => {
         let textTrack;
         if (index < inUseTracks.length) {
-          const inUseTrack = Object.values(inUseTracks).find(inUseTrack => canReuseVttTextTrack(inUseTrack, track));
+          const inUseTrack = [].slice.call(inUseTracks).find(inUseTrack => canReuseVttTextTrack(inUseTrack, track));
           // Reuse tracks with the same label, but do not reuse 608/708 tracks
           if (inUseTrack) {
             textTrack = inUseTrack;

--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -168,11 +168,11 @@ describe('BufferController tests', function () {
       bufferController.bufferCodecEventsExpected = 2;
 
       bufferController.onBufferCodecs({});
-      assert.strictEqual(checkPendingTracksSpy.notCalled, true);
+      assert.strictEqual(checkPendingTracksSpy.calledOnce, true);
       assert.strictEqual(bufferController.bufferCodecEventsExpected, 1);
 
       bufferController.onBufferCodecs({});
-      assert.strictEqual(checkPendingTracksSpy.calledOnce, true);
+      assert.strictEqual(checkPendingTracksSpy.calledTwice, true);
       assert.strictEqual(bufferController.bufferCodecEventsExpected, 0);
     });
 


### PR DESCRIPTION
### This PR will...
- Create sourceBuffers if the max of 2 tracks has been reached, regardless of buffer codec events received
- Replace `Object.values` with `[].slice.call` when checking textTrack reuse

### Why is this Pull Request needed?
- So that if a stream throws a `FRAG_PARSING_ERROR` during demuxing of the first segment (and therefore will not emit a BUFFER_CODEC event) is allowed to play if the expected number of tracks has already been received. See `//playertest.longtailvideo.com/hls/NBCR_Production_-_OCS/809/468/master.m3u8` for a test case.

- There seems to be a bug with ChromeHeadless/Ubuntu's `Object.values` function when called on the textTracks array-like object. The call always returns `[]`, causing tracks to never be reused. `[].slice.call` is also preferable because we don't have to polyfill it, resulting in less code.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
0.11.1 regression from #1993 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
