### PR TITLE
Make the readme example work out of the box again

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
 <video id="video"></video>
 <script>
   var video = document.getElementById('video');
+  var videoSrc = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
   if (Hls.isSupported()) {
     var hls = new Hls();
-    hls.loadSource('https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8');
+    hls.loadSource(videoSrc);
     hls.attachMedia(video);
     hls.on(Hls.Events.MANIFEST_PARSED, function() {
       video.play();
@@ -77,7 +78,7 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
   // Note: it would be more normal to wait on the 'canplay' event below however on Safari (where you are most likely to find built-in HLS support) the video.src URL must be on the user-driven
   // white-list before a 'canplay' event will be emitted; the last video event that can be reliably listened-for when the URL is not on the white-list is 'loadedmetadata'.
   else if (video.canPlayType('application/vnd.apple.mpegurl')) {
-    video.src = 'https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8';
+    video.src = videoSrc;
     video.addEventListener('loadedmetadata', function() {
       video.play();
     });
@@ -119,7 +120,7 @@ hls.js is (being) integrated in the following players:
  - [Videojs](http://videojs.com) through [videojs-contrib-hls.js](https://github.com/Peer5/videojs-contrib-hls.js). Production ready plug-in with full fallback compatibility built-in.
  - [Fluid Player](https://www.fluidplayer.com)
  - [OpenPlayerJS](https://www.openplayerjs.com), as part of the [OpenPlayer project](https://github.com/openplayerjs)
-- [CDNBye](https://github.com/cdnbye/hlsjs-p2p-engine), a p2p engine for hls.js powered by WebRTC Datachannel. 
+- [CDNBye](https://github.com/cdnbye/hlsjs-p2p-engine), a p2p engine for hls.js powered by WebRTC Datachannel.
 
 ## Chrome/Firefox integration
 


### PR DESCRIPTION
### This PR will...

Make it so copying and pasting the example from the README will work right out of the box. It just take the README back to the previous behavior where the example was the same as what shows by default on the test-streams page.

### Why is this Pull Request needed?

Because I copy and paste the example all the time (shh) and it gets me every time when it doesn't work at first.

### Are there any points in the code the reviewer needs to double check?

Well I did refactor the source URL to be a variable because I also find myself having to edit that in two places every time 😇 

### Resolves issues:

Very, very small onboarding pain.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
