### PR TITLE
fix AudioStreamController when media is not attached

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -593,8 +593,8 @@ class AudioStreamController extends BaseStreamController {
 
       let audioSwitch = this.audioSwitch, media = this.media, appendOnBufferFlush = false;
       // Only flush audio from old audio tracks when PTS is known on new audio track
-      if (audioSwitch && media) {
-        if (media.readyState) {
+      if (audioSwitch) {
+        if (media && media.readyState) {
           let currentTime = media.currentTime;
           logger.log('switching audio track : currentTime:' + currentTime);
           if (currentTime >= data.startPTS) {
@@ -697,7 +697,9 @@ class AudioStreamController extends BaseStreamController {
         stats.tbuffered = performance.now();
         hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: frag, id: 'audio' });
         let media = this.mediaBuffer ? this.mediaBuffer : this.media;
-        logger.log(`audio buffered : ${TimeRanges.toString(media.buffered)}`);
+        if (media) {
+          logger.log(`audio buffered : ${TimeRanges.toString(media.buffered)}`);
+        }
         if (this.audioSwitch && this.appended) {
           this.audioSwitch = false;
           hls.trigger(Event.AUDIO_TRACK_SWITCHED, { id: this.trackId });


### PR DESCRIPTION
### This PR will...
Fix AudioStreamController for streams with subtitles if media is not attached
### Why is this Pull Request needed?
Fixes audioSwitch and logging in AudioStreamController

Reproduce example:
```html
<video id="video" controls></video>
<button onclick="attach()">Attach media</button>

<script>
  var video = document.getElementById('video');
  var hls = new Hls({
    startFragPrefetch: true,
    debug: true,
  });
  // attach();
  hls.loadSource('https://faked-multiple-audio-tracks-qdyvgxaayi.now.sh/index.m3u8');
  hls.startLoad();

  function attach () {
    hls.attachMedia(video);
  }
</script>
```
on master branch stream will not play after attach
### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
