### PR TITLE
Fix dropped frames caused by AVC min/max PTS not matching first/last PTS

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1029,6 +1029,10 @@ class StreamController extends BaseStreamController {
               this.nextLoadPosition = data.startPTS;
               this.state = State.IDLE;
               this.fragPrevious = frag;
+              if (this.demuxer) {
+                this.demuxer.destroy();
+                this.demuxer = null;
+              }
               this.tick();
               return;
             }

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -8,7 +8,7 @@ import MP4 from './mp4-generator';
 import Event from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 
-import { toMsFromMpegTsClock, toMpegTsClockFromTimescale, toTimescaleFromScale } from '../utils/timescale-conversion';
+import { toMsFromMpegTsClock, toMpegTsClockFromTimescale } from '../utils/timescale-conversion';
 
 import { logger } from '../utils/logger';
 
@@ -250,7 +250,7 @@ class MP4Remuxer {
     if (PTSDTSshift < 0) {
       logger.warn(`PTS < DTS detected in video samples, shifting DTS by ${toMsFromMpegTsClock(PTSDTSshift, true)} ms to overcome this issue`);
       for (let i = 0; i < inputSamples.length; i++) {
-        inputSamples[i].dts += PTSDTSshift;
+        inputSamples[i].dts = Math.max(0, inputSamples[i].dts + PTSDTSshift);
       }
     }
 
@@ -565,7 +565,7 @@ class MP4Remuxer {
       // logger.log(`Audio/PTS:${toMsFromMpegTsClock(pts, true)}`);
       // if not first sample
 
-      if (lastPTS !== undefined) {
+      if (lastPTS !== undefined && mp4Sample) {
         mp4Sample.duration = Math.round((pts - lastPTS) / scaleFactor);
       } else {
         let delta = pts - nextAudioPts;

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -262,13 +262,13 @@ class MP4Remuxer {
     const delta = firstDTS - nextAvcDts;
     // if fragment are contiguous, detect hole/overlapping between fragments
     if (contiguous) {
-      const foundHole = delta >= 1;
+      const foundHole = delta > 2;
       const foundOverlap = delta < -1;
       if (foundHole || foundOverlap) {
         if (foundHole) {
-          logger.warn(`AVC: ${toMsFromMpegTsClock(delta, true)} ms hole between fragments detected, filling it`);
+          logger.warn(`AVC: ${toMsFromMpegTsClock(delta, true)}ms (${delta}dts) hole between fragments detected, filling it`);
         } else {
-          logger.warn(`AVC: ${toMsFromMpegTsClock(-delta, true)} ms overlapping between fragments detected`);
+          logger.warn(`AVC: ${toMsFromMpegTsClock(-delta, true)}ms (${delta}dts) overlapping between fragments detected`);
         }
         firstDTS = nextAvcDts;
         minPTS -= delta;

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -285,6 +285,10 @@ class MP4Remuxer {
       mp4SampleDuration = Math.round((lastDTS - firstDTS) / (inputSamples.length - 1));
     }
 
+    // Clamp first DTS to 0 so that we're still aligning on initPTS,
+    // and not passing negative values to MP4.traf. This will change initial frame compositionTimeOffset!
+    firstDTS = Math.max(firstDTS, 0);
+
     let nbNalu = 0, naluLen = 0;
     for (let i = 0; i < nbSamples; i++) {
       // compute total/avc sample length and nb of NAL units


### PR DESCRIPTION
### This PR will...

1. Fix segment duration calculation when first and last PTS do not match min and max (fixes #2873)
1. Fix rounding errors in initPTS calculation:
Actual 😞  `90000 * 16.4 === 1475999.9999999998`
Expected ` 90000 * 16.4 === 1476000`
1. Limit how frequently the position of video frames are adjusted based on estimated next DTS, maintaining composition time when possible
   1. Clamp DTS to 0 after timecode hole/overlap check and Safari frame duration calculation (prevents incorrect `nextDTS delta` adjustment from being applied)
   1. Adjust timecode hole tolerance to account for 59.94 and 29.97 frame rate variance (prevents adjustment from being applied with 0-2 dts sample duration variance)
1. When backtracking because of dropped video frames, reset the demuxer so that we don't use next DTS based on dropped frames
1. Do not drop audio frames based on overlap when samples are not from the same level or a discontinuity. The estimated next PTS is often wrong and causes gaps by dropping audio that should be appended

### Why is this Pull Request needed?
Incorrect segment duration calculation causes frame drops at discontinuities, and other playlist alignment and buffer errors. Also prevent some of the sample timecode hacks from doing more harm than good.

### Resolves issues:
#2873

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
