### PR TITLE
Prevent seeking to 0 when startPosition is -1

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1312,7 +1312,7 @@ class StreamController extends BaseStreamController {
     // at that stage, there should be only one buffered range, as we reach that code after first fragment has been buffered
     const startPosition = media.seeking ? currentTime : this.startPosition;
     // if currentTime not matching with expected startPosition or startPosition not buffered but close to first buffered
-    if (currentTime !== startPosition) {
+    if (currentTime !== startPosition && startPosition >= 0) {
       // if startPosition not buffered, let's seek to buffered.start(0)
       logger.log(`target start position not buffered, seek to buffered.start(0) ${startPosition} from current time ${currentTime} `);
       media.currentTime = startPosition;


### PR DESCRIPTION
### This PR will...
Prevent seeking to 0 when startPosition is -1

### Why is this Pull Request needed?
Unnecessary seeking on start will result in fragment loading being aborted if there is a small start gap and `maxBufferHole` is set to 0.


`onMediaSeeking` in base-stream-controller will do a `bufferInfo` check, and without any tolerance, the start gap results in `bufferInfo.len === 0` so the  controller thinks we're seeking outside the buffer and cancels the next fragment load:

https://github.com/video-dev/hls.js/blob/63efbc035a119de9c83bf36e273a2aa047fa7ea8/src/controller/base-stream-controller.js#L80

### Are there any points in the code the reviewer needs to double check?
I think preventing the root cause is a good fix to include now in 0.13.0. More time and consideration needs to go into improving the stream controllers' `onMediaSeeking` handler. 

### Resolves issues:
Fixes #2438

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] ~new unit / functional tests have been added (whenever applicable)~
- [ ] ~API or design changes are documented in API.md~
