### PR TITLE
Close media key sessions and clear media keys when media detached

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -534,23 +534,15 @@ class EMEController extends EventHandler {
     // Close all sessions and remove media keys from the video element.
     Promise.all(mediaKeysList.map((mediaKeysListItem) => {
       if (mediaKeysListItem.mediaKeysSession) {
-        try {
-          return mediaKeysListItem.mediaKeysSession.close();
-        } catch (ex) {
-          // Ignore errors when closing the sessions. Closing a session that
-          // generated no key requests will throw an error.
-        }
+          return mediaKeysListItem.mediaKeysSession.close().catch(() => {
+            // Ignore errors when closing the sessions. Closing a session that
+            // generated no key requests will throw an error.
+          });
       }
     })).then(() => {
-      this._mediaKeysList = [];
-
-      try {
-        return media.setMediaKeys(null);
-      } catch (ex) {
-        // Ignore any failures while removing media keys from the video element.
-      }
-    }).then(() => {
-      this._media = null; // release reference
+      return media.setMediaKeys(null);
+    }).catch(() => {
+      // Ignore any failures while removing media keys from the video element.
     });
   }
 

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -523,12 +523,16 @@ class EMEController extends EventHandler {
 
   onMediaDetached () {
     const media = this._media;
-    if (!media) return;
-
+    const mediaKeysList = this._mediaKeysList;
+    if (!media) {
+      return;
+    }
     media.removeEventListener('encrypted', this._onMediaEncrypted);
-
+    this._media = null;
+    this._mediaKeysList = [];
+ 
     // Close all sessions and remove media keys from the video element.
-    Promise.all(this._mediaKeysList.map((mediaKeysListItem) => {
+    Promise.all(mediaKeysList.map((mediaKeysListItem) => {
       if (mediaKeysListItem.mediaKeysSession) {
         try {
           return mediaKeysListItem.mediaKeysSession.close();

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -530,7 +530,6 @@ class EMEController extends EventHandler {
     media.removeEventListener('encrypted', this._onMediaEncrypted);
     this._media = null;
     this._mediaKeysList = [];
- 
     // Close all sessions and remove media keys from the video element.
     Promise.all(mediaKeysList.map((mediaKeysListItem) => {
       if (mediaKeysListItem.mediaKeysSession) {

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -522,10 +522,32 @@ class EMEController extends EventHandler {
   }
 
   onMediaDetached () {
-    if (this._media) {
-      this._media.removeEventListener('encrypted', this._onMediaEncrypted);
+    const media = this._media;
+    if (!media) return;
+
+    media.removeEventListener('encrypted', this._onMediaEncrypted);
+
+    // Close all sessions and remove media keys from the video element.
+    Promise.all(this._mediaKeysList.map((mediaKeysListItem) => {
+      if (mediaKeysListItem.mediaKeysSession) {
+        try {
+          return mediaKeysListItem.mediaKeysSession.close();
+        } catch (ex) {
+          // Ignore errors when closing the sessions. Closing a session that
+          // generated no key requests will throw an error.
+        }
+      }
+    })).then(() => {
+      this._mediaKeysList = [];
+
+      try {
+        return media.setMediaKeys(null);
+      } catch (ex) {
+        // Ignore any failures while removing media keys from the video element.
+      }
+    }).then(() => {
       this._media = null; // release reference
-    }
+    });
   }
 
   // TODO: Use manifest types here when they are defined


### PR DESCRIPTION
### This PR will...

Close media key sessions and clear media keys when media detached.

### Why is this Pull Request needed?

When we tested Hls.js on Android Webview on FireTV, we found that the player failed to play DRM titles after finishing 5 or 6 titles. After investigation, the root cause is:

> whenever we create a new Hls.js instance for a DRM title, it will set new media key and open a new key session to decrypt DRM media data, but it doesn’t release them when the Hls.js instance destroys. Looks like there is a maximum limitation on FireTV platform for opening key sessions, once we reach it, no new session could be created any more.

Related adb logs:

```bash
29063 10-30 03:49:57.719   295 13552 I WVCdm   : CdmEngine::QueryStatus                                                                                                                                         29064 10-30 03:49:57.720   295 13552 D OEMCryptoCENC: Use MTKTEEClient                                                                                                                                          29065 10-30 03:49:57.721 14024 14523 E cr_media: Security level: current L1, new L3
29066 10-30 03:49:57.721   295 13552 I WVCdm   : CdmEngine::OpenSession
29067 10-30 03:49:57.722   295 13552 E WVCdm   : OEMCrypto_Open failed: 31, open sessions: 17, initialized: 1
29068 10-30 03:49:57.722   295 13552 E WVCdm   : CdmEngine::OpenSession: bad session init: 9
29069 10-30 03:49:57.726 14024 14523 E cr_media: Cannot open a new session
29070 10-30 03:49:57.726 14024 14523 E cr_media: android.media.ResourceBusyException: Failed to open session
29071 10-30 03:49:57.726 14024 14523 E cr_media:  at android.media.MediaDrm.openSession(Native Method)                                                                                                          29072 10-30 03:49:57.726 14024 14523 E cr_media:  at org.chromium.media.MediaDrmBridge.openSession(MediaDrmBridge.java:361)
29073 10-30 03:49:57.726 14024 14523 E cr_media:  at org.chromium.media.MediaDrmBridge.createMediaCrypto(MediaDrmBridge.java:304)
29074 10-30 03:49:57.726 14024 14523 E cr_media:  at org.chromium.media.MediaDrmBridge.create(MediaDrmBridge.java:444)                                                                                          29075 10-30 03:49:57.726 14024 14523 E cr_media: Cannot create MediaCrypto Session.
29076 10-30 03:49:57.727 14024 14523 E chromium: [ERROR:android_cdm_factory.cc(110)] MediaDrmBridge creation failed
```

So we borrow [Google Shaka player](https://github.com/google/shaka-player/blob/v2.5.x/lib/media/drm_engine.js#L241-L254)'s idea, do these necessary cleanups when media is detached.

### Are there any points in the code the reviewer needs to double check?

- There is one point need further discussion: for `recoverMediaError` method in `Hls` class, we need to wait until all cleanups are finished before `attachMedia` again: https://github.com/video-dev/hls.js/blob/master/src/hls.ts#L332. I would suggest we use a new event `EME_DESTROYED` to make it work

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
