### PR TITLE
Fix initial audio video desync for fMP4

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -523,7 +523,7 @@ class AudioStreamController extends BaseStreamController {
         // If not we need to wait for it
         let initPTS = this.initPTS[cc];
         let initSegmentData = details.initSegment ? details.initSegment.data : [];
-        if (details.initSegment || initPTS !== undefined) {
+        if (initPTS !== undefined) {
           this.pendingBuffering = true;
           logger.log(`Demuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
           // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)


### PR DESCRIPTION
### This PR will...
Solves initial AV desync for fMP4.

### Why is this Pull Request needed?
It seems that there are cases when initPTS handling is faulty and it results in misaligned offsets for A/V.
I suspect that audio demuxing can start here without knowing the video's initPTS: [https://github.com/video-dev/hls.js/blob/master/src/controller/audio-stream-controller.js#L526](https://github.com/video-dev/hls.js/blob/master/src/controller/audio-stream-controller.js#L526)

### Resolves issues:
Might be the same issue: https://github.com/video-dev/hls.js/issues/2545

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
