### PR TITLE
Init segment should not be treated as start segment

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -283,7 +283,9 @@ class AudioStreamController extends BaseStreamController {
             // we force a frag loading in audio switch as fragment tracker might not have evicted previous frags in case of quick audio switch
             this.fragCurrent = frag;
             if (audioSwitch || this.fragmentTracker.getState(frag) === FragmentState.NOT_LOADED) {
-              this.startFragRequested = true;
+              if (frag.sn !== 'initSegment') {
+                this.startFragRequested = true;
+              }
               if (Number.isFinite(frag.sn)) {
                 this.nextLoadPosition = frag.start + frag.duration;
               }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -417,7 +417,9 @@ class StreamController extends BaseStreamController {
     let fragState = this.fragmentTracker.getState(frag);
 
     this.fragCurrent = frag;
-    this.startFragRequested = true;
+    if (frag.sn !== 'initSegment') {
+      this.startFragRequested = true;
+    }
     // Don't update nextLoadPosition for fragments which are not buffered
     if (Number.isFinite(frag.sn) && !frag.bitrateTest) {
       this.nextLoadPosition = frag.start + frag.duration;


### PR DESCRIPTION
### This PR will...
Init segment shouldn't be considered as a requested start fragment.

### Why is this Pull Request needed?
We are preparing to switch some streams from HLS TS to HLS MP4 (to use with Widevine/Playready). While doing this I noticed that hls.js didn't start LIVE streams with first video segment (0.m4s) but instead requested the last video segment in playlist first (2.m4s). After some debugging I found out that due to init segment being requested first, the `this.startFragRequested = true;` flag has been set. This caused the `_ensureFragmentAtLivePoint ` trying to find the correct fragment without having any previous fragment as reference. By not setting the `startFragRequested` for initSegment this issue is fixed.

### Are there any points in the code the reviewer needs to double check?
Does it break anything?

### Resolves issues:
Wrong start video fragment requested in LIVE MP4 HLS streams.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
