### PR TITLE
Clear audio tick interval when we stopLoad.

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -111,6 +111,7 @@ class AudioStreamController extends BaseStreamController {
       this.demuxer.destroy();
       this.demuxer = null;
     }
+    this.clearInterval();
     this.state = State.STOPPED;
   }
 

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -46,6 +46,9 @@ class BufferController extends EventHandler {
   // signals that mediaSource should have endOfStream called
   private _needsEos: boolean = false;
 
+  // Track whether the parsed manifest signaled alternate audio
+  private _altAudio: boolean = false;
+
   // this is optional because this property is removed from the class sometimes
   public audioTimestampOffset?: number;
 
@@ -138,6 +141,7 @@ class BufferController extends EventHandler {
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
+    this._altAudio = data.altAudio;
     this.bufferCodecEventsExpected = data.altAudio ? 2 : 1;
     logger.log(`${this.bufferCodecEventsExpected} bufferCodec event(s) expected`);
   }
@@ -203,6 +207,7 @@ class BufferController extends EventHandler {
       this.flushRange = [];
       this.segments = [];
       this.appended = 0;
+      this.bufferCodecEventsExpected = this._altAudio ? 2 : 1;
     }
 
     this.hls.trigger(Events.MEDIA_DETACHED);


### PR DESCRIPTION
### This PR will...

Clears Tick interval in stop load for audio-stream-controller.

### Why is this Pull Request needed?

Looking at #2099 root cause, I noticed that the audio-stream-controller does not clear its tick interval when stopLoad is called, causing it to force loop in the stopped state while the media is detached.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
