### PR TITLE
Adds Needs Triage to be a staleness exempt label.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   - Confirmed
   - Feature proposal
   - Question
+  - Needs Triage
 
 
 # Label to use when marking an issue as stale


### PR DESCRIPTION
### This PR will...

Adds Needs Triage to the exempt list for stale tickets.

### Why is this Pull Request needed?

Too many tickets were being closed that had streams that could be used to make hls.js more bullet-proof.