### PR TITLE
VTT cues are never cleaned up. Fix memory leak in live.

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -453,56 +453,6 @@ class BufferController extends EventHandler {
     this.doFlush();
   }
 
-  getClosestCue (cues: TextTrackCueList, id3TrackendOffset: number): TextTrackCue {
-    // If the offset is less than the first element, the first element is the closest.
-    if (id3TrackendOffset < cues[0].endTime) {
-      return cues[0];
-    }
-    // If the offset is greater than the last cue, the last is the closest.
-    if (id3TrackendOffset > cues[cues.length - 1].endTime) {
-      return cues[cues.length - 1];
-    }
-
-    let left = 0;
-    let right = cues.length - 1;
-
-    while (left <= right) {
-      const mid = (right + left) / 2;
-
-      if (id3TrackendOffset < cues[mid].endTime) {
-        right = mid - 1;
-      } else if (id3TrackendOffset > cues[mid].endTime) {
-        left = mid + 1;
-      } else {
-        // If it's not lower or higher, it must be equal.
-        return cues[mid];
-      }
-    }
-    // At this point, left and right have swapped.
-    // No direct match was found, left or right element must be the closest. Check which one has the smallest diff.
-    return (cues[left].endTime - id3TrackendOffset) < (id3TrackendOffset - cues[right].endTime) ? cues[left] : cues[right];
-  }
-
-  flushId3Cues (textTrack: TextTrack, id3TrackendOffset: number) {
-    if (!textTrack || !textTrack.cues || !textTrack.cues.length) {
-      return;
-    }
-    const foundCue = this.getClosestCue(textTrack.cues, id3TrackendOffset);
-    if (!foundCue) {
-      return;
-    }
-
-    let removeCues = true;
-    while (removeCues) {
-      const cue = textTrack.cues[0];
-      if (!textTrack.cues.length || cue.endTime === foundCue.endTime) {
-        removeCues = false;
-        return;
-      }
-      textTrack.removeCue(cue);
-    }
-  }
-
   flushLiveBackBuffer () {
     if (!this.media) {
       throw Error('flushLiveBackBuffer called without attaching media');
@@ -534,7 +484,7 @@ class BufferController extends EventHandler {
           // time will lead to playback freezing)
           // credits for level target duration - https://github.com/videojs/http-streaming/blob/3132933b6aa99ddefab29c10447624efd6fd6e52/src/segment-loader.js#L91
           this.removeBufferRange(bufferType, sb, 0, targetBackBufferPosition);
-          this.flushId3Cues(this.hls.coreComponents[7].id3Track, targetBackBufferPosition);
+          this.hls.trigger(Events.LIVE_BACK_BUFFER_REACHED, { bufferEnd: targetBackBufferPosition });
         }
       }
     }

--- a/src/controller/id3-track-controller.js
+++ b/src/controller/id3-track-controller.js
@@ -14,7 +14,8 @@ class ID3TrackController extends EventHandler {
       Event.MEDIA_ATTACHED,
       Event.MEDIA_DETACHING,
       Event.FRAG_PARSING_METADATA,
-      Event.LIVE_BACK_BUFFER_REACHED);
+      Event.LIVE_BACK_BUFFER_REACHED
+    );
     this.id3Track = undefined;
     this.media = undefined;
   }

--- a/src/events.js
+++ b/src/events.js
@@ -104,7 +104,9 @@ const HlsEvents = {
   // fired when a decrypt key loading is completed - data: { frag : fragment object, payload : key payload, stats : { trequest, tfirst, tload, length } }
   KEY_LOADED: 'hlsKeyLoaded',
   // fired upon stream controller state transitions - data: { previousState, nextState }
-  STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
+  STREAM_STATE_TRANSITION: 'hlsStreamStateTransition',
+  // fired when the live back buffer is reached defined by the liveBackBufferLength config option - data : { bufferEnd: number }
+  LIVE_BACK_BUFFER_REACHED: 'hlsLiveBackBufferReached'
 };
 
 export default HlsEvents;

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -19,3 +19,42 @@ export function clearCurrentCues (track: TextTrack) {
     }
   }
 }
+
+/**
+ *  Given a list of Cues, finds the closest cue matching the given time.
+ *  Modified verison of binary search O(log(n)).
+ *
+ * @export
+ * @param {(TextTrackCueList | TextTrackCue[])} cues - List of cues.
+ * @param {number} time - Target time, to find closest cue to.
+ * @returns {TextTrackCue}
+ */
+export function getClosestCue (cues: TextTrackCueList | TextTrackCue[], time: number): TextTrackCue {
+  // If the offset is less than the first element, the first element is the closest.
+  if (time < cues[0].endTime) {
+    return cues[0];
+  }
+  // If the offset is greater than the last cue, the last is the closest.
+  if (time > cues[cues.length - 1].endTime) {
+    return cues[cues.length - 1];
+  }
+
+  let left = 0;
+  let right = cues.length - 1;
+
+  while (left <= right) {
+    const mid = Math.floor((right + left) / 2);
+
+    if (time < cues[mid].endTime) {
+      right = mid - 1;
+    } else if (time > cues[mid].endTime) {
+      left = mid + 1;
+    } else {
+      // If it's not lower or higher, it must be equal.
+      return cues[mid];
+    }
+  }
+  // At this point, left and right have swapped.
+  // No direct match was found, left or right element must be the closest. Check which one has the smallest diff.
+  return (cues[left].endTime - time) < (time - cues[right].endTime) ? cues[left] : cues[right];
+}


### PR DESCRIPTION
### This PR will...

Implement flushing of the TextTrackCueList in accordance with the liveBackBufferLength config option, for live mode only. 
This means that the id3 cues relevant to the current live buffer will still be maintained. However, we avoid the continuous growth that eventually consumes all the memory.

### Why is this Pull Request needed?
VTT cues are not cleaned up until a stream is destroyed.
Long Live streams lead to a memory leak, as the TextTrackList continues growing with Cues until the browser runs out of memory and becomes un-responsive.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
