### PR TITLE
only include js files in release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         api_key:
           secure: "kR9xHKhWfOv6vwxz1d//PpC22VDupnPI59L9czLkpLoIdzm5rm3eV7he4XPlQfbSrV1UBgURARgF+yekmeqUZk9vqfo4F5oa+6KiBxAdnI9PjsjYRSXitdq4a6kpIR854nxUIOlDXR5AbD2MgNaKsQHiaNlngdR/870OhiwqRJVwQOLKVUADw1QWECXe/DXrQiFbMunxBrTyutbrGuI8cT7wzqFn+aPkI/3liiw8PTr93GrtxZ/bFxI899KzMSHHMXB+eDDMtxPFD+VApruD7h6f+1C0psJeOV8/PkzrRkbPELPBKKaPH9TvVOPUf2OSRHVna828wnLHwseae0rgtuk7+ZJmB9XZKX9FUBDT4/Gv/AkE+m/cwnoqaatAMJYR+yiQqsosjBLDAaTUOPHu3wBdAaR5uL5fGsSsKe3sUfSQHrv86vReNl9ETU06apmyWtsIbyhMtv98j9I+hNVjKZUI30g1ee6LgjlDlBavMk8KAbLbyBTcJlNAexj8Rppdqg+AdW7rYW+S6SgfTyyYQKTLeFwmDjfrkqzHJnk78sV18+xPLI1hbzBGp/bXaW23sLDBLLV5Sxifr8flUMkUdH28zsLCHUQ7C4GKQ19el2NZgIxSsnxRA8vGZof7OXasR4HJVjv/PSx+DN6Fi1PV1SiNBcwgPCGIIxBF7TUPxJk="
         file_glob: true
-        file: dist/*
+        file: dist/*.{js,js.map}
         draft: true
         tag_name: $TRAVIS_TAG
         target_commitish: $TRAVIS_COMMIT


### PR DESCRIPTION
### This PR will...
update the travis config to only include ".js" and ".js.map" files in the github release. Since we started generating type definitions these ".d.ts" files at the top level were also included, which I don't think is useful for anyone in a github release.

### Why is this Pull Request needed?
Prevents all the ".d.ts" files at the top level being included in the github release.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
