### PR TITLE
Fix false positive ADTS probes

### DIFF
--- a/tests/unit/demuxer/adts.js
+++ b/tests/unit/demuxer/adts.js
@@ -299,6 +299,25 @@ describe('probe', function () {
     data[1] = 0xf0; // protection_absent = 0
     expect(probe(data, 0)).to.be.false;
   });
+
+  it('should return false if the header is broken', function () {
+    const data = new Uint8Array(new ArrayBuffer(9));
+    data[0] = 0xff;
+    data[1] = 0xf0; // protection_absent = 0
+    data[4] = 0x00; // frame_length is 0
+    expect(probe(data, 0)).to.be.false;
+  });
+
+  it('should return false if it does not contain the entire header (2)', function () {
+    const data = new Uint8Array(new ArrayBuffer(8));
+    data[0] = 0xff;
+    data[1] = 0xf0; // protection_absent = 0
+    data[4] = 0x00; // frame_length is 6
+    data[5] = 0xc0;
+    data[6] = 0xff;
+    data[7] = 0xf0;
+    expect(probe(data, 0)).to.be.false;
+  });
 });
 
 describe('initTrackConfig', function () {


### PR DESCRIPTION
### This PR will...
fix a bug: false positive ADTS probe in MP3 stream (may happen in any data stream).

### Why is this Pull Request needed?
To fix the bug.

### Are there any points in the code the reviewer needs to double check?
I removed the check whether a frame ends at the end of the data supplied to probe(). Instead probe() only returns true if there are at least three valid headers and two valid frames in between. I think this makes sense because every HLS chunk should have at least three full frames in it.
The main point of the bug fix is the check against zero sized frames. And to fix the header length check which was broken as I think.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
