### PR TITLE
gap-controller: fix conditions for early return

### DIFF
--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -37,11 +37,11 @@ export default class GapController {
       return;
     }
 
-    if (media.ended || !media.buffered.length || media.readyState > 2) {
+    if (media.ended || !media.buffered.length || media.readyState <= 2) {
       return;
     }
 
-    if (media.seeking && BufferHelper.isBuffered(media, currentTime)) {
+    if (media.seeking && !BufferHelper.isBuffered(media, currentTime)) {
       return;
     }
 

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -13,6 +13,7 @@ export default class GapController {
     this.fragmentTracker = fragmentTracker;
     this.hls = hls;
     this.stallReported = false;
+    this.hasPlayed = false;
   }
 
   /**
@@ -26,6 +27,10 @@ export default class GapController {
     const currentTime = media.currentTime;
     const tnow = window.performance.now();
 
+    if (this.hasPlayed && media.paused) {
+      return;
+    }
+
     if (currentTime !== lastCurrentTime) {
       // The playhead is now moving, but was previously stalled
       if (this.stallReported) {
@@ -34,6 +39,7 @@ export default class GapController {
       }
       this.stalled = null;
       this.nudgeRetry = 0;
+      this.hasPlayed = true;
       return;
     }
 


### PR DESCRIPTION
1. nominal init/ended case: it should return *when* readyState is below or equal 2 (still initializing metadata)

2. nominal seeking case: it should return when the media is seeking and current time is *not* buffered yet
(then there is no actual source-buffer stall but we should just wait for further segments to load)

### This PR will...

Fix conditions on preliminary checks for detecting stalls by gap-controller.

Fix for handling browser behavior described in https://github.com/video-dev/hls.js/issues/1994

### Why is this Pull Request needed?

Fix issues causing stalls on startup and playback of live streams. 

Customer live streams we stalling at constant 50% probability rate on startup. This was not appropriately handled by the gap controller.

When debugging we realized that the conditions used to return-early on the poll logic were "wrong".

### Are there any points in the code the reviewer needs to double check?
.
### Resolves issues:

https://github.com/video-dev/hls.js/issues/1994

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
