### PR TITLE
Guard against undefined errors when accessing MediaSource

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -149,7 +149,7 @@ class BufferController extends EventHandler {
 
   onMediaAttaching (data: { media: HTMLMediaElement }) {
     let media = this.media = data.media;
-    if (media) {
+    if (media && MediaSource) {
       // setup the media source
       let ms = this.mediaSource = new MediaSource();
       // Media Source listeners

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -12,7 +12,7 @@ import { Observer } from '../observer';
 
 // see https://stackoverflow.com/a/11237259/589493
 const global = getSelfScope(); // safeguard for code that might run both on worker and main thread
-const MediaSource = getMediaSource();
+const MediaSource = getMediaSource() || { isTypeSupported: () => false };
 
 class Demuxer {
   constructor (hls, id) {

--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -2,6 +2,9 @@ import { getMediaSource } from './utils/mediasource-helper';
 
 export function isSupported (): boolean {
   const mediaSource = getMediaSource();
+  if (!mediaSource) {
+    return false;
+  }
   const sourceBuffer = SourceBuffer || (window as any).WebKitSourceBuffer;
   const isTypeSupported = mediaSource &&
     typeof mediaSource.isTypeSupported === 'function' &&

--- a/src/utils/mediasource-helper.ts
+++ b/src/utils/mediasource-helper.ts
@@ -2,6 +2,6 @@
  * MediaSource helper
  */
 
-export function getMediaSource (): typeof MediaSource {
-  return MediaSource || (window as any).WebKitMediaSource;
+export function getMediaSource (): typeof MediaSource | undefined {
+  return (window as any).MediaSource || (window as any).WebKitMediaSource;
 }


### PR DESCRIPTION
### Why is this Pull Request needed?
To prevent exceptions from being thrown when Hls.js is loaded into envs without MSE support (i.e. iOS)

### Are there any points in the code the reviewer needs to double check?
Addresses feedback in https://github.com/video-dev/hls.js/pull/2263

### Resolves issues:
https://github.com/video-dev/hls.js/issues/2262

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
