### PR TITLE
GH-2143: Fix flush buffer not accepting undefined types 

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -434,8 +434,14 @@ class BufferController extends EventHandler {
     this._needsEos = false;
   }
 
-  onBufferFlushing (data: { startOffset: number, endOffset: number, type: SourceBufferName }) {
-    this.flushRange.push({ start: data.startOffset, end: data.endOffset, type: data.type });
+  onBufferFlushing (data: { startOffset: number, endOffset: number, type?: SourceBufferName }) {
+    if (data.type) {
+      this.flushRange.push({ start: data.startOffset, end: data.endOffset, type: data.type });
+    } else {
+      this.flushRange.push({ start: data.startOffset, end: data.endOffset, type: 'video' });
+      this.flushRange.push({ start: data.startOffset, end: data.endOffset, type: 'audio' });
+    }
+
     // attempt flush immediately
     this.flushBufferCounter = 0;
     this.doFlush();

--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -20,6 +20,21 @@ describe('BufferController tests', function () {
     sandbox.restore();
   });
 
+  describe('onBufferFlushing', function () {
+    it('flushes a specific type when provided a type', function () {
+      const spy = sandbox.spy(bufferController, 'flushBuffer');
+      bufferController.onBufferFlushing({ startOffset: 0, endOffset: 10, type: 'video' });
+      expect(spy).to.have.been.calledOnce;
+    });
+
+    it('flushes all source buffers when buffer flush event type is undefined', function () {
+      const spy = sandbox.spy(bufferController, 'flushBuffer');
+
+      bufferController.onBufferFlushing({ startOffset: 0, endOffset: 10 });
+      expect(spy).to.have.been.calledTwice;
+    });
+  });
+
   describe('Live back buffer enforcement', function () {
     let mockMedia;
     let mockSourceBuffer;


### PR DESCRIPTION
### This PR will...

Make it so buffer flush events without a type flush both audio and video.

This makes it act like the expected behaviour from a comment in the stream controller stating that a event without type flushes both. See the linked issue for related code.

### Why is this Pull Request needed?

See issue.

### Are there any points in the code the reviewer needs to double check?

Are there any other unit tests that should be added?

### Resolves issues:

Resolves #2143.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
