### PR TITLE
Audio stream stuck

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -281,6 +281,9 @@ class AudioStreamController extends BaseStreamController {
             logger.log(`Loading ${frag.sn}, cc: ${frag.cc} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}, currentTime:${pos},bufferEnd:${bufferEnd.toFixed(3)}`);
             // only load if fragment is not loaded or if in audio switch
             // we force a frag loading in audio switch as fragment tracker might not have evicted previous frags in case of quick audio switch
+            if (this.fragCurrent && this.fragCurrent !== frag) {
+              this.fragmentTracker.removeFragment(this.fragCurrent);
+            }
             this.fragCurrent = frag;
             if (audioSwitch || this.fragmentTracker.getState(frag) === FragmentState.NOT_LOADED) {
               if (frag.sn !== 'initSegment') {


### PR DESCRIPTION
### This PR will...

avoid a stuck player with
* a separate audio stream
* when seeking / changing levels

### Why is this Pull Request needed?

Observed with a separate audio stream: After seeking and/or level adjustments, the audio stream controller would fetch a future fragment which would later be found as having `FragmentState.OK`, causing `doTick()` to be stuck in `State.IDLE` - iow waiting for an already fetched fragment, which would never be pushed to the demuxer.

This feels more like a bandaid, because I have not fully understood the reason for the wrong fragment to be selected in the first place, but at any rate, IIUC, the state machine can only process one fragment at a time and requires `onFragLoaded` to be called in order to push data.

Master playlist with which this issue has been observed:

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="group_aud",NAME="audio_0",DEFAULT=YES,URI="vs0/audio.m3u8"
#EXT-X-STREAM-INF:BANDWIDTH=140800,CODECS="mp4a.40.2",AUDIO="group_aud"
vs0/audio.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1267200,RESOLUTION=1280x720,CODECS="avc1.64001f",AUDIO="group_aud"
vs1/video_high.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=704000,RESOLUTION=854x480,CODECS="avc1.64001f",AUDIO="group_aud"
vs2/video_mid.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=422400,RESOLUTION=426x240,CODECS="avc1.640015",AUDIO="group_aud"
vs3/video_low.m3u8
```

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [v/ ] changes have been done against master branch, and PR does not conflict
- [N/A] new unit / functional tests have been added (whenever applicable)
- [ N/A] API or design changes are documented in API.md
