### PR TITLE
Fix raw duration computation when 'default_sample_duration' field is …

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -342,7 +342,7 @@ export function getDuration (data, initData) {
         sampleDuration = readUint32(tfhd, 8);
       }
       const sampleCount = readUint32(trun, 4);
-      rawDuration += sampleDuration * sampleCount;
+      rawDuration = sampleDuration * sampleCount;
     } else {
       rawDuration = computeRawDurationFromSamples(trun);
     }


### PR DESCRIPTION
…present in the moof fragment

### This PR will...

Fix bug that corrupts DTS & PTS for HLS fMP4 streams that have the 'default_sample_duration' field present inside the moof fragments.

This bug triggers a chain of problems that make impossible to buffer and play these kind of streams.

### Checklist

- [x] changes have been done against feature/v1.0.0 branch, and PR does not conflict

