### PR TITLE
Prevent RangeError exception when parsing incomplete PES

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -499,6 +499,9 @@ class TSDemuxer {
       // 9 bytes : 6 bytes for PES header + 3 bytes for PES extension
       payloadStartOffset = pesHdrLen + 9;
 
+      if (stream.size <= payloadStartOffset) {
+        return null;
+      }
       stream.size -= payloadStartOffset;
       // reassemble PES packet
       pesData = new Uint8Array(stream.size);


### PR DESCRIPTION
### This PR will...
Prevent `RangeError` exception when parsing incomplete PES.

### Why is this Pull Request needed?
Remove exceptions in the critical path.

### Are there any points in the code the reviewer needs to double check?
I'm sure if the issue is that the PES causing this are incomplete, empty or simply mishandled further up in the TS demuxer. I think the issue is related to #2109 and will look into whether those changes would fill in the missing data that results in this case.

### Resolves issues:
Fixes #2415
Relates to #2109

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] ~new unit / functional tests have been added (whenever applicable)~
- [ ] ~API or design changes are documented in API.md~
