### PR TITLE
Cleaning Text Tracks cues on media detachment.

### DIFF
--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -76,7 +76,7 @@ class SubtitleTrackController extends EventHandler {
     textTracks.forEach((track) => {
       clearCurrentCues(track);
     });
-    // Disable all subtitle tracks before detachment so when reattached only the
+    // Disable all subtitle tracks before detachment so when reattached only tracks in that content are enabled.
     this.subtitleTrack = -1;
     this.media = null;
   }

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -2,6 +2,7 @@ import Event from '../events';
 import EventHandler from '../event-handler';
 import { logger } from '../utils/logger';
 import { computeReloadInterval } from './level-helper';
+import { clearCurrentCues } from '../utils/texttrack-utils';
 
 class SubtitleTrackController extends EventHandler {
   constructor (hls) {
@@ -70,7 +71,13 @@ class SubtitleTrackController extends EventHandler {
       this.queuedDefaultTrack = this.subtitleTrack;
     }
 
-    this.trackId = -1;
+    const textTracks = filterSubtitleTracks(this.media.textTracks);
+    // Clear loaded cues on media detachment from tracks
+    textTracks.forEach((track) => {
+      clearCurrentCues(track);
+    });
+    // Disable all subtitle tracks before detachment so when reattached only the
+    this.subtitleTrack = -1;
     this.media = null;
   }
 


### PR DESCRIPTION
### This PR will...

The timeline-controller previously did this but the subtitle controller
did not. What this PR does is clear subtitle cues during the process of
detaching the media, and also disables subtitle tracks on the video
element it is detached from.

### Why is this Pull Request needed?

This fixes odd behaviour I noticed on the demo page where when switching
between Angel-One and Multiple Text Tracks content. If you detach and
reattach to the same video element between two pieces of content that do
not share text tracks, the track elements from the previous content will
be visible in the default video controls. By setting subtitleTrack to -1
we trigger our internal setter logic which goes through and disables all
tracks which hides them from user-agent controls.

Additionally, before disabling them, clearing the cues from the text
track itself will prevent cues from one item appearing on the next.

### Resolves issues:

Closes #2198.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
