### PR TITLE
Remux according to initial PTS so that streams start at 0

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1366,12 +1366,6 @@ class StreamController extends TaskLoop {
 
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;
-      // Need to check what the SourceBuffer reports as start time for the first fragment appended.
-      // If within the threshold of maxBufferHole, adjust this.startPosition for _seekToStartPos().
-      var firstbufferedPosition = buffered.start(0);
-      if (Math.abs(this.startPosition - firstbufferedPosition) < this.config.maxBufferHole) {
-        this.startPosition = firstbufferedPosition;
-      }
       this._seekToStartPos();
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -95,7 +95,7 @@ class Demuxer {
 
   push (data, initSegment, audioCodec, videoCodec, frag, duration, accurateTimeOffset, defaultInitPTS) {
     const w = this.w;
-    const timeOffset = Number.isFinite(frag.startDTS) ? frag.startDTS : frag.start;
+    const timeOffset = Number.isFinite(frag.startPTS) ? frag.startPTS : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
     const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -194,7 +194,6 @@ class MP4Remuxer {
     const outputSamples = [];
     const nbSamples = inputSamples.length;
     const ptsNormalize = this._PTSNormalize;
-    const initDTS = this._initDTS;
     const initPTS = this._initPTS;
 
     // for (let i = 0; i < track.samples.length; i++) {
@@ -228,7 +227,7 @@ class MP4Remuxer {
       //  - less than 200 ms PTS gaps (timeScale/5)
       contiguous |= (inputSamples.length && nextAvcDts &&
                      ((accurateTimeOffset && Math.abs(timeOffset - nextAvcDts / timeScale) < 0.1) ||
-                      Math.abs((inputSamples[0].pts - nextAvcDts - initDTS)) < timeScale / 5)
+                      Math.abs((inputSamples[0].pts - nextAvcDts - initPTS)) < timeScale / 5)
       );
     }
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -425,14 +425,14 @@ class MP4Remuxer {
   }
 
   remuxAudio (track, timeOffset, contiguous, accurateTimeOffset) {
-      const inputTimeScale = track.inputTimeScale;
-      const mp4timeScale = track.timescale;
-      const scaleFactor = inputTimeScale / mp4timeScale;
-      const mp4SampleDuration = track.isAAC ? 1024 : 1152;
-      const inputSampleDuration = mp4SampleDuration * scaleFactor;
-      const ptsNormalize = this._PTSNormalize;
-      const initPTS = this._initPTS;
-      const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
+    const inputTimeScale = track.inputTimeScale;
+    const mp4timeScale = track.timescale;
+    const scaleFactor = inputTimeScale / mp4timeScale;
+    const mp4SampleDuration = track.isAAC ? 1024 : 1152;
+    const inputSampleDuration = mp4SampleDuration * scaleFactor;
+    const ptsNormalize = this._PTSNormalize;
+    const initPTS = this._initPTS;
+    const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
 
     let offset,
       mp4Sample,

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -207,9 +207,6 @@ describe('StreamController', function () {
       };
       streamController.media = {
         buffered: {
-          start: function () {
-            return 6.014;
-          },
           length: 1
         }
       };
@@ -245,15 +242,6 @@ describe('StreamController', function () {
       streamController._checkBuffer();
       assert(seekStub.notCalled);
       assert.strictEqual(streamController.loadedmetadata, undefined);
-    });
-
-    it('should set startPosition to what buffer start reports and seek', function () {
-      const seekStub = sandbox.stub(streamController, '_seekToStartPos');
-      streamController.startPosition = 6;
-      streamController.loadedmetadata = false;
-      streamController._checkBuffer();
-      assert(seekStub.calledOnce);
-      assert.strictEqual(streamController.startPosition, streamController.media.buffered.start());
     });
 
     it('should complete the immediate switch if signalled', function () {

--- a/tests/unit/demuxer/demuxer.js
+++ b/tests/unit/demuxer/demuxer.js
@@ -90,7 +90,7 @@ describe('Demuxer tests', function () {
       cc: 100,
       sn: 6,
       level: 1,
-      startDTS: 1000,
+      startPTS: 1000,
       start: undefined
     };
     let data = new ArrayBuffer(8),
@@ -108,7 +108,7 @@ describe('Demuxer tests', function () {
       assert.equal(obj1.initSegment, initSegment, 'initSegment');
       assert.equal(obj1.audioCodec, audioCodec, 'audioCodec');
       assert.equal(obj1.videoCodec, videoCodec, 'videoCodec');
-      assert.equal(obj1.timeOffset, newFrag.startDTS, 'timeOffset');
+      assert.equal(obj1.timeOffset, newFrag.startPTS, 'timeOffset');
       assert.equal(obj1.discontinuity, false, 'discontinuity');
       assert.equal(obj1.trackSwitch, false, 'trackSwitch');
       assert.equal(obj1.contiguous, true, 'contiguous');
@@ -143,7 +143,7 @@ describe('Demuxer tests', function () {
       cc: 200,
       sn: 5,
       level: 2,
-      startDTS: undefined,
+      startPTS: undefined,
       start: 1000
     };
     let data = {},

--- a/tests/unit/demuxer/demuxer.js
+++ b/tests/unit/demuxer/demuxer.js
@@ -90,8 +90,7 @@ describe('Demuxer tests', function () {
       cc: 100,
       sn: 6,
       level: 1,
-      startPTS: 1000,
-      start: undefined
+      startPTS: 1000
     };
     let data = new ArrayBuffer(8),
       initSegment = {},
@@ -143,7 +142,6 @@ describe('Demuxer tests', function () {
       cc: 200,
       sn: 5,
       level: 2,
-      startPTS: undefined,
       start: 1000
     };
     let data = {},


### PR DESCRIPTION
### This PR will...
- Normalize PTS relative to `initPTS` instead of `initDTS`
- Determine contiguity according to `initPTS`
- Provide `startPTS` instead of `startDTS` as a timeoffset when available
- Remove fix provided in https://github.com/video-dev/hls.js/pull/1992

### Why is this Pull Request needed?

So that all streams begin at their intended start position. This PR ensures that audio/video elementary streams begin at the same time by fixing starting video at `initPTS` , and flushing audio to video by inserting silent audio or dropping extra frames. Since all video now starts at the expected start time, we don't need to set `this.startPosition = buffered.start(0)`.

### Are there any points in the code the reviewer needs to double check?
@dsparacio Tomorrow I'll do some testing on Edge to make sure that the bug you fixed is still OK.

Looking back through the annotations, the original reason for this work was to fix Safari issues with audio/video sync. I tested https://d2u3lzih3uhb7x.cloudfront.net/ubicasttv/680f426d3b4448f8955a051247473f2d/v125867c07c77ws1reji_720.m3u8 on this branch and master and it doesn't seem any different.

### Resolves issues:

Found during regression testing of 0.11.1. Because videos were not starting at 0, certain ad plugins were not functioning correctly with preroll ads.

https://github.com/video-dev/hls.js/issues/1880

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
