### PR TITLE
CC channel and CLOSED-CAPTIONS fixes

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -266,11 +266,9 @@ class StreamController extends BaseStreamController {
 
     if (frag) {
       if (frag.encrypted) {
-        logger.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}`);
-        this._loadKey(frag);
+        this._loadKey(frag, levelDetails);
       } else {
-        logger.log(`Loading ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos.toFixed(3)},bufferEnd:${bufferEnd.toFixed(3)}`);
-        this._loadFragment(frag);
+        this._loadFragment(frag, levelDetails, pos, bufferEnd);
       }
     }
   }
@@ -416,12 +414,13 @@ class StreamController extends BaseStreamController {
     return fragNextLoad;
   }
 
-  _loadKey (frag) {
+  _loadKey (frag, levelDetails) {
+    logger.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${this.level}`);
     this.state = State.KEY_LOADING;
     this.hls.trigger(Event.KEY_LOADING, { frag });
   }
 
-  _loadFragment (frag) {
+  _loadFragment (frag, levelDetails, pos, bufferEnd) {
     // Check if fragment is not loaded
     let fragState = this.fragmentTracker.getState(frag);
 
@@ -438,6 +437,8 @@ class StreamController extends BaseStreamController {
     if (frag.backtracked || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
       frag.autoLevel = this.hls.autoLevelEnabled;
       frag.bitrateTest = this.bitrateTest;
+
+      logger.log(`Loading ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${this.level}, currentTime:${pos.toFixed(3)},bufferEnd:${bufferEnd.toFixed(3)}`);
 
       this.hls.trigger(Event.FRAG_LOADING, { frag });
       // lazy demuxer init, as this could take some time ... do it during frag loading

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -195,7 +195,7 @@ class TimelineController extends EventHandler {
       _id: trackName,
       label,
       kind: 'captions',
-      default: false
+      default: props.default || false
     };
     nonNativeCaptionsTracks[trackName] = track;
     this.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [track] });

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -297,6 +297,7 @@ class PlaylistLoader extends EventHandler {
 
     const audioTracks = M3U8Parser.parseMasterPlaylistMedia(string, url, 'AUDIO', audioGroups);
     const subtitles = M3U8Parser.parseMasterPlaylistMedia(string, url, 'SUBTITLES');
+    const captions = M3U8Parser.parseMasterPlaylistMedia(string, url, 'CLOSED-CAPTIONS');
 
     if (audioTracks.length) {
       // check if we have found an audio track embedded in main playlist (audio track without URI attribute)
@@ -330,6 +331,7 @@ class PlaylistLoader extends EventHandler {
       levels,
       audioTracks,
       subtitles,
+      captions,
       url,
       stats,
       networkDetails

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -914,12 +914,12 @@ class Cea608Parser {
     this.cmdHistory = createCmdHistory();
   }
 
-  getHandler (index: number) {
-    return (this.channels[index] as Cea608Channel).getHandler();
+  getHandler (channel: number) {
+    return (this.channels[channel] as Cea608Channel).getHandler();
   }
 
-  setHandler (index: number, newHandler: OutputFilter) {
-    (this.channels[index] as Cea608Channel).setHandler(newHandler);
+  setHandler (channel: number, newHandler: OutputFilter) {
+    (this.channels[channel] as Cea608Channel).setHandler(newHandler);
   }
 
   /**

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -168,32 +168,32 @@ describe('StreamController', function () {
 
     it('should load a complete fragment which has not been previously appended', function () {
       fragStateStub(FragmentState.NOT_LOADED);
-      streamController._loadFragment(frag);
+      streamController._loadFragment(frag, {}, 0, 0);
       assertLoadingState(frag);
     });
 
     it('should load a partial fragment', function () {
       fragStateStub(FragmentState.PARTIAL);
-      streamController._loadFragment(frag);
+      streamController._loadFragment(frag, {}, 0, 0);
       assertLoadingState(frag);
     });
 
     it('should load a frag which has backtracked', function () {
       fragStateStub(FragmentState.OK);
       frag.backtracked = true;
-      streamController._loadFragment(frag);
+      streamController._loadFragment(frag, {}, 0, 0);
       assertLoadingState(frag);
     });
 
     it('should not load a fragment which has completely & successfully loaded', function () {
       fragStateStub(FragmentState.OK);
-      streamController._loadFragment(frag);
+      streamController._loadFragment(frag, {}, 0, 0);
       assertNotLoadingState();
     });
 
     it('should not load a fragment while it is appending', function () {
       fragStateStub(FragmentState.APPENDING);
-      streamController._loadFragment(frag);
+      streamController._loadFragment(frag, {}, 0, 0);
       assertNotLoadingState();
     });
   });


### PR DESCRIPTION
### This PR will...
1. Apply `config.renderTextTracksNatively` to 608 captions
2. Fix CEA 608 channel indexes (1 based)
3. Parse CLOSED-CAPTIONS manifest attributes to apply language, label and `default` to (non-native) tracks 
4. Only log that we're loading keys and fragments when we're actually starting to load them

### Why is this Pull Request needed?
1. When `renderTextTracksNatively` is `false` hls.js should not create textTracks for 608 captions. Instead it should trigger `NON_NATIVE_TEXT_TRACKS_FOUND` with track information.
2. CEA 608 channel output was off by -1
3. Now we apply the correct language properties from manifest CLOSED-CAPTIONS to 608 output
4. Prevent console spam `Loading ${frag.sn} of [${levelDetails.startSN} ...`

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
