### PR TITLE
Feature: `removeLevel()` API method

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1136,7 +1136,7 @@ get: Returns the current bandwidth estimate in bits/s, if available. Otherwise, 
 
 ### `hls.removeLevel(levelIndex, urlId)`
 
-Remove a loaded level from the list of levels, or a level url in from a list of level fallback urls.
+Remove a loaded level from the list of levels, or a level url in from a list of redundant level urls.
 This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user
 or hls.js can choose from.
 
@@ -1359,6 +1359,8 @@ Full list of errors is described below:
     - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.MANIFEST_LOAD_TIMEOUT`, fatal : `true`, url : manifest URL, loader : URL loader }
   - `Hls.ErrorDetails.MANIFEST_PARSING_ERROR` - raised when manifest parsing failed to find proper content
     - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.MANIFEST_PARSING_ERROR`, fatal : `true`, url : manifest URL, reason : parsing error reason }
+  - `Hls.ErrorDetails.LEVEL_EMPTY_ERROR` - raised when loaded level contains no fragments
+    - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_EMPTY_ERROR`, url: playlist URL, reason: error reason, level: index of the bad level }
   - `Hls.ErrorDetails.LEVEL_LOAD_ERROR` - raised when level loading fails because of a network error
     - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_LOAD_ERROR`, fatal : `true`, url : level URL, response : { code: error code, text: error text }, loader : URL loader }
   - `Hls.ErrorDetails.LEVEL_LOAD_TIMEOUT` - raised when level loading fails because of a timeout

--- a/docs/API.md
+++ b/docs/API.md
@@ -97,6 +97,7 @@
   - [`hls.autoLevelCapping`](#hlsautolevelcapping)
   - [`hls.capLevelToPlayerSize`](#hlscapleveltoplayersize)
   - [`hls.bandwidthEstimate`](#hlsbandwidthestimate)
+  - [`hls.removeLevel(levelIndex, urlId)`](#hlsremoveLevel)
 - [Version Control](#version-control)
   - [`Hls.version`](#hlsversion)
 - [Network Loading Control API](#network-loading-control-api)
@@ -1132,6 +1133,15 @@ Default value is set via [`capLevelToPlayerSize`](#capleveltoplayersize) in conf
 
 get: Returns the current bandwidth estimate in bits/s, if available. Otherwise, `NaN` is returned.
 
+
+### `hls.removeLevel(levelIndex, urlId)`
+
+Remove a loaded level from the list of levels, or a level url in from a list of level fallback urls.
+This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user
+or hls.js can choose from.
+
+Modifying the levels this way will result in a `Hls.Events.LEVELS_UPDATED` event being triggered.
+
 ## Version Control
 
 ### `Hls.version`
@@ -1246,6 +1256,8 @@ Full list of Events is available below:
     -  data: { details : `levelDetails` object (please see [below](#leveldetails) for more information), level : id of updated level }
   - `Hls.Events.LEVEL_PTS_UPDATED`  - fired when a level's PTS information has been updated after parsing a fragment
     -  data: { details : `levelDetails` object (please see [below](#leveldetails) for more information), level : id of updated level, drift: PTS drift observed when parsing last fragment }
+  - `Hls.Events.LEVELS_UPDATED`  - fired when a level is removed after calling `removeLevel()`
+    -  data: { levels : [ available quality levels ] }
   - `Hls.Events.AUDIO_TRACKS_UPDATED`  - fired to notify that audio track lists has been updated
     -  data: { audioTracks : audioTracks }
   - `Hls.Events.AUDIO_TRACK_SWITCHING`  - fired when an audio track switching is requested

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -11,6 +11,7 @@ class CapLevelController extends EventHandler {
       Event.FPS_DROP_LEVEL_CAPPING,
       Event.MEDIA_ATTACHING,
       Event.MANIFEST_PARSED,
+      Event.LEVELS_UPDATED,
       Event.BUFFER_CODECS,
       Event.MEDIA_DETACHING);
 

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -71,23 +71,23 @@ export class FragmentTracker extends EventHandler {
    * @param {TimeRanges} timeRange TimeRange object from a sourceBuffer
    */
   detectEvictedFragments (elementaryStream, timeRange) {
-    let fragmentTimes, time;
     // Check if any flagged fragments have been unloaded
     Object.keys(this.fragments).forEach(key => {
       const fragmentEntity = this.fragments[key];
-      if (fragmentEntity.buffered === true) {
-        const esData = fragmentEntity.range[elementaryStream];
-        if (esData) {
-          fragmentTimes = esData.time;
-          for (let i = 0; i < fragmentTimes.length; i++) {
-            time = fragmentTimes[i];
-
-            if (this.isTimeBuffered(time.startPTS, time.endPTS, timeRange) === false) {
-              // Unregister partial fragment as it needs to load again to be reused
-              this.removeFragment(fragmentEntity.body);
-              break;
-            }
-          }
+      if (!fragmentEntity || !fragmentEntity.buffered) {
+        return;
+      }
+      const esData = fragmentEntity.range[elementaryStream];
+      if (!esData) {
+        return;
+      }
+      const fragmentTimes = esData.time;
+      for (let i = 0; i < fragmentTimes.length; i++) {
+        const time = fragmentTimes[i];
+        if (!this.isTimeBuffered(time.startPTS, time.endPTS, timeRange)) {
+          // Unregister partial fragment as it needs to load again to be reused
+          this.removeFragment(fragmentEntity.body);
+          break;
         }
       }
     });

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -28,6 +28,7 @@ class StreamController extends BaseStreamController {
       Event.MANIFEST_LOADING,
       Event.MANIFEST_PARSED,
       Event.LEVEL_LOADED,
+      Event.LEVELS_UPDATED,
       Event.KEY_LOADED,
       Event.FRAG_LOADED,
       Event.FRAG_LOAD_EMERGENCY_ABORTED,
@@ -1296,6 +1297,10 @@ class StreamController extends BaseStreamController {
     this.state = State.IDLE;
     // reset reference to frag
     this.fragPrevious = null;
+  }
+
+  onLevelsUpdated (data) {
+    this.levels = data.levels;
   }
 
   swapAudioCodec () {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,6 +29,8 @@ export enum ErrorDetails {
   MANIFEST_PARSING_ERROR = 'manifestParsingError',
   // Identifier for a manifest with only incompatible codecs error - data: { url : faulty URL, reason : error reason}
   MANIFEST_INCOMPATIBLE_CODECS_ERROR = 'manifestIncompatibleCodecsError',
+  // Identifier for a level which contains no fragments - data: { url: faulty URL, reason: "no fragments found in level", level: index of the bad level }
+  LEVEL_EMPTY_ERROR = 'levelEmptyError',
   // Identifier for a level load error - data: { url : faulty URL, response : { code: error code, text: error text }}
   LEVEL_LOAD_ERROR = 'levelLoadError',
   // Identifier for a level load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}

--- a/src/events.js
+++ b/src/events.js
@@ -45,6 +45,8 @@ const HlsEvents = {
   LEVEL_UPDATED: 'hlsLevelUpdated',
   // fired when a level's PTS information has been updated after parsing a fragment - data: { details : levelDetails object, level : id of updated level, drift: PTS drift observed when parsing last fragment }
   LEVEL_PTS_UPDATED: 'hlsLevelPtsUpdated',
+  // fired to notify that levels have changed after removing a level - data: { levels : [available quality levels] }
+  LEVELS_UPDATED: 'hlsLevelsUpdated',
   // fired to notify that audio track lists has been updated - data: { audioTracks : audioTracks }
   AUDIO_TRACKS_UPDATED: 'hlsAudioTracksUpdated',
   // fired when an audio track switching is requested - data: { id : audio track id }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -336,7 +336,7 @@ export default class Hls extends Observer {
   }
 
   /**
-   * Remove a loaded level from the list of levels, or a level url in from a list of level fallback urls.
+   * Remove a loaded level from the list of levels, or a level url in from a list of redundant level urls.
    * This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user
    * or hls.js can choose from.
    *

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -34,8 +34,8 @@ export default class Hls extends Observer {
   private _autoLevelCapping: number;
   private abrController: any;
   private capLevelController: any;
-  private levelController: any;
-  private streamController: any;
+  private levelController: LevelController;
+  private streamController: StreamController;
   private networkControllers: any[];
   private audioTrackController: any;
   private subtitleTrackController: any;
@@ -336,6 +336,18 @@ export default class Hls extends Observer {
   }
 
   /**
+   * Remove a loaded level from the list of levels, or a level url in from a list of level fallback urls.
+   * This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user
+   * or hls.js can choose from.
+   *
+   * @param levelIndex {number} The quality level index to of the level to remove
+   * @param urlId {number} The quality level url index in the case that fallback levels are available. Defaults to 0.
+   */
+  removeLevel (levelIndex, urlId = 0) {
+    this.levelController.removeLevel(levelIndex, urlId);
+  }
+
+  /**
    * @type {QualityLevel[]}
    */
   // todo(typescript-levelController)
@@ -355,7 +367,7 @@ export default class Hls extends Observer {
    * Set quality level index immediately .
    * This will flush the current buffer to replace the quality asap.
    * That means playback will interrupt at least shortly to re-buffer and re-sync eventually.
-   * @type {number} -1 for automatic level selection
+   * @param newLevel {number} -1 for automatic level selection
    */
   set currentLevel (newLevel: number) {
     logger.log(`set currentLevel:${newLevel}`);

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -354,6 +354,18 @@ class PlaylistLoader extends EventHandler {
     // TODO(jstackhouse): why? mixing concerns, is it just treated as value bag?
     (levelDetails as any).tload = stats.tload;
 
+    if (!levelDetails.fragments.length) {
+      hls.trigger(Event.ERROR, {
+        type: ErrorTypes.NETWORK_ERROR,
+        details: ErrorDetails.LEVEL_EMPTY_ERROR,
+        fatal: false,
+        url: url,
+        reason: 'no fragments found in level',
+        level: typeof context.level === 'number' ? context.level : undefined
+      });
+      return;
+    }
+
     // We have done our first request (Manifest-type) and receive
     // not a master playlist but a chunk-list (track/level)
     // We fire the manifest-loaded event anyway with the parsed level-details


### PR DESCRIPTION
### This PR will...
- Add a new API method `removeLevel(index, urlIndex)`
- Add a new events `LEVELS_UPDATED` fired after a level is removed
- Add a new error `LEVEL_EMPTY_ERROR` fired when a playlist is loaded/parsed and does not contain any fragments
- Add level removal for level error handling to the demo
- Update documentation to cover new API features

### Why is this Pull Request needed?
These features allow developers to filter out problematic levels, as well as redundant level urls. The demo provides an example of how to implement this.

These features are present in the feature/v1.0.0 branch, but have remained undocumented. These changes will introduce the features and documentation in v0.14.0, which will help ensure they are properly documented in v1.0, and make switching between the upcoming releases and pre-releases easier.

### Test stream:

The 180p rendition will error. The demo will now recover from this by removing that level, selecting the lowest level and then switching to auto:
//playertest.longtailvideo.com/adaptive/bbbfull/bbbfull-child-manifests-404.m3u8
```
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=357103,RESOLUTION=320x180
bbbfull320x180-404.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=707099,RESOLUTION=640x360
bbbfull640x360.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1677946,RESOLUTION=1280x720
bbbfull1280x720.m3u8
```

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
