### PR TITLE
Less verbose webpack output on CI, and attempt to build docs on travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "webpack --progress",
+    "build:ci": "webpack",
     "build:debug": "webpack --progress --env.debug --env.demo",
     "build:watch": "webpack --progress --env.debug --env.demo --watch",
     "build:types": "tsc --emitDeclarationOnly",

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -13,6 +13,9 @@ if [ "${TRAVIS_MODE}" = "build" ]; then
   echo "travis_fold:start:build"
   npm run build
   echo "travis_fold:end:build"
+  echo "travis_fold:start:docs"
+  npm run docs
+  echo "travis_fold:end:docs"
   # check that hls.js doesn't error if requiring in node
   # see https://github.com/video-dev/hls.js/pull/1642
   node -e 'require("./" + require("./package.json").main)'

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -44,7 +44,7 @@ elif [ "${TRAVIS_MODE}" = "release" ] || [ "${TRAVIS_MODE}" = "releaseCanary" ] 
   fi
   node ./scripts/set-package-version.js
   npm run lint
-  npm run build
+  npm run build:ci
   if [ "${TRAVIS_MODE}" != "netlifyPr" ]; then
     npm run test:unit
     if [[ $(node ./scripts/check-already-published.js) = "not published" ]]; then


### PR DESCRIPTION
### This PR will...
Make the webpack output less verbose on CI and attempt to build the docs on travis.

### Why is this Pull Request needed?
Netlify has been failing sometimes and one of the reasons (docs failing to build) wasn't obvious because the webpack output took so long that netlify never shipped the end of the logs before it was terminated, which contained the error from `npm run docs`.

If there is an error building docs again it should now be visible on netlify, but also the build job on travis should fail.