### PR TITLE
Fix: playback stops on short segment

### DIFF
--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -46,12 +46,23 @@ export function findFragmentByPDT (fragments: Array<Fragment>, PDTValue: number 
  * @returns {*} foundFrag - The best matching fragment
  */
 export function findFragmentByPTS (fragPrevious: Fragment, fragments: Array<Fragment>, bufferEnd: number = 0, maxFragLookUpTolerance: number = 0): Fragment | null {
-  const fragNext = fragPrevious ? fragments[fragPrevious.sn as number - (fragments[0].sn as number) + 1] : null;
+  let fragNext: Fragment | null = null;
+  if (fragPrevious) {
+    fragNext = fragments[fragPrevious.sn as number - (fragments[0].sn as number) + 1];
+  } else if (bufferEnd === 0 && fragments[0].start === 0) {
+    fragNext = fragments[0];
+  }
   // Prefer the next fragment if it's within tolerance
-  if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {
+  if (fragNext && fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext) === 0) {
     return fragNext;
   }
-  return BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
+  // We might be seeking past the tolerance so find the best match
+  const foundFragment = BinarySearch.search(fragments, fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance));
+  if (foundFragment) {
+    return foundFragment;
+  }
+  // If no match was found return the next fragment after fragPrevious, or null
+  return fragNext;
 }
 
 /**

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -101,7 +101,7 @@ module.exports = {
   },
   */
   mp3Audio: {
-    'url': 'https://player.webvideocore.net/CL1olYogIrDWvwqiIKK7eLBkzvO18gwo9ERMzsyXzwt_t-ya8ygf2kQBZww38JJT/8i4vvznv8408.m3u8',
+    'url': 'https://playertest.longtailvideo.com/adaptive/vod-with-mp3/manifest.m3u8',
     'description': 'MP3 VOD demo',
     'live': false,
     'abr': false,

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -39,6 +39,30 @@ describe('Fragment finders', function () {
       expect(binarySearchSpy).to.have.not.been.called;
     });
 
+    it('chooses the fragment with the next SN if its contiguous with the end of previous fragment', function () {
+      // See https://github.com/video-dev/hls.js/issues/2776
+      const bufferEnd = 60.139636;
+      const fragments = [{
+        deltaPTS: 0.012346258503441732,
+        cc: 2,
+        duration: 5.017346258503444,
+        start: 55.21705215419478,
+        sn: 11,
+        level: 0
+      },
+      {
+        deltaPTS: 0,
+        cc: 2,
+        duration: 0.033,
+        start: 60.234398412698226,
+        sn: 12,
+        level: 0
+      }];
+      const fragPrevious = fragments[0];
+      const actual = findFragmentByPTS(fragPrevious, fragments, bufferEnd, tolerance);
+      expect(actual).to.equal(fragments[1], `expected sn ${fragments[1].sn}, but got sn ${actual ? actual.sn : null}`);
+    });
+
     it('uses BinarySearch to find a fragment if the subsequent one is not within tolerance', function () {
       const fragments = [mockFragments[0], mockFragments[(mockFragments.length - 1)]];
       findFragmentByPTS(fragments[0], fragments, bufferEnd, tolerance);


### PR DESCRIPTION
### This PR will...
Improve `findFragmentByPTS` and `fragmentWithinToleranceTest` with regards to selecting the next fragment and handling of tiny fragments.

### Why is this Pull Request needed?
The binary search in`findFragmentByPTS` fails to find tiny segments that are smaller than the difference or gap between the end of audio and video in the previous segment. These tiny segments are often created with digital ad insertion or stitching.

The image below illustrates issue #2776  where sn 12 is never loaded and playback stalls near the end of sn 11, because `findFragmentByPTS` consistently returns `null`:

<img width="740" alt="Screen Shot 2020-05-29 at 8 20 28 PM" src="https://user-images.githubusercontent.com/333258/83315420-d3259c80-a1ed-11ea-929b-86f978a0554f.png">

### Are there any points in the code the reviewer needs to double check?
I've kept the original intention and priority of `findFragmentByPTS` in tact as much as possible. Now, it only skips `BinarySearch.search` for the very first segment where it was always being called. And, if `BinarySearch.search` fails but an obvious next segment was chosen based on `fragPrevious` we'll return it.  At least that way the buffer will advance linearly if the search for a fragment at `bufferEnd` with `maxFragLookUpTolerance` fails.

### Resolves issues:
Fixes #2776

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
