### PR TITLE
default TRAVIS_MODE to netlifyBranch on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,8 +6,6 @@
 
 [build.environment]
   NODE_VERSION = "lts/*"
-
-[context.branch-deploy.environment]
   TRAVIS_MODE = "netlifyBranch"
 
 [context.deploy-preview.environment]


### PR DESCRIPTION
### This PR will...

Follow up for https://github.com/video-dev/hls.js/pull/2818. Currently it fails to build for 'master' because `TRAVIS_MODE` is not set on the 'production' environment. I thought 'master' would still fall under 'branch-deploy' like the other branches but it appears it doesn't.

### Why is this Pull Request needed?
It doesn't work otherwise for `master`.