### PR TITLE
ensure we fetch master before getting the latest commit

### DIFF
--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -8,7 +8,6 @@ git remote set-branches origin master
 git fetch
 
 currentCommit=$(git rev-parse HEAD)
-masterLatestCommit=""
 masterLatestCommit=$(git rev-parse origin/master)
 
 id=$currentCommit

--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -3,8 +3,13 @@ set -e
 
 # GITHUB_TOKEN and NETLIFY_ACCESS_TOKEN set in travis
 
+# ensure we have fetched origin/master
+git remote set-branches origin master
+git fetch
+
 currentCommit=$(git rev-parse HEAD)
-masterLatestCommit=$(git rev-parse master)
+masterLatestCommit=""
+masterLatestCommit=$(git rev-parse origin/master)
 
 id=$currentCommit
 root="./netlify"


### PR DESCRIPTION
### This PR will...
Handle `git rev-parse master` failing

### Why is this Pull Request needed?
Without this the pipeline fails when publishing a prerelease. It was failing because it was never fetched. It looks like when using `--branch` with `git fetch` git only pulls the reference to that tag/branch.

Now we explicitly fetch the pointer to `origin/master`.
