### PR TITLE
CEA-608 captions fix (part II)

### DIFF
--- a/src/utils/output-filter.ts
+++ b/src/utils/output-filter.ts
@@ -2,18 +2,16 @@ import { CaptionScreen } from './cea-608-parser';
 import type TimelineController from '../controller/timeline-controller';
 
 export default class OutputFilter {
-  timelineController: TimelineController;
-  trackName: string;
-  startTime: number | null;
-  endTime: number | null;
-  screen: CaptionScreen | null;
+  private timelineController: TimelineController;
+  private cueRanges: Array<[number, number]> = [];
+  private trackName: string;
+  private startTime: number | null = null;
+  private endTime: number | null = null;
+  private screen: CaptionScreen | null = null;
 
   constructor (timelineController: TimelineController, trackName: string) {
     this.timelineController = timelineController;
     this.trackName = trackName;
-    this.startTime = null;
-    this.endTime = null;
-    this.screen = null;
   }
 
   dispatchCue () {
@@ -21,7 +19,7 @@ export default class OutputFilter {
       return;
     }
 
-    this.timelineController.addCues(this.trackName, this.startTime, this.endTime as number, this.screen as CaptionScreen);
+    this.timelineController.addCues(this.trackName, this.startTime, this.endTime as number, this.screen as CaptionScreen, this.cueRanges);
     this.startTime = null;
   }
 
@@ -33,5 +31,9 @@ export default class OutputFilter {
     this.endTime = endTime;
     this.screen = screen;
     this.timelineController.createCaptionsTrack(this.trackName);
+  }
+
+  reset () {
+    this.cueRanges = [];
   }
 }


### PR DESCRIPTION
### This PR will...
Assign separate `cueRanges` to each CEA-608 output filter for merging rollup captions text without destroying cue ranges in other channels.

### Why is this Pull Request needed?
Some captions were being dropped because a single `cueRanges`  time range was shared in timeline-controller across CC 1 and 3 rollup captions.

The last round of fixes (#2834) took care of content (whole words and lines of text) that was being dropped. These changes fix the timing of the content and cues in either channel overlap.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
