### PR TITLE
Remove all unnecessary files form the NPM distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "url": "https://github.com/video-dev/hls.js/issues"
   },
   "main": "./dist/hls.js",
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Currently the NPM module packs all files in the repo, but only a handful of them are necessary to run. Adding [files key to package.json](https://docs.npmjs.com/files/package.json#files) with the ones we want to keep will exclude all unnecessary ones and doing so will greatly reduce the NPM module size.

This will help with speed, bandwidth and so on and so forth.