### PR TITLE
Prevent negative DTS time ranges in fragments

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -313,6 +313,7 @@ class MP4Remuxer {
       minPTS = Math.min(sample.pts, minPTS);
       maxPTS = Math.max(sample.pts, maxPTS);
     }
+    lastDTS = inputSamples[nbSamples - 1].dts;
 
     /* concatenate the video data and construct the mdat in place
       (need 8 more bytes to fill length and mpdat type) */


### PR DESCRIPTION
### This PR will...
Update lastDTS after realigning samples in case firstDTS set to a higher value

### Why is this Pull Request needed?
See #2905

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
