### PR TITLE
Follow up gap controller fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -124,10 +124,6 @@ type TSDemuxerConfig = {
   forceKeyFrameOnDiscontinuity: boolean,
 };
 
-type GapControllerConfig = {
-  enforceAutoPlayByMutingAudioOnly: boolean
-};
-
 export type HlsConfig =
   {
     debug: boolean,
@@ -163,7 +159,6 @@ export type HlsConfig =
   PlaylistLoaderConfig &
   StreamControllerConfig &
   Partial<TimelineControllerConfig> &
-  GapControllerConfig &
   TSDemuxerConfig;
 
 // If possible, keep hlsDefaultConfig shallow
@@ -180,7 +175,6 @@ export const hlsDefaultConfig: HlsConfig = {
   maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
   maxBufferHole: 0.5, // used by stream-controller
-  enforceAutoPlayByMutingAudioOnly: true, // used by gap-controller
 
   lowBufferWatchdogPeriod: 0.5, // used by stream-controller
   highBufferWatchdogPeriod: 3, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,10 @@ type TSDemuxerConfig = {
   forceKeyFrameOnDiscontinuity: boolean,
 };
 
+type GapControllerConfig = {
+  enforceAutoPlayByMutingAudioOnly: boolean
+};
+
 export type HlsConfig =
   {
     debug: boolean,
@@ -159,6 +163,7 @@ export type HlsConfig =
   PlaylistLoaderConfig &
   StreamControllerConfig &
   Partial<TimelineControllerConfig> &
+  GapControllerConfig &
   TSDemuxerConfig;
 
 // If possible, keep hlsDefaultConfig shallow
@@ -175,6 +180,7 @@ export const hlsDefaultConfig: HlsConfig = {
   maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
   maxBufferHole: 0.5, // used by stream-controller
+  enforceAutoPlayByMutingAudioOnly: true, // used by gap-controller
 
   lowBufferWatchdogPeriod: 0.5, // used by stream-controller
   highBufferWatchdogPeriod: 3, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,7 +174,7 @@ export const hlsDefaultConfig: HlsConfig = {
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
-  maxBufferHole: 15, // used by stream-controller
+  maxBufferHole: 0.5, // used by stream-controller
 
   lowBufferWatchdogPeriod: 0.5, // used by stream-controller
   highBufferWatchdogPeriod: 3, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,7 +174,7 @@ export const hlsDefaultConfig: HlsConfig = {
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
-  maxBufferHole: 0.5, // used by stream-controller
+  maxBufferHole: 15, // used by stream-controller
 
   lowBufferWatchdogPeriod: 0.5, // used by stream-controller
   highBufferWatchdogPeriod: 3, // used by stream-controller

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -228,7 +228,7 @@ class EMEController extends EventHandler {
     logger.log('Got EME message event, creating license request');
 
     this._requestLicense(message, (data: ArrayBuffer) => {
-      logger.log('Received license data, updating key-session');
+      logger.log(`Received license data (length: ${data ? data.byteLength : data}), updating key-session`);
       keySession.update(data);
     });
   }

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -64,8 +64,8 @@ export default class GapController {
       return;
     }
 
-    // The playhead isn't moving but it should be
-    // Allow some slack time to for small stalls to resolve themselves
+    // Skip start gaps if we haven't played, but the last poll detected the start of a stall
+    // The addition poll gives the browser a chance to jump the gap for us
     if (!this.moved && this.stalled) {
       if (!seeking && (bufferInfo.nextStart || bufferInfo.start > currentTime)) {
         this._trySkipBufferHole(null);

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -67,7 +67,9 @@ export default class GapController {
     // Skip start gaps if we haven't played, but the last poll detected the start of a stall
     // The addition poll gives the browser a chance to jump the gap for us
     if (!this.moved && this.stalled) {
-      if (!seeking && (bufferInfo.nextStart || bufferInfo.start > currentTime)) {
+      // Jump start gaps within jump threshold
+      const startJump = Math.max(bufferInfo.nextStart || 0, ((bufferInfo.start || 0) - currentTime));
+      if (!seeking && startJump > 0 && startJump <= JUMP_THRESHOLD_SECONDS) {
         this._trySkipBufferHole(null);
       }
       return;

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -142,7 +142,6 @@ export default class GapController {
     // If it was reported stalled, let's log the recovery
     if (this.stallReported) {
       const now = window.performance.now();
-      const currentPlayheadTime = this.media.currentTime;
       logger.warn(`playhead not stalled anymore @${currentPlayheadTime}, after ${(now - this.stallDetectedAtTime)} ms`);
 
       this.stallReported = false;

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -79,14 +79,10 @@ export default class GapController {
       }
       // Checking what the buffer reports as start time for the first fragment appended.
       // We skip the playhead to this position to overcome an apparent initial gap in the stream.
-      // We add a margin value on top (same as the one used for playhead nudging on stall detection)
-      // to fix eventual issues with browser-internal thresholds
-      // where some MSE implementation might not play when the playhead
-      // is exactly on the start value (trying to overcome what would be a browser bug).
       const firstBufferedPosition = media.buffered.start(0);
       if ((firstBufferedPosition - mediaCurrentTime > 0) && !media.seeking) {
         logger.warn(`skipping over gap at startup (first segment buffered time-range starts partially later than assumed) from ${mediaCurrentTime} to ${firstBufferedPosition} seconds`);
-        media.currentTime = firstBufferedPosition + SKIP_BUFFER_HOLE_STEP_SECONDS;
+        media.currentTime = firstBufferedPosition;
       }
     }
 

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -17,32 +17,38 @@ export default class GapController {
     this.hls = hls;
 
     /**
-     * @private @member {boolean}
+     * @private
+     * @member {boolean}
      */
     this.stallReported = false;
 
     /**
-     * @private @member {number | null}
+     * @private
+     * @member {number | null}
      */
     this.stallDetectedAtTime = null;
 
     /**
-     * @private @member {number | null}
+     * @private
+     * @member {number | null}
      */
     this.stallHandledAtTime = null;
 
     /**
-     * @private @member {number | null}
+     * @private
+     * @member {number | null}
      */
     this.currentPlayheadTime = null;
 
     /**
-     * @private @member {boolean}
+     * @private
+     * @member {boolean}
      */
     this.hasPlayed = false;
 
     /**
-     * @private @member {EventListener}
+     * @private
+     * @member {EventListener}
      */
     this.onMediaStalled = null;
   }

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -153,13 +153,19 @@ export default class GapController {
   _isMediaInPlayableState () {
     const currentPlayheadTime = this.currentPlayheadTime;
     const media = this.media;
+    // the first case of unplayable media lies in it being in an "ended" state, or not being "ready",
+    // the necessary data not being available, which can essentially be see from the buffered time-ranges,
+    // but more clearly from the readyState property the browser exposes for the media element.
     if (media.ended || !media.buffered.length || media.readyState <= 2) {
       return false;
+    // the other cases of unplayable are when the media is seeking, and the targetted time for this
+    // is not yet in the buffered time-ranges, meaning that this position can not be decoded or played
+    // in any forseeable latency (or maybe never depending on wether the data for this media time will ever be received/demuxed).
     } else if (media.seeking && !BufferHelper.isBuffered(media, currentPlayheadTime)) {
       return false;
-    } else {
-      return true;
     }
+    // for all other cases we assume by inverse logic conditions that media is in a playable state
+    return true;
   }
 
   _onMediaElWaiting () {

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -64,7 +64,7 @@ export default class GapController {
     const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
     const isBuffered = bufferInfo.len > 0;
 
-    // There is no playable buffer (seeked, waiting for buffer)
+    // There is no playable buffer (waiting for buffer append)
     if (!isBuffered && !bufferInfo.nextStart) {
       return;
     }

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -315,9 +315,18 @@ export default class GapController {
 
     if (nudgeRetry < config.nudgeMaxRetry) {
       const targetTime = currentTime + nudgeRetry * config.nudgeOffset;
-      logger.log(`Adjusting media-element currentTime from ${currentTime} to ${targetTime}`);
       // playback stalled in buffered area ... let's nudge currentTime to try to overcome this
+      logger.log(`Adjusting media-element 'currentTime' from ${currentTime} to ${targetTime}`);
       media.currentTime = targetTime;
+
+      if (nudgeRetry === config.nudgeMaxRetry - 1) {
+        logger.warn('Lastly: Attempting to un-stall playback state by over-calling media-element play() (this should not be necessary, ouch ...)');
+        if (config.enforceAutoPlayByMutingAudioOnly) {
+          logger.warn('Muting media audio now! Needed to allow non-UI-event scheduled play() call (this is a workaround to audio-only autoplay issues on Chrome)');
+          media.muted = true;
+        }
+        media.play();
+      }
 
       hls.trigger(Event.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -79,7 +79,7 @@ export default class GapController {
       // where some MSE implementation might not play when the playhead
       // is exactly on the start value (trying to overcome what would be a browser bug).
       const firstBufferedPosition = this.media.buffered.start(0);
-      if (mediaCurrentTime - firstBufferedPosition > 0 && !this.media.seeking) {
+      if ((firstBufferedPosition - mediaCurrentTime > 0) && !this.media.seeking) {
         logger.warn(`skipping over gap at startup (first segment buffered time-range starts partially later than assumed) from ${mediaCurrentTime} to ${firstBufferedPosition} seconds`);
         this.media.currentTime = firstBufferedPosition + SKIP_BUFFER_HOLE_STEP_SECONDS;
       }

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -61,16 +61,22 @@ export default class GapController {
       return;
     }
 
-    // Waiting for seeking in a buffered range to complete
-    if (seeking && BufferHelper.isBuffered(media, currentTime)) {
+    const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
+    const isBuffered = bufferInfo.len > 0;
+
+    // There is no playable buffer (seeked, waiting for buffer)
+    if (!isBuffered && !bufferInfo.nextStart) {
       return;
     }
 
-    const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
-
-    // There is no playable buffer (seeked, waiting for buffer)
-    if (bufferInfo.len === 0 && !bufferInfo.nextStart) {
-      return;
+    if (seeking) {
+      if (isBuffered) {
+        // Waiting for seeking in a buffered range to complete
+        return;
+      } else if (bufferInfo.nextStart < MAX_START_GAP_JUMP) {
+        // Reset moved state when seeking back to a point before a start gap
+        this.moved = false;
+      }
     }
 
     // Skip start gaps if we haven't played, but the last poll detected the start of a stall
@@ -78,10 +84,10 @@ export default class GapController {
     if (!this.moved && this.stalled) {
       // Jump start gaps within jump threshold
       const startJump = Math.max(bufferInfo.nextStart || 0, ((bufferInfo.start || 0) - currentTime));
-      if (!seeking && startJump > 0 && startJump <= MAX_START_GAP_JUMP) {
+      if (startJump > 0 && startJump <= MAX_START_GAP_JUMP) {
         this._trySkipBufferHole(null);
+        return;
       }
-      return;
     }
 
     // Start tracking stall time

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -71,9 +71,10 @@ export default class GapController {
    * @param {number} previousPlayheadTime Previously read playhead position
    */
   poll (previousPlayheadTime) {
+    const media = this.media;
     if (!this.hasPlayed) {
-      const mediaCurrentTime = this.media.currentTime;
-      if (!isFiniteNumber(mediaCurrentTime) || this.media.buffered.length === 0) {
+      const mediaCurrentTime = media.currentTime;
+      if (!isFiniteNumber(mediaCurrentTime) || media.buffered.length === 0) {
         return;
       }
       // Checking what the buffer reports as start time for the first fragment appended.
@@ -82,15 +83,15 @@ export default class GapController {
       // to fix eventual issues with browser-internal thresholds
       // where some MSE implementation might not play when the playhead
       // is exactly on the start value (trying to overcome what would be a browser bug).
-      const firstBufferedPosition = this.media.buffered.start(0);
-      if ((firstBufferedPosition - mediaCurrentTime > 0) && !this.media.seeking) {
+      const firstBufferedPosition = media.buffered.start(0);
+      if ((firstBufferedPosition - mediaCurrentTime > 0) && !media.seeking) {
         logger.warn(`skipping over gap at startup (first segment buffered time-range starts partially later than assumed) from ${mediaCurrentTime} to ${firstBufferedPosition} seconds`);
-        this.media.currentTime = firstBufferedPosition + SKIP_BUFFER_HOLE_STEP_SECONDS;
+        media.currentTime = firstBufferedPosition + SKIP_BUFFER_HOLE_STEP_SECONDS;
       }
     }
 
     // if we are paused and played before, don't bother at all
-    if (this.hasPlayed && this.media.paused) {
+    if (this.hasPlayed && media.paused) {
       return;
     }
 

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -83,6 +83,7 @@ export default class GapController {
       if ((firstBufferedPosition - mediaCurrentTime > 0) && !media.seeking) {
         logger.warn(`skipping over gap at startup (first segment buffered time-range starts partially later than assumed) from ${mediaCurrentTime} to ${firstBufferedPosition} seconds`);
         media.currentTime = firstBufferedPosition;
+        return;
       }
     }
 

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -65,8 +65,9 @@ export default class GapController {
       if (!isFiniteNumber(this.media.currentTime) || this.media.buffered.length === 0) {
         return;
       }
-      // Need to check what the buffer reports as start time for the first fragment appended.
-      // If within the threshold of maxBufferHole, adjust this.startPosition for _seekToStartPos().
+      // Checking what the buffer reports as start time for the first fragment appended
+      // and when the gap is within treshhold of configured maxBufferHole,
+      // skip playhead to this position to overcome an apparent initial gap in the stream.
       const firstBufferedPosition = this.media.buffered.start(0);
       if (Math.abs(this.media.currentTime - firstBufferedPosition) < this.config.maxBufferHole) {
         if (!this.media.seeking) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -347,65 +347,72 @@ class StreamController extends BaseStreamController {
     return frag;
   }
 
-  _findFragment (start, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails) {
+  _findFragment (start, fragPreviousLoad, fragmentIndexRange, fragments, bufferEnd, end, levelDetails) {
     const config = this.hls.config;
-    let frag;
+    let fragNextLoad;
 
     if (bufferEnd < end) {
       const lookupTolerance = (bufferEnd > end - config.maxFragLookUpTolerance) ? 0 : config.maxFragLookUpTolerance;
       // Remove the tolerance if it would put the bufferEnd past the actual end of stream
       // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-      frag = findFragmentByPTS(fragPrevious, fragments, bufferEnd, lookupTolerance);
+      fragNextLoad = findFragmentByPTS(fragPreviousLoad, fragments, bufferEnd, lookupTolerance);
     } else {
       // reach end of playlist
-      frag = fragments[fragLen - 1];
+      fragNextLoad = fragments[fragmentIndexRange - 1];
     }
-    if (frag) {
-      const curSNIdx = frag.sn - levelDetails.startSN;
-      const sameLevel = fragPrevious && frag.level === fragPrevious.level;
-      const prevFrag = fragments[curSNIdx - 1];
-      const nextFrag = fragments[curSNIdx + 1];
+
+    if (!fragNextLoad) {
+      return null;
+    }
+
+    {
+      const curSNIdx = fragNextLoad.sn - levelDetails.startSN;
+      const sameLevel = fragPreviousLoad && fragNextLoad.level === fragPreviousLoad.level;
+      const prevSnFrag = fragments[curSNIdx - 1];
+      const nextSnFrag = fragments[curSNIdx + 1];
+
       // logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
-      if (fragPrevious && frag.sn === fragPrevious.sn) {
-        if (sameLevel && !frag.backtracked) {
-          if (frag.sn < levelDetails.endSN) {
-            let deltaPTS = fragPrevious.deltaPTS;
+      if (fragPreviousLoad && fragNextLoad.sn === fragPreviousLoad.sn) { // Q: why not use FragmentTracker to determine this condition?
+        if (sameLevel && !fragNextLoad.backtracked) {
+          if (fragNextLoad.sn < levelDetails.endSN) {
+            let deltaPTS = fragPreviousLoad.deltaPTS;
             // if there is a significant delta between audio and video, larger than max allowed hole,
             // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
             // let's try to load previous fragment again to get last keyframe
             // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
-            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
-              frag = prevFrag;
-              logger.warn('SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this');
+            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPreviousLoad.dropped && curSNIdx) {
+              fragNextLoad = prevSnFrag;
+              logger.warn('Previous fragment was dropped with large PTS gap between audio and video. Maybe fragment is not starting with a keyframe? Loading previous one to try to overcome this');
             } else {
-              frag = nextFrag;
-              logger.log(`SN just loaded, load next one: ${frag.sn}`, frag);
+              fragNextLoad = nextSnFrag;
+              logger.log(`Re-loading fragment with SN: ${fragNextLoad.sn}`); // Q: why?
             }
           } else {
-            frag = null;
+            fragNextLoad = null;
           }
-        } else if (frag.backtracked) {
+        } else if (fragNextLoad.backtracked) {
           // Only backtrack a max of 1 consecutive fragment to prevent sliding back too far when little or no frags start with keyframes
-          if (nextFrag && nextFrag.backtracked) {
-            logger.warn(`Already backtracked from fragment ${nextFrag.sn}, will not backtrack to fragment ${frag.sn}. Loading fragment ${nextFrag.sn}`);
-            frag = nextFrag;
+          if (nextSnFrag && nextSnFrag.backtracked) {
+            logger.warn(`Already backtracked from fragment ${nextSnFrag.sn}, will not backtrack to fragment ${fragNextLoad.sn}. Loading fragment ${nextSnFrag.sn}`);
+            fragNextLoad = nextSnFrag;
           } else {
             // If a fragment has dropped frames and it's in a same level/sequence, load the previous fragment to try and find the keyframe
             // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
             logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
-            frag.dropped = 0;
-            if (prevFrag) {
-              frag = prevFrag;
-              frag.backtracked = true;
+            fragNextLoad.dropped = 0;
+            if (prevSnFrag) {
+              fragNextLoad = prevSnFrag;
+              fragNextLoad.backtracked = true; // Q: why are we setting this flag to true, since it has to be true so we even reach this code?
             } else if (curSNIdx) {
               // can't backtrack on very first fragment
-              frag = null;
+              fragNextLoad = null;
             }
           }
         }
       }
     }
-    return frag;
+
+    return fragNextLoad;
   }
 
   _loadKey (frag) {
@@ -450,7 +457,7 @@ class StreamController extends BaseStreamController {
     if (this.state !== nextState) {
       const previousState = this.state;
       this._state = nextState;
-      logger.log(`main stream:${previousState}->${nextState}`);
+      logger.log(`main stream-controller state-transition: ${previousState}->${nextState}`);
       this.hls.trigger(Event.STREAM_STATE_TRANSITION, { previousState, nextState });
     }
   }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -681,6 +681,10 @@ class StreamController extends BaseStreamController {
       this.startPosition = this.lastCurrentTime = 0;
     }
 
+    // release gap-controller
+    this.gapController.destroy();
+    this.gapController = null;
+
     // reset fragment backtracked flag
     let levels = this.levels;
     if (levels) {
@@ -692,6 +696,7 @@ class StreamController extends BaseStreamController {
         }
       });
     }
+
     // remove video listeners
     if (media) {
       media.removeEventListener('seeking', this.onvseeking);
@@ -699,6 +704,7 @@ class StreamController extends BaseStreamController {
       media.removeEventListener('ended', this.onvended);
       this.onvseeking = this.onvseeked = this.onvended = null;
     }
+
     this.fragmentTracker.removeAllFragments();
     this.media = this.mediaBuffer = null;
     this.loadedmetadata = false;

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -83,6 +83,9 @@ export class SubtitleStreamController extends BaseStreamController {
   }
 
   onMediaDetaching () {
+    if (!this.media) {
+      return;
+    }
     this.media.removeEventListener('seeking', this._onMediaSeeking);
     this.fragmentTracker.removeAllFragments();
     this.currentTrackId = -1;

--- a/src/utils/buffer-helper.ts
+++ b/src/utils/buffer-helper.ts
@@ -92,30 +92,34 @@ export class BufferHelper {
     });
 
     let buffered2: BufferTimeRange[] = [];
-    // there might be some small holes between buffer time range
-    // consider that holes smaller than maxHoleDuration are irrelevant and build another
-    // buffer time range representations that discards those holes
-    for (let i = 0; i < buffered.length; i++) {
-      let buf2len = buffered2.length;
-      if (buf2len) {
-        let buf2end = buffered2[buf2len - 1].end;
-        // if small hole (value between 0 or maxHoleDuration ) or overlapping (negative)
-        if ((buffered[i].start - buf2end) < maxHoleDuration) {
-          // merge overlapping time ranges
-          // update lastRange.end only if smaller than item.end
-          // e.g.  [ 1, 15] with  [ 2,8] => [ 1,15] (no need to modify lastRange.end)
-          // whereas [ 1, 8] with  [ 2,15] => [ 1,15] ( lastRange should switch from [1,8] to [1,15])
-          if (buffered[i].end > buf2end) {
-            buffered2[buf2len - 1].end = buffered[i].end;
+    if (maxHoleDuration) {
+      // there might be some small holes between buffer time range
+      // consider that holes smaller than maxHoleDuration are irrelevant and build another
+      // buffer time range representations that discards those holes
+      for (let i = 0; i < buffered.length; i++) {
+        let buf2len = buffered2.length;
+        if (buf2len) {
+          let buf2end = buffered2[buf2len - 1].end;
+          // if small hole (value between 0 or maxHoleDuration ) or overlapping (negative)
+          if ((buffered[i].start - buf2end) < maxHoleDuration) {
+            // merge overlapping time ranges
+            // update lastRange.end only if smaller than item.end
+            // e.g.  [ 1, 15] with  [ 2,8] => [ 1,15] (no need to modify lastRange.end)
+            // whereas [ 1, 8] with  [ 2,15] => [ 1,15] ( lastRange should switch from [1,8] to [1,15])
+            if (buffered[i].end > buf2end) {
+              buffered2[buf2len - 1].end = buffered[i].end;
+            }
+          } else {
+            // big hole
+            buffered2.push(buffered[i]);
           }
         } else {
-          // big hole
+          // first value
           buffered2.push(buffered[i]);
         }
-      } else {
-        // first value
-        buffered2.push(buffered[i]);
       }
+    } else {
+      buffered2 = buffered;
     }
 
     let bufferLen = 0;

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -89,7 +89,7 @@ async function testLoadedData (url, config) {
     url,
     config
   );
-  expect(result.code).to.equal('loadeddata');
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('code').which.equals('loadeddata');
 }
 
 async function testSmoothSwitch (url, config) {
@@ -121,7 +121,7 @@ async function testSmoothSwitch (url, config) {
     url,
     config
   );
-  expect(result.code).to.be.true;
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('code').which.equals(true);
 }
 
 async function testSeekOnLive (url, config) {
@@ -142,7 +142,7 @@ async function testSeekOnLive (url, config) {
     url,
     config
   );
-  expect(result.code).to.equal('seeked');
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('code').which.equals('seeked');
 }
 
 async function testSeekOnVOD (url, config) {
@@ -163,7 +163,7 @@ async function testSeekOnVOD (url, config) {
     url,
     config
   );
-  expect(result.code).to.equal('ended');
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('code').which.equals('ended');
 }
 
 async function testSeekEndVOD (url, config) {
@@ -184,7 +184,7 @@ async function testSeekEndVOD (url, config) {
     url,
     config
   );
-  expect(result.code).to.equal('ended');
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('code').which.equals('ended');
 }
 
 async function testIsPlayingVOD (url, config) {
@@ -218,7 +218,7 @@ async function testIsPlayingVOD (url, config) {
     url,
     config
   );
-  expect(result.playing).to.be.true;
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('playing').which.is.true;
 }
 
 async function testSeekBackToStart (url, config) {
@@ -248,7 +248,7 @@ async function testSeekBackToStart (url, config) {
     url,
     config
   );
-  expect(result.playing).to.be.true;
+  expect(result, JSON.stringify(result, null, 2)).to.have.property('playing').which.is.true;
 }
 
 describe(`testing hls.js playback in the browser on "${browserDescription}"`, function () {

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -183,5 +183,11 @@ module.exports = {
   altAudioAndTracks: {
     url: 'https://wowzaec2demo.streamlock.net/vod-multitrack/_definst_/smil:ElephantsDream/elephantsdream2.smil/playlist.m3u',
     description: 'Alternate audio tracks, and multiple VTT tracks'
+  },
+  altAudioWithPdtAndStartGap: {
+    url: 'https://playertest.longtailvideo.com/adaptive/hls-test-streams/test-audio-pdt/playlist.m3u8',
+    description: 'PDT before each segment, 1.59s start gap',
+    abr: true,
+    startSeek: true
   }
 };

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -64,7 +64,7 @@ module.exports = {
     'abr': false,
     'blacklist_ua': ['internet explorer']
   },
-  /*
+  /// *
   issue666: {
     'url': 'https://test-streams.mux.dev/issue666/playlists/cisq0gim60007xzvi505emlxx.m3u8',
     'description': 'hls.js/issues/666',
@@ -72,7 +72,7 @@ module.exports = {
     'abr': false,
     'blacklist_ua': ['internet explorer']
   },
-  */
+  //* /
   /* // went offline for us :( would be good to replace this for regression test with something mimicking the issue
   issue649: {
     'url': 'https://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw',

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -64,6 +64,7 @@ module.exports = {
     'abr': false,
     'blacklist_ua': ['internet explorer']
   },
+  /*
   issue666: {
     'url': 'https://test-streams.mux.dev/issue666/playlists/cisq0gim60007xzvi505emlxx.m3u8',
     'description': 'hls.js/issues/666',
@@ -71,6 +72,7 @@ module.exports = {
     'abr': false,
     'blacklist_ua': ['internet explorer']
   },
+  */
   /* // went offline for us :( would be good to replace this for regression test with something mimicking the issue
   issue649: {
     'url': 'https://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw',

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -64,7 +64,6 @@ module.exports = {
     'abr': false,
     'blacklist_ua': ['internet explorer']
   },
-  /// *
   issue666: {
     'url': 'https://test-streams.mux.dev/issue666/playlists/cisq0gim60007xzvi505emlxx.m3u8',
     'description': 'hls.js/issues/666',
@@ -72,7 +71,6 @@ module.exports = {
     'abr': false,
     'blacklist_ua': ['internet explorer']
   },
-  //* /
   /* // went offline for us :( would be good to replace this for regression test with something mimicking the issue
   issue649: {
     'url': 'https://cdn3.screen9.com/media/c/W/cW87csHkxsgu5TV1qs78aA_auto_hls.m3u8?auth=qlUjeCtbVdtkDfZYrtveTIVUXX1yuSqgF8wfWabzKpX72r-d5upW88-FHuyRRdnZA_1PKRTGAtTt_6Z-aj22kw',

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import Hls from '../../../src/hls';
 
-import GapController, { STALL_MINIMUM_DURATION_MS } from '../../../src/controller/gap-controller';
+import GapController, { STALL_MINIMUM_DURATION_MS, SKIP_BUFFER_RANGE_START } from '../../../src/controller/gap-controller';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 
 import Event from '../../../src/events';
@@ -316,20 +316,7 @@ describe('GapController', function () {
       expect(gapController.stalled).to.equal(TIMER_STEP_MS);
     });
 
-    it('should jump start gaps', function () {
-      wallClock.tick(TIMER_STEP_MS);
-
-      // set stalling from the start
-      isStalling = true;
-
-      tickMediaClock();
-
-      expect(gapController.moved).to.equal(true);
-      expect(mockMedia.currentTime).to.equal(100);
-      expect(gapController.stalled).to.equal(null);
-    });
-
-    it('should skip any initial gap when not having played yet', function () {
+    it('should skip any initial gap before playing', function () {
       wallClock.tick(TIMER_STEP_MS);
 
       mockMedia.currentTime = 0;
@@ -338,7 +325,9 @@ describe('GapController', function () {
 
       tickMediaClock();
 
-      expect(mockMedia.currentTime).to.equal(100);
+      expect(gapController.moved).to.equal(true);
+      expect(mockMedia.currentTime).to.equal(100 + SKIP_BUFFER_RANGE_START);
+      expect(gapController.stalled).to.equal(null);
     });
   });
 });

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -128,7 +128,7 @@ describe('GapController', function () {
     beforeEach(function () {
       wallClock = sandbox.useFakeTimers(0);
       isStalling = false;
-      mockTimeRangesData = [[100, 200], [400, 500]];
+      mockTimeRangesData = [[0.1, 0.2], [0.4, 0.5]];
       mockTimeRanges = {
         length: mockTimeRangesData.length,
         start (index) {
@@ -334,7 +334,7 @@ describe('GapController', function () {
 
       expect(gapController.moved).to.equal(true);
       expect(gapController.stalled).to.equal(null);
-      expect(mockMedia.currentTime).to.equal(100 + SKIP_BUFFER_RANGE_START);
+      expect(mockMedia.currentTime).to.equal(0.1 + SKIP_BUFFER_RANGE_START);
     });
   });
 });

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -146,6 +146,7 @@ describe('GapController', function () {
       mockMedia = {
         currentTime: 0,
         paused: false,
+        seeking: false,
         readyState: 4,
         buffered: mockTimeRanges,
         addEventListener () {}
@@ -316,7 +317,7 @@ describe('GapController', function () {
       expect(gapController.stalled).to.equal(TIMER_STEP_MS);
     });
 
-    it('should skip any initial gap before playing', function () {
+    it('should skip any initial gap before playing on the second poll (so that Chrome can jump the gap first)', function () {
       wallClock.tick(TIMER_STEP_MS);
 
       mockMedia.currentTime = 0;
@@ -325,9 +326,15 @@ describe('GapController', function () {
 
       tickMediaClock();
 
+      expect(gapController.moved).to.equal(false);
+      expect(gapController.stalled).to.equal(1234);
+      expect(mockMedia.currentTime).to.equal(0);
+
+      tickMediaClock();
+
       expect(gapController.moved).to.equal(true);
-      expect(mockMedia.currentTime).to.equal(100 + SKIP_BUFFER_RANGE_START);
       expect(gapController.stalled).to.equal(null);
+      expect(mockMedia.currentTime).to.equal(100 + SKIP_BUFFER_RANGE_START);
     });
   });
 });

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -2,8 +2,7 @@ import sinon from 'sinon';
 
 import Hls from '../../../src/hls';
 
-import GapController from '../../../src/controller/gap-controller'; // eslint-disable-line import/no-duplicates
-import { STALL_MINIMUM_DURATION_MS } from '../../../src/controller/gap-controller'; // eslint-disable-line import/no-duplicates
+import GapController, { STALL_MINIMUM_DURATION_MS, STALL_HANDLING_RETRY_PERIOD_MS } from '../../../src/controller/gap-controller';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 
 import Event from '../../../src/events';


### PR DESCRIPTION
### This PR will...

Align the gap-controller with changes from https://github.com/video-dev/hls.js/pull/2359 and https://github.com/video-dev/hls.js/pull/2370 (https://github.com/video-dev/hls.js/compare/68fb4010c8c8632f9abeaf03cdaded0acb27fc74...c7c0e132e0bbead453ff53dad5928e8f77d79fa8)

### Why is this Pull Request needed?

1. Jump start gaps (fixes).
2. Do not report stalls before playback has started or when seeking.

#### Sample streams with gaps:
https://playertest.longtailvideo.com/adaptive/short/short.m3u8 (start gap and partial)
https://playertest.longtailvideo.com/adaptive/sintel_aes/playlist.m3u8
https://dapian.video-yongjiu.com/20190901/9943_6699ca5d/index.m3u8 (Safari)

### Resolves issues:
Fixes #2323
Fixes #2381
Fixes #2436

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] ~API or design changes are documented in API.md~
