### PR TITLE
create netlify sites under new team

### DIFF
--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -23,7 +23,7 @@ deploy () {
 echo "Creating site for current commit ($id)."
 uuid=$(uuidgen)
 commitSiteName="hls-js-$uuid"
-commitSiteId=$(curl --fail -d "{\"name\":\"$commitSiteName\"}" -H "Content-Type: application/json" -X POST "https://api.netlify.com/api/v1/sites?access_token=$NETLIFY_ACCESS_TOKEN" | jq -r '.site_id')
+commitSiteId=$(curl --fail -d "{\"name\":\"$commitSiteName\"}" -H "Content-Type: application/json" -X POST "https://api.netlify.com/api/v1/hls-js/sites?access_token=$NETLIFY_ACCESS_TOKEN" | jq -r '.site_id')
 echo "Created site '$commitSiteId'."
 
 deploy "$commitSiteId"


### PR DESCRIPTION
so that the sites are created under the new team that has the open source account policy

https://open-api.netlify.com/#/default/createSiteInTeam