### PR TITLE
Use getBoundingClientRect in cap-level-controller

### DIFF
--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -21,11 +21,13 @@ class CapLevelController extends EventHandler {
     this.media = null;
     this.restrictedLevels = [];
     this.timer = null;
+    this.clientRect = null;
   }
 
   destroy () {
     if (this.hls.config.capLevelToPlayerSize) {
       this.media = null;
+      this.clientRect = null;
       this.stopCapping();
     }
   }
@@ -98,6 +100,7 @@ class CapLevelController extends EventHandler {
       CapLevelController.isLevelAllowed(index, this.restrictedLevels) && index <= capLevelIndex
     );
 
+    this.clientRect = null;
     return CapLevelController.getMaxLevelByMediaSize(validLevels, this.mediaWidth, this.mediaHeight);
   }
 
@@ -123,24 +126,37 @@ class CapLevelController extends EventHandler {
     }
   }
 
-  get mediaWidth () {
-    let width = 0;
-    const media = this.media;
-    if (media) {
-      width = Math.max(media.width, media.clientWidth, media.offsetWidth);
-      width *= CapLevelController.contentScaleFactor;
+  getDimensions () {
+    if (this.clientRect) {
+      return this.clientRect;
     }
-    return width;
+    const media = this.media;
+    const boundsRect = {
+      width: 0,
+      height: 0
+    };
+
+    if (media) {
+      const clientRect = media.getBoundingClientRect();
+      boundsRect.width = clientRect.width;
+      boundsRect.height = clientRect.height;
+      if (!boundsRect.width && !boundsRect.height) {
+        // When the media element has no width or height (equivalent to not being in the DOM),
+        // then use its width and height attributes (media.width, media.height)
+        boundsRect.width = clientRect.right - clientRect.left || media.width || 0;
+        boundsRect.height = clientRect.bottom - clientRect.top || media.height || 0;
+      }
+    }
+    this.clientRect = boundsRect;
+    return boundsRect;
+  }
+
+  get mediaWidth () {
+    return this.getDimensions().width * CapLevelController.contentScaleFactor;
   }
 
   get mediaHeight () {
-    let height = 0;
-    const media = this.media;
-    if (media) {
-      height = Math.max(media.height, media.clientHeight, media.offsetHeight);
-      height *= CapLevelController.contentScaleFactor;
-    }
-    return height;
+    return this.getDimensions().height * CapLevelController.contentScaleFactor;
   }
 
   static get contentScaleFactor () {

--- a/tests/unit/controller/cap-level-controller.js
+++ b/tests/unit/controller/cap-level-controller.js
@@ -58,6 +58,65 @@ describe('CapLevelController', function () {
     });
   });
 
+  describe('getDimensions', function () {
+    let hls;
+    let media;
+    let capLevelController;
+    beforeEach(function () {
+      const fixture = document.createElement('div');
+      fixture.id = 'test-fixture';
+      document.body.appendChild(fixture);
+
+      hls = new Hls({ capLevelToPlayerSize: true });
+      media = document.createElement('video');
+      capLevelController = new CapLevelController(hls);
+      capLevelController.onMediaAttaching({
+        media
+      });
+      capLevelController.onManifestParsed({
+        levels
+      });
+    });
+
+    afterEach(function () {
+      if (media.parentNode) {
+        media.parentNode.removeChild(media);
+      }
+      document.body.removeChild(document.querySelector('#test-fixture'));
+    });
+
+    it('gets 0 for width and height when the media element is not in the DOM', function () {
+      const bounds = capLevelController.getDimensions();
+      expect(bounds.width).to.equal(0);
+      expect(bounds.height).to.equal(0);
+      expect(capLevelController.mediaWidth).to.equal(0);
+      expect(capLevelController.mediaHeight).to.equal(0);
+    });
+
+    it('gets width and height attributes when the media element is not in the DOM', function () {
+      media.setAttribute('width', 320);
+      media.setAttribute('height', 240);
+      const pixelRatio = CapLevelController.contentScaleFactor;
+      const bounds = capLevelController.getDimensions();
+      expect(bounds.width).to.equal(320);
+      expect(bounds.height).to.equal(240);
+      expect(capLevelController.mediaWidth).to.equal(320 * pixelRatio);
+      expect(capLevelController.mediaHeight).to.equal(240 * pixelRatio);
+    });
+
+    it('gets client bounds width and height when media element is in the DOM', function () {
+      media.style.width = '1280px';
+      media.style.height = '720px';
+      document.querySelector('#test-fixture').appendChild(media);
+      const pixelRatio = CapLevelController.contentScaleFactor;
+      const bounds = capLevelController.getDimensions();
+      expect(bounds.width).to.equal(1280);
+      expect(bounds.height).to.equal(720);
+      expect(capLevelController.mediaWidth).to.equal(1280 * pixelRatio);
+      expect(capLevelController.mediaHeight).to.equal(720 * pixelRatio);
+    });
+  });
+
   describe('initialization', function () {
     let hls;
     let capLevelController;


### PR DESCRIPTION
### This PR will...
Use `getBoundingClientRect()` in cap-level-controller to get media element width and height

### Why is this Pull Request needed?
The cap-level-controller should calculate media element width and height at once when calling `getMaxLevel`. It should only use the video element's `width` and `height` attributes, when the client width and height are unavailable (for example when the media element is not in the DOM or is scaled to 0).

### Resolves issues:
Improvement relates to #2659

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)