### PR TITLE
always check version is greater than previous

### DIFF
--- a/scripts/set-package-version.js
+++ b/scripts/set-package-version.js
@@ -52,7 +52,7 @@ try {
   }
 
   if (!versionParser.isGreaterOrEqual(newVersion, latestVersion)) {
-    throw new Error(`New version "${newVersion}" is not > than latest version "${latestVersion}" on this branch.`);
+    throw new Error(`New version "${newVersion}" is not >= latest version "${latestVersion}" on this branch.`);
   }
   packageJson.version = newVersion;
   fs.writeFileSync('./package.json', JSON.stringify(packageJson));

--- a/scripts/set-package-version.js
+++ b/scripts/set-package-version.js
@@ -47,14 +47,13 @@ try {
         : `0.alpha.${getCommitNum()}`;
 
     newVersion = `${intermediateVersion}${isStable ? '-' : '.'}${suffix}`;
-
-    if (!versionParser.isGreater(newVersion, latestVersion)) {
-      throw new Error(`New version "${newVersion}" is not > than latest version "${latestVersion}" on this branch.`);
-    }
   } else {
     throw new Error('Unsupported travis mode: ' + TRAVIS_MODE);
   }
 
+  if (!versionParser.isGreaterOrEqual(newVersion, latestVersion)) {
+    throw new Error(`New version "${newVersion}" is not > than latest version "${latestVersion}" on this branch.`);
+  }
   packageJson.version = newVersion;
   fs.writeFileSync('./package.json', JSON.stringify(packageJson));
   console.log('Set version: ' + newVersion);

--- a/scripts/version-parser.js
+++ b/scripts/version-parser.js
@@ -19,8 +19,8 @@ module.exports = {
     }
     return newVersion;
   },
-  isGreater: (newVersion, previousVersion) => {
-    return semver.gt(newVersion, previousVersion);
+  isGreaterOrEqual: (newVersion, previousVersion) => {
+    return semver.gte(newVersion, previousVersion);
   },
   // returns true if the provided version is definitely greater than any existing
   // auto generated alpha versions


### PR DESCRIPTION
### This PR will...
Update the fix in https://github.com/video-dev/hls.js/commit/90cf214d1a0d8be659784c0b20290a6e46421e02 to prevent accidentally publishing older versions.

### Why is this Pull Request needed?
I noticed the fix in https://github.com/video-dev/hls.js/commit/90cf214d1a0d8be659784c0b20290a6e46421e02. Minor thing but I think it would be better to still check all the time, but allow the current version. With the current fix it's still possible to accidentally publish a tag earlier than the current one. 
