### PR TITLE
Add fragment.encrypted unit tests for manifest signalled DRM (PlayReady and Widevine)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1448,7 +1448,8 @@
           "dependencies": {
             "acorn": {
               "version": "6.4.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
               "dev": true
             }
           }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -279,7 +279,7 @@ class AudioStreamController extends BaseStreamController implements ComponentAPI
       return;
     }
 
-    if (frag.encrypted) {
+    if (frag.decryptdata?.keyFormat === 'identity' && !frag.decryptdata?.key) {
       this.log(`Loading key for ${frag.sn} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}`);
       this.state = State.KEY_LOADING;
       hls.trigger(Events.KEY_LOADING, { frag: frag });

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -179,7 +179,21 @@ export default class Fragment {
   }
 
   get encrypted () {
-    return !!((this.decryptdata && this.decryptdata.uri !== null) && (this.decryptdata.key === null));
+    // TODO: Need to understand why a fragment should only be considered encrypted
+    // when there is no key payload attached, this seems like an odd part of
+    // the API, but keeping it for backwards compatability until fully understood.
+    if (this.decryptdata?.keyFormat === 'identity') {
+      return this.decryptdata?.uri !== null && this.decryptdata?.key === null;
+    }
+
+    // At the m3u8-parser level we need to add support for manifest signalled keyformats
+    // when we want the fragment to start reporting that it is encrypted.
+    // Currently, keyFormat will only be set for identity keys
+    if (this.decryptdata?.keyFormat && this.decryptdata.uri) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -206,10 +220,11 @@ export default class Fragment {
   setDecryptDataFromLevelKey (levelkey: LevelKey, segmentNumber: number): LevelKey {
     let decryptdata = levelkey;
 
-    if (levelkey?.method && levelkey.uri && !levelkey.iv) {
-      decryptdata = new LevelKey(levelkey.baseuri, levelkey.reluri);
+    if (levelkey?.method === 'AES-128' && levelkey.uri && !levelkey.iv) {
+      decryptdata = LevelKey.fromURI(levelkey.uri);
       decryptdata.method = levelkey.method;
       decryptdata.iv = this.createInitializationVector(segmentNumber);
+      decryptdata.keyFormat = 'identity';
     }
 
     return decryptdata;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -179,13 +179,6 @@ export default class Fragment {
   }
 
   get encrypted () {
-    // TODO: Need to understand why a fragment should only be considered encrypted
-    // when there is no key payload attached, this seems like an odd part of
-    // the API, but keeping it for backwards compatability until fully understood.
-    if (this.decryptdata?.keyFormat === 'identity') {
-      return this.decryptdata?.uri !== null && this.decryptdata?.key === null;
-    }
-
     // At the m3u8-parser level we need to add support for manifest signalled keyformats
     // when we want the fragment to start reporting that it is encrypted.
     // Currently, keyFormat will only be set for identity keys

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -2,23 +2,30 @@ import { buildAbsoluteURL } from 'url-toolkit';
 
 export default class LevelKey {
   private _uri: string | null = null;
-
-  public baseuri: string;
-  public reluri: string;
   public method: string | null = null;
+  public keyFormat: string | null = null;
+  public keyFormatVersions: string | null = null;
+  public keyID: string | null = null;
   public key: Uint8Array | null = null;
   public iv: Uint8Array | null = null;
 
-  constructor (baseURI: string, relativeURI: string) {
-    this.baseuri = baseURI;
-    this.reluri = relativeURI;
+  static fromURL (baseUrl: string, relativeUrl: string): LevelKey {
+    return new LevelKey(baseUrl, relativeUrl);
+  }
+
+  static fromURI (uri: string): LevelKey {
+    return new LevelKey(uri);
+  }
+
+  private constructor (absoluteOrBaseURI: string, relativeURL?: string) {
+    if (relativeURL) {
+      this._uri = buildAbsoluteURL(absoluteOrBaseURI, relativeURL, { alwaysNormalize: true });
+    } else {
+      this._uri = absoluteOrBaseURI;
+    }
   }
 
   get uri () {
-    if (!this._uri && this.reluri) {
-      this._uri = buildAbsoluteURL(this.baseuri, this.reluri, { alwaysNormalize: true });
-    }
-
     return this._uri;
   }
 }

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -300,19 +300,46 @@ export default class M3U8Parser {
           const decryptmethod = keyAttrs.enumeratedString('METHOD');
           const decrypturi = keyAttrs.URI;
           const decryptiv = keyAttrs.hexadecimalInteger('IV');
+          const decryptkeyformatversions = keyAttrs.enumeratedString('KEYFORMATVERSIONS');
+          const decryptkeyid = keyAttrs.enumeratedString('KEYID');
           // From RFC: This attribute is OPTIONAL; its absence indicates an implicit value of "identity".
-          const decryptkeyformat = keyAttrs.KEYFORMAT || 'identity';
+          const decryptkeyformat = keyAttrs.enumeratedString('KEYFORMAT') ?? 'identity';
 
-          if (decryptkeyformat === 'com.apple.streamingkeydelivery') {
-            logger.warn('Keyformat com.apple.streamingkeydelivery is not supported');
+          const unsupportedKnownKeyformatsInManifest = [
+            'com.apple.streamingkeydelviery',
+            'com.microsoft.playready',
+            'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed', // widevine (v2)
+            'com.widevine' // earlier widevine (v1)
+          ];
+
+          if (unsupportedKnownKeyformatsInManifest.includes(decryptkeyformat)) {
+            logger.warn(`Keyformat ${decryptkeyformat} is not supported from the manifest`);
+            continue;
+          } else if (decryptkeyformat !== 'identity') {
+            // We are supposed to skip keys we don't understand.
+            // As we currently only officially support identity keys
+            // from the manifest we shouldn't save any other key.
             continue;
           }
 
+          // TODO: multiple keys can be defined on a fragment, and we need to support this
+          // for clients that support both playready and widevine
           if (decryptmethod) {
-            levelkey = new LevelKey(baseurl, decrypturi);
+            // TODO: need to determine if the level key is actually a relative URL
+            // if it isn't, then we should instead construct the LevelKey using fromURI.
+            levelkey = LevelKey.fromURL(baseurl, decrypturi);
             if ((decrypturi) && (['AES-128', 'SAMPLE-AES', 'SAMPLE-AES-CENC'].indexOf(decryptmethod) >= 0)) {
               levelkey.method = decryptmethod;
-              levelkey.key = null;
+              levelkey.keyFormat = decryptkeyformat;
+
+              if (decryptkeyid) {
+                levelkey.keyID = decryptkeyid;
+              }
+
+              if (decryptkeyformatversions) {
+                levelkey.keyFormatVersions = decryptkeyformatversions;
+              }
+
               // Initialization Vector (IV)
               levelkey.iv = decryptiv;
             }

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -306,7 +306,7 @@ export default class M3U8Parser {
           const decryptkeyformat = keyAttrs.enumeratedString('KEYFORMAT') ?? 'identity';
 
           const unsupportedKnownKeyformatsInManifest = [
-            'com.apple.streamingkeydelviery',
+            'com.apple.streamingkeydelivery',
             'com.microsoft.playready',
             'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed', // widevine (v2)
             'com.widevine' // earlier widevine (v1)

--- a/src/utils/attr-list.ts
+++ b/src/utils/attr-list.ts
@@ -57,7 +57,7 @@ class AttrList {
     return parseFloat(this[attrName]);
   }
 
-  enumeratedString (attrName: string): string {
+  enumeratedString (attrName: string): string | undefined {
     return this[attrName];
   }
 

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -1,4 +1,5 @@
 import Fragment from '../../../src/loader/fragment';
+import LevelKey from '../../../src/loader/level-key';
 
 describe('Fragment class tests', function () {
   /**
@@ -7,6 +8,59 @@ describe('Fragment class tests', function () {
   let frag;
   beforeEach(function () {
     frag = new Fragment();
+  });
+
+  describe('encrypted', function () {
+    it('returns true if an EXT-X-KEY is associated with the fragment', function () {
+      // From https://docs.microsoft.com/en-us/azure/media-services/previous/media-services-protect-with-aes128
+
+      const key = LevelKey.fromURL('https://wamsbayclus001kd-hs.cloudapp.net', './HlsHandler.ashx?kid=da3813af-55e6-48e7-aa9f-a4d6031f7b4d');
+      key.method = 'AES-128';
+      key.iv = '0XD7D7D7D7D7D7D7D7D7D7D7D7D7D7D7D7';
+      key.keyFormat = 'identity';
+      frag.levelkey = key;
+      expect(frag.decryptdata.uri).to.equal('https://wamsbayclus001kd-hs.cloudapp.net/HlsHandler.ashx?kid=da3813af-55e6-48e7-aa9f-a4d6031f7b4d');
+      expect(frag.encrypted).to.equal(true);
+    });
+
+    it('returns true for widevine v2 manifest signalled encryption', function () {
+      // #EXT-X-KEY:METHOD=SAMPLE-AES,URI=”data:text/plain;base64,AAAAPXBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB0aDXdpZGV2aW5lX3Rlc3QiDHRlc3QgY29udGVudA==”,KEYID=0x112233445566778899001122334455,KEYFORMAT=”urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed”,KEYFORMATVERSION=”1”
+      // From https://www.academia.edu/36030972/Widevine_DRM_for_HLS
+
+      const key = LevelKey.fromURI('data:text/plain;base64,AAAAPXBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB0aDXdpZGV2aW5lX3Rlc3QiDHRlc3QgY29udGVudA==');
+      key.method = 'SAMPLE-AES';
+      key.keyFormat = 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
+      key.keyFormatVersions = '1';
+      frag.levelkey = key;
+      expect(frag.decryptdata.uri).to.equal('data:text/plain;base64,AAAAPXBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB0aDXdpZGV2aW5lX3Rlc3QiDHRlc3QgY29udGVudA==');
+      expect(frag.encrypted).to.equal(true);
+    });
+
+    it('returns true for widevine v1 manifest signalled encryption', function () {
+      // #EXT-X-KEY:METHOD=SAMPLE-AES,URI=”data:text/plain;base64,eyAKICAgInByb3ZpZGVyIjoibWxiYW1oYm8iLAogICAiY29udGVudF9pZCI6Ik1qQXhOVjlVWldGeWN3PT0iLAogICAia2V5X2lkcyI6CiAgIFsKICAgICAgIjM3MWUxMzVlMWE5ODVkNzVkMTk4YTdmNDEwMjBkYzIzIgogICBdCn0=",IV=0x6df49213a781e338628d0e9c812d328e,KEYFORMAT=”com.widevine”,KEYFORMATVERSIONS=”1”
+      // From https://www.academia.edu/36030972/Widevine_DRM_for_HLS
+
+      const key = LevelKey.fromURI('data:text/plain;base64,eyAKICAgInByb3ZpZGVyIjoibWxiYW1oYm8iLAogICAiY29udGVudF9pZCI6Ik1qQXhOVjlVWldGeWN3PT0iLAogICAia2V5X2lkcyI6CiAgIFsKICAgICAgIjM3MWUxMzVlMWE5ODVkNzVkMTk4YTdmNDEwMjBkYzIzIgogICBdCn0=');
+      key.method = 'SAMPLE-AES';
+      key.keyFormat = 'com.widevine';
+      key.keyFormatVersions = '1';
+      frag.levelkey = key;
+      expect(frag.decryptdata.uri).to.equal('data:text/plain;base64,eyAKICAgInByb3ZpZGVyIjoibWxiYW1oYm8iLAogICAiY29udGVudF9pZCI6Ik1qQXhOVjlVWldGeWN3PT0iLAogICAia2V5X2lkcyI6CiAgIFsKICAgICAgIjM3MWUxMzVlMWE5ODVkNzVkMTk4YTdmNDEwMjBkYzIzIgogICBdCn0=');
+      expect(frag.encrypted).to.equal(true);
+    });
+
+    it('returns true for a playready manifest signalled encryption', function () {
+      // #EXT-X-KEY:METHOD=SAMPLE-AES,KEYFORMAT="com.microsoft.playready",KEYFORMATVERSIONS="1",URI="data:text/plain;charset=UTF-16;base64,xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AdgBHAFYAagBOAEsAZwBZAE0ARQBxAHAATwBMAGgAMQBWAGQAUgBUADAAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA="
+      // From https://docs.microsoft.com/en-us/playready/packaging/mp4-based-formats-supported-by-playready-clients?tabs=case4
+
+      const key = LevelKey.fromURI('data:text/plain;charset=UTF-16;base64,xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AdgBHAFYAagBOAEsAZwBZAE0ARQBxAHAATwBMAGgAMQBWAGQAUgBUADAAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=');
+      key.method = 'SAMPLE-AES';
+      key.keyFormat = 'com.microsoft.playready';
+      key.keyFormatVersions = '1';
+      frag.levelkey = key;
+      expect(frag.decryptdata.uri).to.equal('data:text/plain;charset=UTF-16;base64,xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AdgBHAFYAagBOAEsAZwBZAE0ARQBxAHAATwBMAGgAMQBWAGQAUgBUADAAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=');
+      expect(frag.encrypted).to.equal(true);
+    });
   });
 
   describe('setByteRange', function () {


### PR DESCRIPTION
### This PR will...

When fragments are signalled from the manifest they are encrypted we
need to be able to detect this fact. Currently we use the boolean
"encrypted" on Fragment to support this. So I've added some tests that
cover the current behaviour for AES-128 encryption, and some ~skipped~
tests that cover the future usecase.

Additionally, this change includes a tiny change to the LevelKey class.
It now has a private constructor, and two static methods to create
itself. `fromURL` and `fromURI`, one supports the current usecase for
absolute or relative URLs, and the other is for supporting the future
use-case of URI keys.

As the meaning of the `encrypted` getter on Fragment has been changed
to mean that a fragment has a `EXT-X-KEY` associated with it, locations where it was used
currently for determining if a key needed to be loaded have been changed to
directly reference the appropriate properties.

### Why is this Pull Request needed?

We need to know when fragments are encrypted beyond the current 
support for AES-128 segments if we are going to notify users when 
encrypted content is being encountered from a manifest only
perspective.

### Are there any points in the code the reviewer needs to double check?

The unit tests make sense.