### PR TITLE
Support drm system options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -368,6 +368,7 @@ Configuration parameters could be provided to hls.js upon instantiation of `Hls`
       minAutoBitrate: 0,
       emeEnabled: false,
       widevineLicenseUrl: undefined,
+      drmSystemOptions: {},
       requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess
   };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,10 +42,16 @@ type CapLevelControllerConfig = {
   capLevelToPlayerSize: boolean
 };
 
+export type DRMSystemOptions = {
+  audioRobustness?: string,
+  videoRobustness?: string,
+}
+
 export type EMEControllerConfig = {
   licenseXhrSetup?: (xhr: XMLHttpRequest, url: string) => void,
   emeEnabled: boolean,
   widevineLicenseUrl?: string,
+  drmSystemOptions: DRMSystemOptions,
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null,
 };
 
@@ -240,6 +246,7 @@ export const hlsDefaultConfig: HlsConfig = {
   minAutoBitrate: 0, // used by hls
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: void 0, // used by eme-controller
+  drmSystemOptions: {}, // used by eme-controller
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
   testBandwidth: true,
 

--- a/tests/unit/controller/eme-controller.js
+++ b/tests/unit/controller/eme-controller.js
@@ -75,6 +75,37 @@ describe('EMEController', function () {
     }, 0);
   });
 
+  it('should request keys with specified robustness options when `emeEnabled` is true', function (done) {
+    let reqMediaKsAccessSpy = sinon.spy(function () {
+      return Promise.resolve({
+        // Media-keys mock
+      });
+    });
+
+    setupEach({
+      emeEnabled: true,
+      drmSystemOptions: {
+        audioRobustness: 'HW_SECURE_ALL',
+        videoRobustness: 'HW_SECURE_ALL'
+      },
+      requestMediaKeySystemAccessFunc: reqMediaKsAccessSpy
+    });
+
+    emeController.onMediaAttached({ media });
+
+    expect(media.setMediaKeys.callCount).to.equal(0);
+    expect(reqMediaKsAccessSpy.callCount).to.equal(0);
+
+    emeController.onManifestParsed({ levels: fakeLevels });
+
+    setTimeout(function () {
+      const baseConfig = reqMediaKsAccessSpy.getCall(0).args[1][0];
+      expect(baseConfig.audioCapabilities[0]).to.have.property('robustness', 'HW_SECURE_ALL');
+      expect(baseConfig.videoCapabilities[0]).to.have.property('robustness', 'HW_SECURE_ALL');
+      done();
+    }, 0);
+  });
+
   it('should trigger key system error(s) when bad encrypted data is received', function (done) {
     let reqMediaKsAccessSpy = sinon.spy(function () {
       return Promise.resolve({


### PR DESCRIPTION
### This PR will...

Add a new Hls config option `drmSystemOptions` to be able to customize `audioRobustness` and `videoRobustness` in EMEController.

### Why is this Pull Request needed?

Robustness is required in more and more devices, for example, we need to specify robustness to be `HW_SECURE_CRYPTO` in order to support HDCP on FireTV Stick 4K and gen 2.

And there is also a robustness warning in Chrome if not specified:

> It is recommended that a robustness level be specified. Not specifying the robustness level could result in unexpected behavior in the future, potentially including failure to play

### Are there any points in the code the reviewer needs to double check?

N/A

### Resolves issues:

N/A

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
