### PR TITLE
add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    version_requirement_updates: "increase_versions_if_necessary"


### PR DESCRIPTION
### This PR will...
Add a config file for dependabot to the repo. See https://dependabot.com/docs/config-file/ for all the options.


https://video-dev.slack.com/archives/C4FC8GGEP/p1584190135188200
```
tjenkinson  12:48
We could enable https://dependabot.com/ on the repo to get prs with dependency updates. Thoughts?

robwalch:video-dev:  16:38
sounds good @tjenkinson

Miloš Rašić  16:55
I'm not even a contributor, so that this with a pinch of salt, but dependabot doesn't make much sense without fixed dependencies (without ^), which in turn don't make much sense since most packages out there respect semver. For example, if it bumps url-toolkit from ^2.1.6 to ^2.1.7, this signals that hls.js is no longer compatible with anything lower than 2.1.7, but is that really the case? Usually not. Also, it seems hls.js has very few dependencies, and most are dev dependencies, used in build only. npm audit will scream for dependencies of your dev dependencies, but those are usually only security issue when used in node.js server-side code, not when used in a build tool.

jstackhouse  16:57
Yeah. I think Tom is just thinking about those test dependencies that tend to get out of date (like chromedriver) that we need to manually update every so often so Travis continues to build green.
16:58
Also, generally it’s better to stay up to date so we don’t have those large breaking PRs on the build process as we’ve just gone through on a few updates.
16:59
But yeah, in the actual code, agree @Miloš Rašić. It’s almost entirely like.. Babel, Babel plugins and testing deps that I think we would see benefit around.
Seems better than having to do npm audit manually. I think they’ll also use the same pr for updates if needed so there shouldn’t be loads of spam and they solve conflicts themselves 
```

### Why is this Pull Request needed?
I think it's better to keep the config in the repo instead of having it just in the control panel for visibility.