### PR TITLE
Bump stale time to close from 7 days to 60, add more exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,13 +2,16 @@
 daysUntilStale: 60
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 30
 
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
   - Confirmed
+  - Feature proposal
+  - Question
+
 
 # Label to use when marking an issue as stale
 staleLabel: Stale


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we give developers more time to respond to inquires, and so that we don't close questions which have not been answered
