### PR TITLE
Fix for issue #2336: Remove misplaced timescale normalizing in delta computation

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -239,7 +239,7 @@ class MP4Remuxer {
     });
 
     // handle broken streams with PTS < DTS, tolerance up 0.2 seconds
-    let PTSDTSshift = inputSamples.reduce((prev, curr) => Math.max(Math.min(prev, curr.pts - curr.dts), PTS_DTS_SHIFT_TOLERANCE_90KHZ), 0);
+    let PTSDTSshift = inputSamples.reduce((prev, curr) => Math.max(Math.min(prev, curr.pts - curr.dts), -1 * PTS_DTS_SHIFT_TOLERANCE_90KHZ), 0);
     if (PTSDTSshift < 0) {
       logger.warn(`PTS < DTS detected in video samples, shifting DTS by ${toMsFromMpegTsClock(PTSDTSshift, true)} ms to overcome this issue`);
       for (let i = 0; i < inputSamples.length; i++) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -435,14 +435,16 @@ class MP4Remuxer {
     const initPTS = this._initPTS;
     const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
 
-    let mp4Sample,
-      fillFrame,
-      mdat, moof,
-      firstPTS, lastPTS,
-      offset = (rawMPEG ? 0 : 8),
-      inputSamples = track.samples,
-      outputSamples = [],
-      nextAudioPts = this.nextAudioPts;
+    let mp4Sample;
+    let fillFrame;
+    let mdat;
+    let moof;
+    let firstPTS;
+    let lastPTS;
+    let offset = (rawMPEG ? 0 : 8);
+    let inputSamples = track.samples;
+    let outputSamples = [];
+    let nextAudioPts = this.nextAudioPts;
 
     // for audio samples, also consider consecutive fragments as being contiguous (even if a level switch occurs),
     // for sake of clarity:

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -688,23 +688,23 @@ class MP4Remuxer {
   }
 
   remuxEmptyAudio (track, timeOffset, contiguous, videoData) {
-    let inputTimeScale = track.inputTimeScale,
-      mp4timeScale = track.samplerate ? track.samplerate : inputTimeScale,
-      scaleFactor = inputTimeScale / mp4timeScale,
-      nextAudioPts = this.nextAudioPts,
+    let inputTimeScale = track.inputTimeScale;
+    let mp4timeScale = track.samplerate ? track.samplerate : inputTimeScale;
+    let scaleFactor = inputTimeScale / mp4timeScale;
+    let nextAudioPts = this.nextAudioPts;
 
-      // sync with video's timestamp
-      startDTS = (nextAudioPts !== undefined ? nextAudioPts : videoData.startDTS * inputTimeScale) + this._initDTS,
-      endDTS = videoData.endDTS * inputTimeScale + this._initDTS,
-      // one sample's duration value
-      sampleDuration = 1024,
-      frameDuration = scaleFactor * sampleDuration,
+    // sync with video's timestamp
+    let startDTS = (nextAudioPts !== undefined ? nextAudioPts : videoData.startDTS * inputTimeScale) + this._initDTS;
+    let endDTS = videoData.endDTS * inputTimeScale + this._initDTS;
+    // one sample's duration value
+    let sampleDuration = 1024;
+    let frameDuration = scaleFactor * sampleDuration;
 
-      // samples count of this segment's duration
-      nbSamples = Math.ceil((endDTS - startDTS) / frameDuration),
+    // samples count of this segment's duration
+    let nbSamples = Math.ceil((endDTS - startDTS) / frameDuration);
 
-      // silent frame
-      silentFrame = AAC.getSilentFrame(track.manifestCodec || track.codec, track.channelCount);
+    // silent frame
+    let silentFrame = AAC.getSilentFrame(track.manifestCodec || track.codec, track.channelCount);
 
     logger.warn('remux empty Audio');
     // Can't remux if we can't generate a silent frame...

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -251,7 +251,7 @@ class MP4Remuxer {
     firstPTS = Math.max(sample.pts, 0);
 
     // check timestamp continuity accross consecutive fragments (this is to remove inter-fragment gap/hole)
-    let delta = Math.round((firstDTS - nextAvcDts) / 90);
+    let delta = firstDTS - nextAvcDts;
     // if fragment are contiguous, detect hole/overlapping between fragments
     if (contiguous) {
       if (delta) {

--- a/src/utils/timescale-conversion.ts
+++ b/src/utils/timescale-conversion.ts
@@ -1,0 +1,14 @@
+const MPEG_TS_CLOCK_FREQ_HZ = 90000;
+
+export function toTimescaleFromBase (value, destScale: number, srcBase: number = 1): number {
+  return value * destScale * srcBase; // equivalent to `(value * scale) / (1 / base)`
+}
+
+export function toMsFromMpegTsClock (value: number, round: boolean = true): number {
+  const result = toTimescaleFromBase(value, 1000, 1 / MPEG_TS_CLOCK_FREQ_HZ);
+  return round ? Math.round(result) : result;
+}
+
+export function toMpegTsClockFromTimescale (value: number, srcScale: number = 1) {
+  return toTimescaleFromBase(value, MPEG_TS_CLOCK_FREQ_HZ, 1 / srcScale);
+}

--- a/src/utils/timescale-conversion.ts
+++ b/src/utils/timescale-conversion.ts
@@ -1,14 +1,14 @@
 const MPEG_TS_CLOCK_FREQ_HZ = 90000;
 
-export function toTimescaleFromBase (value, destScale: number, srcBase: number = 1): number {
-  return value * destScale * srcBase; // equivalent to `(value * scale) / (1 / base)`
-}
-
-export function toMsFromMpegTsClock (value: number, round: boolean = true): number {
-  const result = toTimescaleFromBase(value, 1000, 1 / MPEG_TS_CLOCK_FREQ_HZ);
+export function toTimescaleFromBase (value, destScale: number, srcBase: number = 1, round: boolean = false): number {
+  const result = value * destScale * srcBase; // equivalent to `(value * scale) / (1 / base)`
   return round ? Math.round(result) : result;
 }
 
-export function toMpegTsClockFromTimescale (value: number, srcScale: number = 1) {
+export function toMsFromMpegTsClock (value: number, round: boolean = true): number {
+  return toTimescaleFromBase(value, 1000, 1 / MPEG_TS_CLOCK_FREQ_HZ, round);
+}
+
+export function toMpegTsClockFromTimescale (value: number, srcScale: number = 1): number {
   return toTimescaleFromBase(value, MPEG_TS_CLOCK_FREQ_HZ, 1 / srcScale);
 }

--- a/src/utils/timescale-conversion.ts
+++ b/src/utils/timescale-conversion.ts
@@ -1,11 +1,15 @@
 const MPEG_TS_CLOCK_FREQ_HZ = 90000;
 
+export function toTimescaleFromScale (value, destScale: number, srcScale: number = 1, round: boolean = false): number {
+  return toTimescaleFromBase(value, destScale, 1 / srcScale);
+}
+
 export function toTimescaleFromBase (value, destScale: number, srcBase: number = 1, round: boolean = false): number {
   const result = value * destScale * srcBase; // equivalent to `(value * scale) / (1 / base)`
   return round ? Math.round(result) : result;
 }
 
-export function toMsFromMpegTsClock (value: number, round: boolean = true): number {
+export function toMsFromMpegTsClock (value: number, round: boolean = false): number {
   return toTimescaleFromBase(value, 1000, 1 / MPEG_TS_CLOCK_FREQ_HZ, round);
 }
 


### PR DESCRIPTION
### This PR will...

Remove a misplaced scale normalization in a timestamp delta compuation in the mp4-remuxer when checking for sample gaps and overlapping.

### Why is this Pull Request needed?

Currently we will simply compute the wrong value which obviously is an issue.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/2336

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
