### PR TITLE
Hls live webvtt subtitle

### DIFF
--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -220,8 +220,7 @@ export class SubtitleStreamController extends TaskLoop {
       const config = this.config;
       const maxBufferHole = config.maxBufferHole;
       const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
-      // if PTSKnown, start is defined by cues range, shift lookup tolerance to front
-      const maxFragLookUpTolerance = !trackDetails.PTSKnown ? config.maxFragLookUpTolerance : config.maxFragLookUpTolerance + (trackDetails.averagetargetduration - this.fragPrevious.duration ? this.fragPrevious.duration : 0);
+      const maxFragLookUpTolerance = config.maxFragLookUpTolerance;
 
       const bufferedInfo = BufferHelper.bufferedInfo(this._getBuffered(), this.media.currentTime, maxBufferHole);
       const bufferEnd = bufferedInfo.end;

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -220,8 +220,8 @@ export class SubtitleStreamController extends TaskLoop {
       const config = this.config;
       const maxBufferHole = config.maxBufferHole;
       const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
-      // if PTSKnown, start is defined by cues range, increase lookup tolerance by averagetargetduration
-      const maxFragLookUpTolerance = trackDetails.PTSKnown ? config.maxFragLookUpTolerance + trackDetails.averagetargetduration : config.maxFragLookUpTolerance;
+      // if PTSKnown, start is defined by cues range, shift lookup tolerance to front
+      const maxFragLookUpTolerance = !trackDetails.PTSKnown ? config.maxFragLookUpTolerance : config.maxFragLookUpTolerance + (trackDetails.averagetargetduration - this.fragPrevious.duration ? this.fragPrevious.duration : 0);
 
       const bufferedInfo = BufferHelper.bufferedInfo(this._getBuffered(), this.media.currentTime, maxBufferHole);
       const bufferEnd = bufferedInfo.end;

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -148,7 +148,10 @@ class SubtitleTrackController extends EventHandler {
   onSubtitleTrackLoaded (data) {
     if (data.id < this.tracks.length) {
       logger.log(`subtitle track ${data.id} loaded`);
-      this.tracks[data.id].details = data.details;
+      if (!this.tracks[data.id].details) {
+        this.tracks[data.id].details = data.details;
+      }
+
       // check if current playlist is a live playlist
       if (data.details.live && !this.timer) {
         // if live playlist we will have to reload it periodically

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -296,9 +296,9 @@ class TimelineController extends EventHandler {
         }
       }
       );
-      if (cues[0] && (cues[0].startTime - frag.start > frag.duration || cues[0].startTime < frag.start)) {
+      if (cues.length > 0 && (cues[0].startTime - frag.start > frag.duration || cues[0].startTime < frag.start)) {
         // subtitle start time do not match cue PTS (init. with delay / sliding failed), or new cue PTS is more accurate than pervious estimation
-        logger.warn(`Adjust subtitle fragment start time [${frag.start},${frag.end}] to [${cues[0].startTime},${cues[cues.length - 1].endTime}]`);
+        logger.warn(`Adjust subtitle fragment start time [${frag.start},${frag.end}] to [${cues[0].startTime},${frag.startPTS + frag.duration}]`);
         frag.startPTS = cues[0].startTime;
         frag.endPTS = frag.startPTS + frag.duration; // boundary of findPTS shift by lookup tolorance
       }

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -296,15 +296,11 @@ class TimelineController extends EventHandler {
         }
       }
       );
-      if (cues[0] && cues[0].startTime - frag.start > frag.duration) {
-        // subtitle start time do not match cue start time. Maybe playlist sliding failed, switch subtitle playlist or init. with delay
+      if (cues[0] && (cues[0].startTime - frag.start > frag.duration || cues[0].startTime < frag.start)) {
+        // subtitle start time do not match cue PTS (init. with delay / sliding failed), or new cue PTS is more accurate than pervious estimation
         logger.warn(`Adjust subtitle fragment start time [${frag.start},${frag.end}] to [${cues[0].startTime},${cues[cues.length - 1].endTime}]`);
-        // adjust start and end
-        frag.start = cues[0].startTime;
-        frag.end = cues[cues.length - 1].endTime;
-        // adjust PTS, subtitle-stream-controller update track detail with PTS
         frag.startPTS = cues[0].startTime;
-        frag.endPTS = cues[cues.length - 1].endTime;
+        frag.endPTS = frag.startPTS + frag.duration; // boundary of findPTS shift by lookup tolorance
       }
       hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
     },


### PR DESCRIPTION
### This PR will...
1. subtitle default map 0 to 0 if X-TIMESTAMP-MAP not found
2. merge subtitle playlist so that subtitle can be found by PTS
3. update range of fragments (+subtitle buffer) by cue range if the difference of range of fragment and its cues > average duration

### Why is this Pull Request needed?
hls.js cannot display live webVTT subtitle

### Resolves issues:
hls.js cannot play webVTT subtitle because it
1. do not sync PTS when there is no X-TIMESTAMP-MAP, while Spec mention:
>   If a WebVTT segment does not have the X-TIMESTAMP-MAP, the client
>    MUST assume that the WebVTT cue time of 0 maps to an MPEG-2 timestamp
>    of 0.
2.  When reload subtitle playlist, it always start from 0 and subtitle-stream-controller unable to find fragment in the reloaded subtitle playlist
3.  fragment.start range maybe incorrect when 1. switching text track, 2. SN of new playlist out of range of previous playlist, 3. delay of loading subtitle playlist during initialization

### Are there any points in the code the reviewer needs to double check?
alt. subtitle switching + fail sliding (e.g. can checked by hide subtitle, wait all fragments in the the previous playlist out of range, show subtitle)
When the fragment range is updated by cue range, the range of other fragments are shifted to front because the range of cue usually smaller than the actual fragment range. I increase the subtitle lookup tolerance by duration so that it can still find next subtitle fragment. Is there other design that update fragment range without increase tolerance?
subtitle with fmp4's initPTS
Other type of subtitle

### Checklist
- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
