### PR TITLE
Fix XSS on metrics page

### DIFF
--- a/demo/metrics.html
+++ b/demo/metrics.html
@@ -59,8 +59,19 @@ if (data) {
 
 function updateMetrics() {
   var hlsLink = document.URL.substr(0,document.URL.lastIndexOf("/")+1) + 'index.html?src=' + encodeURIComponent(events.url);
-  var description = 'playlist: ' + "<a href=\"" + events.url + "\">" + events.url + "</a>" + '<br>replay: ' + "<a href=\"" + hlsLink + "\">" + hlsLink + "</a>";
-  $("#StreamPermalink").html(description);
+  var playlistLink = document.createElement("a");
+  playlistLink.setAttribute("href", events.url);
+  var replayLink = document.createElement("a");
+  replayLink.setAttribute('href", hlsLink);
+  
+  var fragment = document.createDocumentFragment();
+  fragment.appendChild(document.createTextNode('playlist: '));
+  fragment.appendChild(playlistLink);
+  fragment.appendChild(document.createElement("br"));
+  fragment.appendChild(document.createTextNode('replay: '));
+  fragment.appendChild(replayLink);
+  
+  $("#StreamPermalink").html(fragment);
   $("#HlsDate").text("session Start Date:" + new Date(events.t0));
   metricsDisplayed=true;
   showMetrics();

--- a/demo/metrics.html
+++ b/demo/metrics.html
@@ -62,7 +62,7 @@ function updateMetrics() {
   var playlistLink = document.createElement("a");
   playlistLink.setAttribute("href", events.url);
   var replayLink = document.createElement("a");
-  replayLink.setAttribute('href", hlsLink);
+  replayLink.setAttribute("href", hlsLink);
   
   var fragment = document.createDocumentFragment();
   fragment.appendChild(document.createTextNode('playlist: '));

--- a/demo/metrics.html
+++ b/demo/metrics.html
@@ -61,8 +61,11 @@ function updateMetrics() {
   var hlsLink = document.URL.substr(0,document.URL.lastIndexOf("/")+1) + 'index.html?src=' + encodeURIComponent(events.url);
   var playlistLink = document.createElement("a");
   playlistLink.setAttribute("href", events.url);
+  playlistLink.textContent = events.url;
+  
   var replayLink = document.createElement("a");
   replayLink.setAttribute("href", hlsLink);
+  replayLink.textContent = hlsLink;
   
   var fragment = document.createDocumentFragment();
   fragment.appendChild(document.createTextNode('playlist: '));


### PR DESCRIPTION
### This PR will...

This utilizes the DOM APIs to utilize user data, this prevents innerHTML or jQuery html issues that enable XSS as found in #2161.

### Why is this Pull Request needed?

Some could craft a metrics page and pass it to create XSS. It was worse because it was jsonpack'd so it wouldn't even look out of the ordinary until the XSS had been performed.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

Closes #2161.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
