### PR TITLE
Audio-only with main audio and alt audio support

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -141,12 +141,17 @@ class BufferController extends EventHandler {
     }
   }
 
-  onManifestParsed (data: { altAudio: boolean }) {
-    // in case of alt audio 2 BUFFER_CODECS events will be triggered, one per stream controller
+  onManifestParsed (data: { altAudio: boolean, audio: boolean, video: boolean }) {
+    // in case of alt audio (where all tracks have urls) 2 BUFFER_CODECS events will be triggered, one per stream controller
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
-    this.bufferCodecEventsExpected = this._bufferCodecEventsTotal = data.altAudio ? 2 : 1;
+    let codecEvents: number = 2;
+    if (data.audio && !data.video || !data.altAudio) {
+      codecEvents = 1;
+    }
+    this.bufferCodecEventsExpected = this._bufferCodecEventsTotal = codecEvents;
+
     logger.log(`${this.bufferCodecEventsExpected} bufferCodec event(s) expected`);
   }
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -111,7 +111,7 @@ class MP4Remuxer {
       typeSupported = this.typeSupported,
       container = 'audio/mp4',
       tracks = {},
-      data = { tracks: tracks },
+      data = { tracks },
       computePTSDTS = (this._initPTS === undefined),
       initPTS, initDTS;
 
@@ -165,8 +165,11 @@ class MP4Remuxer {
       if (computePTSDTS) {
         initPTS = Math.min(initPTS, videoSamples[0].pts - inputTimeScale * timeOffset);
         initDTS = Math.min(initDTS, videoSamples[0].dts - inputTimeScale * timeOffset);
-        this.observer.trigger(Event.INIT_PTS_FOUND, { initPTS: initPTS });
+        this.observer.trigger(Event.INIT_PTS_FOUND, { initPTS });
       }
+    } else if (computePTSDTS && tracks.audio) {
+      // initPTS found for audio-only stream with main and alt audio
+      this.observer.trigger(Event.INIT_PTS_FOUND, { initPTS });
     }
 
     if (Object.keys(tracks).length) {


### PR DESCRIPTION
### This PR will...
Support playback and audio track switching of audio-only streams with main audio and alt audio.

1. The buffer-controller should only expect one `BUFFER_CODECS` event when the manifest  STREAM-INF and MEDIA specify an audio codec and no video codec. This unblocks the buffer-controller from waiting for an event that never comes before creating source buffers (Fix #2706 not playing).
2. The mp4-remuxer must trigger `INIT_PTS_FOUND` when there is an audio track and no video track. This unblocks the audio-track-controller from loading and appending alt audio segments after switching tracks and clearing the forward buffer (Fix #2706 not switching tracks).
3. **TODO**: 😪 Stop the stream-controller from loading and buffering "main" (STREAM-INF) audio, when the audio-controller is loading and buffering alt "audio" audio. 


### Why is this Pull Request needed?
To support audio-only streams like this:
```
#EXTM3U

#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="stereo",LANGUAGE="en",NAME="A"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="stereo",LANGUAGE="de",NAME="B",URI="B.m3u8"

#EXT-X-STREAM-INF:BANDWIDTH=831270,CODECS="mp4a.40.2",AUDIO="stereo"
A.m3u8
```

### Are there any points in the code the reviewer needs to double check?
This is still a work-in-progress as I haven't worked out how to prevent the stream-controller from buffering main audio ahead of the audio-track-controller loading it's audio when an alt track is active. Since the audio always follows "main" buffering this could be tricky.

### Resolves issues:
#2706

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
