### PR TITLE
Prevent loading com.apple.streamingkeydelivery key format

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -253,12 +253,19 @@ export default class M3U8Parser {
           discontinuityCounter = parseInt(value1);
           break;
         case 'KEY': {
-          // https://tools.ietf.org/html/draft-pantos-http-live-streaming-08#section-3.4.4
+          // https://tools.ietf.org/html/rfc8216#section-4.3.2.4
           const decryptparams = value1;
           const keyAttrs = new AttrList(decryptparams);
           const decryptmethod = keyAttrs.enumeratedString('METHOD');
           const decrypturi = keyAttrs.URI;
           const decryptiv = keyAttrs.hexadecimalInteger('IV');
+          // From RFC: This attribute is OPTIONAL; its absence indicates an implicit value of "identity".
+          const decryptkeyformat = keyAttrs.KEYFORMAT || 'identity';
+
+          if (decryptkeyformat === 'com.apple.streamingkeydelivery') {
+            logger.warn('Keyformat com.apple.streamingkeydelivery is not supported');
+            continue;
+          }
 
           if (decryptmethod) {
             levelkey = new LevelKey(baseurl, decrypturi);

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -266,6 +266,35 @@ chop/segment-5.ts
     expect(result.startTimeOffset).to.equal(10.3);
   });
 
+  it('parse AES encrypted URLS, with a com.apple.streamingkeydelivery KEYFORMAT', function () {
+    let level = `#EXTM3U
+#EXT-X-VERSION:1
+## Created with Unified Streaming Platform(version=1.6.7)
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-TARGETDURATION:11
+#EXT-X-KEY:METHOD=AES-128,URI="skd://assetid?keyId=1234",KEYFORMAT="com.apple.streamingkeydelivery"
+#EXTINF:11,no desc
+oceans_aes-audio=65000-video=236000-1.ts
+#EXTINF:7,no desc
+oceans_aes-audio=65000-video=236000-2.ts
+#EXTINF:7,no desc
+oceans_aes-audio=65000-video=236000-3.ts
+#EXT-X-ENDLIST`;
+    let result = M3U8Parser.parseLevelPlaylist(level, 'http://foo.com/adaptive/oceans_aes/oceans_aes.m3u8', 0);
+    expect(result.totalduration).to.equal(25);
+    expect(result.startSN).to.equal(1);
+    expect(result.targetduration).to.equal(11);
+    expect(result.live).to.be.false;
+    expect(result.fragments).to.have.lengthOf(3);
+    expect(result.fragments[0].cc).to.equal(0);
+    expect(result.fragments[0].duration).to.equal(11);
+    expect(result.fragments[0].title).to.equal('no desc');
+    expect(result.fragments[0].level).to.equal(0);
+    expect(result.fragments[0].url).to.equal('http://foo.com/adaptive/oceans_aes/oceans_aes-audio=65000-video=236000-1.ts');
+    expect(result.fragments[0].decryptdata).to.be.null;
+  });
+
   it('parse AES encrypted URLs, with implicit IV', function () {
     let level = `#EXTM3U
 #EXT-X-VERSION:1


### PR DESCRIPTION
### This PR will...
Prevent trying to load a com.apple.streamingkeydelivery format `skd://...` and warn the integrator this isn't supported out-of-the-box by hls.js

### Why is this Pull Request needed?
I am working on playing HLS fMP4 w/ Fairplay encryption `com.apple.fps.2_0` with hls.js and it was creating an error while trying to load `skd://` over HTTP.
Preventing it allows segments to be added to Buffer/MediaSource and therefore trigger the `webkitneedkey` and `webkitkeymessage` events that I need to get a license from our DRM provider 

### Are there any points in the code the reviewer needs to double check?
Any other KEYFORMAT should work

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
