### PR TITLE
Performance improvements for v1.0

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -304,7 +304,6 @@ export function setStreamingMode (config, allowProgressive) {
   } else {
     config.loader = XhrLoader;
     config.progressive = false;
-    config.enableSoftwareAES = false;
     logger.log('[config]: Progressive streaming disabled, using XhrLoader');
   }
 }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -81,7 +81,8 @@ class AudioStreamController extends BaseStreamController {
       this.state = State.IDLE;
     } else {
       this.lastCurrentTime = this.startPosition ? this.startPosition : startPosition;
-      this.state = State.STARTING;
+      this.loadedmetadata = false;
+      this.state = State.WAITING_TRACK;
     }
     this.nextLoadPosition = this.startPosition = this.lastCurrentTime = startPosition;
     this.tick();
@@ -97,10 +98,6 @@ class AudioStreamController extends BaseStreamController {
     case State.PAUSED:
       // TODO: Remove useless PAUSED state
       // don't do anything in paused state either ...
-      break;
-    case State.STARTING:
-      this.state = State.WAITING_TRACK;
-      this.loadedmetadata = false;
       break;
     case State.IDLE:
       this.doTickIdle();
@@ -128,12 +125,6 @@ class AudioStreamController extends BaseStreamController {
       if (Number.isFinite(this.initPTS[videoTrackCC])) {
         this.state = State.IDLE;
       }
-      break;
-    case State.STOPPED:
-    case State.FRAG_LOADING:
-    case State.PARSING:
-    case State.PARSED:
-    case State.ENDED:
       break;
     default:
       break;
@@ -330,7 +321,7 @@ class AudioStreamController extends BaseStreamController {
     if (!this.startFragRequested) {
       this.setStartPosition(track.details, sliding);
     }
-    // only switch batck to IDLE state if we were waiting for track to start downloading a new fragment
+    // only switch back to IDLE state if we were waiting for track to start downloading a new fragment
     if (this.state === State.WAITING_TRACK) {
       this.state = State.IDLE;
     }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -8,11 +8,12 @@ import { FragmentState } from './fragment-tracker';
 import Fragment, { ElementaryStreamTypes } from '../loader/fragment';
 import BaseStreamController, { State } from './base-stream-controller';
 import FragmentLoader from '../loader/fragment-loader';
+import ChunkCache from '../demux/chunk-cache';
+import LevelDetails from '../loader/level-details';
 import { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import { BufferAppendingEventPayload, TrackLoadedData, AudioTracksUpdated } from '../types/events';
 import { TrackSet } from '../types/track';
 import { Level } from '../types/level';
-import LevelDetails from '../loader/level-details';
 
 const { performance } = self;
 
@@ -28,6 +29,7 @@ class AudioStreamController extends BaseStreamController {
   private videoTrackCC: number = -1;
   private audioSwitch: boolean = false;
   private trackId: number = -1;
+  private waitingData: { frag: Fragment, cache: ChunkCache, complete: boolean } | null = null;
 
   protected readonly logPrefix = '[audio-stream-controller]';
 
@@ -123,7 +125,24 @@ class AudioStreamController extends BaseStreamController {
     case State.WAITING_INIT_PTS:
       const videoTrackCC = this.videoTrackCC;
       if (Number.isFinite(this.initPTS[videoTrackCC])) {
-        this.state = State.IDLE;
+        // Ensure we don't get stuck in the WAITING_INIT_PTS state if the waiting frag CC doesn't match any initPTS
+        const waitingData = this.waitingData;
+        if (waitingData) {
+          const { frag, cache, complete } = waitingData;
+          this.waitingData = null;
+          if (videoTrackCC === frag.cc) {
+            this.state = State.FRAG_LOADING;
+            const payload = cache.flush();
+            this._handleFragmentLoadProgress(frag, payload);
+            if (complete) {
+              super._handleFragmentLoadComplete(frag, payload);
+            }
+          } else {
+            this.state = State.IDLE;
+          }
+        } else {
+          this.state = State.IDLE;
+        }
       }
       break;
     default:
@@ -277,6 +296,7 @@ class AudioStreamController extends BaseStreamController {
       fragCurrent.loader.abort();
     }
     this.fragCurrent = null;
+    this.waitingData = null;
     // destroy useless transmuxer when switching audio to main
     if (!altAudio) {
       if (transmuxer) {
@@ -356,15 +376,28 @@ class AudioStreamController extends BaseStreamController {
           new TransmuxerInterface(this.hls, 'audio', this._handleTransmuxComplete.bind(this), this._handleTransmuxerFlush.bind(this));
     }
 
-    // initPTS from the video track is required for transmuxing. It should exist before loading a fragment.
+    // Check if we have video initPTS
+    // If not we need to wait for it
     const initPTS = this.initPTS[frag.cc];
-
     const initSegmentData = details.initSegment ? details.initSegment.data : [];
-    // this.log(`Transmuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
-    // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
-    const accurateTimeOffset = false; // details.PTSKnown || !details.live;
-    const chunkMeta = new ChunkMetadata(frag.level, frag.sn, frag.stats.chunkCount, payload.byteLength);
-    transmuxer.push(payload, initSegmentData, audioCodec, '', frag, details.totalduration, accurateTimeOffset, chunkMeta, initPTS);
+    if (details.initSegment || initPTS !== undefined) {
+      // this.log(`Transmuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
+      // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
+      const accurateTimeOffset = false; // details.PTSKnown || !details.live;
+      const chunkMeta = new ChunkMetadata(frag.level, frag.sn, frag.stats.chunkCount, payload.byteLength);
+      transmuxer.push(payload, initSegmentData, audioCodec, '', frag, details.totalduration, accurateTimeOffset, chunkMeta, initPTS);
+    } else {
+      const { cache } = this.waitingData = this.waitingData || { frag, cache: new ChunkCache(), complete: false };
+      cache.push(payload);
+      this.state = State.WAITING_INIT_PTS;
+    }
+  }
+
+  protected _handleFragmentLoadComplete (frag: Fragment, payload: ArrayBuffer | Uint8Array) {
+    if (this.waitingData) {
+      return;
+    }
+    super._handleFragmentLoadComplete(frag, payload);
   }
 
   onBufferReset () {

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -249,9 +249,7 @@ class AudioTrackController extends EventHandler {
 
   private _selectInitialAudioTrack (): void {
     let tracks = this.tracks;
-    if (!tracks.length) {
-      return;
-    }
+    console.assert(tracks.length, 'Initial audio track should be selected when tracks are known');
 
     const currentAudioTrack = this.tracks[this._trackId];
 

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -71,7 +71,7 @@ class AudioTrackController extends EventHandler {
       Event.MANIFEST_PARSED,
       Event.AUDIO_TRACK_LOADED,
       Event.AUDIO_TRACK_SWITCHED,
-      Event.LEVEL_LOADED,
+      Event.LEVEL_LOADING,
       Event.ERROR
     );
 
@@ -167,13 +167,13 @@ class AudioTrackController extends EventHandler {
   }
 
   /**
-   * When a level gets loaded, if it has redundant audioGroupIds (in the same ordinality as it's redundant URLs)
+   * When a level is loading, if it has redundant audioGroupIds (in the same ordinality as it's redundant URLs)
    * we are setting our audio-group ID internally to the one set, if it is different from the group ID currently set.
    *
    * If group-ID got update, we re-select the appropriate audio-track with this group-ID matching the currently
    * selected one (based on NAME property).
    */
-  protected onLevelLoaded (data: LevelLoadedData): void {
+  protected onLevelLoading (data: LevelLoadedData): void {
     const levelInfo = this.hls.levels[data.level];
 
     if (!levelInfo.audioGroupIds) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -243,7 +243,9 @@ export default class BaseStreamController extends TaskLoop {
       this.hls.trigger(Event.ERROR, errorData);
     };
 
-    return this.fragmentLoader.load(frag, progressCallback)
+    const level = (this.levels as Array<any>)[frag.level];
+
+    return this.fragmentLoader.load(frag, progressCallback, level.bitrate)
       .catch(errorHandler);
   }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -19,7 +19,6 @@ import { RemuxedTrack } from '../types/remuxer';
 
 export const State = {
   STOPPED: 'STOPPED',
-  STARTING: 'STARTING',
   IDLE: 'IDLE',
   PAUSED: 'PAUSED',
   KEY_LOADING: 'KEY_LOADING',

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -4,18 +4,18 @@ import { BufferHelper } from '../utils/buffer-helper';
 import { logger } from '../utils/logger';
 import Event from '../events';
 import { ErrorDetails } from '../errors';
-import Fragment from '../loader/fragment';
-import TransmuxerInterface from '../demux/transmuxer-interface';
-import FragmentLoader, { FragLoadSuccessResult, FragmentLoadProgressCallback } from '../loader/fragment-loader';
 import * as LevelHelper from './level-helper';
 import { ChunkMetadata } from '../types/transmuxer';
 import { appendUint8Array } from '../utils/mp4-tools';
-import LevelDetails from '../loader/level-details';
 import { alignStream } from '../utils/discontinuities';
 import { findFragmentByPDT, findFragmentByPTS, findFragWithCC } from './fragment-finders';
+import TransmuxerInterface from '../demux/transmuxer-interface';
+import Fragment from '../loader/fragment';
+import FragmentLoader, { FragLoadSuccessResult, FragmentLoadProgressCallback } from '../loader/fragment-loader';
+import LevelDetails from '../loader/level-details';
 import { BufferAppendingEventPayload } from '../types/events';
 import { Level } from '../types/level';
-import { SourceBufferName } from '../types/buffer';
+import { RemuxedTrack } from '../types/remuxer';
 
 export const State = {
   STOPPED: 'STOPPED',
@@ -288,7 +288,7 @@ export default class BaseStreamController extends TaskLoop {
     return { frag, level: currentLevel };
   }
 
-  protected bufferFragmentData (data: { data1: Uint8Array, data2?: Uint8Array, type: SourceBufferName }, frag: Fragment, chunkMeta: ChunkMetadata) {
+  protected bufferFragmentData (data: RemuxedTrack, frag: Fragment, chunkMeta: ChunkMetadata) {
     if (!data || this.state !== State.PARSING) {
       return;
     }
@@ -587,8 +587,8 @@ export default class BaseStreamController extends TaskLoop {
   }
 
   set state (nextState) {
-    if (this.state !== nextState) {
-      const previousState = this.state;
+    const previousState = this._state;
+    if (previousState !== nextState) {
       this._state = nextState;
       this.log(`${previousState}->${nextState}`);
     }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -31,6 +31,7 @@ export default class LevelController extends EventHandler {
   private levelRetryCount: number = 0;
   private manualLevelIndex: number = -1;
   private timer: number | null = null;
+  public onParsedComplete!: Function;
 
   constructor (hls) {
     super(hls,
@@ -168,6 +169,8 @@ export default class LevelController extends EventHandler {
         video: videoCodecFound,
         altAudio: audioTracks.some(t => !!t.url)
       } as ManifestParsedData);
+
+      this.onParsedComplete();
     } else {
       this.hls.trigger(Event.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -24,7 +24,7 @@ export default class StreamController extends BaseStreamController {
   private bitrateTest: boolean = false;
   private gapController: GapController | null = null;
   private level: number = -1;
-  private forceStartLoad: boolean = false;
+  private _forceStartLoad: boolean = false;
   private retryDate: number = 0;
   private altAudio: boolean = false;
   private fragPlaying: Fragment | null = null;
@@ -97,13 +97,13 @@ export default class StreamController extends BaseStreamController {
       this.nextLoadPosition = this.startPosition = this.lastCurrentTime = startPosition;
       this.tick();
     } else {
-      this.forceStartLoad = true;
+      this._forceStartLoad = true;
       this.state = State.STOPPED;
     }
   }
 
   stopLoad () {
-    this.forceStartLoad = false;
+    this._forceStartLoad = false;
     super.stopLoad();
   }
 
@@ -472,10 +472,6 @@ export default class StreamController extends BaseStreamController {
 
     this.levels = data.levels;
     this.startFragRequested = false;
-    const config = this.config;
-    if (config.autoStartLoad || this.forceStartLoad) {
-      this.hls.startLoad(config.startPosition);
-    }
   }
 
   onLevelLoaded (data) {
@@ -1055,6 +1051,10 @@ export default class StreamController extends BaseStreamController {
 
   set liveSyncPosition (value) {
     this._liveSyncPosition = value;
+  }
+
+  get forceStartLoad () {
+    return this._forceStartLoad;
   }
 }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -222,7 +222,9 @@ export default class StreamController extends BaseStreamController {
         this.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}`);
         this._loadKey(frag);
       } else {
-        this.log(`Loading fragment ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos.toFixed(3)},bufferEnd:${bufferInfo.end.toFixed(3)}`);
+        if (this.fragCurrent !== frag) {
+          this.log(`Loading fragment ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos.toFixed(3)},bufferEnd:${bufferInfo.end.toFixed(3)}`);
+        }
         this._loadFragment(frag);
       }
     }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -131,13 +131,6 @@ export default class StreamController extends BaseStreamController {
       }
     }
       break;
-    case State.ERROR:
-    case State.STOPPED:
-    case State.FRAG_LOADING:
-    case State.PARSING:
-    case State.PARSED:
-    case State.ENDED:
-      break;
     default:
       break;
     }

--- a/src/crypt/aes-decryptor.ts
+++ b/src/crypt/aes-decryptor.ts
@@ -1,14 +1,13 @@
 import { sliceUint8 } from '../utils/typed-array';
 
 // PKCS7
-export function removePadding (buffer) {
-  const outputBytes = buffer.byteLength;
-  const paddingBytes = outputBytes && (new DataView(buffer)).getUint8(outputBytes - 1);
+export function removePadding (array: Uint8Array): Uint8Array {
+  const outputBytes = array.byteLength;
+  const paddingBytes = outputBytes && (new DataView(array.buffer)).getUint8(outputBytes - 1);
   if (paddingBytes) {
-    return sliceUint8(buffer, 0, outputBytes - paddingBytes);
-  } else {
-    return buffer;
+    return sliceUint8(array, 0, outputBytes - paddingBytes);
   }
+  return array;
 }
 
 export default class AESDecryptor {

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -64,7 +64,7 @@ export default class Decrypter {
     }
   }
 
-  public softwareDecrypt (data: Uint8Array, key: ArrayBuffer, iv: ArrayBuffer): Uint8Array | null {
+  public softwareDecrypt (data: Uint8Array, key: ArrayBuffer, iv: ArrayBuffer): ArrayBuffer | null {
     const { currentIV, currentResult, remainderData } = this;
     this.logOnce('JS AES decrypt');
     // The output is staggered during progressive parsing - the current result is cached, and emitted on the next call
@@ -101,7 +101,7 @@ export default class Decrypter {
     if (!result) {
       return null;
     }
-    return new Uint8Array(result);
+    return result;
   }
 
   public webCryptoDecrypt (data: Uint8Array, key: ArrayBuffer, iv: ArrayBuffer): Promise<ArrayBuffer> {
@@ -114,17 +114,14 @@ export default class Decrypter {
       .then((aesKey) => {
         // decrypt using web crypto
         const crypto = new AESCrypto(subtle, iv);
-        return crypto.decrypt(data.buffer, aesKey)
-          .catch((err) => {
-            return this.onWebCryptoError(err, data, key, iv);
-          });
+        return crypto.decrypt(data.buffer, aesKey);
       })
       .catch((err) => {
-        return this.onWebCryptoError(err, data, key, iv);
+        return this.onWebCryptoError(err, data, key, iv) as ArrayBuffer;
       });
   }
 
-  private onWebCryptoError (err, data, key, iv) {
+  private onWebCryptoError (err, data, key, iv): ArrayBuffer | null {
     logger.warn('[decrypter.ts]: WebCrypto Error, disable WebCrypto API:', err);
     this.config.enableSoftwareAES = true;
     this.logEnabled = true;

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -47,12 +47,12 @@ export default class Decrypter {
       this.reset();
       return;
     }
-    let data = currentResult;
-    if (this.removePKCS7Padding) {
-      data = removePadding(currentResult);
-    }
+    const data = new Uint8Array(currentResult);
     this.reset();
-    return new Uint8Array(data);
+    if (this.removePKCS7Padding) {
+      return removePadding(data);
+    }
+    return data;
   }
 
   reset () {

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -72,7 +72,7 @@ export default class Transmuxer {
     const stats = chunkMeta.transmuxing;
     stats.executeStart = now();
 
-    let uintData = new Uint8Array(data);
+    let uintData: Uint8Array = new Uint8Array(data);
     const { cache, config, currentTransmuxState: state, transmuxConfig } = this;
 
     const encryptionType = getEncryptionType(uintData, decryptdata);
@@ -82,12 +82,12 @@ export default class Transmuxer {
       if (config.enableSoftwareAES) {
         // Software decryption is progressive. Progressive decryption may not return a result on each call. Any cached
         // data is handled in the flush() call
-        const decryptedData = decrypter.softwareDecrypt(uintData, decryptdata.key.buffer, decryptdata.iv.buffer);
+        const decryptedData: ArrayBuffer = decrypter.softwareDecrypt(uintData, decryptdata.key.buffer, decryptdata.iv.buffer);
         if (!decryptedData) {
           stats.executeEnd = now();
           return emptyResult(chunkMeta);
         }
-        uintData = decryptedData;
+        uintData = new Uint8Array(decryptedData);
       } else {
         this.decryptionPromise = decrypter.webCryptoDecrypt(uintData, decryptdata.key.buffer, decryptdata.iv.buffer)
           .then((decryptedData) : TransmuxerResult => {

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -59,7 +59,7 @@ class TSDemuxer implements Demuxer {
   private _txtTrack!: DemuxedTrack;
   private aacOverFlow: any;
   private avcSample: any;
-  private remainderData?: Uint8Array;
+  private remainderData: Uint8Array | null = null;
 
   constructor (observer, config, typeSupported) {
     this.observer = observer;
@@ -195,7 +195,7 @@ class TSDemuxer implements Demuxer {
     if (this.remainderData) {
       data = appendUint8Array(this.remainderData, data);
       len = data.length;
-      this.remainderData = undefined;
+      this.remainderData = null;
     }
 
     const syncOffset = TSDemuxer._syncOffset(data);
@@ -209,7 +209,9 @@ class TSDemuxer implements Demuxer {
       };
     }
     len -= (len + syncOffset) % 188;
-    this.remainderData = sliceUint8(data, len);
+    if (len < data.byteLength) {
+      this.remainderData = sliceUint8(data, len);
+    }
 
     // loop through TS packets
     for (start = syncOffset; start < len; start += 188) {
@@ -353,7 +355,7 @@ class TSDemuxer implements Demuxer {
       };
     }
     this.extractRemainingSamples(result);
-    this.remainderData = undefined;
+    this.remainderData = null;
     return result;
   }
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -428,8 +428,10 @@ export default class Hls extends Observer {
    * @type {number}
    */
   set autoLevelCapping (newLevel: number) {
-    logger.log(`set autoLevelCapping:${newLevel}`);
-    this._autoLevelCapping = newLevel;
+    if (this._autoLevelCapping !== newLevel) {
+      logger.log(`set autoLevelCapping:${newLevel}`);
+      this._autoLevelCapping = newLevel;
+    }
   }
 
   /**

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -111,6 +111,13 @@ export default class Hls extends Observer {
     const fragmentTracker = new FragmentTracker(this);
     const streamController = this.streamController = new StreamController(this, fragmentTracker);
 
+    // Level Controller initiates loading after all controllers have received MANIFEST_PARSED
+    levelController.onParsedComplete = () => {
+      if (config.autoStartLoad || streamController.forceStartLoad) {
+        this.startLoad(config.startPosition);
+      }
+    };
+
     // Cap level controller uses streamController to flush the buffer
     capLevelController.setStreamController(streamController);
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -12,8 +12,6 @@ import { FragmentTracker } from './controller/fragment-tracker';
 import StreamController from './controller/stream-controller';
 import LevelController from './controller/level-controller';
 
-import PerformanceMonitor from './performance/performance-monitor';
-
 import { isSupported } from './is-supported';
 import { logger, enableLogs } from './utils/logger';
 import { HlsConfig, hlsDefaultConfig, mergeConfig, setStreamingMode } from './config';
@@ -139,9 +137,6 @@ export default class Hls extends Observer {
     this.createController(config.subtitleStreamController, fragmentTracker, networkControllers);
     this.createController(config.timelineController, null, coreComponents);
     this.emeController = this.createController(config.emeController, null, coreComponents);
-
-    // Push the performance monitor last so that it is the last class to handle events
-    coreComponents.push(new PerformanceMonitor(this));
 
     this.coreComponents = coreComponents;
   }

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -9,16 +9,17 @@ import {
   LoaderCallbacks
 } from '../types/loader';
 
-const MIN_CHUNK_SIZE = Math.pow(2, 14); // 16kb
+const MIN_CHUNK_SIZE = Math.pow(2, 15); // 32kb
 
 export default class FragmentLoader {
-  private config: any;
+  private readonly config: any;
   private loader: Loader<FragmentLoaderContext> | null = null;
+
   constructor (config) {
     this.config = config;
   }
 
-  load (frag: Fragment, onProgress?: FragmentLoadProgressCallback): Promise<FragLoadSuccessResult | LoadError> {
+  load (frag: Fragment, onProgress?: FragmentLoadProgressCallback, bitrate?: number): Promise<FragLoadSuccessResult | LoadError> {
     if (!frag.url) {
       return Promise.reject(new LoadError(null, 'Fragment does not have a url'));
     }
@@ -51,12 +52,13 @@ export default class FragmentLoader {
       loaderContext.rangeEnd = end;
     }
 
+    const bytesPerSecond: number = (bitrate ? bitrate / 8 : 0) | 0;
     const loaderConfig: LoaderConfiguration = {
       timeout: config.fragLoadingTimeOut,
       maxRetry: 0,
       retryDelay: 0,
       maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-      highWaterMark: MIN_CHUNK_SIZE
+      highWaterMark: Math.max(bytesPerSecond, MIN_CHUNK_SIZE)
     };
 
     return new Promise((resolve, reject) => {

--- a/src/performance/performance-monitor.ts
+++ b/src/performance/performance-monitor.ts
@@ -1,3 +1,12 @@
+/*
+ * Push the performance monitor as the last core component in hls.ts
+ * so that it is the last class to handle events.
+ *
+ * coreComponents.push(new PerformancMonitor(this));
+ *
+ * TODO: Add this to the demo page or a performance test page
+ */
+
 import EventHandler from '../event-handler';
 import Events from '../events';
 import Fragment from '../loader/fragment';

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -21,8 +21,7 @@ export function fetchSupported () {
   return false;
 }
 
-class
-FetchLoader implements Loader<LoaderContext> {
+class FetchLoader implements Loader<LoaderContext> {
   private fetchSetup: Function;
   private requestTimeout?: number;
   private request!: Request;
@@ -129,30 +128,27 @@ FetchLoader implements Loader<LoaderContext> {
 
     const pump = () => {
       reader.read().then((data: { done: boolean, value: Uint8Array }) => {
-        const { done, value: chunk } = data;
-        if (done) {
+        if (data.done) {
           if (chunkCache.dataLength) {
             onProgress(stats, context, chunkCache.flush(), response);
           }
           return;
         }
+        const chunk = data.value;
         const len = chunk.length;
         stats.loaded += len;
-        if (len >= highWaterMark) {
-          // The cache already has data, and the current chunk is large enough to be emitted. Push it to the cache
-          // and flush in order to join the typed arrays
-          if (chunkCache.dataLength) {
-            chunkCache.push(chunk);
-            onProgress(stats, context, chunkCache.flush(), response);
-          } else {
-            // If there's nothing cached already, just emit the progress event
-            onProgress(stats, context, chunk, response);
-          }
-        } else {
+        if (len < highWaterMark || chunkCache.dataLength) {
+          // The current chunk is too small to to be emitted or the cache already has data
+          // Push it to the cache
           chunkCache.push(chunk);
           if (chunkCache.dataLength >= highWaterMark) {
+            // flush in order to join the typed arrays
             onProgress(stats, context, chunkCache.flush(), response);
           }
+        } else {
+          // If there's nothing cached already, and the chache is large enough
+          // just emit the progress event
+          onProgress(stats, context, chunk, response);
         }
         pump();
       }).catch(() => { /* aborted */ });

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -20,21 +20,10 @@ let exportedLogger = fakeLogger;
 //   return msg;
 // }
 
-function formatMsg (type, msg) {
-  msg = '[' + type + '] > ' + msg;
-  return msg;
-}
-
 function consolePrintFn (type) {
   const func = self.console[type];
   if (func) {
-    return function (...args) {
-      if (args[0]) {
-        args[0] = formatMsg(type, args[0]);
-      }
-
-      func.apply(self.console, args);
-    };
+    return func.bind(self.console, `[${type}] >`);
   }
   return noop;
 }

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -434,8 +434,8 @@ export function offsetStartDTS (initData, fragment, timeOffset) {
 // TODO: Check if the last moof+mdat pair is part of the valid range
 export function segmentValidRange (data: Uint8Array): SegmentedRange {
   const segmentedRange: SegmentedRange = {
-    valid: new Uint8Array(0),
-    remainder: new Uint8Array(0)
+    valid: null,
+    remainder: null
   };
 
   const moofs = findBox(data, ['moof']);
@@ -453,8 +453,8 @@ export function segmentValidRange (data: Uint8Array): SegmentedRange {
 }
 
 export interface SegmentedRange {
-  valid: Uint8Array,
-  remainder: Uint8Array,
+  valid: Uint8Array | null,
+  remainder: Uint8Array | null,
 }
 
 export function appendUint8Array (data1: Uint8Array, data2: Uint8Array) : Uint8Array {


### PR DESCRIPTION
### This PR will...
- Push streamed data to the transmuter in roughly one second payloads based on level bitrate
- Prevent the transmux-worker from posting empty "transmuxComplete" messages (Don't create empty ArrayBuffers)
- Cleanup and optimize logging
  - Only log frag loading message when fragment changes
  - Remove performance monitor logger (this can be implemented externally)
  - Bind console method in `consolePrintFn` for direct logging 
- Reduce the amount empty array buffers created and prevent unnecessary copying
- Load audio track on level loading event rather than level loaded (tracks load at the same time)
- Remove `STARTING` state which was only used in the audio stream controller to wait a tick
- Load first audio fragment while waiting for initPTS (similar to the solution in master using `waitingFragment`)

### Why is this Pull Request needed?
To improve performance of https://github.com/video-dev/hls.js/pull/2370:

- On sites with other applications and ads competing for resources on the main thread.
  - Pushing too little data to workers is inefficient as it adds round trip time to and from the worker and each of those posts has to occur on the main event loop.
  - [ ] It may make sense to change the loader high watermark based on whether or not workers are enabled. The same goes for any other parts of the pipeline that are async (hardware decryption)
- When starting streams with audio tracks
  - Audio track manifests should be requested in tandem with the chose level playlist, and the first audio fragment should be requested as soon as possible to ensure the fastest start time. Waiting for initPTS made start time worse in this branch compared to master.
- Reduce major and minor GC by reducing object and memory allocation

### Are there any points in the code the reviewer needs to double check?
Still a work in progress and needs rebasing. 

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
