### PR TITLE
Parse Low-Latency HLS playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,22 +285,37 @@ All HLS resources must be delivered with [CORS headers](https://developer.mozill
 
 ### Supported M3U8 tags
 
+For details on the HLS format and these tags meanings see https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-07
+
+Manifest tags
+  - `#EXT-X-STREAM-INF:<attribute-list>`
+    `<URI>`
+  - `#EXT-X-MEDIA:<attribute-list>`
+  - `#EXT-X-SESSION-DATA:<attribute-list>`
+  
+Playlist tags
   - `#EXTM3U`
-  - `#EXTINF`
-  - `#EXT-X-STREAM-INF` (adaptive streaming)
-  - `#EXT-X-ENDLIST` (Live playlist)
-  - `#EXT-X-MEDIA-SEQUENCE`
-  - `#EXT-X-TARGETDURATION`
-  - `#EXT-X-CONTINUITY`
+  - `#EXT-X-VERSION=<n>`
+  - `#EXTINF:<duration>,[<title>]`
+  - `#EXT-X-ENDLIST`
+  - `#EXT-X-MEDIA-SEQUENCE=<n>`
+  - `#EXT-X-TARGETDURATION=<n>`
   - `#EXT-X-DISCONTINUITY`
-  - `#EXT-X-DISCONTINUITY-SEQUENCE`
-  - `#EXT-X-BYTERANGE`
-  - `#EXT-X-MAP`
-  - `#EXT-X-KEY` (https://tools.ietf.org/html/draft-pantos-http-live-streaming-08#section-3.4.4)
-  - `#EXT-X-PROGRAM-DATE-TIME` (https://tools.ietf.org/html/draft-pantos-http-live-streaming-18#section-4.3.2.6)
-  - `EXT-X-START:TIME-OFFSET=x` (https://tools.ietf.org/html/draft-pantos-http-live-streaming-18#section-4.3.5.2)
-  - `#EXT-X-PREFETCH`
-  - `#EXT-X-PREFETCH-DISCONTINUITY`
+  - `#EXT-X-DISCONTINUITY-SEQUENCE=<n>`
+  - `#EXT-X-BYTERANGE=<n>[@<o>]`
+  - `#EXT-X-MAP:<attribute-list>`
+  - `#EXT-X-KEY:<attribute-list>`
+  - `#EXT-X-PROGRAM-DATE-TIME:<attribute-list>`
+  - `#EXT-X-START:TIME-OFFSET=<n>`
+  - `#EXT-X-SERVER-CONTROL:<attribute-list>`
+  - `#EXT-X-PART-INF:PART-TARGET=<n>`
+  - `#EXT-X-PART:<attribute-list>`
+  - `#EXT-X-PRELOAD-HINT:<attribute-list>`
+  - `#EXT-X-RENDITION-REPORT:<attribute-list>`
+  - The following tags are added to their respective fragment's attribute list
+      - `#EXT-X-DATERANGE:<attribute-list>`
+      - `#EXT-X-BITRATE`
+      - `#EXT-X-GAP`
 
 ## License
 

--- a/demo-timeline/src/player.ts
+++ b/demo-timeline/src/player.ts
@@ -13,12 +13,13 @@ import {
   SubtitleTrackLoadedData,
   SubtitleTracksUpdatedData
 } from '../../src/types/events';
+import type { HlsConfig } from '../../src/config';
 
 const Hls = self.Hls;
 
 export class Player {
   public hls: any = null;
-  private config: any = null;
+  private config: Partial<HlsConfig> | null = null;
   private url: string | null = null;
   private width: number | null = null;
   private chart: TimelineChart;
@@ -29,7 +30,7 @@ export class Player {
     this.video = video;
   }
 
-  public setConfig (config) {
+  public setConfig (config: Partial<HlsConfig>) {
     this.config = config;
     this.loadSelectedStream();
   }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -49,7 +49,6 @@ class AudioStreamController extends BaseStreamController implements ComponentAPI
 
   constructor (hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls);
-    this.config = hls.config;
     this.fragmentTracker = fragmentTracker;
     this.fragmentLoader = new FragmentLoader(hls.config);
 

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -59,7 +59,7 @@ export class FragmentTracker implements ComponentAPI {
    */
   getAppendedFrag (position: number, levelType: PlaylistLevelType) : Fragment | null {
     const { activeFragment } = this;
-    if (activeFragment && activeFragment.start <= position && position <= activeFragment.appendedPTS) {
+    if (activeFragment?.appendedPTS !== undefined && activeFragment.start <= position && position <= activeFragment.appendedPTS) {
       return activeFragment;
     }
     return this.getBufferedFrag(position, levelType);

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -57,7 +57,6 @@ export default class StreamController extends BaseStreamController implements Ne
   constructor (hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls);
     this.fragmentLoader = new FragmentLoader(hls.config);
-    this.config = hls.config;
     this.fragmentTracker = fragmentTracker;
     this.state = State.STOPPED;
 
@@ -566,7 +565,7 @@ export default class StreamController extends BaseStreamController implements Ne
     if (newDetails.live) {
       sliding = this.mergeLivePlaylists(curLevel.details, newDetails);
       if (sliding) {
-        this._liveSyncPosition = this.computeLivePosition(sliding, newDetails.targetduration, newDetails.totalduration);
+        this._liveSyncPosition = this.computeLivePosition(sliding, newDetails);
       }
     } else {
       newDetails.PTSKnown = false;

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -4,10 +4,10 @@ import OutputFilter from '../utils/output-filter';
 import { parseWebVTT } from '../utils/webvtt-parser';
 import { logger } from '../utils/logger';
 import { sendAddTrackEvent, clearCurrentCues } from '../utils/texttrack-utils';
-
 import { parseIMSC1, IMSC1_CODEC } from '../utils/imsc1-ttml-parser';
 import Fragment from '../loader/fragment';
 import { FragParsingUserdataData, FragLoadedData, FragDecryptedData, MediaAttachingData, ManifestLoadedData, InitPTSFoundData } from '../types/events';
+import { PlaylistLevelType } from '../types/loader';
 
 import type Hls from '../hls';
 import type { ComponentAPI } from '../types/component-api';
@@ -517,7 +517,7 @@ export class TimelineController implements ComponentAPI {
     // If we receive this event, we have not received an onInitPtsFound event. This happens when the video track has no samples (but has audio)
     // In order to have captions display, which requires an initPTS, we assume one of 90000
     if (typeof this.initPTS === 'undefined') {
-      this.onInitPtsFound(Events.INIT_PTS_FOUND, { id: '', frag: new Fragment(), initPTS: 90000 });
+      this.onInitPtsFound(Events.INIT_PTS_FOUND, { id: '', frag: new Fragment(PlaylistLevelType.MAIN), initPTS: 90000 });
     }
   }
 

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -517,7 +517,7 @@ export class TimelineController implements ComponentAPI {
     // If we receive this event, we have not received an onInitPtsFound event. This happens when the video track has no samples (but has audio)
     // In order to have captions display, which requires an initPTS, we assume one of 90000
     if (typeof this.initPTS === 'undefined') {
-      this.onInitPtsFound(Events.INIT_PTS_FOUND, { id: '', frag: new Fragment(PlaylistLevelType.MAIN), initPTS: 90000 });
+      this.onInitPtsFound(Events.INIT_PTS_FOUND, { id: '', frag: new Fragment(PlaylistLevelType.MAIN, ''), initPTS: 90000 });
     }
   }
 

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -4,13 +4,15 @@ import AESDecryptor, { removePadding } from './aes-decryptor';
 import { logger } from '../utils/logger';
 import { appendUint8Array } from '../utils/mp4-tools';
 import { sliceUint8 } from '../utils/typed-array';
+import type { HlsConfig } from '../config';
+import type { HlsEventEmitter } from '../events';
 
 const CHUNK_SIZE = 16; // 16 bytes, 128 bits
 
 export default class Decrypter {
   private logEnabled: boolean = true;
-  private observer: any;
-  private config: any;
+  private observer: HlsEventEmitter;
+  private config: HlsConfig;
   private removePKCS7Padding: boolean;
   private subtle: SubtleCrypto | null = null;
   private softwareDecrypter: AESDecryptor | null = null;
@@ -20,7 +22,7 @@ export default class Decrypter {
   private currentIV: ArrayBuffer | null = null;
   private currentResult: ArrayBuffer | null = null;
 
-  constructor (observer, config, { removePKCS7Padding = true } = {}) {
+  constructor (observer: HlsEventEmitter, config: HlsConfig, { removePKCS7Padding = true } = {}) {
     this.observer = observer;
     this.config = config;
     this.removePKCS7Padding = removePKCS7Padding;

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -6,14 +6,15 @@ import {
   FragmentLoaderContext,
   LoaderCallbacks
 } from '../types/loader';
+import type { HlsConfig } from '../config';
 
 const MIN_CHUNK_SIZE = Math.pow(2, 17); // 128kb
 
 export default class FragmentLoader {
-  private readonly config: any;
+  private readonly config: HlsConfig;
   private loader: Loader<FragmentLoaderContext> | null = null;
 
-  constructor (config) {
+  constructor (config: HlsConfig) {
     this.config = config;
   }
 

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -67,7 +67,7 @@ export default class KeyLoader implements ComponentAPI {
         return;
       }
 
-      frag.loader = this.loaders[type] = new config.loader(config);
+      const fragLoader = frag.loader = this.loaders[type] = new config.loader(config);
       this.decrypturl = uri;
       this.decryptkey = null;
 
@@ -94,7 +94,7 @@ export default class KeyLoader implements ComponentAPI {
         onTimeout: this.loadtimeout.bind(this)
       };
 
-      frag.loader.load(loaderContext, loaderConfig, loaderCallbacks);
+      fragLoader.load(loaderContext, loaderConfig, loaderCallbacks);
     } else if (this.decryptkey) {
       // Return the key if it's already been loaded
       frag.decryptdata.key = this.decryptkey;
@@ -111,7 +111,7 @@ export default class KeyLoader implements ComponentAPI {
     this.decryptkey = frag.decryptdata.key = new Uint8Array(response.data as ArrayBuffer);
 
     // detach fragment loader on load success
-    frag.loader = undefined;
+    frag.loader = null;
     delete this.loaders[frag.type];
     this.hls.trigger(Events.KEY_LOADED, { frag: frag });
   }

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -24,6 +24,11 @@ export default class LevelDetails {
   public misses: number = 0;
   public url: string;
   public version: number | null = null;
+  public canBlockReload: boolean = false;
+  public canSkipUntil: number = 0;
+  public canSkipDateRanges: boolean = false;
+  public partHoldBack: number = 0;
+  public holdBack: number = 0;
 
   constructor (baseUrl) {
     this.fragments = [];

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -1,4 +1,5 @@
-import Fragment from './fragment';
+import type Fragment from './fragment';
+import type AttrList from '../utils/attr-list';
 
 const DEFAULT_TARGET_DURATION = 10;
 
@@ -30,6 +31,8 @@ export default class LevelDetails {
   public partHoldBack: number = 0;
   public holdBack: number = 0;
   public partTarget: number = 0;
+  public preloadHint?: AttrList;
+  public renditionReports?: AttrList[];
 
   constructor (baseUrl) {
     this.fragments = [];

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -29,6 +29,7 @@ export default class LevelDetails {
   public canSkipDateRanges: boolean = false;
   public partHoldBack: number = 0;
   public holdBack: number = 0;
+  public partTarget: number = 0;
 
   constructor (baseUrl) {
     this.fragments = [];

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -41,6 +41,7 @@ const LEVEL_PLAYLIST_REGEX_SLOW = new RegExp([
   /#EXT-X-(VERSION):(\d+)/.source,
   /#EXT-X-(MAP):(.+)/.source,
   /#EXT-X-(SERVER-CONTROL):(.+)/.source,
+  /#EXT-X-(PART-INF):(.+)/.source,
   /(#)([^:]*):(.*)/.source,
   /(#)(.*)(?:.*)\r?\n?/.source
 ].join('|'));
@@ -369,6 +370,11 @@ export default class M3U8Parser {
           level.canSkipDateRanges = level.canSkipUntil > 0 && serverControlAttrs.bool('CAN-SKIP-DATERANGES');
           level.partHoldBack = serverControlAttrs.optionalFloat('PART-HOLD-BACK', 0);
           level.holdBack = serverControlAttrs.optionalFloat('HOLD-BACK', 0);
+          break;
+        }
+        case 'PART-INF': {
+          const partInfAttrs = new AttrList(value1);
+          level.partTarget = partInfAttrs.decimalFloatingPoint('PART-TARGET');
           break;
         }
         default:

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -28,6 +28,7 @@ import { ManifestLoadingData, LevelLoadingData, AudioTrackLoadingData, SubtitleT
 import LevelDetails from './level-details';
 import Fragment from './fragment';
 import Hls from '../hls';
+import AttrList from '../utils/attr-list';
 
 const { performance } = self;
 
@@ -342,7 +343,7 @@ class PlaylistLoader {
           autoselect: false,
           forced: false,
           id: -1,
-          attrs: {},
+          attrs: new AttrList({}),
           bitrate: 0,
           url: ''
         });
@@ -400,7 +401,7 @@ class PlaylistLoader {
     // by creating a single-level structure for it.
     if (type === PlaylistContextType.MANIFEST) {
       const singleLevel: LevelParsed = {
-        attrs: {},
+        attrs: new AttrList({}),
         bitrate: 0,
         details: levelDetails,
         name: '',

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -1,4 +1,5 @@
 import LevelDetails from '../loader/level-details';
+import AttrList from '../utils/attr-list';
 
 export interface LevelParsed {
   attrs: LevelAttributes
@@ -16,7 +17,7 @@ export interface LevelParsed {
   width?: number
 }
 
-export interface LevelAttributes {
+export interface LevelAttributes extends AttrList {
   AUDIO?: string
   AUTOSELECT?: string
   'AVERAGE-BANDWIDTH'?: string

--- a/src/utils/attr-list.ts
+++ b/src/utils/attr-list.ts
@@ -57,8 +57,17 @@ class AttrList {
     return parseFloat(this[attrName]);
   }
 
+  optionalFloat (attrName: string, defaultValue: number): number {
+    const value = this[attrName];
+    return value ? parseFloat(value) : defaultValue;
+  }
+
   enumeratedString (attrName: string): string | undefined {
     return this[attrName];
+  }
+
+  bool (attrName: string): boolean {
+    return this[attrName] === 'YES';
   }
 
   decimalResolution (attrName: string): {

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -201,5 +201,10 @@ module.exports = {
     // Disable smooth switch on this stream. Test is flakey because of what looks like (auto)play issue. To be expected with this large a gap (for now).
     // abr: true,
     startSeek: true
+  },
+  AppleLowLatencyHlsHoldBack: {
+    url: 'https://playertest.longtailvideo.com/adaptive/low-latency-hls/archived/hold-back-8s.m3u8',
+    description: 'Apple Low-Latency HLS archived sample. No blocking, no delta, PART-HOLD-BACK=2.004,HOLD-BACK=8, Safari MediaError 4',
+    live: true
   }
 };

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -140,8 +140,7 @@ describe('BufferController SourceBuffer operation queueing', function () {
       queueNames.forEach((name, i) => {
         const buffer = buffers[name];
         const segmentData = new Uint8Array();
-        const frag = new Fragment();
-        frag.type = PlaylistLevelType.MAIN;
+        const frag = new Fragment(PlaylistLevelType.MAIN, '');
         const chunkMeta = new ChunkMetadata(0, 0, 0, 0);
         const data: BufferAppendingData = {
           type: name,
@@ -176,7 +175,7 @@ describe('BufferController SourceBuffer operation queueing', function () {
         bufferController.onBufferAppending(Events.BUFFER_APPENDING, {
           type: name,
           data: new Uint8Array(),
-          frag: new Fragment(),
+          frag: new Fragment(PlaylistLevelType.MAIN, ''),
           chunkMeta: new ChunkMetadata(0, 0, 0, 0)
         });
 
@@ -190,7 +189,7 @@ describe('BufferController SourceBuffer operation queueing', function () {
   describe('onFragParsed', function () {
     it('should trigger FRAG_BUFFERED when all audio/video data has been buffered', function () {
       const flushLiveBackBufferSpy = sandbox.spy(bufferController, 'flushLiveBackBuffer');
-      const frag = new Fragment();
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
       frag.setElementaryStreamInfo(ElementaryStreamTypes.AUDIO, 0, 0, 0, 0);
       frag.setElementaryStreamInfo(ElementaryStreamTypes.VIDEO, 0, 0, 0, 0);
 

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -2,13 +2,14 @@ import * as LevelHelper from '../../../src/controller/level-helper';
 import LevelDetails from '../../../src/loader/level-details';
 import Fragment from '../../../src/loader/fragment';
 import LoadStats from '../../../src/loader/load-stats';
+import { PlaylistLevelType } from '../../../src/types/loader';
 
 const generatePlaylist = (sequenceNumbers) => {
   const playlist = new LevelDetails('');
   playlist.startSN = sequenceNumbers[0];
   playlist.endSN = sequenceNumbers[sequenceNumbers.length - 1];
   playlist.fragments = sequenceNumbers.map((n, i) => {
-    const frag = new Fragment();
+    const frag = new Fragment(PlaylistLevelType.MAIN, '');
     frag.sn = n;
     frag.start = i * 5;
     frag.duration = 5;

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -6,7 +6,7 @@ import { State } from '../../../src/controller/base-stream-controller';
 import { mockFragments } from '../../mocks/data';
 import Fragment from '../../../src/loader/fragment';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
-
+import { PlaylistLevelType } from '../../../src/types/loader';
 import sinon from 'sinon';
 
 describe('StreamController', function () {
@@ -133,7 +133,7 @@ describe('StreamController', function () {
     beforeEach(function () {
       streamController.levels = [{ bitrate: 500000 }];
       triggerSpy = sinon.spy(hls, 'trigger');
-      frag = new Fragment();
+      frag = new Fragment(PlaylistLevelType.MAIN, '');
       frag.level = 0;
       frag.url = 'file';
     });

--- a/tests/unit/demuxer/transmuxer.js
+++ b/tests/unit/demuxer/transmuxer.js
@@ -2,6 +2,7 @@ import TransmuxerInterface from '../../../src/demux/transmuxer-interface';
 import { TransmuxState, TransmuxConfig } from '../../../src/demux/transmuxer';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
 import Fragment from '../../../src/loader/fragment';
+import { PlaylistLevelType } from '../../../src/types/loader';
 
 const sinon = require('sinon');
 
@@ -77,14 +78,14 @@ describe('TransmuxerInterface tests', function () {
     };
     const id = 'main';
     const transmuxerInterface = new TransmuxerInterface(hls, id);
-    const currentFrag = new Fragment();
+    const currentFrag = new Fragment(PlaylistLevelType.MAIN, '');
     currentFrag.cc = 100;
     currentFrag.sn = 5;
     currentFrag.level = 1;
     // Config for push
     transmuxerInterface.frag = currentFrag;
 
-    const newFrag = new Fragment();
+    const newFrag = new Fragment(PlaylistLevelType.MAIN, '');
     newFrag.cc = 100;
     newFrag.sn = 6;
     newFrag.level = 1;
@@ -130,7 +131,7 @@ describe('TransmuxerInterface tests', function () {
     const id = 'main';
     const transmuxerInterface = new TransmuxerInterface(hls, id);
 
-    const currentFrag = new Fragment();
+    const currentFrag = new Fragment(PlaylistLevelType.MAIN, '');
     currentFrag.cc = 100;
     currentFrag.sn = 5;
     currentFrag.level = 1;
@@ -138,7 +139,7 @@ describe('TransmuxerInterface tests', function () {
     // Config for push
     transmuxerInterface.frag = currentFrag;
 
-    const newFrag = new Fragment();
+    const newFrag = new Fragment(PlaylistLevelType.MAIN, '');
     newFrag.cc = 200;
     newFrag.sn = 5;
     newFrag.level = 2;

--- a/tests/unit/loader/fragment-loader.js
+++ b/tests/unit/loader/fragment-loader.js
@@ -3,6 +3,7 @@ import Fragment from '../../../src/loader/fragment';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import sinon from 'sinon';
 import LoadStats from '../../../src/loader/load-stats';
+import { PlaylistLevelType } from '../../../src/types/loader';
 
 class MockXhr {
   constructor () {
@@ -26,7 +27,7 @@ describe('FragmentLoader tests', function () {
   let networkDetails;
   beforeEach(function () {
     fragmentLoader = new FragmentLoader({ loader: MockXhr });
-    frag = new Fragment();
+    frag = new Fragment(PlaylistLevelType.MAIN, '');
     frag.url = 'foo';
     response = {};
     context = {};

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -1,5 +1,6 @@
 import Fragment from '../../../src/loader/fragment';
 import LevelKey from '../../../src/loader/level-key';
+import { PlaylistLevelType } from '../../../src/types/loader';
 
 describe('Fragment class tests', function () {
   /**
@@ -7,7 +8,7 @@ describe('Fragment class tests', function () {
    */
   let frag;
   beforeEach(function () {
-    frag = new Fragment();
+    frag = new Fragment(PlaylistLevelType.MAIN, '');
   });
 
   describe('encrypted', function () {
@@ -77,7 +78,7 @@ describe('Fragment class tests', function () {
     });
 
     it('set byte range with no offset and uses 0 as offset', function () {
-      const prevFrag = new Fragment();
+      const prevFrag = new Fragment(PlaylistLevelType.MAIN, '');
       prevFrag.setByteRange('1000@10000');
       frag.setByteRange('5000', prevFrag);
       expect(frag.byteRangeStartOffset).to.equal(11000);

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -986,53 +986,61 @@ fileSequence1151226.ts`, 'http://dummy.url.com/playlist.m3u8', 0, PlaylistLevelT
       expect(details.fragments[5].partList).to.equal(null);
       expect(details.fragments[6].partList).to.be.an('array').which.has.lengthOf(4);
       expect(details.fragments[7].partList).to.be.an('array').which.has.lengthOf(4);
-      expect(details.fragments[6].partList[0], '6-0').to.deep.equal({
+      expectWithJSONMessage(details.fragments[6].partList[0], '6-0').to.deep.include({
         duration: 1,
         gap: false,
         independent: true,
-        uri: 'lowLatencyHLS.php?segment=filePart1151232.1.ts'
+        index: 0,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151232.1.ts'
       });
-      expect(details.fragments[6].partList[1], '6-1').to.deep.equal({
+      expectWithJSONMessage(details.fragments[6].partList[1], '6-1').to.deep.include({
         duration: 1.00001,
         gap: false,
         independent: false,
-        uri: 'lowLatencyHLS.php?segment=filePart1151232.2.ts'
+        index: 1,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151232.2.ts'
       });
-      expect(details.fragments[6].partList[2], '6-2').to.deep.equal({
+      expectWithJSONMessage(details.fragments[6].partList[2], '6-2').to.deep.include({
         duration: 1,
         gap: false,
         independent: true,
-        uri: 'lowLatencyHLS.php?segment=filePart1151232.3.ts'
+        index: 2,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151232.3.ts'
       });
-      expect(details.fragments[6].partList[3], '6-3').to.deep.equal({
+      expectWithJSONMessage(details.fragments[6].partList[3], '6-3').to.deep.include({
         duration: 1,
         gap: false,
         independent: true,
-        uri: 'lowLatencyHLS.php?segment=filePart1151232.4.ts'
+        index: 3,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151232.4.ts'
       });
-      expect(details.fragments[7].partList[0], '7-0').to.deep.equal({
+      expectWithJSONMessage(details.fragments[7].partList[0], '7-0').to.deep.include({
         duration: 1,
         gap: false,
         independent: true,
-        uri: 'lowLatencyHLS.php?segment=filePart1151233.1.ts'
+        index: 0,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151233.1.ts'
       });
-      expect(details.fragments[7].partList[1], '7-1').to.deep.equal({
+      expectWithJSONMessage(details.fragments[7].partList[1], '7-1').to.deep.include({
         duration: 0.99999,
         gap: false,
         independent: true,
-        uri: 'lowLatencyHLS.php?segment=filePart1151233.2.ts'
+        index: 1,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151233.2.ts'
       });
-      expect(details.fragments[7].partList[2], '7-2').to.deep.equal({
+      expectWithJSONMessage(details.fragments[7].partList[2], '7-2').to.deep.include({
         duration: 1,
         gap: false,
         independent: false,
-        uri: 'lowLatencyHLS.php?segment=filePart1151233.3.ts'
+        index: 2,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151233.3.ts'
       });
-      expect(details.fragments[7].partList[3], '7-3').to.deep.equal({
+      expectWithJSONMessage(details.fragments[7].partList[3], '7-3').to.deep.include({
         duration: 1,
         gap: true,
         independent: true,
-        uri: 'lowLatencyHLS.php?segment=filePart1151233.4.ts'
+        index: 3,
+        relurl: 'lowLatencyHLS.php?segment=filePart1151233.4.ts'
       });
     });
 
@@ -1205,6 +1213,6 @@ http://dummy.url.com/hls/live/segment/segment_022916_164500865_719928.ts
   });
 });
 
-function expectWithJSONMessage (value) {
-  return expect(value, JSON.stringify(value));
+function expectWithJSONMessage (value, msg) {
+  return expect(value, `${msg || 'actual:'} ${JSON.stringify(value, null, 2)}`);
 }


### PR DESCRIPTION
### This PR will...

Adds support for Low-latency HLS playlist parsing https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-07#section-4.4.3.8

- `EXT-X-SERVER-CONTROL` attributes are added to level details
  - `levelDetails.canBlockReload: boolean`
  - `levelDetails.canSkipUntil: number`
  - `levelDetails.canSkipDateRanges: boolean`
  - `levelDetails.partHoldBack: number`
  - `levelDetails.holdBack: number`
- `EXT-X-PART-INF: PART-TARGET` attribute  is added to level details  
  - `levelDetails.partTarget: number`
- `EXT-X-PART` tags are added to fragments (parts for incomplete fragments will be added to the fragment list later when loader support is added)
  - `levelDetails.fragments[].partList: { duration: number, gap: boolean, independent: boolean, uri: string }`
- `EXT-X-GAP` is added to `fragment.tagList`
- `EXT-X-BITRATE` is added to `fragment.tagList`
- `EXT-X-PRELOAD-HINT` attributes are added to level details
- `EXT-X-RENDITION-REPORT` list is added to level details

### Why is this Pull Request needed?
This work is a precursor to adding support for delta playlist updates, playlist block reloading, part support, and cdn tune-in.

### Are there any notes?
In order to implement `HOLD-BACK` start time for live, the config passed in is no longer mutated. It is added to the merged config as `userConfig` so that we can distinguish between default options and options set by the user. This allows us to use hold-back as the target latency when the user has not set liveDurationSync/liveDurationSyncConut.

### Checklist

- [x] changes have been done against ~master~ feature/v1.0.0 > apple-ll-hls branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
