### PR TITLE
Fail faster for HTTP 4XX fragment responses

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -502,6 +502,10 @@ class AudioStreamController extends BaseStreamController implements ComponentAPI
       }
 
       if (!data.fatal) {
+        // If the response was final then it's useless to retry
+        // (the level controller handles this as a level error)
+        if (data.response.final) break;
+
         let loadError = this.fragLoadError;
         if (loadError) {
           loadError++;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -733,6 +733,10 @@ export default class StreamController extends BaseStreamController implements Ne
     case ErrorDetails.KEY_LOAD_ERROR:
     case ErrorDetails.KEY_LOAD_TIMEOUT:
       if (!data.fatal) {
+        // If the response was final then it's useless to retry
+        // (the level controller handles this as a level error)
+        if (data.response.final) break;
+
         // keep retrying until the limit will be reached
         if ((this.fragLoadError + 1) <= this.config.fragLoadingMaxRetry) {
           // exponential backoff capped to config.fragLoadingMaxRetryTimeout

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -83,6 +83,8 @@ type LoaderOnError < T extends LoaderContext > = (
   error: {
     // error status code
     code: number,
+    // expect same response if request is repeated
+    final: boolean,
     // error description
     text: string,
   },

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -112,7 +112,9 @@ class FetchLoader implements Loader<LoaderContext> {
       }
       // CORS errors result in an undefined code. Set it to 0 here to align with XHR's behavior
       const code = error.code || 0;
-      callbacks.onError({ code, text: error.message }, context, error.details);
+      // CORS errors and 4XX responses are final (i.e. should not be retried)
+      const final = error.code && error.code >= 400 && error.code < 499;
+      callbacks.onError({ code, final, text: error.message }, context, error.details);
     });
   }
 

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -79,8 +79,9 @@ class XhrLoader implements Loader<LoaderContext> {
         xhr.open('GET', context.url, true);
       }
     } catch (e) {
+      const final = xhr.status >= 400 && xhr.status < 499;
       // IE11 throws an exception on xhr.open if attempting to access an HTTP resource over HTTPS
-      this.callbacks.onError({ code: xhr.status, text: e.message }, context, xhr);
+      this.callbacks.onError({ code: xhr.status, final, text: e.message }, context, xhr);
       return;
     }
 
@@ -142,9 +143,10 @@ class XhrLoader implements Loader<LoaderContext> {
           this.callbacks.onSuccess(response, stats, context, xhr);
         } else {
           // if max nb of retries reached or if http status between 400 and 499 (such error cannot be recovered, retrying is useless), return error
-          if (stats.retry >= config.maxRetry || (status >= 400 && status < 499)) {
+          const final = status >= 400 && status < 499;
+          if (stats.retry >= config.maxRetry || final) {
             logger.error(`${status} while loading ${context.url}`);
-            this.callbacks.onError({ code: status, text: xhr.statusText }, context, xhr);
+            this.callbacks.onError({ code: status, final, text: xhr.statusText }, context, xhr);
           } else {
             // retry
             logger.warn(`${status} while loading ${context.url}, retrying in ${this.retryDelay}...`);


### PR DESCRIPTION
### This PR will...
This PR restates [logic from the XHR loader](https://github.com/redoPop/hls.js/blob/5df6560e48c0d21e1bcdd3df277ca1f0fa415efe/src/utils/xhr-loader.js#L107-L108) in the fragment loader, causing 4XX errors to be marked as fatal and thus allowing the AV controllers' error-handling to bypass retries when a response indicates that a request _cannot_ succeed. (AV controllers implement their own retry logic, so they don't benefit from the XHR loader's decision to skip retries.)

### Why is this Pull Request needed?
* Pointless retry requests are avoided
* End users can receive feedback sooner when a stream is failing
* Stream issues will escalate sooner where fatal error logs are monitored

### Are there any points in the code the reviewer needs to double check?
Per @OrenMe's [feedback](https://github.com/video-dev/hls.js/pull/2440#issuecomment-551429061) I'm opening this PR against the 1.0.0 branch instead of master.

Some clarification may be needed here, from the same feedback:

> it is achievable with configuring different fail and retry values

The goal of this change is to avoid retrying 4XX requests _specifically_ since they have no hope of success. Hls.js should maintain the configured fail and retry values for other network errors; the HTTP 4XX status range represents a special class of error in which retries are useless.

### Checklist
- [ ] (See above) changes have been done against master branch and PR does not conflict
- [x] (N/A) new unit / functional tests have been added whenever applicable
- [x] (N/A) API or design changes are documented in API.md
