### PR TITLE
update eventemitter3 to 4.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9651,9 +9651,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.1.tgz",
-      "integrity": "sha512-MnI0l35oYL2C/c80rjJN7qu50MDx39yYE7y7oYck2YA3v+y7EaAenY8IU8AP4d1RWqE8VAKWFGSh3rfP87ll3g=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.3.tgz",
+      "integrity": "sha512-HyaFeyfTa18nYjft59vEPsvuq6ZVcrCC1rBw6Fx8ZV9NcuUITBNCnTOyr0tHHkkHn//d+lzhsL1YybgtLQ7lng=="
     },
     "events": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "dependencies": {
-    "eventemitter3": "4.0.1",
+    "eventemitter3": "^4.0.3",
     "url-toolkit": "^2.1.6"
   },
   "devDependencies": {

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'eventemitter3';
 /**
  * Simple adapter sub-class of Nodejs-like EventEmitter.
  */
-export class Observer extends EventEmitter<any> {
+export class Observer extends EventEmitter {
   /**
    * We simply want to pass along the event-name itself
    * in every call to a handler, which is the purpose of our `trigger` method


### PR DESCRIPTION
### This PR will...
Update eventemitter3 to 4.0.3 and remove the workaround that was added (6f98604319bcb09f72438483ae1b7ad4477e5013) to make 4.0.1 work. The issue was fixed in https://github.com/primus/eventemitter3/pull/223 and https://github.com/primus/eventemitter3/pull/224
