### PR TITLE
Implement live VTT subtitle loading

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -46,17 +46,6 @@ class AudioStreamController extends BaseStreamController {
     this.videoTrackCC = null;
   }
 
-  onHandlerDestroying () {
-    this.stopLoad();
-    super.onHandlerDestroying();
-  }
-
-  onHandlerDestroyed () {
-    this.state = State.STOPPED;
-    this.fragmentTracker = null;
-    super.onHandlerDestroyed();
-  }
-
   // Signal that video PTS was found
   onInitPtsFound (data) {
     let demuxerId = data.id, cc = data.frag.cc, initPTS = data.initPTS;
@@ -94,24 +83,6 @@ class AudioStreamController extends BaseStreamController {
       this.startPosition = startPosition;
       this.state = State.STOPPED;
     }
-  }
-
-  stopLoad () {
-    let frag = this.fragCurrent;
-    if (frag) {
-      if (frag.loader) {
-        frag.loader.abort();
-      }
-
-      this.fragmentTracker.removeFragment(frag);
-      this.fragCurrent = null;
-    }
-    this.fragPrevious = null;
-    if (this.demuxer) {
-      this.demuxer.destroy();
-      this.demuxer = null;
-    }
-    this.state = State.STOPPED;
   }
 
   set state (nextState) {

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -234,13 +234,15 @@ export class FragmentTracker extends EventHandler {
     const fragment = e.frag;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
-    if (Number.isFinite(fragment.sn) && !fragment.bitrateTest) {
-      this.fragments[this.getFragmentKey(fragment)] = {
-        body: fragment,
-        range: Object.create(null),
-        buffered: false
-      };
+    if (!Number.isFinite(fragment.sn) || fragment.bitrateTest) {
+      return;
     }
+
+    this.fragments[this.getFragmentKey(fragment)] = {
+      body: fragment,
+      range: Object.create(null),
+      buffered: false
+    };
   }
 
   /**

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -110,45 +110,38 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
 }
 
 export function mergeDetails (oldDetails, newDetails) {
-  let start = Math.max(oldDetails.startSN, newDetails.startSN) - newDetails.startSN,
-    end = Math.min(oldDetails.endSN, newDetails.endSN) - newDetails.startSN,
-    delta = newDetails.startSN - oldDetails.startSN,
-    oldfragments = oldDetails.fragments,
-    newfragments = newDetails.fragments,
-    ccOffset = 0,
-    PTSFrag;
-
   // potentially retrieve cached initsegment
   if (newDetails.initSegment && oldDetails.initSegment) {
     newDetails.initSegment = oldDetails.initSegment;
   }
 
   // check if old/new playlists have fragments in common
-  if (end < start) {
-    newDetails.PTSKnown = false;
-    return;
-  }
   // loop through overlapping SN and update startPTS , cc, and duration if any found
-  for (var i = start; i <= end; i++) {
-    let oldFrag = oldfragments[delta + i],
-      newFrag = newfragments[i];
-    if (newFrag && oldFrag) {
-      ccOffset = oldFrag.cc - newFrag.cc;
-      if (Number.isFinite(oldFrag.startPTS)) {
-        newFrag.start = newFrag.startPTS = oldFrag.startPTS;
-        newFrag.endPTS = oldFrag.endPTS;
-        newFrag.duration = oldFrag.duration;
-        newFrag.backtracked = oldFrag.backtracked;
-        newFrag.dropped = oldFrag.dropped;
-        PTSFrag = newFrag;
-      }
+  let ccOffset = 0;
+  let PTSFrag;
+  mapFragmentIntersection(oldDetails, newDetails, (oldFrag, newFrag) => {
+    ccOffset = oldFrag.cc - newFrag.cc;
+    if (Number.isFinite(oldFrag.startPTS)) {
+      newFrag.start = newFrag.startPTS = oldFrag.startPTS;
+      newFrag.endPTS = oldFrag.endPTS;
+      newFrag.duration = oldFrag.duration;
+      newFrag.backtracked = oldFrag.backtracked;
+      newFrag.dropped = oldFrag.dropped;
+      PTSFrag = newFrag;
     }
+    // PTS is known when there are overlapping segments
+    newDetails.PTSKnown = true;
+  });
+
+  if (!newDetails.PTSKnown) {
+    return;
   }
 
   if (ccOffset) {
     logger.log('discontinuity sliding from playlist, take drift into account');
-    for (i = 0; i < newfragments.length; i++) {
-      newfragments[i].cc += ccOffset;
+    const newFragments = newDetails.fragments;
+    for (let i = 0; i < newFragments.length; i++) {
+      newFragments[i].cc += ccOffset;
     }
   }
 
@@ -156,18 +149,81 @@ export function mergeDetails (oldDetails, newDetails) {
   if (PTSFrag) {
     updateFragPTSDTS(newDetails, PTSFrag, PTSFrag.startPTS, PTSFrag.endPTS, PTSFrag.startDTS, PTSFrag.endDTS);
   } else {
-    // ensure that delta is within oldfragments range
+    // ensure that delta is within oldFragments range
     // also adjust sliding in case delta is 0 (we could have old=[50-60] and new=old=[50-61])
     // in that case we also need to adjust start offset of all fragments
-    if (delta >= 0 && delta < oldfragments.length) {
-      // adjust start by sliding offset
-      let sliding = oldfragments[delta].start;
-      for (i = 0; i < newfragments.length; i++) {
-        newfragments[i].start += sliding;
-      }
-    }
+    adjustSliding(oldDetails, newDetails);
   }
   // if we are here, it means we have fragments overlapping between
   // old and new level. reliable PTS info is thus relying on old level
   newDetails.PTSKnown = oldDetails.PTSKnown;
+}
+
+export function mergeSubtitlePlaylists (oldPlaylist, newPlaylist, referenceStart = 0) {
+  let lastIndex = -1;
+  mapFragmentIntersection(oldPlaylist, newPlaylist, (oldFrag, newFrag, index) => {
+    newFrag.start = oldFrag.start;
+    lastIndex = index;
+  });
+
+  const frags = newPlaylist.fragments;
+  if (lastIndex < 0) {
+    frags.forEach(frag => {
+      frag.start += referenceStart;
+    });
+    return;
+  }
+
+  for (let i = lastIndex + 1; i < frags.length; i++) {
+    frags[i].start = (frags[i - 1].start + frags[i - 1].duration);
+  }
+}
+
+export function mapFragmentIntersection (oldPlaylist, newPlaylist, intersectionFn) {
+  if (!oldPlaylist || !newPlaylist) {
+    return;
+  }
+
+  const start = Math.max(oldPlaylist.startSN, newPlaylist.startSN) - newPlaylist.startSN;
+  const end = Math.min(oldPlaylist.endSN, newPlaylist.endSN) - newPlaylist.startSN;
+  const delta = newPlaylist.startSN - oldPlaylist.startSN;
+
+  for (let i = start; i <= end; i++) {
+    const oldFrag = oldPlaylist.fragments[delta + i];
+    const newFrag = newPlaylist.fragments[i];
+    if (!oldFrag || !newFrag) {
+      break;
+    }
+    intersectionFn(oldFrag, newFrag, i);
+  }
+}
+
+export function adjustSliding (oldPlaylist, newPlaylist) {
+  const delta = newPlaylist.startSN - oldPlaylist.startSN;
+  const oldFragments = oldPlaylist.fragments;
+  const newFragments = newPlaylist.fragments;
+
+  if (delta < 0 || delta > oldFragments.length) {
+    return;
+  }
+  for (let i = 0; i < newFragments.length; i++) {
+    newFragments[i].start += oldFragments[delta].start;
+  }
+}
+
+export function computeReloadInterval (currentPlaylist, newPlaylist, lastRequestTime) {
+  let reloadInterval = 1000 * (newPlaylist.averagetargetduration ? newPlaylist.averagetargetduration : newPlaylist.targetduration);
+  const minReloadInterval = reloadInterval / 2;
+  if (currentPlaylist && newPlaylist.endSN === currentPlaylist.endSN) {
+    // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
+    // changed then it MUST wait for a period of one-half the target
+    // duration before retrying.
+    reloadInterval = minReloadInterval;
+  }
+
+  if (lastRequestTime) {
+    reloadInterval = Math.max(minReloadInterval, reloadInterval - (window.performance.now() - lastRequestTime));
+  }
+  // in any case, don't reload more than half of target duration
+  return Math.round(reloadInterval);
 }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -49,17 +49,6 @@ class StreamController extends BaseStreamController {
     this.gapController = null;
   }
 
-  onHandlerDestroying () {
-    this.stopLoad();
-    super.onHandlerDestroying();
-  }
-
-  onHandlerDestroyed () {
-    this.state = State.STOPPED;
-    this.fragmentTracker = null;
-    super.onHandlerDestroyed();
-  }
-
   startLoad (startPosition) {
     if (this.levels) {
       let lastCurrentTime = this.lastCurrentTime, hls = this.hls;
@@ -95,23 +84,8 @@ class StreamController extends BaseStreamController {
   }
 
   stopLoad () {
-    let frag = this.fragCurrent;
-    if (frag) {
-      if (frag.loader) {
-        frag.loader.abort();
-      }
-
-      this.fragmentTracker.removeFragment(frag);
-      this.fragCurrent = null;
-    }
-    this.fragPrevious = null;
-    if (this.demuxer) {
-      this.demuxer.destroy();
-      this.demuxer = null;
-    }
-    this.clearInterval();
-    this.state = State.STOPPED;
     this.forceStartLoad = false;
+    super.stopLoad();
   }
 
   doTick () {

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -76,9 +76,9 @@ export class SubtitleStreamController extends BaseStreamController {
     }
   }
 
-  onMediaAttached (data) {
-    this.media = data.media;
-    this.media.addEventListener('seeking', this._onMediaSeeking);
+  onMediaAttached ({ media }) {
+    this.media = media;
+    media.addEventListener('seeking', this._onMediaSeeking);
     this.state = State.IDLE;
   }
 

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -35,6 +35,7 @@ export class SubtitleStreamController extends BaseStreamController {
     this.tracksBuffered = [];
     this.currentTrackId = -1;
     this.decrypter = new Decrypter(hls, hls.config);
+    // lastAVStart stores the time in seconds for the start time of a level load
     this.lastAVStart = 0;
     this._onMediaSeeking = this.onMediaSeeking.bind(this);
   }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -36,6 +36,7 @@ export class SubtitleStreamController extends BaseStreamController {
     this.currentTrackId = -1;
     this.decrypter = new Decrypter(hls, hls.config);
     this.lastAVStart = 0;
+    this._onMediaSeeking = this.onMediaSeeking.bind(this);
   }
 
   onSubtitleFragProcessed (data) {
@@ -76,10 +77,12 @@ export class SubtitleStreamController extends BaseStreamController {
 
   onMediaAttached (data) {
     this.media = data.media;
+    this.media.addEventListener('seeking', this._onMediaSeeking);
     this.state = State.IDLE;
   }
 
   onMediaDetaching () {
+    this.media.removeEventListener('seeking', this._onMediaSeeking);
     this.media = null;
     this.state = State.STOPPED;
   }
@@ -230,5 +233,9 @@ export class SubtitleStreamController extends BaseStreamController {
 
   _getBuffered () {
     return this.tracksBuffered[this.currentTrackId] || [];
+  }
+
+  onMediaSeeking () {
+    this.fragPrevious = null;
   }
 }

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -280,7 +280,7 @@ class TimelineController extends EventHandler {
 
     // Parse the WebVTT file contents.
     WebVTTParser.parse(payload, this.initPTS[frag.cc], vttCCs, frag.cc, function (cues) {
-      const currentTrack = textTracks[frag.trackId];
+      const currentTrack = textTracks[frag.level];
       // WebVTTParser.parse is an async method and if the currently selected text track mode is set to "disabled"
       // before parsing is done then don't try to access currentTrack.cues.getCueById as cues will be null
       // and trying to access getCueById method of cues will throw an exception

--- a/src/hls.js
+++ b/src/hls.js
@@ -194,7 +194,7 @@ export default class Hls extends Observer {
        * @member {SubtitleTrackController} subtitleTrackController
        */
       this.subtitleTrackController = subtitleTrackController;
-      coreComponents.push(subtitleTrackController);
+      networkControllers.push(subtitleTrackController);
     }
 
     Controller = config.emeController;
@@ -211,7 +211,7 @@ export default class Hls extends Observer {
     // optional subtitle controllers
     Controller = config.subtitleStreamController;
     if (Controller) {
-      coreComponents.push(new Controller(this, fragmentTracker));
+      networkControllers.push(new Controller(this, fragmentTracker));
     }
     Controller = config.timelineController;
     if (Controller) {

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -1,0 +1,203 @@
+import * as LevelHelper from '../../../src/controller/level-helper';
+import Level from '../../../src/loader/level';
+import Fragment from '../../../src/loader/fragment';
+import sinon from 'sinon';
+
+const generatePlaylist = (sequenceNumbers) => {
+  const playlist = new Level('');
+  playlist.startSN = sequenceNumbers[0];
+  playlist.endSN = sequenceNumbers[sequenceNumbers.length - 1];
+  playlist.fragments = sequenceNumbers.map((n, i) => {
+    const frag = new Fragment();
+    frag.sn = n;
+    frag.start = i * 5;
+    frag.duration = 5;
+    return frag;
+  });
+  return playlist;
+};
+
+const getIteratedSequence = (oldPlaylist, newPlaylist) => {
+  const actual = [];
+  LevelHelper.mapFragmentIntersection(oldPlaylist, newPlaylist, (oldFrag, newFrag) => {
+    if (oldFrag.sn !== newFrag.sn) {
+      throw new Error('Expected old frag and new frag to have the same SN');
+    }
+    actual.push(newFrag.sn);
+  });
+  return actual;
+};
+
+describe('LevelHelper Tests', function () {
+  let sandbox;
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('mapSegmentIntersection', function () {
+    it('iterates over the intersection of the fragment arrays', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4, 5]);
+      const newPlaylist = generatePlaylist([3, 4, 5, 6, 7]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([3, 4, 5]);
+    });
+
+    it('can iterate with one overlapping fragment', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4, 5]);
+      const newPlaylist = generatePlaylist([5, 6, 7, 8, 9]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([5]);
+    });
+
+    it('can iterate over the entire segment array', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([1, 2, 3]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([1, 2, 3]);
+    });
+
+    it('can iterate when overlapping happens at the start of the old playlist', function () {
+      const oldPlaylist = generatePlaylist([5, 6, 7, 8]);
+      const newPlaylist = generatePlaylist([3, 4, 5, 6]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([5, 6]);
+    });
+
+    it('never executes the callback if no intersection exists', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4, 5]);
+      const newPlaylist = generatePlaylist([10, 11, 12]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('exits early if either playlist does not exist', function () {
+      let oldPlaylist = null;
+      let newPlaylist = generatePlaylist([10, 11, 12]);
+      expect(getIteratedSequence(oldPlaylist, newPlaylist)).to.deep.equal([]);
+      oldPlaylist = newPlaylist;
+      newPlaylist = null;
+      expect(getIteratedSequence(oldPlaylist, newPlaylist)).to.deep.equal([]);
+    });
+  });
+
+  describe('adjustSliding', function () {
+    // generatePlaylist creates fragments with a duration of 5 seconds
+    it('adds the start time of the first comment segment to all other segment', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]); // start times: 0, 5, 10
+      const newPlaylist = generatePlaylist([3, 4, 5]);
+      LevelHelper.adjustSliding(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([10, 15, 20]);
+    });
+
+    it('does not apply sliding if no common segments exist', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([5, 6, 7]);
+      LevelHelper.adjustSliding(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([0, 5, 10]);
+    });
+  });
+
+  describe('mergeSubtitlePlaylists', function () {
+    it('transfers start times where segments overlap, and extrapolates the start of any new segment', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4]); // start times: 0, 5, 10, 15
+      const newPlaylist = generatePlaylist([2, 3, 4, 5]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([5, 10, 15, 20]);
+    });
+
+    it('does not change start times when there is no segment overlap', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([5, 6, 7]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([0, 5, 10]);
+    });
+
+    it('adjusts sliding using the reference start if there is no segment overlap', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([5, 6, 7]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist, 30);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([30, 35, 40]);
+    });
+
+    it('does not extrapolate if the new playlist starts before the old', function () {
+      const oldPlaylist = generatePlaylist([3, 4, 5]);
+      oldPlaylist.fragments.forEach(f => {
+        f.start += 10;
+      });
+      const newPlaylist = generatePlaylist([1, 2, 3]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([0, 5, 10]);
+    });
+  });
+
+  describe('computeReloadInterval', function () {
+    it('returns the averagetargetduration of the new level if available', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([3, 4]);
+      newPlaylist.averagetargetduration = 5;
+      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      expect(actual).to.equal(5000);
+    });
+
+    it('returns the targetduration of the new level if averagetargetduration is falsy', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([3, 4]);
+      newPlaylist.averagetargetduration = null;
+      newPlaylist.targetduration = 4;
+      let actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      expect(actual).to.equal(4000);
+
+      newPlaylist.averagetargetduration = null;
+      actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      expect(actual).to.equal(4000);
+    });
+
+    it('halves the reload interval if the playlist contains the same segments', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([1, 2]);
+      newPlaylist.averagetargetduration = 5;
+      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      expect(actual).to.equal(2500);
+    });
+
+    it('rounds the reload interval', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([3, 4]);
+      newPlaylist.averagetargetduration = 5.9999;
+      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      expect(actual).to.equal(6000);
+    });
+
+    it('subtracts the request time of the last level load from the reload interval', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([3, 4]);
+      newPlaylist.averagetargetduration = 5;
+
+      const clock = sandbox.useFakeTimers();
+      clock.tick(2000);
+      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
+      expect(actual).to.equal(4000);
+    });
+
+    it('returns a minimum of half the target duration', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([3, 4]);
+      newPlaylist.averagetargetduration = 5;
+
+      const clock = sandbox.useFakeTimers();
+      clock.tick(9000);
+      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
+      expect(actual).to.equal(2500);
+    });
+  });
+});

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -17,18 +17,18 @@ const tracksMock = [
 describe('SubtitleStreamController', function () {
   let hls;
   let fragmentTracker;
-  let streamController;
+  let subtitleStreamController;
 
   beforeEach(function () {
     hls = new Hls({});
     fragmentTracker = new FragmentTracker(hls);
-    streamController = new SubtitleStreamController(hls, fragmentTracker);
+    subtitleStreamController = new SubtitleStreamController(hls, fragmentTracker);
 
-    streamController.onMediaAttached(mediaMock);
+    subtitleStreamController.onMediaAttached(mediaMock);
   });
 
   afterEach(function () {
-    streamController.onMediaDetaching(mediaMock);
+    subtitleStreamController.onMediaDetaching(mediaMock);
   });
 
   describe('onSubtitleTracksUpdate', function () {
@@ -39,15 +39,15 @@ describe('SubtitleStreamController', function () {
     });
 
     it('should update tracks list', function () {
-      expect(streamController.tracks).to.equal(tracksMock);
+      expect(subtitleStreamController.tracks).to.equal(tracksMock);
     });
   });
 
   describe('onSubtitleTrackSwitch', function () {
     beforeEach(function () {
-      streamController.tracks = tracksMock;
-      streamController.clearInterval = sinon.spy();
-      streamController.setInterval = sinon.spy();
+      subtitleStreamController.tracks = tracksMock;
+      subtitleStreamController.clearInterval = sinon.spy();
+      subtitleStreamController.setInterval = sinon.spy();
 
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: 0
@@ -55,56 +55,75 @@ describe('SubtitleStreamController', function () {
     });
 
     it('should call setInterval if details available', function () {
-      expect(streamController.setInterval).to.have.been.calledOnce;
+      expect(subtitleStreamController.setInterval).to.have.been.calledOnce;
     });
 
     it('should call clearInterval if no tracks present', function () {
-      streamController.tracks = null;
+      subtitleStreamController.tracks = null;
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: 0
       });
-      expect(streamController.clearInterval).to.have.been.calledOnce;
+      expect(subtitleStreamController.clearInterval).to.have.been.calledOnce;
     });
 
     it('should call clearInterval if new track id === -1', function () {
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: -1
       });
-      expect(streamController.clearInterval).to.have.been.calledOnce;
+      expect(subtitleStreamController.clearInterval).to.have.been.calledOnce;
     });
   });
 
   describe('onSubtitleTrackLoaded', function () {
-    let detailsMock = {};
-
     beforeEach(function () {
-      streamController.setInterval = sinon.spy();
-      streamController.tracks = tracksMock;
+      subtitleStreamController.setInterval = sinon.spy();
+      subtitleStreamController.tracks = tracksMock;
+    });
+
+    // Details are in subtitle-track-controller.js' onSubtitleTrackLoaded handler
+    it('should handle the event if the data matches the current track', function () {
+      const details = { foo: 'bar' };
+      subtitleStreamController.currentTrackId = 1;
       hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
-        id: 1, details: detailsMock
+        id: 1, details
       });
+      expect(subtitleStreamController.tracks[1].details).to.equal(details);
+      expect(subtitleStreamController.setInterval).to.have.been.calledOnce;
     });
 
-    it('should add details to track object in list', function () {
-      expect(streamController.tracks[1].details).to.equal(detailsMock);
-    });
-
-    it('should call setInterval', function () {
-      expect(streamController.setInterval).to.have.been.calledOnce;
-    });
-
-    it('should not crash when no tracks present', function () {
-      streamController.tracks = null;
+    it('should ignore the event if the data does not match the current track', function () {
+      const details = { foo: 'bar' };
+      subtitleStreamController.currentTrackId = 0;
       hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
-        id: 0, details: {}
+        id: 1, details
       });
+      expect(subtitleStreamController.tracks[0].details).to.not.equal(details);
+      expect(subtitleStreamController.setInterval).to.not.have.been.called;
     });
 
-    it('should not crash when no track id does not exist', function () {
-      streamController.tracks = null;
+    it('should ignore the event if there are no tracks, or the id is not within the tracks array', function () {
+      subtitleStreamController.tracks = [];
+      subtitleStreamController.trackId = 0;
+      const details = { foo: 'bar' };
       hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
-        id: 5, details: {}
+        id: 0, details
       });
+      expect(subtitleStreamController.tracks[0]).to.not.exist;
+      expect(subtitleStreamController.setInterval).to.not.have.been.called;
+    });
+  });
+
+  describe('onLevelLoaded', function () {
+    it('records the start time of the last known A/V track', function () {
+      hls.trigger(Event.LEVEL_UPDATED, {
+        details: { fragments: [{ start: 5 }] }
+      });
+      expect(subtitleStreamController.lastAVStart).to.equal(5);
+
+      hls.trigger(Event.LEVEL_UPDATED, {
+        details: { fragments: [] }
+      });
+      expect(subtitleStreamController.lastAVStart).to.equal(0);
     });
   });
 });

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -8,7 +8,7 @@ import { SubtitleStreamController } from '../../../src/controller/subtitle-strea
 const mediaMock = {
   currentTime: 0,
   addEventListener () {},
-  removeEventListener() {}
+  removeEventListener () {}
 };
 
 const tracksMock = [

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -6,7 +6,9 @@ import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 import { SubtitleStreamController } from '../../../src/controller/subtitle-stream-controller';
 
 const mediaMock = {
-  currentTime: 0
+  currentTime: 0,
+  addEventListener () {},
+  removeEventListener() {}
 };
 
 const tracksMock = [
@@ -24,11 +26,11 @@ describe('SubtitleStreamController', function () {
     fragmentTracker = new FragmentTracker(hls);
     subtitleStreamController = new SubtitleStreamController(hls, fragmentTracker);
 
-    subtitleStreamController.onMediaAttached(mediaMock);
+    subtitleStreamController.onMediaAttached({ media: mediaMock });
   });
 
   afterEach(function () {
-    subtitleStreamController.onMediaDetaching(mediaMock);
+    subtitleStreamController.onMediaDetaching({ media: mediaMock });
   });
 
   describe('onSubtitleTracksUpdate', function () {
@@ -124,6 +126,14 @@ describe('SubtitleStreamController', function () {
         details: { fragments: [] }
       });
       expect(subtitleStreamController.lastAVStart).to.equal(0);
+    });
+  });
+
+  describe('onMediaSeeking', function () {
+    it('nulls fragPrevious', function () {
+      subtitleStreamController.fragPrevious = {};
+      subtitleStreamController.onMediaSeeking();
+      expect(subtitleStreamController.fragPrevious).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
### This PR will...
- Start and stop subtitle loading in sync with `startLoad()/stopLoad()` API calls
- Compute sliding & merge subtitle playlists during live playback
- Fix shared references between `subtitle-track-controller` and `subtitle-stream-controller`
- Refactoring:
    - Extend `subtitle-stream-controller` from `base-stream-controller`
    - Move more shared logic into `base-stream-controller`
    - Move live reload interval calculation into a shared function & import into `subtitle-track-controller`
    - Remove the `trackId` from subtitle fragments, and refer to them by their `level` property
    - Several other minor refactorings (flipped conditionals, destructuring args, organizing functions)
- Add a bunch of unit tests

### Why is this Pull Request needed?

Live subtitle playback is not functioning correctly - on first glance, it appears that sliding isn't being calculated between live refreshes. This is true, but in the course of fixing it I noticed that the live VTT implementation was incomplete and had several unhandled edge cases.

### Are there any points in the code the reviewer needs to double check?
We (JW) QA tested this and shipped it in our 8.7.6 release. It would be good to double-check that any code specific to the JW fork didn't make it in. This was our test criteria:

- When live captions are enabled, cues should appear within 1 segment duration
- When VOD captions are enabled, cues should appear immediately
- Cues should appear at the expected times for as long as captions are enabled
- When the live stream is paused/stopped captions loading must stop
- When captions are disabled, no cues or captions manifest should load

### Test streams:
- https://wowzaec2demo.streamlock.net/vod-multitrack/_definst_/smil:ElephantsDream/elephantsdream2.smil/playlist.m3u
- https://liveaffect.cdn01.live.rd.insyscd.net/vtt-test-live/live.m3u8

