### PR TITLE
Do not deploy to netlify-latest and update links to netlify-dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ about: Create a report to help us improve
 - [ ] The issue observed is not already reported by searching on Github under https://github.com/video-dev/hls.js/issues
 - [ ] The issue occurs in the stable client on https://hls-js.netlify.com/demo and not just on my page
 <!-- The stable client is built from the latest release -->
-- [ ] The issue occurs in the latest client on https://hls-js-latest.netlify.com/demo and not just on my page
+- [ ] The issue occurs in the latest client on https://hls-js-dev.netlify.com/demo and not just on my page
 <!-- The latest client is built from the head of the master branch -->
 - [ ] The stream has correct Access-Control-Allow-Origin headers (CORS)
 - [ ] There are no network errors such as 404s in the browser console when trying to play the stream

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To build our distro bundle and serve our development environment we use [Webpack
 * [API and usage docs, with code examples](./docs/API.md)
 
 * [Auto-Generated Docs (Latest Release)](https://hls-js.netlify.com/api-docs)
-* [Auto-Generated Docs (Master)](https://hls-js-latest.netlify.com/api-docs)
+* [Auto-Generated Docs (Master)](https://hls-js-dev.netlify.com/api-docs)
 
 _Note you can access the docs for a particular version using "[https://github.com/video-dev/hls.js/blob/deployments/README.md](https://github.com/video-dev/hls.js/blob/deployments/README.md)"_
 
@@ -48,7 +48,7 @@ _Note you can access the docs for a particular version using "[https://github.co
 [https://hls-js.netlify.com/demo](https://hls-js.netlify.com/demo)
 
 ### Master
-[https://hls-js-latest.netlify.com/demo](https://hls-js-latest.netlify.com/demo)
+[https://hls-js-dev.netlify.com/demo](https://hls-js-dev.netlify.com/demo)
 
 ### Specific Version
 Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.md](https://github.com/video-dev/hls.js/blob/deployments/README.md).

--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -14,7 +14,6 @@ id=$currentCommit
 root="./netlify"
 version=$(jq -r -e '.version' "./package.json")
 idShort="$(echo "$id" | cut -c 1-8) ($version)"
-latestSiteId="642d9ad4-f002-4104-9309-40ed9cd81a1f"
 stableSiteId="deef7ecf-4c3e-4de0-b6bb-676b02e1c20e"
 
 deploy () {
@@ -31,11 +30,6 @@ commitSiteId=$(curl --fail -d "{\"name\":\"$commitSiteName\"}" -H "Content-Type:
 echo "Created site '$commitSiteId'."
 
 deploy "$commitSiteId"
-
-if [ $currentCommit = $masterLatestCommit ]; then
-  echo "On latest master commit."
-  deploy "$latestSiteId"
-fi
 
 if [[ $version != *"-"* ]]; then
   echo "Detected new version: $version"


### PR DESCRIPTION
### This PR will...
- Stop deploying to netlify-latest because hls-js-dev now automatically builds master.
- Update links.

hls-js-latest now just redirects to hls-js-dev so old links should still work.