### PR TITLE
Rolling dvr cmaf fix

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -367,6 +367,7 @@ class BufferController extends EventHandler {
           this.tracks[trackName] = {
             buffer: sb,
             codec: codec,
+            id: track.id,
             container: track.container,
             levelCodec: track.levelCodec
           };

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -7,6 +7,7 @@ export interface AudioTrack {
   buffer: SourceBuffer;
   container: string;
   codec: string;
+  id: string;
   initSegment?: Uint8Array;
   levelCodec: string;
 }
@@ -15,6 +16,7 @@ export interface VideoTrack {
   buffer: SourceBuffer;
   container: string;
   codec: string;
+  id: string;
   initSegment?: Uint8Array;
   levelCodec: string;
 }


### PR DESCRIPTION
### This PR will...
Fix rolling dvr cmaf streams
### Why is this Pull Request needed?
On conversion to typescript this.tracks was passed to buffer created event which has less properties than the actual tracks. One property that was missing was track.id which is necessary in onBufferCreated method in stream-controller.js in order to find the main track which is needed to scheduled main fragment loading. This was causing the rolling dvr cmaf stream to not seek to the live point and play the video. 
### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#2264 
### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
