### PR TITLE
Add `testBandwidth` config option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,7 @@
   - [`fragLoadingMaxRetryTimeout` / `manifestLoadingMaxRetryTimeout` / `levelLoadingMaxRetryTimeout`](#fragloadingmaxretrytimeout--manifestloadingmaxretrytimeout--levelloadingmaxretrytimeout)
   - [`fragLoadingRetryDelay` / `manifestLoadingRetryDelay` / `levelLoadingRetryDelay`](#fragloadingretrydelay--manifestloadingretrydelay--levelloadingretrydelay)
   - [`startFragPrefetch`](#startfragprefetch)
+  - [`testBandwidth`](#testBandwidth) 
   - [`appendErrorMaxRetry`](#appenderrormaxretry)
   - [`loader`](#loader)
   - [`fLoader`](#floader)
@@ -335,6 +336,7 @@ Configuration parameters could be provided to hls.js upon instantiation of `Hls`
       fragLoadingRetryDelay: 1000,
       fragLoadingMaxRetryTimeout: 64000,
       startFragPrefetch: false,
+      testBandwidth: true,
       fpsDroppedMonitoringPeriod: 5000,
       fpsDroppedMonitoringThreshold: 0.2,
       appendErrorMaxRetry: 3,
@@ -629,6 +631,13 @@ Prefetch start fragment although media not attached.
 (default: `false`)
 
 Start prefetching start fragment although media not attached yet.
+
+### `testBandwidth`
+                  
+(default: `true`)
+
+Load the first fragment of the lowest level to establish a bandwidth estimate before selecting the first auto-level.
+Disable this test if you'd like to provide your own estimate or use the default `abrEwmaDefaultEstimate`.
 
 ### `appendErrorMaxRetry`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ type StreamControllerConfig = {
   maxMaxBufferLength: number,
 
   startFragPrefetch: boolean,
+  testBandwidth: boolean
 };
 
 type TimelineControllerConfig = {
@@ -240,6 +241,7 @@ export const hlsDefaultConfig: HlsConfig = {
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: void 0, // used by eme-controller
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
+  testBandwidth: true,
 
   // Dynamic Modules
   ...timelineConfig(),

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -49,6 +49,7 @@ class StreamController extends BaseStreamController {
     this.stallReported = false;
     this.gapController = null;
     this.altAudio = false;
+    this.bitrateTest = false;
   }
 
   startLoad (startPosition) {
@@ -62,9 +63,13 @@ class StreamController extends BaseStreamController {
         // determine load level
         let startLevel = hls.startLevel;
         if (startLevel === -1) {
-          // -1 : guess start Level by doing a bitrate test by loading first fragment of lowest quality level
-          startLevel = 0;
-          this.bitrateTest = true;
+          if (hls.config.testBandwidth) {
+            // -1 : guess start Level by doing a bitrate test by loading first fragment of lowest quality level
+            startLevel = 0;
+            this.bitrateTest = true;
+          } else {
+            startLevel = hls.nextAutoLevel;
+          }
         }
         // set new level to playlist loader : this will trigger start level load
         // hls.nextLoadLevel remains until it is set to a new value or until a new frag is successfully loaded

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -303,6 +303,17 @@ describe('StreamController', function () {
         expect(streamController.level).to.equal(0);
         expect(streamController.bitrateTest).to.be.true;
       });
+
+      it('should not signal a bandwidth test if config.testBandwidth is false', function () {
+        streamController.startFragRequested = false;
+        hls.startLevel = -1;
+        hls.nextAutoLevel = 3;
+        hls.config.testBandwidth = false;
+
+        streamController.startLoad();
+        expect(streamController.level).to.equal(hls.nextAutoLevel);
+        expect(streamController.bitrateTest).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
### Why is this Pull Request needed?
The `testBandwidth` config option defaults to `true` maintaining existing ABR behavior which samples a low quality segment to improve the bandwidth estimate before selecting a start level. This option can be set to `false` when you'd like to provide your own estimate or use the default `abrEwmaDefaultEstimate` to speed up start times.

### Are there any points in the code the reviewer needs to double check?
This feature is already implemented in feature/v1.0.0, and is being added in v0.14 to aid in testing and the transition to v1.

### Related issues:
#2407 
#2433

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
