### PR TITLE
Add SEI with resolution payloadType 5 based on H264 specification (Us…

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -688,6 +688,33 @@ class TSDemuxer {
                 }
               }
             }
+          } else if (payloadType === 5 && expGolombDecoder.bytesAvailable !== 0) {
+            endOfCaptions = true;
+
+            if (payloadSize > 16) {
+              let uuidStrArray = [];
+              let userDataPayloadBytes = [];
+
+              for (i = 0; i < 16; i++) {
+                uuidStrArray.push(expGolombDecoder.readUByte().toString(16));
+
+                if (i === 3 || i === 5 || i === 7 || i === 9) {
+                  uuidStrArray.push('-');
+                }
+              }
+
+              for (i = 16; i < payloadSize; i++) {
+                userDataPayloadBytes.push(expGolombDecoder.readUByte());
+              }
+
+              this._insertSampleInOrder(this._txtTrack.samples, {
+                pts: pes.pts,
+                payloadType: payloadType,
+                uuid: uuidStrArray.join(''),
+                userData: String.fromCharCode.apply(null, userDataPayloadBytes),
+                userDataBytes: userDataPayloadBytes
+              });
+            }
           } else if (payloadSize < expGolombDecoder.bytesAvailable) {
             for (i = 0; i < payloadSize; i++) {
               expGolombDecoder.readUByte();


### PR DESCRIPTION
### This PR will parse SEI with resolution payloadType 5 based on H264 specification. Now you can write custom data to H264 and get it from 'Hls.Events.FRAG_PARSING_USERDATA' event.

### Why is this Pull Request needed?
A: User can get custom data from SEI. It's especially useful in live streaming.

### Are there any points in the code the reviewer needs to double check?
A:  No.

### Resolves issues:
A: Just add a SEI parsing rule.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict

