### PR TITLE
Seek once into buffer start when starting live

### DIFF
--- a/src/controller/base-stream-controller.js
+++ b/src/controller/base-stream-controller.js
@@ -63,9 +63,7 @@ export default class BaseStreamController extends TaskLoop {
     const currentTime = media ? media.currentTime : null;
     const bufferInfo = BufferHelper.bufferInfo(mediaBuffer || media, currentTime, this.config.maxBufferHole);
 
-    if (Number.isFinite(currentTime)) {
-      logger.log(`media seeking to ${currentTime.toFixed(3)}`);
-    }
+    logger.log(`media seeking to ${Number.isFinite(currentTime) ? currentTime.toFixed(3) : currentTime}`);
 
     if (state === State.FRAG_LOADING) {
       let fragCurrent = this.fragCurrent;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1336,14 +1336,22 @@ class StreamController extends BaseStreamController {
    * @private
    */
   _seekToStartPos () {
-    const { media, startPosition } = this;
+    const { media } = this;
     const currentTime = media.currentTime;
+    let startPosition = this.startPosition;
     // only adjust currentTime if different from startPosition or if startPosition not buffered
     // at that stage, there should be only one buffered range, as we reach that code after first fragment has been buffered
     if (currentTime !== startPosition && startPosition >= 0) {
       if (media.seeking) {
         logger.log(`could not seek to ${startPosition}, already seeking at ${currentTime}`);
         return;
+      }
+      const bufferStart = media.buffered.length ? media.buffered.start(0) : 0;
+      const delta = bufferStart - startPosition;
+      if (delta > 0 && delta < this.config.maxBufferHole) {
+        logger.log(`adjusting start position by ${delta} to match buffer start`);
+        startPosition += delta;
+        this.startPosition = startPosition;
       }
       logger.log(`seek to target start position ${startPosition} from current time ${currentTime}. ready state ${media.readyState}`);
       media.currentTime = startPosition;

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -198,6 +198,7 @@ describe('StreamController', function () {
 
   describe('checkBuffer', function () {
     const sandbox = sinon.createSandbox();
+    let bufStart = 5;
 
     beforeEach(function () {
       streamController.gapController = {
@@ -205,6 +206,9 @@ describe('StreamController', function () {
       };
       streamController.media = {
         buffered: {
+          start () {
+            return bufStart;
+          },
           length: 1
         }
       };


### PR DESCRIPTION
### This PR will...
Seek into buffer start when starting a live stream.

### Why is this Pull Request needed?
This avoids a video rendering bug in IE11 and Edge where video is not rendered when seeking into an unbuffered range to start playback.

It also avoids requiring the gap-controller to step forward playback and potentially reporting stalls.

### Resolves issues:
#2498
#2507

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
