### PR TITLE
Bug when switching quality

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -149,7 +149,7 @@ class BufferController extends EventHandler {
 
   onMediaAttaching (data: { media: HTMLMediaElement }) {
     let media = this.media = data.media;
-    if (media) {
+    if (media && MediaSource) {
       // setup the media source
       let ms = this.mediaSource = new MediaSource();
       // Media Source listeners

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -12,7 +12,7 @@ import { Observer } from '../observer';
 
 // see https://stackoverflow.com/a/11237259/589493
 const global = getSelfScope(); // safeguard for code that might run both on worker and main thread
-const MediaSource = getMediaSource();
+const MediaSource = getMediaSource() || { isTypeSupported: () => false };
 
 class Demuxer {
   constructor (hls, id) {

--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -2,6 +2,9 @@ import { getMediaSource } from './utils/mediasource-helper';
 
 export function isSupported (): boolean {
   const mediaSource = getMediaSource();
+  if (!mediaSource) {
+    return false;
+  }
   const sourceBuffer = SourceBuffer || (window as any).WebKitSourceBuffer;
   const isTypeSupported = mediaSource &&
     typeof mediaSource.isTypeSupported === 'function' &&

--- a/src/utils/mediasource-helper.ts
+++ b/src/utils/mediasource-helper.ts
@@ -2,6 +2,6 @@
  * MediaSource helper
  */
 
-export function getMediaSource (): typeof MediaSource {
-  return MediaSource || (window as any).WebKitMediaSource;
+export function getMediaSource (): typeof MediaSource | undefined {
+  return (window as any).MediaSource || (window as any).WebKitMediaSource;
 }


### PR DESCRIPTION
Hello, when video and audio streams are separated when switching quality the picture hangs for a couple of seconds.
Here are the parameters I used.
c:\ffmpeg\bin\ffmpeg -threads 0 -i TOS_1080p.mov -r 24 -g 48 -keyint_min 48 -sc_threshold 0 -c:v libx264^
 -s:v:0 960x540 -b:v:0 2400k -maxrate:v:0 2640k -bufsize:v:0 2400k^
 -s:v:1 1920x1080 -b:v:1 5200k -maxrate:v:1 5720k -bufsize:v:1 5200k^
 -s:v:2 1280x720 -b:v:2 3100k -maxrate:v:2 3410k -bufsize:v:2 3100k^
 -s:v:3 640x360 -b:v:3 1200k -maxrate:v:3 1320k -bufsize:v:3 1200k^
 -b:a 128k -ar 44100 -ac 2^
 -map 0:v -map 0:v -map 0:v -map 0:v -map 0:a^
 -f hls -var_stream_map "v:0,agroup:audio v:1,agroup:audio v:2,agroup:audio v:3,agroup:audio a:0,agroup:audio"^
 -hls_flags single_file -hls_segment_type fmp4 -hls_list_size 0 -hls_time 6  -master_pl_name master.m3u8 -y TOS%v.m3u8
I use this player http://playerjs.com/
