### PR TITLE
fix: consider paused state

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -282,7 +282,7 @@ class StreamController extends BaseStreamController {
       let liveSyncPosition = this.liveSyncPosition = this.computeLivePosition(start, levelDetails);
       logger.log(`buffer end: ${bufferEnd.toFixed(3)} is located too far from the end of live sliding playlist, reset currentTime to : ${liveSyncPosition.toFixed(3)}`);
       bufferEnd = liveSyncPosition;
-      if (media && media.readyState && media.duration > liveSyncPosition) {
+      if (media && !media.paused && media.readyState && media.duration > liveSyncPosition) {
         media.currentTime = liveSyncPosition;
       }
 


### PR DESCRIPTION
when the video is paused the currentTime should not be updated. 



### This PR will...
fixes #2417

and by that will not update the current time of the video if it paused

### Why is this Pull Request needed?
#2417

### Are there any points in the code the reviewer needs to double check?
I am only wondering whether the `!medi.paused` should be before, i.e with the line 

```js
if (bufferEnd < Math.max(start - config.maxFragLookUpTolerance, end - maxLatency)) {
```

### Resolves issues:
#2417

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
