### PR TITLE
Improve seek to start position for live streams

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -12,7 +12,7 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import { findFragWithCC } from '../utils/discontinuities';
 import { FragmentState } from './fragment-tracker';
-import Fragment, { ElementaryStreamTypes } from '../loader/fragment';
+import { ElementaryStreamTypes } from '../loader/fragment';
 import BaseStreamController, { State } from './base-stream-controller';
 const { performance } = window;
 


### PR DESCRIPTION
### This PR will...
Ensure that live streams start at the determined or specified `startPosition`.

### Why is this Pull Request needed?
Live streams with audio tracks sometimes start in the middle rather than the `startPosition` determined by `computeLivePosition`. That "middle" segment might not even align between the main playlist and the track playlist complicating playback and start position.

### Are there any points in the code the reviewer needs to double check?

These changes are based on a PR in the JW player fork that addressed this issue:
https://github.com/jwplayer/hls.js/pull/259

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
