### PR TITLE
fix missing captions issue when nalus overlap pes

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -628,6 +628,11 @@ class TSDemuxer {
     });
   }
 
+  _processAVCSample (avcSample, avcTrack) {
+    this._parseSEI(avcSample);
+    this.pushAccesUnit(avcSample, avcTrack);
+  }
+
   pushAccesUnit (avcSample, avcTrack) {
     if (avcSample.units.length && avcSample.frame) {
       const samples = avcTrack.samples;
@@ -661,8 +666,7 @@ class TSDemuxer {
       push,
       spsfound = false,
       i,
-      parseSEI = this._parseSEI.bind(this),
-      pushAccesUnit = this.pushAccesUnit.bind(this),
+      processAVCSample = this._processAVCSample.bind(this),
       createAVCSample = function (key, pts, dts, debug) {
         return { key: key, pts: pts, dts: dts, units: [], debug: debug };
       };
@@ -672,8 +676,7 @@ class TSDemuxer {
     // if new NAL units found and last sample still there, let's push ...
     // this helps parsing streams with missing AUD (only do this if AUD never found)
     if (avcSample && units.length && !track.audFound) {
-      parseSEI(avcSample);
-      pushAccesUnit(avcSample, track);
+      processAVCSample(avcSample, track);
       avcSample = this.avcSample = createAVCSample(false, pes.pts, pes.dts, '');
     }
 
@@ -777,8 +780,7 @@ class TSDemuxer {
         push = false;
         track.audFound = true;
         if (avcSample) {
-          parseSEI(avcSample);
-          pushAccesUnit(avcSample, track);
+          processAVCSample(avcSample, track);
         }
 
         avcSample = this.avcSample = createAVCSample(false, pes.pts, pes.dts, debug ? 'AUD ' : '');
@@ -802,8 +804,7 @@ class TSDemuxer {
     });
     // if last PES packet, push samples
     if (last && avcSample) {
-      parseSEI(avcSample);
-      pushAccesUnit(avcSample, track);
+      processAVCSample(avcSample, track);
       this.avcSample = null;
     }
   }


### PR DESCRIPTION
### This PR will...

change the tsdemuxer behaviour to execute the SEI parsing code just before calls to pushAccesUnit in order to parse complete SEI nalus when ES is overlapping between PES.

### Why is this Pull Request needed?

some captions are not properly displayed : 

```
# example of m3u8 with the issue.
https://prod-ec-eu-west-1.video.pscp.tv/Transcoding/v1/hls/4XbVJmYpcQWvqU65fdNZMsiXj4bEkFK6Cax0boLhWjH9wFh-V1sT5nmfVAZEJf24rqPvv16TadVVDYxVe1r4zg/transcode/eu-west-1/periscope-replay-direct-prod-eu-west-1-public/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInZlcnNpb24iOiIyIn0.eyJIZWlnaHQiOjI3MCwiS2JwcyI6NTAwLCJXaWR0aCI6NDgwfQ.0PLzHwJpzC4wA_jNo8XOma8zOx8uPmEDTD3WKSRLYOA/playlist_16878701106869010712.m3u8?type=replay
```

`_parseAVCNALu` detects if NAL units are not starting right at the beginning of the PES packet, if true => it push preceding data into previous NAL unit : `lastUnit.data = tmp;`
but caption parsing of that nalu was already done during the previous call of `_parseAVCPES`

```js
// in _parseAVCPES :
units = this._parseAVCNALu(pes.data),
// (...)
// this loop is done before the next call to _parseAVCNALu => we sometime miss data in the last unit.
units.forEach(unit => { 
 switch (unit.type) {
        // SEI
      case 6:
        // captions are processed immediately here => we lose captions if the SEI is overlapping between PES.
 }
})
``` 

### Are there any points in the code the reviewer needs to double check?

Could the truncated data in last unit have impacts elsewhere (SPS?) ?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
