### PR TITLE
Fix for IE11 missing Number.MAX_SAFE_INTEGER

### DIFF
--- a/src/polyfills/number.js
+++ b/src/polyfills/number.js
@@ -1,3 +1,5 @@
 export const isFiniteNumber = Number.isFinite || function (value) {
   return typeof value === 'number' && isFinite(value);
 };
+
+export const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || 9007199254740991;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,9 @@ const baseConfig = {
               visitor: {
                 CallExpression: function (espath) {
                   if (espath.get('callee').matchesPattern('Number.isFinite')) {
-                    espath.node.callee = importHelper.addNamed(espath, 'isFiniteNumber', path.resolve('src/polyfills/number-isFinite'));
+                    espath.node.callee = importHelper.addNamed(espath, 'isFiniteNumber', path.resolve('src/polyfills/number'));
+                  } else if (espath.get('callee').matchesPattern('Number.MAX_SAFE_INTEGER')) {
+                    espath.node.callee = importHelper.addNamed(espath, 'MAX_SAFE_INTEGER', path.resolve('src/polyfills/number'));
                   }
                 }
               }


### PR DESCRIPTION
### This PR will...
- Replace `Number.MAX_SAFE_INTEGER` with an import the same way we replace `Number.isFinite` for IE11.
- Use `Number.POSITIVE_INFINITY` and `Number.NEGATIVE_INFINITY` for default min/max values in `remuxVideo`.
- Cleanup use of `inputSamples.length` in `remuxVideo`

### Why is this Pull Request needed?
Fixes playback on IE11.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
