### PR TITLE
convert TaskLoop to TypeScript

### DIFF
--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -34,8 +34,8 @@ class EventHandler {
     this.onHandlerDestroyed();
   }
 
-  onHandlerDestroying () {}
-  onHandlerDestroyed () {}
+  protected onHandlerDestroying () {}
+  protected onHandlerDestroyed () {}
 
   isEventHandler () {
     return typeof this.handledEvents === 'object' && this.handledEvents.length && typeof this.onEvent === 'function';


### PR DESCRIPTION
### This PR will...
Convert `TaskLoop` to TypeScript

### Why is this Pull Request needed?
#2070

### Are there any points in the code the reviewer needs to double check?
I changed `setTimeout` to `self.setTimeout`, `clearTimeout` to `self.clearTimeout` and the same for `setInterval` and `clearInterval`.

This made typescript use the correct type, and using `self` instead of `window` means it should also work in a worker.

https://stackoverflow.com/a/11237259
>While the main thread window self points to the Window object, in worker threads self points to a separate WorkerGlobalScope object.

I wonder why we don't use `self` everywhere in place of `window`, and then we wouldn't need `getSelfScope()` 🤔