### PR TITLE
fix #2400 issue - cues doesn't show up on browsers which addCue doesn't throw error with invalid structure

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -294,6 +294,7 @@ class TimelineController extends EventHandler {
         if (!currentTrack.cues.getCueById(cue.id)) {
           try {
             currentTrack.addCue(cue);
+            if (!currentTrack.cues.getCueById(cue.id)) throw new Error('browser which doesnt throw error when cues structure is invalid');
           } catch (err) {
             const textTrackCue = new (window as any).TextTrackCue(cue.startTime, cue.endTime, cue.text);
             textTrackCue.id = cue.id;

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -294,8 +294,11 @@ class TimelineController extends EventHandler {
         if (!currentTrack.cues.getCueById(cue.id)) {
           try {
             currentTrack.addCue(cue);
-            if (!currentTrack.cues.getCueById(cue.id)) throw new Error('browser which doesnt throw error when cues structure is invalid');
+            if (!currentTrack.cues.getCueById(cue.id)) {
+              throw new Error(`addCue is failed for: ${cue}`);
+            }
           } catch (err) {
+            logger.debug(`Failed occurred on adding cues: ${err}`);
             const textTrackCue = new (window as any).TextTrackCue(cue.startTime, cue.endTime, cue.text);
             textTrackCue.id = cue.id;
             currentTrack.addCue(textTrackCue);


### PR DESCRIPTION
fix #2400 for example LG SDK 2 has bug on their addCue method with different structure it won't addCue, check if the added cue is entered otherwise try the fallback structure.

### Why is this Pull Request needed?

enable captions on problematic OS such as LG SDK 2

### Resolves issues:

#2400 

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] API or design changes are documented in API.md
