### PR TITLE
don't cache native globals

### DIFF
--- a/src/utils/fetch-loader.js
+++ b/src/utils/fetch-loader.js
@@ -5,8 +5,6 @@
  * but still it is not bullet proof as it fails to avoid data waste....
 */
 
-const { Request, Headers, fetch, performance } = window;
-
 class FetchLoader {
   constructor (config) {
     this.fetchSetup = config.fetchSetup;
@@ -18,7 +16,7 @@ class FetchLoader {
 
   load (context, config, callbacks) {
     let stats = {
-      trequest: performance.now(),
+      trequest: window.performance.now(),
       retry: 0
     };
 
@@ -37,20 +35,20 @@ class FetchLoader {
       headersObj['Range'] = 'bytes=' + context.rangeStart + '-' + String(context.rangeEnd - 1);
     } /* jshint ignore:line */
 
-    initParams.headers = new Headers(headersObj);
+    initParams.headers = new window.Headers(headersObj);
 
     if (this.fetchSetup) {
       request = this.fetchSetup(context, initParams);
     } else {
-      request = new Request(context.url, initParams);
+      request = new window.Request(context.url, initParams);
     }
 
-    let fetchPromise = fetch(request, initParams);
+    let fetchPromise = window.fetch(request, initParams);
 
     // process fetchPromise
     let responsePromise = fetchPromise.then(function (response) {
       if (response.ok) {
-        stats.tfirst = Math.max(stats.trequest, performance.now());
+        stats.tfirst = Math.max(stats.trequest, window.performance.now());
         targetURL = response.url;
         if (context.responseType === 'arraybuffer') {
           return response.arrayBuffer();
@@ -66,7 +64,7 @@ class FetchLoader {
     // process response Promise
     responsePromise.then(function (responseData) {
       if (responseData) {
-        stats.tload = Math.max(stats.tfirst, performance.now());
+        stats.tload = Math.max(stats.tfirst, window.performance.now());
         let len;
         if (typeof responseData === 'string') {
           len = responseData.length;

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -4,8 +4,6 @@
 
 import { logger } from '../utils/logger';
 
-const { performance, XMLHttpRequest } = window;
-
 class XhrLoader {
   constructor (config) {
     if (config && config.xhrSetup) {
@@ -35,14 +33,14 @@ class XhrLoader {
     this.context = context;
     this.config = config;
     this.callbacks = callbacks;
-    this.stats = { trequest: performance.now(), retry: 0 };
+    this.stats = { trequest: window.performance.now(), retry: 0 };
     this.retryDelay = config.retryDelay;
     this.loadInternal();
   }
 
   loadInternal () {
     let xhr, context = this.context;
-    xhr = this.loader = new XMLHttpRequest();
+    xhr = this.loader = new window.XMLHttpRequest();
 
     let stats = this.stats;
     stats.tfirst = 0;
@@ -99,14 +97,14 @@ class XhrLoader {
       // clear xhr timeout and rearm it if readyState less than 4
       window.clearTimeout(this.requestTimeout);
       if (stats.tfirst === 0) {
-        stats.tfirst = Math.max(performance.now(), stats.trequest);
+        stats.tfirst = Math.max(window.performance.now(), stats.trequest);
       }
 
       if (readyState === 4) {
         let status = xhr.status;
         // http status between 200 to 299 are all successful
         if (status >= 200 && status < 300) {
-          stats.tload = Math.max(stats.tfirst, performance.now());
+          stats.tload = Math.max(stats.tfirst, window.performance.now());
           let data, len;
           if (context.responseType === 'arraybuffer') {
             data = xhr.response;


### PR DESCRIPTION
in case they are patched by a different library after hls.js is loaded

### This PR will...

Update the xhr/fetch loaders to directly use the native globals from the `window.`, without caching their reference at the top of the modules.

### Why is this Pull Request needed?

Some sites/libraries modify the native globals.
When hls.js is loaded before such libraries, hls.js will not use the patched ones because it has already cached the native ones.

### Are there any points in the code the reviewer needs to double check?

Not really, pretty simple change

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
