### PR TITLE
Improve handling of large start gaps

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -15,7 +15,7 @@ import { ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import { alignStream } from '../utils/discontinuities';
 import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
-import GapController from './gap-controller';
+import GapController, { MAX_START_GAP_JUMP } from './gap-controller';
 import BaseStreamController, { State } from './base-stream-controller';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
@@ -184,8 +184,9 @@ class StreamController extends BaseStreamController {
     // determine next candidate fragment to be loaded, based on current position and end of buffer position
     // ensure up to `config.maxMaxBufferLength` of buffer upfront
 
-    const bufferInfo = BufferHelper.bufferInfo(this.mediaBuffer ? this.mediaBuffer : media, pos, config.maxBufferHole),
-      bufferLen = bufferInfo.len;
+    const maxBufferHole = pos < config.maxBufferHole ? Math.max(MAX_START_GAP_JUMP, config.maxBufferHole) : config.maxBufferHole;
+    const bufferInfo = BufferHelper.bufferInfo(this.mediaBuffer ? this.mediaBuffer : media, pos, maxBufferHole);
+    const bufferLen = bufferInfo.len;
     // Stay idle if we are still with buffer margins
     if (bufferLen >= maxBufLen) {
       return;

--- a/tests/functional/auto/testbench.js
+++ b/tests/functional/auto/testbench.js
@@ -69,7 +69,7 @@ function objectAssign (target, firstSource) {
   return to;
 }
 
-function startStream (streamUrl, config, callback) {
+function startStream (streamUrl, config, callback, autoplay) {
   var Hls = window.Hls;
   if (!Hls) {
     throw new Error('Hls not installed');
@@ -86,20 +86,22 @@ function startStream (streamUrl, config, callback) {
   try {
     window.hls = hls = new Hls(objectAssign({}, config, { debug: true }));
     console.log('[test] > userAgent:', navigator.userAgent);
-    hls.on(Hls.Events.MANIFEST_PARSED, function () {
-      console.log('[test] > Manifest parsed. Calling video.play()');
-      var playPromise = video.play();
-      if (playPromise) {
-        playPromise.catch(function (error) {
-          console.log('[test] > video.play() failed with error:', error);
-          if (error.name === 'NotAllowedError') {
-            console.log('[test] > Attempting to play with video muted');
-            video.muted = true;
-            return video.play();
-          }
-        });
-      }
-    });
+    if (autoplay !== false) {
+      hls.on(Hls.Events.MANIFEST_PARSED, function () {
+        console.log('[test] > Manifest parsed. Calling video.play()');
+        var playPromise = video.play();
+        if (playPromise) {
+          playPromise.catch(function (error) {
+            console.log('[test] > video.play() failed with error:', error);
+            if (error.name === 'NotAllowedError') {
+              console.log('[test] > Attempting to play with video muted');
+              video.muted = true;
+              return video.play();
+            }
+          });
+        }
+      });
+    }
     hls.on(Hls.Events.ERROR, function (event, data) {
       if (data.fatal) {
         console.log('[test] > hlsjs fatal error :' + data.details);


### PR DESCRIPTION
### This PR will...
Prevent the first two segments from being reloaded at the start of a stream with a start gap larger than `maxBufferHole` but smaller than `MAX_START_GAP_JUMP`.

### Why is this Pull Request needed?
The audio and main stream controller depend on `BufferHelper.bufferInfo` to determine the end of the buffer relevant to `currentTime` used to find which fragment it will load next. In a gap or hole this buffer end would be for a range before `currentTime`. `maxBufferHole` is used to look past a gap or hole that `currentTime` is in. At the start of the stream, when playback starts, hls.js can jump up to 2 seconds (`MAX_START_GAP_JUMP`) or `maxBufferHole`, whichever is larger, so this change uses that to prevent the stream controller logic from getting stuck picking the first two segments for loading because `BufferHelper.bufferInfo` returns and end of 0.

A new functional test has been added that verifies buffering up to `maxBufferLength` or `duration - 1` (whichever comes first). The test passes for all streams with these changes, and fails before these changes on two of our test streams which have start gaps larger than 0.5 (default `maxBufferHole`) seconds.

### Resolves issues:
#2684

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
