### PR TITLE
Follow up clear-vtt-cues-with-live-back-buffer-length

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -18,7 +18,8 @@ if (demoConfig) {
 
 const hlsjsDefaults = {
   debug: true,
-  enableWorker: true
+  enableWorker: true,
+  liveBackBufferLength: 60 * 15
 };
 
 let enableStreaming = getDemoConfigPropOrDefault('enableStreaming', true);

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -488,8 +488,9 @@ class BufferController extends EventHandler {
           // remove buffer up until current time minus minimum back buffer length (removing buffer too close to current
           // time will lead to playback freezing)
           // credits for level target duration - https://github.com/videojs/http-streaming/blob/3132933b6aa99ddefab29c10447624efd6fd6e52/src/segment-loader.js#L91
-          this.removeBufferRange(bufferType, sb, 0, targetBackBufferPosition);
-          this.hls.trigger(Events.LIVE_BACK_BUFFER_REACHED, { bufferEnd: targetBackBufferPosition });
+          if (this.removeBufferRange(bufferType, sb, 0, targetBackBufferPosition)) {
+            this.hls.trigger(Events.LIVE_BACK_BUFFER_REACHED, { bufferEnd: targetBackBufferPosition });
+          }
         }
       }
     }

--- a/src/controller/id3-track-controller.js
+++ b/src/controller/id3-track-controller.js
@@ -95,22 +95,16 @@ class ID3TrackController extends EventHandler {
   }
 
   onLiveBackBufferReached ({ bufferEnd }) {
-    if (!this.id3Track || !this.id3Track.cues || !this.id3Track.cues.length) {
+    const { id3Track } = this;
+    if (!id3Track || !id3Track.cues || !id3Track.cues.length) {
       return;
     }
-    const foundCue = getClosestCue(this.id3Track.cues, bufferEnd);
+    const foundCue = getClosestCue(id3Track.cues, bufferEnd);
     if (!foundCue) {
       return;
     }
-
-    let removeCues = true;
-    while (removeCues) {
-      const cue = this.id3Track.cues[0];
-      if (!this.id3Track.cues.length || cue.id === foundCue.id) {
-        removeCues = false;
-        return;
-      }
-      this.id3Track.removeCue(cue);
+    while (id3Track.cues[0] !== foundCue) {
+      id3Track.removeCue(id3Track.cues[0]);
     }
   }
 }


### PR DESCRIPTION
### This PR will...
Follow up on https://github.com/video-dev/hls.js/pull/2309 by @JordanPawlett with a few enhancements:
1. Set `liveBackBufferLength` to 15 minutes in the demo (the default is `Infinity`)
1. Only emit `LIVE_BACK_BUFFER_REACHED` when `SourceBuffer.remove` does not throw
1. Optimize id3-track-controller `onLiveBackBufferReached`

### Why is this Pull Request needed?
1. Test back buffer removal in the demo by default.
1. Only fire `LIVE_BACK_BUFFER_REACHED` when the back buffer actually is flushed (if the method throws the last sourceBuffer request is still being processed)
1. Reduce code complexity 
1. To introduce the new event in 0.13.0 rather than a later patch

### Are there any points in the code the reviewer needs to double check?
We don't have any tests for `liveBackBufferLength`. Adding it to the demo is just a stop-gap to provide some coverage for folks testing live streams in the demo app.

Why is `liveBackBufferLength` set to `Infinity` by default? This lets the browser handle buffer removal, but why can't we clear cues when the browser clears the buffer?

Rather than a fixed `liveBackBufferLength`, I would like it to be based on a live level's `totalduration`. I propose that a value of `-1` signify that it is dynamic and we clear the back buffer based on the level's `totalduration` or start of the first available segment. This way, the buffer would more closely reflect the changing window of segments after a playlist refresh. Anyone wanting a shorter back buffer could continue to use a fixed positive value. 

I don't think `LIVE_BACK_BUFFER_REACHED`  accurately describes the event. `BACK_BUFFER_REMOVED` would be better and serve more purposes - it could also be dispatched in v1 after `sb.remove` resolves. I would also like to see removal ranges be fragment range based and update the fragment tracker. This would be useful for long DVR live streams that require buffer removal in memory constrained environments.


### Checklist

- [x] changes have been done against master branch, and PR does not conflict

### Other
I'm not contributing these as part of this follow up, but would like to see them in v1.x
- [ ] Add a test for this event being fired in buffer-controller.ts
- [ ] Add tests for id3-track-controller.js
