### PR TITLE
Fixed incorrect calculation of PTS for mp3/ID3 timestamp equal to zero (important in case of discontinuity)

### DIFF
--- a/src/demux/mp3demuxer.js
+++ b/src/demux/mp3demuxer.js
@@ -41,7 +41,7 @@ class MP3Demuxer {
   append (data, timeOffset, contiguous, accurateTimeOffset) {
     let id3Data = ID3.getID3Data(data, 0);
     let timestamp = ID3.getTimeStamp(id3Data);
-    let pts = timestamp ? 90 * timestamp : timeOffset * 90000;
+    let pts = timestamp !== undefined ? 90 * timestamp : timeOffset * 90000;
     let offset = id3Data.length;
     let length = data.length;
     let frameIndex = 0, stamp = 0;


### PR DESCRIPTION
### This PR will...
Fix the problem of discontinuity of mp3 fragment where first fragment have timestamp == 0.
Right now playlist like this:
    #EXTM3U
    #EXT-X-VERSION:3
    #EXT-X-MEDIA-SEQUENCE:0
    #EXT-X-TARGETDURATION:2
    #EXTINF:2,
    fragA000.mp3
    #EXTINF:2,
    fragA001.mp3
    #EXTINF:2,
    fragA002.mp3
    #EXT-X-DISCONTINUITY
    #EXTINF:2,
    fragB000.mp3
    #EXTINF:2,
    fragB001.mp3
    #EXTINF:2,
    fragB002.mp3
    #EXT-X-ENDLIST

will be played incorrectly. fragB000 have timestamp equal to 0 and will have discontinuity flag internally, but PTS will be calculated as 6 * 90000. This will break playback badly.

### Why is this Pull Request needed?

It fixes a bug.

### Are there any points in the code the reviewer needs to double check?

Don't think so.

### Resolves issues:

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
