### PR TITLE
Sub-Second Segments With 0 Target Duration

### DIFF
--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -487,7 +487,7 @@ class PlaylistLoader extends EventHandler {
   _handlePlaylistLoaded (response: LoaderResponse, stats: LoaderStats, context: PlaylistLoaderContext, networkDetails: unknown) {
     const { type, level, id, levelDetails } = context;
 
-    if (!levelDetails || !levelDetails.targetduration) {
+    if (!levelDetails || Number.isNaN(levelDetails.targetduration)) {
       this._handleManifestParsingError(response, context, 'invalid target duration', networkDetails);
       return;
     }


### PR DESCRIPTION
### This PR will...
Allow target duration of 0, still raises fatal error on invalid values (non numeric).

### Why is this Pull Request needed?
This allows support for sub-second segments on muxers such as FFMPEG which write an integer value for target duration (0). This is evaluated as false on the pre-commit condition which raises a fatal error.

### Are there any points in the code the reviewer needs to double check?
Not that I'm aware of, change is very focused

### Resolves issues:
#2043 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] ~~new unit / functional tests have been added (whenever applicable)~~
  - Not required for this change?
- [ ] ~~API or design changes are documented in API.md~~
  - Not required for this change?