### PR TITLE
tsdemuxer: if PES does not contain PTS/DTS, use last PES PTS/DTS instead

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -184,7 +184,7 @@ class TSDemuxer {
         switch (pid) {
         case avcId:
           if (stt) {
-            if (avcData && (pes = parsePES(avcData)) && pes.pts !== undefined) {
+            if (avcData && (pes = parsePES(avcData))) {
               parseAVCPES(pes, false);
             }
 
@@ -197,7 +197,7 @@ class TSDemuxer {
           break;
         case audioId:
           if (stt) {
-            if (audioData && (pes = parsePES(audioData)) && pes.pts !== undefined) {
+            if (audioData && (pes = parsePES(audioData))) {
               if (audioTrack.isAAC) {
                 parseAACPES(pes);
               } else {
@@ -213,7 +213,7 @@ class TSDemuxer {
           break;
         case id3Id:
           if (stt) {
-            if (id3Data && (pes = parsePES(id3Data)) && pes.pts !== undefined) {
+            if (id3Data && (pes = parsePES(id3Data))) {
               parseID3PES(pes);
             }
 
@@ -279,7 +279,7 @@ class TSDemuxer {
       }
     }
     // try to parse last PES packets
-    if (avcData && (pes = parsePES(avcData)) && pes.pts !== undefined) {
+    if (avcData && (pes = parsePES(avcData))) {
       parseAVCPES(pes, true);
       avcTrack.pesData = null;
     } else {
@@ -287,7 +287,7 @@ class TSDemuxer {
       avcTrack.pesData = avcData;
     }
 
-    if (audioData && (pes = parsePES(audioData)) && pes.pts !== undefined) {
+    if (audioData && (pes = parsePES(audioData))) {
       if (audioTrack.isAAC) {
         parseAACPES(pes);
       } else {
@@ -304,7 +304,7 @@ class TSDemuxer {
       audioTrack.pesData = audioData;
     }
 
-    if (id3Data && (pes = parsePES(id3Data)) && pes.pts !== undefined) {
+    if (id3Data && (pes = parsePES(id3Data))) {
       parseID3PES(pes);
       id3Track.pesData = null;
     } else {
@@ -534,6 +534,18 @@ class TSDemuxer {
     if (avcSample.units.length && avcSample.frame) {
       const samples = avcTrack.samples;
       const nbSamples = samples.length;
+      // if sample does not have PTS/DTS, patch with last sample PTS/DTS
+      if (isNaN(avcSample.pts)) {
+        if (nbSamples) {
+          const lastSample = samples[nbSamples - 1];
+          avcSample.pts = lastSample.pts;
+          avcSample.dts = lastSample.dts;
+        } else {
+          // dropping samples, no timestamp found
+          avcTrack.dropped++;
+          return;
+        }
+      }
       // only push AVC sample if starting with a keyframe is not mandatory OR
       //    if keyframe already found in this fragment OR
       //       keyframe found in last fragment (track.sps) AND


### PR DESCRIPTION
### This PR will ...
attempt to fix #1469
### Why is this Pull Request needed?
we are currently dropping any PES packet without PTS/DTS
this was introduced by https://github.com/video-dev/hls.js/commit/9a80c9804dbfdf939bdd3c4056c7ac9e3bcfed42. this filtering was added as we were previously providing AVC samples with undefined PTS/DTS to mp4-remuxer.
the mp4-remuxer isnt resilient to that and is generating corrupted video fmp4 in that case.
let's try to be more resilient and fallback on last AVC sample PTS/DTS (PTS/DTS are optional fields of PES headers)
### Are there any points in the code the reviewer needs to double check?
we need to test against streams with PES not signalling PTS/DTS.

### Resolves issues:
#1469 
### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
