### PR TITLE
fix #2079: drop fragCurrent on buffer flush

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -836,6 +836,23 @@ class AudioStreamController extends BaseStreamController {
       this.state = State.IDLE;
       // reset reference to frag
       this.fragPrevious = null;
+
+      const { fragCurrent } = this;
+      if (fragCurrent) {
+        const { loader } = fragCurrent;
+        if (loader) {
+          // abort current frag to reload it and re-trigger onFragLoaded
+          loader.abort();
+        }
+
+        const state = this.fragmentTracker.getState(fragCurrent);
+        if (state === FragmentState.APPENDING || state === FragmentState.PARTIAL) {
+          // if frag is not loaded, remove it from fragment tracker to prevent loop
+          this.fragmentTracker.removeFragment(fragCurrent);
+          this.fragCurrent = null;
+        }
+      }
+
       this.tick();
     }
   }


### PR DESCRIPTION
### This PR will...
Abort AudioStreamController's fragCurrent loader and clear fragCurrent in fragmentTracker on buffer flush
### Why is this Pull Request needed?
AudioStreamController may hang up on buffer flush, see https://github.com/video-dev/hls.js/issues/2079 for reproducing info
### Are there any points in the code the reviewer needs to double check?
I'll left comments in PR
### Resolves issues:
https://github.com/video-dev/hls.js/issues/2079
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
