### PR TITLE
use `npm ci` instead of `npm install`

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -3,7 +3,7 @@
 set -ev
 
 echo "travis_fold:start:npm_install"
-npm install
+npm ci
 echo "travis_fold:end:npm_install"
 
 if [ "${TRAVIS_MODE}" = "build" ]; then


### PR DESCRIPTION
### This PR will...

Use `npm ci` instead of `npm install` on CI.

### Why is this Pull Request needed?
This is quicker, but also validates that the package-lock is in sync with the package.json

Without this anything in the package.json that is out of sync with the package-lock gets silently updated and the integrity is not checked
