### PR TITLE
feat: Correspond to segment URI that contains query parameters by using custom loader

### DIFF
--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -230,8 +230,8 @@ describe('BufferController tests', function () {
 
       bufferController.onManifestParsed({ altAudio: true });
       bufferController._onMediaSourceOpen();
-      bufferController.onBufferCodecs({ audio: {} });
-      bufferController.onBufferCodecs({ video: {} });
+      bufferController.onBufferCodecs({ tracks: { audio: {} } });
+      bufferController.onBufferCodecs({ tracks: { video: {} } });
 
       expect(createSbStub).to.have.been.calledOnce;
       expect(createSbStub).to.have.been.calledWith({ audio: {}, video: {} });


### PR DESCRIPTION
### This PR will...

This PR will implement custom loader for segment URI that contains query parameters.
And, This PR will fix the controllers to always have two tracks.

### Why is this Pull Request needed?

This Pull Request enabled to parse segment URI that contains query parameters.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/2213

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md