### PR TITLE
Remove TypeScript types build step

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -13,7 +13,6 @@ if [ "${TRAVIS_MODE}" = "build" ]; then
   echo "travis_fold:start:build"
   npm run type-check
   npm run build
-  npm run build:types
   echo "travis_fold:end:build"
   echo "travis_fold:start:docs"
   npm run docs

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -50,7 +50,6 @@ elif [ "${TRAVIS_MODE}" = "release" ] || [ "${TRAVIS_MODE}" = "releaseCanary" ] 
   npm run lint
   npm run type-check
   npm run build:ci
-  npm run build:types
 
   if [ "${TRAVIS_MODE}" != "netlifyPr" ]; then
     npm run test:unit


### PR DESCRIPTION
### This PR will...

This makes it so until we are ready to flip the switch on adding types, there won't be conflicting Typescript definitions for users that are using `@types/hls.js`.

### Why is this Pull Request needed?

Currently, the types even without a type root are being found by various language servers, and confusing typecheckers with projects that pull in the DefinitelyTyped version of hls.js

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

Closes #2474 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
