### PR TITLE
[WIP] Loading another source should reset internals

### DIFF
--- a/src/hls.ts
+++ b/src/hls.ts
@@ -281,6 +281,7 @@ export default class Hls extends Observer {
    * @param {string} url
    */
   loadSource (url: string) {
+    this.stopLoad();
     url = URLToolkit.buildAbsoluteURL(window.location.href, url, { alwaysNormalize: true });
     logger.log(`loadSource:${url}`);
     this.url = url;


### PR DESCRIPTION
### This PR will...
Support the use of `loadSource()` after loading or playing another stream.

This is a work in progress. Right now it's just a small change to get the ball rolling and discuss what other changes are required. So far it will:

- Stop network controllers before loading a new stream

### Why is this Pull Request needed?
We get a lot of issues where folks expect to be able to call `loadSource()` to load a new video after already playing or starting to load another one. The canned answer is, it is always best to start with a new player instance when loading a new stream. I don't think this should be the case. We should know the internals, and how media elements and MSE work, well enough to handle the clean up.

### Are there any points in the code the reviewer needs to double check?
We also need to reset source buffers. Usually folks call attach/detach and hope that will take care of things. I don't think we should have to detach media at all. An important consideration is that removing / replacing source buffers is an async operation. 

I will probably move this work to feature/v1.0.0. For now, this will do.

### Resolves issues:
#2473

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
