### PR TITLE
support preprelease publishes from git tag

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,8 +1,14 @@
 # Performing A Release
 Releases are performed automatically with travis.
 
-1. `git tag -a v<major>.<minor>.<patch>` _('v' required)_
-2. `git push --tag`
-3. Wait for travis to create a new draft GitHub release with the build attached. At this point the new npm package should have been published.
-4. Add the release notes to the new draft GitHub release.
-5. Publish the GitHub release.
+1. `git tag -a v<major>.<minor>.<patch>` or `git tag -a v<major>.<minor>.<patch>-<prerelease>`   _('v' required)_ where anything before the first `.` in `<prerelease>` will be become the [npm dist-tag](https://docs.npmjs.com/cli/dist-tag).
+2. `git push`
+3. `git push --tag`
+4. Wait for travis to create a new draft GitHub release with the build attached. At this point the new npm package should have been published.
+5. Add the release notes to the new draft GitHub release.
+6. Publish the GitHub release.
+
+## Examples
+- `git tag -a -v1.2.3` will result in `1.2.3` being published with the `latest` npm tag.
+- `git tag -a -v1.2.3-beta` will result in `1.2.3-beta` being published with the `beta` npm tag.
+- `git tag -a -v1.2.3-beta.1` will result in `1.2.3-beta.1` being published with the `beta` npm tag.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,11 +2,11 @@
 Releases are performed automatically with travis.
 
 1. `git tag -a v<major>.<minor>.<patch>` or `git tag -a v<major>.<minor>.<patch>-<prerelease>`   _('v' required)_ where anything before the first `.` in `<prerelease>` will be become the [npm dist-tag](https://docs.npmjs.com/cli/dist-tag).
-2. `git push`
-3. `git push --tag`
-4. Wait for travis to create a new draft GitHub release with the build attached. At this point the new npm package should have been published.
-5. Add the release notes to the new draft GitHub release.
-6. Publish the GitHub release.
+1. `git push`
+1. `git push --tag`
+1. Wait for travis to create a new draft GitHub release with the build attached. At this point the new npm package should have been published.
+1. Add the release notes to the new draft GitHub release.
+1. Publish the GitHub release.
 
 ## Examples
 - `git tag -a v1.2.3` will result in `1.2.3` being published with the `latest` npm tag.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -9,6 +9,6 @@ Releases are performed automatically with travis.
 6. Publish the GitHub release.
 
 ## Examples
-- `git tag -a -v1.2.3` will result in `1.2.3` being published with the `latest` npm tag.
-- `git tag -a -v1.2.3-beta` will result in `1.2.3-beta` being published with the `beta` npm tag.
-- `git tag -a -v1.2.3-beta.1` will result in `1.2.3-beta.1` being published with the `beta` npm tag.
+- `git tag -a v1.2.3` will result in `1.2.3` being published with the `latest` npm tag.
+- `git tag -a v1.2.3-beta` will result in `1.2.3-beta` being published with the `beta` npm tag.
+- `git tag -a v1.2.3-beta.1` will result in `1.2.3-beta.1` being published with the `beta` npm tag.

--- a/scripts/get-version-tag.js
+++ b/scripts/get-version-tag.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const versionParser = require('./version-parser.js');
+const packageJson = require('../package.json');
+
+console.log(versionParser.getVersionTag('v' + packageJson.version));

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -58,8 +58,15 @@ elif [ "${TRAVIS_MODE}" = "release" ] || [ "${TRAVIS_MODE}" = "releaseCanary" ] 
         curl https://purge.jsdelivr.net/npm/hls.js@canary/dist/hls-demo.js
         echo "Cleared jsdelivr cache."
       elif [ "${TRAVIS_MODE}" = "release" ]; then
-        npm publish
-        curl https://purge.jsdelivr.net/npm/hls.js@latest
+        tag=$(node ./scripts/get-version-tag.js)
+        if [ "${tag}" = "canary" ]; then
+          # canary is blacklisted because this is handled separately on every commit
+          echo "canary not supported as explicit tag"
+          exit 1
+        fi
+        echo "Publishing tag: ${tag}"
+        npm publish --tag "${tag}"
+        curl "https://purge.jsdelivr.net/npm/hls.js@${tag}"
         echo "Published."
       fi
     else

--- a/scripts/version-parser.js
+++ b/scripts/version-parser.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const VALID_VERSION_REGEX = /^v\d+\.\d+\.\d+(?:-([0-9A-Za-z-]+))?/;
+const STABLE_VERSION_REGEX = /^v\d+\.\d+\.\d+$/;
+
+module.exports = {
+  isValidVersion: function(version) {
+    return VALID_VERSION_REGEX.test(version);
+  },
+  isValidStableVersion: function(version) {
+    return STABLE_VERSION_REGEX.test(version);
+  },
+  // extract what we should use as the npm dist-tag (https://docs.npmjs.com/cli/dist-tag)
+  // e.g
+  // 1.2.3-beta => beta
+  // 1.2.3-beta.1 => beta
+  // 1.2.3 => latest
+  getVersionTag: function(version) {
+    const match = VALID_VERSION_REGEX.exec(version);
+    if (!match) {
+      throw new Error('Invalid version.');
+    }
+    return match[1] || 'latest';
+  }
+}

--- a/scripts/version-parser.js
+++ b/scripts/version-parser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const VALID_VERSION_REGEX = /^v\d+\.\d+\.\d+(?:-([0-9A-Za-z-]+))?/;
+const VALID_VERSION_REGEX = /^v\d+\.\d+\.\d+(?:-([a-zA-Z][0-9a-zA-Z-]*))?/;
 const STABLE_VERSION_REGEX = /^v\d+\.\d+\.\d+$/;
 
 module.exports = {

--- a/scripts/version-parser.js
+++ b/scripts/version-parser.js
@@ -12,9 +12,9 @@ module.exports = {
   },
   // extract what we should use as the npm dist-tag (https://docs.npmjs.com/cli/dist-tag)
   // e.g
-  // 1.2.3-beta => beta
-  // 1.2.3-beta.1 => beta
-  // 1.2.3 => latest
+  // v1.2.3-beta => beta
+  // v1.2.3-beta.1 => beta
+  // v1.2.3 => latest
   getVersionTag: function(version) {
     const match = VALID_VERSION_REGEX.exec(version);
     if (!match) {


### PR DESCRIPTION
### This PR will...
Update the deployment scripts so that pushing a preprelase git tag will trigger an npm publish on a separate tag automatically, similarly to how the stable releases work.

### Why is this Pull Request needed?
It makes it possible for prereleases to go through the same build process and publish in a clean environment as the stable ones do. It would also create a draft github release that could be published and marked as a prerelease.

After this we could consider removing publishing rights from all users except the CI user to help [protect against malicious publishes](https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident).

### Examples
- `git tag -a -v1.2.3` will result in `1.2.3` being published with the `latest` npm tag.
- `git tag -a -v1.2.3-beta` will result in `1.2.3-beta` being published with the `beta` npm tag.
- `git tag -a -v1.2.3-beta.1` will result in `1.2.3-beta.1` being published with the `beta` npm tag.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
