### PR TITLE
Adds BufferHelper.getBuffered()

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -703,7 +703,7 @@ class AudioStreamController extends BaseStreamController {
         hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: frag, id: 'audio' });
         let media = this.mediaBuffer ? this.mediaBuffer : this.media;
         if (media) {
-          logger.log(`audio buffered : ${TimeRanges.toString(media.buffered)}`);
+          logger.log(`audio buffered : ${TimeRanges.toString(BufferHelper.getBuffered(media))}`);
         }
         if (this.audioSwitch && this.appended) {
           this.audioSwitch = false;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -4,6 +4,7 @@
 
 import Events from '../events';
 import EventHandler from '../event-handler';
+import { BufferHelper } from '../utils/buffer-helper';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { getMediaSource } from '../utils/mediasource-helper';
@@ -293,7 +294,7 @@ class BufferController extends EventHandler {
       if (!sb) {
         throw Error(`handling source buffer update end error: source buffer for ${streamType} uninitilized and unable to update buffered TimeRanges.`);
       }
-      timeRanges[streamType as SourceBufferName] = sb.buffered;
+      timeRanges[streamType as SourceBufferName] = BufferHelper.getBuffered(sb);
     }
 
     this.hls.trigger(Events.BUFFER_APPENDED, { parent, pending, timeRanges });
@@ -491,7 +492,7 @@ class BufferController extends EventHandler {
       const bufferType = bufferTypes[index];
       const sb = sourceBuffer[bufferType as SourceBufferName];
       if (sb) {
-        const buffered = sb.buffered;
+        const buffered = BufferHelper.getBuffered(sb);
         // when target buffer start exceeds actual buffer start
         if (buffered.length > 0 && targetBackBufferPosition > buffered.start(0)) {
           // remove buffer up until current time minus minimum back buffer length (removing buffer too close to current
@@ -596,17 +597,11 @@ class BufferController extends EventHandler {
       // let's recompute this.appended, which is used to avoid flush looping
       let appended = 0;
       let sourceBuffer = this.sourceBuffer;
-      try {
-        for (let type in sourceBuffer) {
-          const sb = sourceBuffer[type];
-          if (sb) {
-            appended += sb.buffered.length;
-          }
+      for (let type in sourceBuffer) {
+        const sb = sourceBuffer[type];
+        if (sb) {
+          appended += BufferHelper.getBuffered(sb).length;
         }
-      } catch (error) {
-        // error could be thrown while accessing buffered, in case sourcebuffer has already been removed from MediaSource
-        // this is harmess at this stage, catch this to avoid reporting an internal exception
-        logger.error('error while accessing sourceBuffer.buffered');
       }
       this.appended = appended;
       this.hls.trigger(Events.BUFFER_FLUSHED);
@@ -742,9 +737,10 @@ class BufferController extends EventHandler {
    */
   removeBufferRange (type: string, sb: ExtendedSourceBuffer, startOffset: number, endOffset: number): boolean {
     try {
-      for (let i = 0; i < sb.buffered.length; i++) {
-        let bufStart = sb.buffered.start(i);
-        let bufEnd = sb.buffered.end(i);
+      const buffered = BufferHelper.getBuffered(sb);
+      for (let i = 0; i < buffered.length; i++) {
+        let bufStart = buffered.start(i);
+        let bufEnd = buffered.end(i);
         let removeStart = Math.max(bufStart, startOffset);
         let removeEnd = Math.min(bufEnd, endOffset);
 

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -57,7 +57,7 @@ export default class GapController {
     }
 
     // The playhead should not be moving
-    if (media.paused || media.ended || media.playbackRate === 0 || !media.buffered.length) {
+    if (media.paused || media.ended || media.playbackRate === 0 || !BufferHelper.getBuffered(media).length) {
       return;
     }
 
@@ -185,8 +185,9 @@ export default class GapController {
     const currentTime = media.currentTime;
     let lastEndTime = 0;
     // Check if currentTime is between unbuffered regions of partial fragments
-    for (let i = 0; i < media.buffered.length; i++) {
-      const startTime = media.buffered.start(i);
+    const buffered = BufferHelper.getBuffered(media);
+    for (let i = 0; i < buffered.length; i++) {
+      const startTime = buffered.start(i);
       if (currentTime + config.maxBufferHole >= lastEndTime && currentTime < startTime) {
         const targetTime = Math.max(startTime + SKIP_BUFFER_RANGE_START, media.currentTime + SKIP_BUFFER_HOLE_STEP_SECONDS);
         logger.warn(`skipping hole, adjusting currentTime from ${currentTime} to ${targetTime}`);
@@ -204,7 +205,7 @@ export default class GapController {
         }
         return targetTime;
       }
-      lastEndTime = media.buffered.end(i);
+      lastEndTime = buffered.end(i);
     }
     return 0;
   }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -600,7 +600,7 @@ class StreamController extends BaseStreamController {
    */
   immediateLevelSwitchEnd () {
     const media = this.media;
-    if (media && media.buffered.length) {
+    if (media && BufferHelper.getBuffered(media).length) {
       this.immediateSwitch = false;
       if (media.currentTime > 0 && BufferHelper.isBuffered(media, media.currentTime)) {
         // only nudge if currentTime is buffered
@@ -1182,7 +1182,7 @@ class StreamController extends BaseStreamController {
       const frag = this.fragCurrent;
       if (frag) {
         const media = this.mediaBuffer ? this.mediaBuffer : this.media;
-        logger.log(`main buffered : ${TimeRanges.toString(media.buffered)}`);
+        logger.log(`main buffered : ${TimeRanges.toString(BufferHelper.getBuffered(media))}`);
         this.fragPrevious = frag;
         const stats = this.stats;
         stats.tbuffered = window.performance.now();
@@ -1298,7 +1298,7 @@ class StreamController extends BaseStreamController {
     }
 
     const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
-    const buffered = mediaBuffer.buffered;
+    const buffered = BufferHelper.getBuffered(mediaBuffer);
 
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;
@@ -1329,7 +1329,7 @@ class StreamController extends BaseStreamController {
     if (media) {
       // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
       const elementaryStreamType = this.audioOnly ? ElementaryStreamTypes.AUDIO : ElementaryStreamTypes.VIDEO;
-      this.fragmentTracker.detectEvictedFragments(elementaryStreamType, media.buffered);
+      this.fragmentTracker.detectEvictedFragments(elementaryStreamType, BufferHelper.getBuffered(media));
     }
     // reset reference to frag
     this.fragPrevious = null;
@@ -1359,7 +1359,8 @@ class StreamController extends BaseStreamController {
         logger.log(`could not seek to ${startPosition}, already seeking at ${currentTime}`);
         return;
       }
-      const bufferStart = media.buffered.length ? media.buffered.start(0) : 0;
+      const buffered = BufferHelper.getBuffered(media);
+      const bufferStart = buffered.length ? buffered.start(0) : 0;
       const delta = bufferStart - startPosition;
       if (delta > 0 && delta < this.config.maxBufferHole) {
         logger.log(`adjusting start position by ${delta} to match buffer start`);

--- a/tests/unit/utils/buffer-helper.js
+++ b/tests/unit/utils/buffer-helper.js
@@ -282,4 +282,26 @@ describe('BufferHelper', function () {
       });
     });
   });
+
+  describe('getBuffered', function () {
+    it('should return buffered if no error is thrown', function () {
+      const media = {
+        buffered: {
+          length: 10,
+          start () {},
+          end () {}
+        }
+      };
+      expect(BufferHelper.getBuffered(media)).to.eql(media.buffered);
+    });
+
+    it('should return return noop value if error is thrown', function () {
+      const media = {
+        get buffered () {
+          throw new Error();
+        }
+      };
+      expect(BufferHelper.getBuffered(media).length).to.eql(0);
+    });
+  });
 });


### PR DESCRIPTION
### This PR will...
Fix posible SourceBuffer related error `Failed to read the 'buffered' property from 'SourceBuffer': This SourceBuffer has been removed from the parent media source.`
This error has been reported several times https://github.com/video-dev/hls.js/issues/1787
### Why is this Pull Request needed?
This error is handled in some places but not everywhere. This PR adds a wrappers that makes reading this property safe.
### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
https://github.com/video-dev/hls.js/issues/1787
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
