### PR TITLE
hls.js loader memory leak fix

### DIFF
--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -16,12 +16,8 @@ class FragmentLoader extends EventHandler {
   destroy () {
     let loaders = this.loaders;
     for (let loaderName in loaders) {
-      let loader = loaders[loaderName];
-      if (loader) {
-        loader.destroy();
-      }
+      this.destroyLoader(loaderName);
     }
-    this.loaders = {};
 
     super.destroy();
   }
@@ -79,8 +75,7 @@ class FragmentLoader extends EventHandler {
     let payload = response.data, frag = context.frag;
     // detach fragment loader on load success
     frag.loader = undefined;
-    this.loaders[frag.type].destroy();
-    this.loaders[frag.type] = undefined;
+    this.destroyLoader(frag.type);
     this.hls.trigger(Event.FRAG_LOADED, { payload: payload, frag: frag, stats: stats, networkDetails: networkDetails });
   }
 
@@ -91,8 +86,7 @@ class FragmentLoader extends EventHandler {
       loader.abort();
     }
 
-    this.loaders[frag.type].destroy();
-    this.loaders[frag.type] = undefined;
+    this.destroyLoader(frag.type);
     this.hls.trigger(Event.ERROR, { type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: context.frag, response: response, networkDetails: networkDetails });
   }
 
@@ -103,8 +97,7 @@ class FragmentLoader extends EventHandler {
       loader.abort();
     }
 
-    this.loaders[frag.type].destroy();
-    this.loaders[frag.type] = undefined;
+    this.destroyLoader(frag.type);
     this.hls.trigger(Event.ERROR, { type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_TIMEOUT, fatal: false, frag: context.frag, networkDetails: networkDetails });
   }
 
@@ -113,6 +106,15 @@ class FragmentLoader extends EventHandler {
     let frag = context.frag;
     frag.loaded = stats.loaded;
     this.hls.trigger(Event.FRAG_LOAD_PROGRESS, { frag: frag, stats: stats, networkDetails: networkDetails });
+  }
+
+  destroyLoader (loaderName) {
+    const loaders = this.loaders;
+    const loader = loaders[loaderName];
+    if (loader) {
+      loader.destroy();
+      delete loaders[loaderName];
+    }
   }
 }
 

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -79,6 +79,7 @@ class FragmentLoader extends EventHandler {
     let payload = response.data, frag = context.frag;
     // detach fragment loader on load success
     frag.loader = undefined;
+    this.loaders[frag.type].destroy();
     this.loaders[frag.type] = undefined;
     this.hls.trigger(Event.FRAG_LOADED, { payload: payload, frag: frag, stats: stats, networkDetails: networkDetails });
   }
@@ -90,6 +91,7 @@ class FragmentLoader extends EventHandler {
       loader.abort();
     }
 
+    this.loaders[frag.type].destroy();
     this.loaders[frag.type] = undefined;
     this.hls.trigger(Event.ERROR, { type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: context.frag, response: response, networkDetails: networkDetails });
   }
@@ -101,6 +103,7 @@ class FragmentLoader extends EventHandler {
       loader.abort();
     }
 
+    this.loaders[frag.type].destroy();
     this.loaders[frag.type] = undefined;
     this.hls.trigger(Event.ERROR, { type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_TIMEOUT, fatal: false, frag: context.frag, networkDetails: networkDetails });
   }

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -141,11 +141,6 @@ class PlaylistLoader extends EventHandler {
    */
   destroyInternalLoaders () {
     for (let contextType in this.loaders) {
-      let loader = this.loaders[contextType];
-      if (loader) {
-        loader.destroy();
-      }
-
       this.resetInternalLoader(contextType);
     }
   }

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -131,6 +131,7 @@ class PlaylistLoader extends EventHandler {
 
   resetInternalLoader (contextType) {
     if (this.loaders[contextType]) {
+      this.loaders[contextType].destroy();
       delete this.loaders[contextType];
     }
   }


### PR DESCRIPTION
### This PR will...
Call destroy on the loader instance before removing the reference to it. In cases where the loader has resources that need to be destroyed, this can cause a memory leak.

### Why is this Pull Request needed?
Frag/Playlist loaders are only destroyed sometimes, instead of all the time.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fix #2104

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
