### PR TITLE
(misc) Removing IE8-specific (dead) vtt/cue code

### DIFF
--- a/src/utils/vttcue.js
+++ b/src/utils/vttcue.js
@@ -65,20 +65,9 @@ export default (function () {
 
   function VTTCue (startTime, endTime, text) {
     let cue = this;
-    let isIE8 = (function () {
-      if (typeof navigator === 'undefined') {
-        return;
-      }
-
-      return (/MSIE\s8\.0/).test(navigator.userAgent);
-    })();
     let baseObj = {};
 
-    if (isIE8) {
-      cue = document.createElement('custom');
-    } else {
-      baseObj.enumerable = true;
-    }
+    baseObj.enumerable = true;
 
     /**
      * Shim implementation specific properties. These properties are not in
@@ -294,11 +283,7 @@ export default (function () {
      */
 
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state
-    cue.displayState = undefined;
-
-    if (isIE8) {
-      return cue;
-    }
+    cue.displayState = void 0;
   }
 
   /**


### PR DESCRIPTION
### This PR will...
... remove IE8 specific handling in VTT/Cue related code. It's essentially dead because we don't support Internet Explorer 8, minimum supported version is 11.

### Why is this Pull Request needed?
No need for it to stay within the distributable bundle

`hls.min.js` before:
`225,970` bytes 

`hls.min.js` after:
`225,822` bytes

Total: `-148` bytes ⬇️ 

### Are there any points in the code the reviewer needs to double check?
Not that I'm aware of

### Resolves issues:
None in particular

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- ~[ ] new unit / functional tests have been added (whenever applicable)~ N/A
- ~[ ] API or design changes are documented in API.md~ N/A
