### PR TITLE
mp4-remuxer / remuxAudio() : recompute mdatSize / dont rely on audioTrack.len

### DIFF
--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -229,8 +229,6 @@ export function appendFrame (track, data, offset, pts, frameIndex) {
     };
 
     track.samples.push(aacSample);
-    track.len += frameLength;
-
     return { sample: aacSample, length: frameLength + headerLength };
   }
 

--- a/src/demux/mpegaudio.js
+++ b/src/demux/mpegaudio.js
@@ -67,7 +67,6 @@ const MpegAudio = {
       track.channelCount = header.channelCount;
       track.samplerate = header.sampleRate;
       track.samples.push(sample);
-      track.len += header.frameLength;
 
       return { sample, length: header.frameLength };
     }

--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -94,7 +94,6 @@ class TSDemuxer {
       inputTimeScale: 90000,
       sequenceNumber: 0,
       samples: [],
-      len: 0,
       dropped: type === 'video' ? 0 : undefined,
       isAAC: type === 'audio' ? true : undefined,
       duration: type === 'audio' ? duration : undefined

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -588,15 +588,16 @@ class MP4Remuxer {
         // remember first PTS of our audioSamples
         firstPTS = pts;
         if (mdatSize > 0) {
+          mdatSize += offset;
           try {
-            mdat = new Uint8Array(mdatSize + offset);
+            mdat = new Uint8Array(mdatSize);
           } catch (err) {
             this.observer.trigger(Event.ERROR, { type: ErrorTypes.MUX_ERROR, details: ErrorDetails.REMUX_ALLOC_ERROR, fatal: false, bytes: mdatSize, reason: `fail allocating audio mdat ${mdatSize}` });
             return;
           }
           if (!rawMPEG) {
             const view = new DataView(mdat.buffer);
-            view.setUint32(0, mdatSize + offset);
+            view.setUint32(0, mdatSize);
             mdat.set(MP4.types.mdat, 4);
           }
         } else {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -393,7 +393,6 @@ class MP4Remuxer {
     // next AVC sample DTS should be equal to last sample DTS + last sample duration (in PES timescale)
     this.nextAvcDts = lastDTS + mp4SampleDuration;
     let dropped = track.dropped;
-    track.len = 0;
     track.nbNalu = 0;
     track.dropped = 0;
     if (outputSamples.length && navigator.userAgent.toLowerCase().indexOf('chrome') > -1) {
@@ -434,11 +433,11 @@ class MP4Remuxer {
     const initPTS = this._initPTS;
     const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
 
-    let offset,
-      mp4Sample,
+    let mp4Sample,
       fillFrame,
       mdat, moof,
       firstPTS, lastPTS,
+      offset = (rawMPEG ? 0 : 8),
       inputSamples = track.samples,
       outputSamples = [],
       nextAudioPts = this.nextAudioPts;
@@ -503,7 +502,6 @@ class MP4Remuxer {
         if (delta <= -maxAudioFramesDrift * inputSampleDuration) {
           logger.warn(`Dropping 1 audio frame @ ${(nextPts / inputTimeScale).toFixed(3)}s due to ${Math.round(duration)} ms overlap.`);
           inputSamples.splice(i, 1);
-          track.len -= sample.unit.length;
           // Don't touch nextPtsNorm or i
         } // eslint-disable-line brace-style
 
@@ -522,7 +520,6 @@ class MP4Remuxer {
               fillFrame = sample.unit.subarray();
             }
             inputSamples.splice(i, 0, { unit: fillFrame, pts: newStamp, dts: newStamp });
-            track.len += fillFrame.length;
             nextPts += inputSampleDuration;
             i++;
           }
@@ -541,6 +538,13 @@ class MP4Remuxer {
           i++;
         }
       }
+    }
+
+    // compute mdat size, as we eventually filtered/added some samples
+    let nbSamples = inputSamples.length;
+    let mdatSize = 0;
+    while (nbSamples--) {
+      mdatSize += inputSamples[nbSamples].unit.byteLength;
     }
 
     for (let j = 0, nbSamples = inputSamples.length; j < nbSamples; j++) {
@@ -568,13 +572,13 @@ class MP4Remuxer {
                   fillFrame = unit.subarray();
                 }
 
-                track.len += numMissingFrames * fillFrame.length;
+                mdatSize += numMissingFrames * fillFrame.length;
               }
               // if we have frame overlap, overlapping for more than half a frame duraion
             } else if (delta < -12) {
               // drop overlapping audio frames... browser will deal with it
               logger.log(`drop overlapping AAC sample, expected/parsed/delta:${(nextAudioPts / inputTimeScale).toFixed(3)}s/${(pts / inputTimeScale).toFixed(3)}s/${(-delta)}ms`);
-              track.len -= unit.byteLength;
+              mdatSize -= unit.byteLength;
               continue;
             }
             // set PTS/DTS to expected PTS/DTS
@@ -583,13 +587,9 @@ class MP4Remuxer {
         }
         // remember first PTS of our audioSamples
         firstPTS = pts;
-        if (track.len > 0) {
-          /* concatenate the audio data and construct the mdat in place
-            (need 8 more bytes to fill length and mdat type) */
-          let mdatSize = rawMPEG ? track.len : track.len + 8;
-          offset = rawMPEG ? 0 : 8;
+        if (mdatSize > 0) {
           try {
-            mdat = new Uint8Array(mdatSize);
+            mdat = new Uint8Array(mdatSize + offset);
           } catch (err) {
             this.observer.trigger(Event.ERROR, { type: ErrorTypes.MUX_ERROR, details: ErrorDetails.REMUX_ALLOC_ERROR, fatal: false, bytes: mdatSize, reason: `fail allocating audio mdat ${mdatSize}` });
             return;
@@ -646,7 +646,7 @@ class MP4Remuxer {
       lastPTS = pts;
     }
     let lastSampleDuration = 0;
-    let nbSamples = outputSamples.length;
+    nbSamples = outputSamples.length;
     // set last sample duration as being identical to previous sample
     if (nbSamples >= 2) {
       lastSampleDuration = outputSamples[nbSamples - 2].duration;
@@ -656,7 +656,6 @@ class MP4Remuxer {
       // next audio sample PTS should be equal to last sample PTS + duration
       this.nextAudioPts = nextAudioPts = lastPTS + scaleFactor * lastSampleDuration;
       // logger.log('Audio/PTS/PTSend:' + audioSample.pts.toFixed(0) + '/' + this.nextAacDts.toFixed(0));
-      track.len = 0;
       track.samples = outputSamples;
       if (rawMPEG) {
         moof = new Uint8Array();
@@ -715,7 +714,6 @@ class MP4Remuxer {
     for (let i = 0; i < nbSamples; i++) {
       let stamp = startDTS + i * frameDuration;
       samples.push({ unit: silentFrame, pts: stamp, dts: stamp });
-      track.len += silentFrame.length;
     }
     track.samples = samples;
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -596,7 +596,7 @@ class MP4Remuxer {
           }
           if (!rawMPEG) {
             const view = new DataView(mdat.buffer);
-            view.setUint32(0, mdatSize);
+            view.setUint32(0, mdatSize + offset);
             mdat.set(MP4.types.mdat, 4);
           }
         } else {

--- a/tests/unit/demuxer/adts.js
+++ b/tests/unit/demuxer/adts.js
@@ -394,7 +394,6 @@ describe('appendFrame', function () {
       length: 16
     });
     expect(track.samples.length).to.equal(1);
-    expect(track.len).to.equal(7);
   });
 
   it('should not append sample if `parseFrameHeader` fails', function () {
@@ -410,6 +409,5 @@ describe('appendFrame', function () {
 
     expect(appendFrame(track, data, 0, 0, 0)).to.be.undefined;
     expect(track.samples.length).to.equal(0);
-    expect(track.len).to.equal(0);
   });
 });


### PR DESCRIPTION
### This PR will ...
- recompute audio mdat size by summing the size of all  audio samples, instead of trusting track.len
- get rid of track.len

### Why is this Pull Request needed?
- this fixes the RangeError exception

### Are there any points in the code the reviewer needs to double check?
we might want to clone the problematic stream and add it to the test suite. if fine with the owner. thought ?

### Resolves issues:
#2063 
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [?] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
