### PR TITLE
Bugfix: Uncaught exception trying to flush back buffer when starting live stream

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -454,10 +454,6 @@ class BufferController extends EventHandler {
   }
 
   flushLiveBackBuffer () {
-    if (!this.media) {
-      throw Error('flushLiveBackBuffer called without attaching media');
-    }
-
     // clear back buffer for live only
     if (!this._live) {
       return;
@@ -465,6 +461,11 @@ class BufferController extends EventHandler {
 
     const liveBackBufferLength = this.config.liveBackBufferLength;
     if (!isFinite(liveBackBufferLength) || liveBackBufferLength < 0) {
+      return;
+    }
+
+    if (!this.media) {
+      logger.error('flushLiveBackBuffer called without attaching media');
       return;
     }
 

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -146,12 +146,12 @@ module.exports = {
     blacklist_ua: ['firefox', 'safari', 'internet explorer']
   },
   {
-    widevineLicenseUrl: 'https://cwip-shaka-proxy.appspot.com/no_auth',
+    widevineLicenseUrl: 'http://cwip-shaka-proxy.appspot.com/no_auth',
     emeEnabled: true
   }
   ),
   audioOnlyMultipleLevels: {
-    'url': 'https://s3.amazonaws.com/bob.jwplayer.com/~alex/121628/new_master.m3u8',
+    'url': 'https://s3.amazonaws.com/qa.jwplayer.com/~alex/121628/new_master.m3u8',
     'description': 'Multiple non-alternate audio levels',
     'live': false,
     'abr': false
@@ -173,7 +173,7 @@ module.exports = {
     description: 'One PDT, no discontinuities'
   },
   noTrackIntersection: {
-    url: 'https://s3.amazonaws.com/bob.jwplayer.com/%7Ealex/123633/new_master.m3u8',
+    url: 'https://s3.amazonaws.com/qa.jwplayer.com/~alex/123633/new_master.m3u8',
     description: 'Audio/video track PTS values do not intersect; 10 second start gap'
   },
   // altAudioNoVideoCodecSignaled: {


### PR DESCRIPTION
### This PR will...
Log an error rather than throwing an exception when `flushLiveBackBuffer` is called for a live stream without media attached.

### Why is this Pull Request needed?
Fixes an edge-case where the exception prevents a live stream starting.

### Resolves issues:
Fixes #2333

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- N/A new unit / functional tests have been added (whenever applicable)
- N/A API or design changes are documented in API.md
