### PR TITLE
Fixed error on destroying the instance of `Hls`

### DIFF
--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -25,8 +25,8 @@ export class FragmentTracker extends EventHandler {
   }
 
   destroy () {
-    this.fragments = null;
-    this.timeRanges = null;
+    this.fragments = Object.create(null);
+    this.timeRanges = Object.create(null);
     this.config = null;
     EventHandler.prototype.destroy.call(this);
     super.destroy();


### PR DESCRIPTION
### This PR will...

This PR will fix error on destroying the instance of `Hls`.

The following is error detail (hls.js@0.12.3).

1. Visit [hls.js demo page](https://hls-js.netlify.com/demo/)
1. Change playlist file to [Shaka-packager Widevine DRM (EME) HLS-fMP4 - Angel One Demo](https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine-hls/hls.m3u8)
1. Change playlist file to [Big Buck Bunny - adaptive qualities](https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8)

<img width="1426" alt="hls-destroy-error" src="https://user-images.githubusercontent.com/4006693/54344637-a76bd480-4684-11e9-9482-c31422181d44.png">

### Why is this Pull Request needed?

This PR needed to change playlist file.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
