### PR TITLE
Revert PTS wrapping code which produces incorrect cue times

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -58,29 +58,6 @@ const calculateOffset = function (vttCCs, cc, presentationTime) {
   vttCCs.presentationOffset = presentationTime;
 };
 
-const wrapPtsInteger = function (value, reference) {
-  let offset;
-  if (!Number.isFinite(reference)) {
-    return value;
-  }
-
-  if (reference < value) {
-    // - 2^33
-    offset = -8589934592;
-  } else {
-    // + 2^33
-    offset = 8589934592;
-  }
-  /* PTS is 33bit (from 0 to 2^33 -1)
-    if diff between value and reference is bigger than half of the amplitude (2^32) then it means that
-    PTS looping occured. fill the gap */
-  while (Math.abs(value - reference) > 4294967296) {
-    value += offset;
-  }
-
-  return value;
-};
-
 const WebVTTParser = {
   parse: function (vttByteArray, syncPTS, vttCCs, cc, callBack, errorCallBack) {
     // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
@@ -163,7 +140,9 @@ const WebVTTParser = {
           });
           try {
             // Calculate subtitle offset in milliseconds.
-            mpegTs = wrapPtsInteger(mpegTs - syncPTS, vttCCs.ccOffset * 90000);
+            syncPTS = syncPTS < 0 ? syncPTS + 8589934592 : syncPTS;
+            // Adjust MPEGTS by sync PTS.
+            mpegTs -= syncPTS;
             // Convert cue time to seconds
             localTime = cueString2millis(cueTime) / 1000;
             // Convert MPEGTS to seconds from 90kHz.


### PR DESCRIPTION
### Why is this Pull Request needed?
Live streams which start with an initial negative PTS do not show cues.

Test stream: http://playertest.longtailvideo.com/adaptive/live-webvtt/webvttTest/playlist.m3u8

### Are there any points in the code the reviewer needs to double check?
No. I know we have an open issue with regards to PTS wrapping; however, I believe the best solution here is to revert to known working code instead of attempting to address it in a hotfix.

### Resolves issues:
0.12.0 regression

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
