### PR TITLE
Fix MediaSource getter error

### DIFF
--- a/src/utils/mediasource-helper.ts
+++ b/src/utils/mediasource-helper.ts
@@ -3,5 +3,5 @@
  */
 
 export function getMediaSource (): typeof MediaSource {
-  return MediaSource || (window as any).WebKitMediaSource;
+  return (window as any).MediaSource || (window as any).WebKitMediaSource;
 }


### PR DESCRIPTION
### This PR will...

Fix an error where getting the MediaSource object on Safari iOS throws an uncaught error, causing hls.js loading to fail

### Why is this Pull Request needed?

If hls.js is currently loaded on iOS Safari, it will fail due to an uncaught error trying to get an undefined object

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

#2262 

### Checklist

- [ x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
