### PR TITLE
Prevent internal exceptions with bad fragments

### DIFF
--- a/src/controller/id3-track-controller.js
+++ b/src/controller/id3-track-controller.js
@@ -70,9 +70,12 @@ class ID3TrackController extends EventHandler {
     for (let i = 0; i < samples.length; i++) {
       const frames = ID3.getID3Frames(samples[i].data);
       if (frames) {
-        const startTime = samples[i].pts;
+        // Ensure the pts is positive - sometimes it's reported as a small negative number
+        let startTime = Math.max(samples[i].pts, 0);
         let endTime = i < samples.length - 1 ? samples[i + 1].pts : fragment.endPTS;
-
+        if (!endTime) {
+          endTime = fragment.start + fragment.duration;
+        }
         if (startTime === endTime) {
           // Give a slight bump to the endTime if it's equal to startTime to avoid a SyntaxError in IE
           endTime += 0.0001;

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -730,23 +730,24 @@ class MP4Remuxer {
   }
 
   remuxID3 (track) {
-    let length = track.samples.length, sample;
+    const length = track.samples.length;
+    if (!length) {
+      return;
+    }
     const inputTimeScale = track.inputTimeScale;
     const initPTS = this._initPTS;
     const initDTS = this._initDTS;
     // consume samples
-    if (length) {
-      for (let index = 0; index < length; index++) {
-        sample = track.samples[index];
-        // setting id3 pts, dts to relative time
-        // using this._initPTS and this._initDTS to calculate relative time
-        sample.pts = ((sample.pts - initPTS) / inputTimeScale);
-        sample.dts = ((sample.dts - initDTS) / inputTimeScale);
-      }
-      this.observer.trigger(Event.FRAG_PARSING_METADATA, {
-        samples: track.samples
-      });
+    for (let index = 0; index < length; index++) {
+      const sample = track.samples[index];
+      // setting id3 pts, dts to relative time
+      // using this._initPTS and this._initDTS to calculate relative time
+      sample.pts = ((sample.pts - initPTS) / inputTimeScale);
+      sample.dts = ((sample.dts - initDTS) / inputTimeScale);
     }
+    this.observer.trigger(Event.FRAG_PARSING_METADATA, {
+      samples: track.samples
+    });
 
     track.samples = [];
   }


### PR DESCRIPTION
### This PR will...
Add defensive handling to ID3 cue time parsing to prevent exceptions constructing cues from incomplete fragments or samples.

### Why is this Pull Request needed?
I've found streams that have fragments at the end of stream with only id3 data. The lack of media results in invalid end time. These changes fix that.

### Are there any points in the code the reviewer needs to double check?
These changes are already present in feature/v1.0.0. Including them in v0.14.0 will help make a smoother transition to v1.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
