### PR TITLE
feat: Enable access externally

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,10 @@ const baseConfig = {
     __dirname: false,
     Buffer: false,
     setImmediate: false
-  }
+  },
+  devServer: {
+    host: '0.0.0.0'
+  },
 };
 
 function getAliasesForLightDist () {


### PR DESCRIPTION
### This PR will...

This PR adds options for `webpack-dev-server`.
In concrete, [host option](https://webpack.js.org/configuration/dev-server/#devserverhost) is added.

For example,

```bash
$ ifconfig | grep inet
	inet 127.0.0.1 netmask 0xff000000
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	inet6 fe80::a42f:73ff:fea5:a66b%awdl0 prefixlen 64 scopeid 0x8
	inet6 fe80::a138:32eb:9f26:6d24%utun0 prefixlen 64 scopeid 0xc
	inet6 fe80::2ecb:ded1:62bb:3e3e%utun1 prefixlen 64 scopeid 0xe
	inet6 fe80::1401:2383:bb5f:2e4c%en4 prefixlen 64 secured scopeid 0xd
	inet 172.20.10.2 netmask 0xfffffff0 broadcast 172.20.10.15
$ npm run dev
```

Then, enable to access `webpack-dev-server` by typing `172.20.10.2:8000` (For example, iOS Safari).

### Why is this Pull Request needed?

This PR needs to access `webpack-dev-server` externally (from iPhone, iPad and Android devices) .

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/2267

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
