### PR TITLE
prefer media.client{Width,Height} over media.{width,height}

### DIFF
--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -124,7 +124,7 @@ class CapLevelController extends EventHandler {
   }
 
   get mediaWidth () {
-    let width;
+    let width = 0;
     const media = this.media;
     if (media) {
       width = Math.max(media.width, media.clientWidth, media.offsetWidth);
@@ -134,7 +134,7 @@ class CapLevelController extends EventHandler {
   }
 
   get mediaHeight () {
-    let height;
+    let height = 0;
     const media = this.media;
     if (media) {
       height = Math.max(media.height, media.clientHeight || media.offsetHeight);

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -137,7 +137,7 @@ class CapLevelController extends EventHandler {
     let height = 0;
     const media = this.media;
     if (media) {
-      height = Math.max(media.height, media.clientHeight || media.offsetHeight);
+      height = Math.max(media.height, media.clientHeight, media.offsetHeight);
       height *= CapLevelController.contentScaleFactor;
     }
     return height;

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -127,7 +127,7 @@ class CapLevelController extends EventHandler {
     let width;
     const media = this.media;
     if (media) {
-      width = media.width || media.clientWidth || media.offsetWidth;
+      width = Math.max(media.width, media.clientWidth, media.offsetWidth);
       width *= CapLevelController.contentScaleFactor;
     }
     return width;
@@ -137,7 +137,7 @@ class CapLevelController extends EventHandler {
     let height;
     const media = this.media;
     if (media) {
-      height = media.height || media.clientHeight || media.offsetHeight;
+      height = Math.max(media.height, media.clientHeight || media.offsetHeight);
       height *= CapLevelController.contentScaleFactor;
     }
     return height;


### PR DESCRIPTION
With firefox 75.0 64bit on MacOS 10.13.6 aka HighSierra we noticed that `capLevelToPlayerSize: true` would not work: The player would always select the lowest level even at player sizes way above the highest available level's resolution.

Adding debug output to `CapLevelController.mediaWidth()` / `.mediaHeight()` gave us the following values (example):

```
[log] > media.width 89 clientWidth 963 offsetWidth 963 logger.js:40:11
[log] > media.height 0 clientHeight 543 offsetHeight 543 logger.js:40:11
[log] > set autoLevelCapping:0
```

So it seems we should prefer `media.clientWidth` over `media.width` in accordance with
https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements

### This PR will...

fix `capLevelToPlayerSize: true` on MacOS

### Why is this Pull Request needed?

To make `capLevelToPlayerSize: true`  work on MacOS

### Are there any points in the code the reviewer needs to double check?

Please note that I am not an experienced frontend developer, the suggested fix is just what appeared obvious to me after tracking down the cause of the issue.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
