### PR TITLE
Support for encrypted initialization segments for fMP4

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -201,11 +201,12 @@ export default class BaseStreamController extends TaskLoop {
     this._doFragLoad(frag)
       .then((data: FragLoadSuccessResult) => {
         if (!data || this._fragLoadAborted(frag) || !this.levels) {
-          return;
+          throw new Error('init load aborted');
         }
 
         return data;
-      }).then((data: FragLoadSuccessResult) => {
+      })
+      .then((data: FragLoadSuccessResult) => {
         const { hls } = this;
         const { payload } = data;
         const decryptData = frag.decryptdata;
@@ -234,7 +235,7 @@ export default class BaseStreamController extends TaskLoop {
       }).then((data: FragLoadSuccessResult) => {
         const { fragCurrent, hls, levels } = this;
         if (!levels) {
-          return;
+          throw new Error('init load aborted, missing levels');
         }
 
         const details = levels[frag.level].details as LevelDetails;
@@ -255,6 +256,8 @@ export default class BaseStreamController extends TaskLoop {
           hls.trigger(Events.FRAG_BUFFERED, { stats, frag: fragCurrent, id: frag.type });
         }
         this.tick();
+      }).catch(reason => {
+        logger.warn(reason);
       });
   }
 

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -240,7 +240,12 @@ export default class BufferController implements ComponentAPI {
         chunkStats.executeStart = performance.now();
         this.appendExecutor(data, type);
       },
+      onStart: () => {
+        logger.debug(`[buffer-controller]: ${type} SourceBuffer updatestart`);
+        console.assert(this.sourceBuffer[type]?.updating, 'Expected source buffer updating flag to be true');
+      },
       onComplete: () => {
+        logger.debug(`[buffer-controller]: ${type} SourceBuffer updateend`);
         const end = performance.now();
         chunkStats.executeEnd = chunkStats.end = end;
         if (!fragStats.first) {
@@ -265,6 +270,7 @@ export default class BufferController implements ComponentAPI {
           err,
           fatal: false
         };
+
         if (err.code === DOMException.QUOTA_EXCEEDED_ERR) {
           // TODO: enum MSE error codes
           // TODO: Should queues be cleared on this error?
@@ -285,14 +291,18 @@ export default class BufferController implements ComponentAPI {
         hls.trigger(Events.ERROR, event);
       }
     };
-    operationQueue.append(operation, type as SourceBufferName);
+    operationQueue.append(operation, type);
   }
 
   protected onBufferFlushing (event: Events.BUFFER_FLUSHING, data: BufferFlushingData) {
     const { operationQueue } = this;
     const flushOperation = (type): BufferOperation => ({
       execute: this.removeExecutor.bind(this, type, data.startOffset, data.endOffset),
+      onStart: () => {
+        logger.debug(`[buffer-controller]: Started flushing ${data.startOffset} -> ${data.endOffset} for ${type} Source Buffer`);
+      },
       onComplete: () => {
+        logger.debug(`[buffer-controller]: Finished flushing ${data.startOffset} -> ${data.endOffset} for ${type} Source Buffer`);
         this.hls.trigger(Events.BUFFER_FLUSHED);
       },
       onError: (e) => {
@@ -406,6 +416,9 @@ export default class BufferController implements ComponentAPI {
 
     const operation = {
       execute: this.abortExecutor.bind(this, type),
+      onStart () {
+        logger.debug(`[buffer-controller]: Starting abort on source buffer ${type}`);
+      },
       onComplete () {
         if (audioBuffer) {
           logger.log(`[buffer-controller]: Updating audio SourceBuffer timestampOffset to ${data.start}`);
@@ -524,6 +537,7 @@ export default class BufferController implements ComponentAPI {
         try {
           const sb = sourceBuffer[trackName] = mediaSource.addSourceBuffer(mimeType);
           const sbName = trackName as SourceBufferName;
+          this.addBufferListener(sbName, 'updatestart', this._onSBUpdateStart);
           this.addBufferListener(sbName, 'updateend', this._onSBUpdateEnd);
           this.addBufferListener(sbName, 'error', this._onSBUpdateError);
           this.tracks[trackName] = {
@@ -572,6 +586,14 @@ export default class BufferController implements ComponentAPI {
   private _onMediaSourceEnded = () => {
     logger.log('[buffer-controller]: Media source ended');
   };
+
+  private _onSBUpdateStart (type: SourceBufferName) {
+    const { operationQueue } = this;
+    const operation = operationQueue.current(type);
+    console.assert(operation, 'Operation should exist on update start');
+
+    operation.onStart();
+  }
 
   private _onSBUpdateEnd (type: SourceBufferName) {
     const { operationQueue } = this;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -242,7 +242,6 @@ export default class BufferController implements ComponentAPI {
       },
       onStart: () => {
         logger.debug(`[buffer-controller]: ${type} SourceBuffer updatestart`);
-        console.assert(this.sourceBuffer[type]?.updating, 'Expected source buffer updating flag to be true');
       },
       onComplete: () => {
         logger.debug(`[buffer-controller]: ${type} SourceBuffer updateend`);
@@ -590,16 +589,12 @@ export default class BufferController implements ComponentAPI {
   private _onSBUpdateStart (type: SourceBufferName) {
     const { operationQueue } = this;
     const operation = operationQueue.current(type);
-    console.assert(operation, 'Operation should exist on update start');
-
     operation.onStart();
   }
 
   private _onSBUpdateEnd (type: SourceBufferName) {
     const { operationQueue } = this;
     const operation = operationQueue.current(type);
-    console.assert(operation, 'Operation should exist on update end');
-
     operation.onComplete();
     operationQueue.shiftAndExecuteNext(type);
   }

--- a/src/controller/buffer-operation-queue.ts
+++ b/src/controller/buffer-operation-queue.ts
@@ -30,6 +30,7 @@ export default class BufferOperationQueue {
     });
     const operation: BufferOperation = {
       execute,
+      onStart: () => {},
       onComplete: () => {},
       onError: () => {}
     };

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -6,6 +6,7 @@ import { PlaylistLevelType } from '../types/loader';
 import { ComponentAPI } from '../types/component-api';
 import Hls from '../hls';
 import { BufferAppendedData, FragBufferedData, FragLoadedData } from '../types/events';
+import { logger } from '../utils/logger';
 
 export const FragmentState = {
   NOT_LOADED: 'NOT_LOADED',

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -6,7 +6,6 @@ import { PlaylistLevelType } from '../types/loader';
 import { ComponentAPI } from '../types/component-api';
 import Hls from '../hls';
 import { BufferAppendedData, FragBufferedData, FragLoadedData } from '../types/events';
-import { logger } from '../utils/logger';
 
 export const FragmentState = {
   NOT_LOADED: 'NOT_LOADED',

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -39,7 +39,6 @@ export class SubtitleStreamController extends BaseStreamController implements Co
   protected levels: Array<Level> = [];
 
   private currentTrackId: number = -1;
-  private decrypter: Decrypter;
   private tracksBuffered: Array<TimeRange[]>;
   // lastAVStart stores the time in seconds for the start time of a level load
   private lastAVStart: number = 0;
@@ -48,7 +47,6 @@ export class SubtitleStreamController extends BaseStreamController implements Co
   constructor (hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls);
     this.config = hls.config;
-    this.decrypter = new Decrypter(hls, hls.config);
     this.fragCurrent = null;
     this.fragmentTracker = fragmentTracker;
     this.fragPrevious = null;

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -132,7 +132,7 @@ export class LoadError extends Error {
 }
 
 export interface FragLoadSuccessResult {
-  payload: ArrayBuffer | Uint8Array
+  payload: ArrayBuffer
   networkDetails: XMLHttpRequest | null
 }
 

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -83,7 +83,7 @@ export default class Fragment {
   public stats: LoadStats = new LoadStats();
   public urlId: number = 0;
   // TODO: Create InitSegment class extended from Fragment
-  public data?: ArrayBuffer;
+  public data?: Uint8Array;
   // A flag indicating whether the segment was downloaded in order to test bitrate, and was not buffered
   public bitrateTest: boolean = false;
   // Total video frames dropped by the transmuxer

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -365,6 +365,9 @@ export default class M3U8Parser {
           frag.level = id;
           frag.type = type;
           frag.sn = 'initSegment';
+          if (levelkey) {
+            frag.levelkey = levelkey;
+          }
           level.initSegment = frag;
           frag = new Fragment();
           frag.rawProgramDateTime = level.initSegment.rawProgramDateTime;

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -14,8 +14,9 @@ export interface BufferOperationQueues {
 
 export interface BufferOperation {
   execute: Function
+  onStart: Function
   onComplete: Function
-  onError: Function,
+  onError: Function
   start?: number
   end?: number
 }


### PR DESCRIPTION
### Why is this Pull Request needed?

Init segments are currently not decrypted if EXT-X-KEY applies to them, this causes the initialization segment to not work.

Turns out this media also contains multiple `trun` boxes. Which is something we previously haven't dealt with, and was causing issues with our parsing the duration of the media. This is likely due to a restriction in CMAF. That limits you to only one `trun`. But MSE targets a BMFF bytestream, which doesn't have this restriction.

### Are there any points in the code the reviewer needs to double check?

On the test stream in #2259 (https://t2.qluv.io/test-aes-enc-init/master.m3u8), ~I'm seeing gaps~ fixed with the `trun` changes. Regression testing still needs to be done.

~Additionally, I'm wondering if we should add some kind of "decrypted" boolean to Fragment and store the result.~ Answered.

### Resolves issues:

Closes #2259.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
