### PR TITLE
CEA-608 captions fix

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -53,7 +53,8 @@ class TimelineController extends EventHandler {
     textTrack3: TrackProperties
     textTrack4: TrackProperties
   };
-  private readonly cea608Parser!: Cea608Parser;
+  private readonly cea608Parser1!: Cea608Parser;
+  private readonly cea608Parser2!: Cea608Parser;
   private lastSn: number = -1;
   private prevCC: number = -1;
   private vttCCs: VTTCCs = newVTTCCs();
@@ -97,7 +98,8 @@ class TimelineController extends EventHandler {
       const channel2 = new OutputFilter(this, 'textTrack2');
       const channel3 = new OutputFilter(this, 'textTrack3');
       const channel4 = new OutputFilter(this, 'textTrack4');
-      this.cea608Parser = new Cea608Parser(channel1, channel2, channel3, channel4);
+      this.cea608Parser1 = new Cea608Parser(1, channel1, channel2);
+      this.cea608Parser2 = new Cea608Parser(3, channel3, channel4);
     }
   }
 
@@ -339,13 +341,14 @@ class TimelineController extends EventHandler {
 
   onFragLoaded (data: { frag: Fragment, payload: ArrayBuffer }) {
     const { frag, payload } = data;
-    const { cea608Parser, initPTS, lastSn, unparsedVttFrags } = this;
+    const { cea608Parser1, cea608Parser2, initPTS, lastSn, unparsedVttFrags } = this;
     if (frag.type === 'main') {
       const sn = frag.sn;
       // if this frag isn't contiguous, clear the parser so cues with bad start/end times aren't added to the textTrack
       if (frag.sn !== lastSn + 1) {
-        if (cea608Parser) {
-          cea608Parser.reset();
+        if (cea608Parser1 && cea608Parser2) {
+          cea608Parser1.reset();
+          cea608Parser2.reset();
         }
       }
       this.lastSn = sn as number;
@@ -439,19 +442,19 @@ class TimelineController extends EventHandler {
   }
 
   onFragParsingUserdata (data: { samples: Array<any> }) {
-    if (!this.enabled || !this.cea608Parser) {
+    const { cea608Parser1, cea608Parser2 } = this;
+    if (!this.enabled || !(cea608Parser1 && cea608Parser2)) {
       return;
     }
 
     // If the event contains captions (found in the bytes property), push all bytes into the parser immediately
     // It will create the proper timestamps based on the PTS value
-    const cea608Parser = this.cea608Parser;
     for (let i = 0; i < data.samples.length; i++) {
       const ccBytes = data.samples[i].bytes;
       if (ccBytes) {
         const ccdatas = this.extractCea608Data(ccBytes);
-        cea608Parser.addData(data.samples[i].pts, ccdatas[0], 1);
-        cea608Parser.addData(data.samples[i].pts, ccdatas[1], 3);
+        cea608Parser1.addData(data.samples[i].pts, ccdatas[0]);
+        cea608Parser2.addData(data.samples[i].pts, ccdatas[1]);
       }
     }
   }

--- a/src/utils/output-filter.ts
+++ b/src/utils/output-filter.ts
@@ -1,14 +1,14 @@
 import { CaptionScreen } from './cea-608-parser';
+import type TimelineController from '../controller/timeline-controller';
 
 export default class OutputFilter {
-  timelineController: any;
+  timelineController: TimelineController;
   trackName: string;
   startTime: number | null;
   endTime: number | null;
   screen: CaptionScreen | null;
 
-  // TODO(typescript-timelineController)
-  constructor (timelineController: any, trackName: string) {
+  constructor (timelineController: TimelineController, trackName: string) {
     this.timelineController = timelineController;
     this.trackName = trackName;
     this.startTime = null;
@@ -21,7 +21,7 @@ export default class OutputFilter {
       return;
     }
 
-    this.timelineController.addCues(this.trackName, this.startTime, this.endTime, this.screen);
+    this.timelineController.addCues(this.trackName, this.startTime, this.endTime as number, this.screen as CaptionScreen);
     this.startTime = null;
   }
 


### PR DESCRIPTION
### This PR will...
Fix simultaneous parsing of CEA-608 captions in multiple channels.

### Why is this Pull Request needed?
A regression was introduced after v0.13.2 when incorporating cea-608-parser changes from the feature/v1.0.0 branch.

The changes attempted to parse both channel 1 and 3 caption fields simultaneously, and in some cases this appeared to work. But when the `currChNr` property was updated for one field, it could impact the other, causing CC content to get dropped.

These changes track the current channel independently for each field removing the interference.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
