### PR TITLE
Eslint type assertion rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,6 +91,7 @@ module.exports = {
     'no-empty': 1,
     'no-mixed-operators': 1,
     'no-unused-vars': 1,
+    '@typescript-eslint/no-unused-vars': 1,
     'no-console': 1,
     'no-fallthrough': 1,
     'no-case-declarations': 1,
@@ -106,6 +107,12 @@ module.exports = {
     'no-void': 0,
     'no-useless-catch': 2,
     'lines-between-class-members': 2,
-    'no-prototype-builtins': 0
+    'no-prototype-builtins': 0,
+    '@typescript-eslint/consistent-type-assertions': [ 2, 
+      {
+        'assertionStyle': 'as',
+        'objectLiteralTypeAssertions': 'never'
+      }
+    ]
   }
 };

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -160,7 +160,7 @@ export default class LevelController extends EventHandler {
       }
 
       // Audio is only alternate if manifest include a URI along with the audio group tag
-      this.hls.trigger(Event.MANIFEST_PARSED, {
+      const edata: ManifestParsedData = {
         levels,
         audioTracks,
         firstLevel: this._firstLevel,
@@ -168,7 +168,8 @@ export default class LevelController extends EventHandler {
         audio: audioCodecFound,
         video: videoCodecFound,
         altAudio: audioTracks.some(t => !!t.url)
-      } as ManifestParsedData);
+      };
+      this.hls.trigger(Event.MANIFEST_PARSED, edata);
 
       this.onParsedComplete();
     } else {

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -143,7 +143,7 @@ export default class MP4Remuxer implements Remuxer {
     const audioSamples = audioTrack.samples;
     const videoSamples = videoTrack.samples;
     const typeSupported = this.typeSupported;
-    const tracks = {} as TrackSet;
+    const tracks: TrackSet = {};
     const computePTSDTS = (!Number.isFinite(this._initPTS));
     let container = 'audio/mp4';
     let initPTS;

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -50,7 +50,7 @@ class PassThroughRemuxer implements Remuxer {
       videoCodec = 'avc1.42e01e';
     }
 
-    const tracks = {} as TrackSet;
+    const tracks: TrackSet = {};
     if (initData.audio && initData.video) {
       tracks.audiovideo = {
         container: 'video/mp4',

--- a/tests/unit/controller/buffer-operation-queue.ts
+++ b/tests/unit/controller/buffer-operation-queue.ts
@@ -19,7 +19,7 @@ describe('BufferOperationQueue tests', function () {
     video: {
       updating: false
     }
-  } as SourceBuffers;
+  } as any as SourceBuffers;
 
   beforeEach(function () {
     operationQueue = new BufferOperationQueue(sbMock);


### PR DESCRIPTION
### This PR will...

Prevent `<string>` style type assertion (not to be confused with generic type definitions) in the code.

### Why is this Pull Request needed?

Rob mentioned that these type assertions were making the docs fail.

### Are there any points in the code the reviewer needs to double check?

`as any as Type` - If you want to have a partial type for "quick assertions" like with unit tests, this is the way you do it, you don't need a eslint disable rule.