### PR TITLE
Check if PTS has wrapped after applying PTS time offset

### DIFF
--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -232,6 +232,6 @@ export class SubtitleStreamController extends TaskLoop {
   }
 
   _getBuffered () {
-    return this.tracksBuffered[this.currentTrackId].buffered || [];
+    return this.tracksBuffered[this.currentTrackId] || [];
   }
 }

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -140,7 +140,9 @@ const WebVTTParser = {
           });
           try {
             // Calculate subtitle offset in milliseconds.
-            syncPTS = syncPTS < 0 ? syncPTS + 8589934592 : syncPTS;
+            if (syncPTS + ((vttCCs[cc].start * 90000) || 0) < 0) {
+              syncPTS += 8589934592;
+            }
             // Adjust MPEGTS by sync PTS.
             mpegTs -= syncPTS;
             // Convert cue time to seconds


### PR DESCRIPTION
### What does this Pull Request do?
-  Subtracts the timeOffset applied in the demuxer from the syncPTS before determining if it has wrapped
- Fixed a typo accessing the frag buffered array, which caused vtt segments to load too late & miss cues

### Why is this Pull Request needed?

In the mp4 remuxer, we apply a timeOffset to PTS:

`initPTS = Math.min(initPTS, videoSamples[0].pts - inputTimeScale * timeOffset);`

Which may make the initPTS negative after a discontinuity. The webvtt parser always assumes that a negativePTS is one which has wrapped around; however, this is not always true. By applying the original offset we can correctly apply the wrapping value.

Test streams:

https://mtoczko.github.io/hls-test-streams/test-vtt/playlist.m3u8
http://playertest.longtailvideo.com/adaptive/live-webvtt/webvttTest/playlist.m3u8

### Are there any points in the code the reviewer needs to double check?
I didn't pass the time base to the initPTS value. How common is a time base not of 90000? Can we improve this in the future, or should we make a more comprehensive fix now?

### Resolves issues:

#2046 