### PR TITLE
use `webworkify-webpack` fork with fix for `create-react-app`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4112,7 +4112,7 @@
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
@@ -20474,8 +20474,8 @@
       "dev": true
     },
     "webworkify-webpack": {
-      "version": "github:johnBartos/webworkify-webpack#4da76bf2821969b19c5de79edaa526cc295cff33",
-      "from": "github:johnBartos/webworkify-webpack#refs/heads/master",
+      "version": "github:tjenkinson/webworkify-webpack#ea2572b2babdc0f5e24c29f0b65d113a20802597",
+      "from": "github:tjenkinson/webworkify-webpack#refs/heads/hlsjs",
       "dev": true
     },
     "whatwg-url-compat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20474,7 +20474,7 @@
       "dev": true
     },
     "webworkify-webpack": {
-      "version": "github:tjenkinson/webworkify-webpack#ea2572b2babdc0f5e24c29f0b65d113a20802597",
+      "version": "github:tjenkinson/webworkify-webpack#0dd42b6d41f1d33f1ab9eabb52d64d16094d4ff1",
       "from": "github:tjenkinson/webworkify-webpack#refs/heads/hlsjs",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.2.1",
-    "webworkify-webpack": "johnBartos/webworkify-webpack#refs/heads/master"
+    "webworkify-webpack": "tjenkinson/webworkify-webpack#refs/heads/hlsjs"
   }
 }


### PR DESCRIPTION
### This PR will...
Use [this patched version](https://github.com/tjenkinson/webworkify-webpack/tree/hlsjs) of `webworkify-webpack` which fixes the issue which is causing hls.js to crash when used with `create-react-app`. If https://github.com/borisirota/webworkify-webpack/pull/40 gets merged then we should switch to the official npm package again.

@johnBartos I am not sure why we were using your fork before? It looks like it matches master.

### Why is this Pull Request needed?
So that hls.js works with `create-react-app`.

### Resolves issues:
fixes https://github.com/video-dev/hls.js/issues/2064
