### PR TITLE
Remove cue position alignment by adding 50 for Firefox

### DIFF
--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -49,7 +49,7 @@ export function newCue (track, startTime, endTime, captionScreen) {
 
       cue.align = 'left';
       // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
-      cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
+      cue.position = Math.max(0, Math.min(100, 100 * (indent / 32)));
       track.addCue(cue);
     }
   }


### PR DESCRIPTION
### This PR will...

Remove IMO unnecessary cue position alignment.

### Why is this Pull Request needed?

Cues are wrongly positioned in current Firefox. Why we use const (50) for Firefox?

### Are there any points in the code the reviewer needs to double check?

Yes, if we keep backward compatibility, maybe this is still needed on older Firefoxes.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
