### PR TITLE
Fragment Finders Typescriptify

### DIFF
--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -20,6 +20,9 @@ export default class Fragment {
     [ElementaryStreamTypes.VIDEO]: false
   };
 
+  // deltaPTS tracks the change in presentation timestamp between fragments
+  public deltaPTS: number = 0;
+
   public rawProgramDateTime: string | null = null;
   public programDateTime: number | null = null;
   public tagList: Array<string[]> = [];
@@ -37,6 +40,8 @@ export default class Fragment {
   public baseurl!: string;
   // EXTINF has to be present for a m3u8 to be considered valid
   public duration!: number;
+  // When this segment starts in the timeline
+  public start!: number;
   // sn notates the sequence number for a segment, and if set to a string can be 'initSegment'
   public sn: number | 'initSegment' = 0;
   // levelkey is the EXT-X-KEY that applies to this segment for decryption

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -835,9 +835,9 @@ http://dummy.url.com/hls/live/segment/segment_022916_164500865_719928.ts
 #EXT-X-MEDIA-SEQUENCE:1
 #EXT-X-PLAYLIST-TYPE:VOD
 #EXTINF:6.006,
-180724_Allison VLOG v3_00001.ts 
+180724_Allison VLOG v3_00001.ts
 #EXTINF:6.006,
-180724_Allison VLOG v3_00002.ts 
+180724_Allison VLOG v3_00002.ts
 #EXT-X-ENDLIST
     `;
     const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);


### PR DESCRIPTION
~Seperate fragment class from Initialization Segments.~

~Some code changes that will likely conflict with the open m3u8-parser PR, so one will have to be updated after one is merged.~

Just added types to fragment-finders, and instead type-asserted `frag.sn` to number.

### This PR will...

Progress towards #2070

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

~Separation of Initialization Segments from Fragments.~

This broke some of the MP4 demuxing the code path in the demuxer-worker, so I pulled it out.

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
