### PR TITLE
Fix possible bug in adjustPTS (setting invalid startPTS/endPTS)

### DIFF
--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -60,9 +60,11 @@ export function findDiscontinuousReferenceFrag (prevDetails, curDetails) {
 export function adjustPts (sliding, details) {
   details.fragments.forEach((frag) => {
     if (frag) {
-      let start = frag.start + sliding;
-      frag.start = frag.startPTS = start;
-      frag.endPTS = start + frag.duration;
+      frag.start += sliding;
+      if (Number.isFinite(frag.startPTS)) {
+        frag.startPTS = frag.start;
+        frag.endPTS = frag.start + frag.duration;
+      }
     }
   });
   details.PTSKnown = true;


### PR DESCRIPTION
### This PR will...
Set startPTS/endPTS for frag only if it's already known
### Why is this Pull Request needed?
We are investigating a very rare issue in our production env: hls.js sometimes calculates negative chunks duration. 
We detect it by subscribing to FRAG_PARSED event and log event if frag duration is < 0
We cannot reproduce this error locally.

I found a strange place in the code which I suppose may result in incorrect fragemnt duration calculation
`adjustPTS` sets startPTS/endPTS for all fragments in a level, event if it was not known before
https://github.com/video-dev/hls.js/blob/0cb933ab178d497b6a1801e058ead64f7640eee8/src/utils/discontinuities.js#L64

I suppose it may break duration calculation in `updatePts` https://github.com/video-dev/hls.js/blob/656a681f7c2653bc11ca9b4da65706a699bad4d8/src/controller/level-helper.js#L36

because it relies on `fragToPTS` which may be incorrectly set by `adjustPts` earlier
I think frag pts may be only set after demuxing and changing it in `adjustPts` may be a bug
### Are there any points in the code the reviewer needs to double check?
Check that this change is safe
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
