### PR TITLE
Fix smooth switch test

### DIFF
--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -102,14 +102,14 @@ async function testSmoothSwitch (url, config) {
         window.switchToHighestLevel('next');
       });
       window.hls.on(window.Hls.Events.LEVEL_SWITCHED, (event, data) => {
-        console.log(`[log] > level switched: ${data.level}`);
+        console.log(`[test] > level switched: ${data.level}`);
         let currentTime = video.currentTime;
         if (data.level === window.hls.levels.length - 1) {
-          console.log(`[log] > switched on level: ${data.level}`);
+          console.log(`[test] > switched on level: ${data.level}`);
           window.setTimeout(() => {
             let newCurrentTime = video.currentTime;
             console.log(
-              `[log] > currentTime delta : ${newCurrentTime - currentTime}`
+              `[test] > currentTime delta : ${newCurrentTime - currentTime}`
             );
             callback({
               code: newCurrentTime > currentTime,
@@ -204,13 +204,13 @@ async function testIsPlayingVOD (url, config) {
         if (expectedPlaying) {
           window.setTimeout(() => {
             console.log(
-              `video expected playing. [last currentTime/new currentTime]=[${currentTime}/${video.currentTime}]`
+              `[test] > video expected playing. [last currentTime/new currentTime]=[${currentTime}/${video.currentTime}]`
             );
             callback({ playing: currentTime !== video.currentTime });
           }, 5000);
         } else {
           console.log(
-            `video not playing. [paused/ended/buffered.length]=[${video.paused}/${video.ended}/${video.buffered.length}]`
+            `[test] > video not playing. [paused/ended/buffered.length]=[${video.paused}/${video.ended}/${video.buffered.length}]`
           );
           callback({ playing: false });
         }

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -98,10 +98,11 @@ async function testSmoothSwitch (url, config) {
       let callback = arguments[arguments.length - 1];
       window.startStream(url, config, callback);
       const video = window.video;
-      video.onloadeddata = () => {
+      window.hls.once(window.Hls.Events.FRAG_CHANGED, (event, data) => {
         window.switchToHighestLevel('next');
-      };
+      });
       window.hls.on(window.Hls.Events.LEVEL_SWITCHED, (event, data) => {
+        console.log(`[log] > level switched: ${data.level}`);
         let currentTime = video.currentTime;
         if (data.level === window.hls.levels.length - 1) {
           console.log(`[log] > switched on level: ${data.level}`);


### PR DESCRIPTION
### This PR will...
- Not attempt to switch levels until playback starts on a different level in the "smooth switch" test
- Differentiate test logs from player logs with `[test] >` prefix
- Fail test and return early when `!Hls.isSupported()`

### Why is this Pull Request needed?
The "smooth switch" function test fails when `switchToHighestLevel` is called before playback begins because `LEVEL_SWITCHED` is never triggered. `LEVEL_SWITCHED` is only triggered when `FRAG_CHANGED` has already been fired for a fragment on a different level. That, or playback isn't starting on certain streams and it's unclear from the logs why...
