### PR TITLE
Update light build targets to include Typescript extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16473,6 +16473,23 @@
         }
       }
     },
+    "webpack-merge": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
+      "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "webpack-bundle-analyzer": "^2.9.1",
     "webpack-cli": "^3.0.2",
     "webpack-dev-server": "^3.1.4",
+    "webpack-merge": "^4.2.1",
     "webworkify-webpack": "^2.1.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,12 @@
 const pkgJson = require('./package.json');
 const path = require('path');
 const webpack = require('webpack');
+const merge = require('webpack-merge');
 
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const getGitVersion = require('git-tag-version');
 const getGitCommitInfo = require('git-commit-info');
-
-const clone = (...args) => Object.assign({}, ...args);
 
 /* Allow to customise builds through env-vars */
 const env = process.env;
@@ -22,19 +21,22 @@ const baseConfig = {
   entry: './src/hls',
   resolve: {
     // Add `.ts` as a resolvable extension.
-    extensions: [".ts", ".js"]
+    extensions: ['.ts', '.js']
   },
   module: {
     strictExportPresence: true,
     rules: [
       // all files with a `.ts` extension will be handled by `ts-loader`
-      { test: /\.ts?$/, loader: "ts-loader" },
-      { test: /\.js?$/, exclude: [/node_modules/], loader: "ts-loader" },
+      {
+        test: /\.(ts|js)$/,
+        loader: 'ts-loader',
+        exclude: /node_modules/
+      }
     ]
   }
 };
 
-const demoConfig = clone(baseConfig, {
+const demoConfig = merge(baseConfig, {
   name: 'demo',
   mode: 'development',
   entry: './demo/main',
@@ -47,7 +49,7 @@ const demoConfig = clone(baseConfig, {
     library: 'HlsDemo',
     libraryTarget: 'umd',
     libraryExport: 'default',
-    globalObject: 'this'  // https://github.com/webpack/webpack/issues/6642#issuecomment-370222543
+    globalObject: 'this' // https://github.com/webpack/webpack/issues/6642#issuecomment-370222543
   },
   optimization: {
     minimize: false
@@ -56,7 +58,7 @@ const demoConfig = clone(baseConfig, {
   devtool: 'source-map'
 });
 
-function getPluginsForConfig(type, minify = false) {
+function getPluginsForConfig (type, minify = false) {
   // common plugins.
 
   const defineConstants = getConstantsForConfig(type);
@@ -86,7 +88,6 @@ function getPluginsForConfig(type, minify = false) {
 }
 
 function getConstantsForConfig (type) {
-
   const gitCommitInfo = getGitCommitInfo();
   const suffix = gitCommitInfo.shortCommit ? ('-' + gitCommitInfo.shortCommit) : '';
 
@@ -109,7 +110,7 @@ function getAliasesForLightDist () {
   }
 
   if (!addSubtitleSupport) {
-    aliases = clone(aliases, {
+    aliases = Object.assign(aliases, {
       './utils/cues': './empty.js',
       './controller/timeline-controller': './empty.js',
       './controller/subtitle-track-controller': './empty.js',
@@ -118,7 +119,7 @@ function getAliasesForLightDist () {
   }
 
   if (!addAltAudioSupport) {
-    aliases = clone(aliases, {
+    aliases = Object.assign(aliases, {
       './controller/audio-track-controller': './empty.js',
       './controller/audio-stream-controller': './empty.js'
     });
@@ -206,13 +207,12 @@ const multiConfig = [
     },
     devtool: 'source-map'
   }
-].map(config => clone(baseConfig, config));
+].map(config => merge(baseConfig, config));
 
 multiConfig.push(demoConfig);
 
 // webpack matches the --env arguments to a string; for example, --env.debug.min translates to { debug: true, min: true }
 module.exports = (envArgs) => {
-
   let configs;
 
   if (!envArgs) {


### PR DESCRIPTION
This fixes an issue where light-dist / light defined their own resolve property causing them to not get the base config resolve for extensions, etc.

Includes a few minor lint fixes that popped in my editor as well.

Before:

![Before](https://dl.dropboxusercontent.com/s/nt092oasr15ydvp/Screen%20Shot%202019-01-10%20at%2010.39.56%20AM.png?dl=0)

After:

![After](https://dl.dropboxusercontent.com/s/thxl3wkssbsshhl/Screen%20Shot%202019-01-10%20at%2010.41.03%20AM.png?dl=0)

- [x] changes have been done against master branch, and PR does not conflict