### PR TITLE
Skip gap poll if playback is paused

### DIFF
--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -37,7 +37,7 @@ export default class GapController {
       return;
     }
 
-    if (media.ended || !media.buffered.length || media.readyState > 2) {
+    if (media.ended || !media.buffered.length || media.readyState > 2 || media.paused) {
       return;
     }
 

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -181,5 +181,18 @@ describe('checkBuffer', function () {
       gapController.poll(lastCurrentTime, buffered);
       assert(reportStallSpy.calledOnce);
     });
+
+    it('should do nothing if the playback is paused', function () {
+      mockMedia.paused = true;
+      mockMedia.readyState = 4;
+      mockMedia.currentTime = 5;
+      lastCurrentTime = 5;
+      gapController.nudgeRetry = 1;
+      const fixStallStub = sandbox.stub(gapController, '_tryFixBufferStall');
+      gapController.poll(lastCurrentTime, buffered);
+
+      assert.strictEqual(gapController.nudgeRetry, 1);
+      assert(fixStallStub.notCalled);
+    });
   });
 });


### PR DESCRIPTION
### This PR will skip gap poll check if playback is paused

### Why is this Pull Request needed?

The current issue is:

1. When we pack our content in HLSv3, the first PTS is a little bit larger than 0s, usually 0.08342s
2. In Safari, when autoplay isn't enabled, hls.js player will preload data
3. When entering gap controller poll check, since there is no buffered data at 0s, it will try to nudge. But this causes the poster image disappears, which isn't expected

### Are there any points in the code the reviewer needs to double check?

No

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
