### PR TITLE
(misc) Fix - Demo hls.js config persistence issue

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -1202,6 +1202,7 @@ function setupConfigEditor() {
   const elPersistence = document.querySelector('#configPersistence');
   elPersistence.addEventListener('change', onConfigPersistenceChanged);
   elPersistence.checked = shouldRestorePersisted;
+  configPersistenceEnabled = shouldRestorePersisted;
 
   updateConfigEditorValue(contents);
 }


### PR DESCRIPTION
### This PR will...

Fix a persistence issue in the demo page, where a config might not become persisted under certain conditions.

### Why is this Pull Request needed?

If loading the demo page with a persisted config, effectively "restoring" that config, the demo page isn't implicitly enabling persistence - even though the persistence user input checkbox is being `checked`

This effectively made persistence work only on a clean slate (e.g. no pre-existing persisted config)

Steps to reproduce the issue:
1. Persist a config. For clarity, add some custom fields to the JSON prior to applying
2. Reload the page. Observe the persisted config was restored as expected, and that the persist user input checkbox is `checked`
3. Change the config JSON in some way (but otherwise be syntactically valid)
4. Apply the changed config, observe that the config does take effect right away
5. Reload the page, observe that the previous config was loaded.

### Are there any points in the code the reviewer needs to double check?

None

### Resolves issues:

None in particular

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- ~[ ] new unit / functional tests have been added (whenever applicable)~ N/A
- ~[ ] API or design changes are documented in API.md~ N/A
