### PR TITLE
Docs: abrBandWidthFactor and abrBandWidthUpFactor

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -947,14 +947,14 @@ parameter should be a float
 (default: `0.95`)
 
 Scale factor to be applied against measured bandwidth average, to determine whether we can stay on current or lower quality level.
-If `abrBandWidthFactor * bandwidth average < level.bitrate` then ABR can switch to that level providing that it is equal or less than current level.
+If `abrBandWidthFactor * bandwidth average > level.bitrate` then ABR can switch to that level providing that it is equal or less than current level.
 
 ### `abrBandWidthUpFactor`
 
 (default: `0.7`)
 
 Scale factor to be applied against measured bandwidth average, to determine whether we can switch up to a higher quality level.
-If `abrBandWidthUpFactor * bandwidth average < level.bitrate` then ABR can switch up to that quality level.
+If `abrBandWidthUpFactor * bandwidth average > level.bitrate` then ABR can switch up to that quality level.
 
 ### `abrMaxWithRealBitrate`
 


### PR DESCRIPTION
### Why is this Pull Request needed?

In the explanations of how abrBandWidthFactor and abrBandWidthUpFactor work the example calculation uses less than, but it should be greater than(?).

Currently the docs have: `abrBandWidthUpFactor * bandwidth average < level.bitrate`

Should it should read `abrBandWidthUpFactor * bandwidth average > level.bitrate`?

The abr-controller has it as: `adjustedbw > bitrate` 
https://github.com/video-dev/hls.js/blob/master/src/controller/abr-controller.js#L303

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
