### PR TITLE
fix: calling detatchMedia() followed by attachMedia() causes audio to not play

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -381,6 +381,7 @@ class AudioStreamController extends BaseStreamController {
     }
     this.media = this.mediaBuffer = this.videoBuffer = null;
     this.loadedmetadata = false;
+    this.fragmentTracker.removeAllFragments();
     this.stopLoad();
   }
 

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -47,6 +47,9 @@ class BufferController extends EventHandler {
   // signals that mediaSource should have endOfStream called
   private _needsEos: boolean = false;
 
+  // Track whether the parsed manifest signaled alternate audio
+  // private _altAudio: boolean = false;
+
   private config: BufferControllerConfig;
 
   // this is optional because this property is removed from the class sometimes
@@ -143,6 +146,7 @@ class BufferController extends EventHandler {
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
+    // this._altAudio = data.altAudio;
     this.bufferCodecEventsExpected = data.altAudio ? 2 : 1;
     logger.log(`${this.bufferCodecEventsExpected} bufferCodec event(s) expected`);
   }
@@ -202,6 +206,7 @@ class BufferController extends EventHandler {
       this.mediaSource = null;
       this.media = null;
       this._objectUrl = null;
+      // this.bufferCodecEventsExpected = this._altAudio ? 2 : 1;
       this.pendingTracks = {};
       this.tracks = {};
       this.sourceBuffer = {};

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -48,7 +48,7 @@ class BufferController extends EventHandler {
   private _needsEos: boolean = false;
 
   // Track whether the parsed manifest signaled alternate audio
-  // private _altAudio: boolean = false;
+  private _altAudio: boolean = false;
 
   private config: BufferControllerConfig;
 
@@ -146,7 +146,7 @@ class BufferController extends EventHandler {
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
-    // this._altAudio = data.altAudio;
+    this._altAudio = data.altAudio;
     this.bufferCodecEventsExpected = data.altAudio ? 2 : 1;
     logger.log(`${this.bufferCodecEventsExpected} bufferCodec event(s) expected`);
   }
@@ -206,7 +206,7 @@ class BufferController extends EventHandler {
       this.mediaSource = null;
       this.media = null;
       this._objectUrl = null;
-      // this.bufferCodecEventsExpected = this._altAudio ? 2 : 1;
+      this.bufferCodecEventsExpected = this._altAudio ? 2 : 1;
       this.pendingTracks = {};
       this.tracks = {};
       this.sourceBuffer = {};

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -47,9 +47,6 @@ class BufferController extends EventHandler {
   // signals that mediaSource should have endOfStream called
   private _needsEos: boolean = false;
 
-  // Track whether the parsed manifest signaled alternate audio
-  private _altAudio: boolean = false;
-
   private config: BufferControllerConfig;
 
   // this is optional because this property is removed from the class sometimes
@@ -57,6 +54,9 @@ class BufferController extends EventHandler {
 
   // The number of BUFFER_CODEC events received before any sourceBuffers are created
   public bufferCodecEventsExpected: number = 0;
+
+  // The total number of BUFFER_CODEC events received
+  private _bufferCodecEventsTotal: number = 0;
 
   // A reference to the attached media element
   public media: HTMLMediaElement | null = null;
@@ -146,8 +146,7 @@ class BufferController extends EventHandler {
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
-    this._altAudio = data.altAudio;
-    this.bufferCodecEventsExpected = data.altAudio ? 2 : 1;
+    this.bufferCodecEventsExpected = this._bufferCodecEventsTotal = data.altAudio ? 2 : 1;
     logger.log(`${this.bufferCodecEventsExpected} bufferCodec event(s) expected`);
   }
 
@@ -206,7 +205,7 @@ class BufferController extends EventHandler {
       this.mediaSource = null;
       this.media = null;
       this._objectUrl = null;
-      this.bufferCodecEventsExpected = this._altAudio ? 2 : 1;
+      this.bufferCodecEventsExpected = this._bufferCodecEventsTotal;
       this.pendingTracks = {};
       this.tracks = {};
       this.sourceBuffer = {};

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -692,7 +692,7 @@ class StreamController extends BaseStreamController {
       this.onvseeking = this.onvseeked = this.onvended = null;
     }
     this.fragmentTracker.removeAllFragments();
-    this.media = this.mediaBuffer = this.altAudio = null;
+    this.media = this.mediaBuffer = null;
     this.loadedmetadata = false;
     this.stopLoad();
   }
@@ -736,6 +736,7 @@ class StreamController extends BaseStreamController {
       logger.log('both AAC/HE-AAC audio found in levels; declaring level codec as HE-AAC');
     }
 
+    this.altAudio = data.altAudio;
     this.levels = data.levels;
     this.startFragRequested = false;
     let config = this.config;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -691,7 +691,8 @@ class StreamController extends BaseStreamController {
       media.removeEventListener('ended', this.onvended);
       this.onvseeking = this.onvseeked = this.onvended = null;
     }
-    this.media = this.mediaBuffer = null;
+    this.fragmentTracker.removeAllFragments();
+    this.media = this.mediaBuffer = this.altAudio = null;
     this.loadedmetadata = false;
     this.stopLoad();
   }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -47,6 +47,7 @@ class StreamController extends BaseStreamController {
     this._state = State.STOPPED;
     this.stallReported = false;
     this.gapController = null;
+    this.altAudio = false;
   }
 
   startLoad (startPosition) {

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -84,6 +84,11 @@ export class SubtitleStreamController extends BaseStreamController {
 
   onMediaDetaching () {
     this.media.removeEventListener('seeking', this._onMediaSeeking);
+    this.fragmentTracker.removeAllFragments();
+    this.currentTrackId = -1;
+    this.tracks.forEach((track) => {
+      this.tracksBuffered[track.id] = [];
+    });
     this.media = null;
     this.state = State.STOPPED;
   }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -116,7 +116,7 @@ export class SubtitleStreamController extends BaseStreamController {
   onSubtitleTrackSwitch (data) {
     this.currentTrackId = data.id;
 
-    if (!this.tracks || this.currentTrackId === -1) {
+    if (!this.tracks || !this.tracks.length || this.currentTrackId === -1) {
       this.clearInterval();
       return;
     }

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -66,6 +66,11 @@ class SubtitleTrackController extends EventHandler {
       this.media.textTracks.removeEventListener('change', this.trackChangeListener);
     }
 
+    if (Number.isFinite(this.subtitleTrack)) {
+      this.queuedDefaultTrack = this.subtitleTrack;
+    }
+
+    this.trackId = -1;
     this.media = null;
   }
 

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -61,7 +61,7 @@ describe('SubtitleStreamController', function () {
     });
 
     it('should call clearInterval if no tracks present', function () {
-      subtitleStreamController.tracks = null;
+      subtitleStreamController.tracks = [];
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: 0
       });


### PR DESCRIPTION
### This PR will...
Fix the detach-attach workflow when using a media with alternative audio tracks

### Why is this Pull Request needed?
On re-attch the context of altAudio is not saved in buffer control so it doesn't know to create two source buffers.
Also, in context of stream controller it doesn't reset the `altAudio` flag.
I also noticed that stream controller is reloading the entire frags it has in `fragmentTracker` and it seems it needs to be reset on detach, otherwise there's a very long start delay where unnecessary buffering occurs. Unfortunately I'm not too sure what are the side effects.

### Are there any points in the code the reviewer needs to double check?
I think there's a bigger issue here(and some smaller ones).
Big issue:
The logic seems problematic in general.
For stream with altAudio we first get the the main init segment in `stream-controller` and it will usually contain muxed video and audio.
The `altAudio` flag is `undefined` in this stage, which seems like a potential bug on its own, and because of this the audio track deletion doesn't happen.
The `stream-controller` will emit `BUFFER_CODECS` event that will be used in `buffer-controller`.
`buffer-controller` gets the event with payload of audio and video of main muxed content and as a side effect, cause it got altAudio flag from its manifest parsed event handler, it will create two source buffer now - it's a side effect cause it what we want but not how we want it.
from now on and `BUFFER_CODECS` event won't be processed by `buffer-controller` cause it has a flag that checks if `sourceBuffer` were created.
In this stage the `audio-stream-controller` will also get initSegement of the audio stream(not the main) and it will emit a `BUFFER_CODECS` event but it is already redundant as to what I wrote above.
Now, all of this seems a bit of a problem, cause I started with an assumption that first init segment is the main elementary one, but if it is the audio one then all goes down the drain cause first `BUFFER_CODECS` event that will arrive to `buffer-controller` will be audio and it will lock the creation of further sourceBuffer for video.
Before we decide if this fix is even acceptable and if my long description is even valid I will let it be reviewed.
It seems to me we need to start managing this better across controllers.
In high level: 
* keep flag for altAudio from manifestParsed in streamController. 
* manage the sourcebuffer creation per use case in buffer controller, by managing the source buffer object per audio and video and getting them separately from their respective controllers.

### Resolves issues:
based on #2110 and fixes #2099.
@itsjamie I tried to cherry-pick your original changes but couldn't resolve the git issue of fetching from a fork.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
