### PR TITLE
Stop loading and reset selected audio track when reloading streams

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -264,6 +264,7 @@ function loadSelectedStream () {
 
   hls.on(Hls.Events.MEDIA_DETACHED, function () {
     logStatus('Media element detached');
+    clearInterval(hls.bufferTimer);
     bufferingIdx = -1;
     tracks = [];
     events.video.push({
@@ -271,6 +272,13 @@ function loadSelectedStream () {
       type: 'Media detached'
     });
     trimEventHistory();
+  });
+
+  hls.on(Hls.Events.DESTROYING, function () {
+    clearInterval(hls.bufferTimer);
+  });
+  hls.on(Hls.Events.BUFFER_RESET, function () {
+    clearInterval(hls.bufferTimer);
   });
 
   hls.on(Hls.Events.FRAG_PARSING_INIT_SEGMENT, function (eventName, data) {

--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -79,6 +79,7 @@ class AudioTrackController extends TaskLoop {
     this.tracks = [];
     this._trackId = -1;
     this._selectDefaultTrack = true;
+    this.audioGroupId = null;
   }
 
   /**

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -231,7 +231,6 @@ class StreamController extends BaseStreamController {
 
   _fetchPayloadOrEos (pos, bufferInfo, levelDetails) {
     const fragPrevious = this.fragPrevious,
-      level = this.level,
       fragments = levelDetails.fragments,
       fragLen = fragments.length;
 
@@ -1332,10 +1331,10 @@ class StreamController extends BaseStreamController {
       const elementaryStreamType = this.audioOnly ? ElementaryStreamTypes.AUDIO : ElementaryStreamTypes.VIDEO;
       this.fragmentTracker.detectEvictedFragments(elementaryStreamType, media.buffered);
     }
-    // move to IDLE once flush complete. this should trigger new fragment loading
-    this.state = State.IDLE;
     // reset reference to frag
     this.fragPrevious = null;
+    // move to IDLE once flush complete. this should trigger new fragment loading
+    this.state = State.IDLE;
   }
 
   onLevelsUpdated (data) {

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -281,6 +281,7 @@ export default class Hls extends Observer {
    * @param {string} url
    */
   loadSource (url: string) {
+    this.stopLoad();
     url = URLToolkit.buildAbsoluteURL(window.location.href, url, { alwaysNormalize: true });
     logger.log(`loadSource:${url}`);
     this.url = url;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -282,6 +282,11 @@ export default class Hls extends Observer {
    */
   loadSource (url: string) {
     this.stopLoad();
+    const media = this.media;
+    if (media && this.url) {
+      this.detachMedia();
+      this.attachMedia(media);
+    }
     url = URLToolkit.buildAbsoluteURL(window.location.href, url, { alwaysNormalize: true });
     logger.log(`loadSource:${url}`);
     this.url = url;


### PR DESCRIPTION
### This PR will...
Support the use of `loadSource()` after loading or playing another stream.

This is a work in progress. Right now it's just a small set of changes to get the ball rolling and discuss what other changes are required. So far it will:

- Stop network controllers before loading a new stream
- Reset the selected audio track so that the audio-track-controller will call `_selectInitialAudioTrack` in `_selectAudioGroup` to load the media playlist and begin buffering alt-audio

### Why is this Pull Request needed?
We get a lot of issues where folks expect to be able to call `loadSource()` to load a new video after already playing or starting to load another one. The canned answer is, it is always best to start with a new player instance when loading a new stream. I don't think this should be the case. We should know the internals, and how media elements and MSE work, well enough to handle the clean up.

### Are there any points worth discussing?
We also need to reset source buffers. Usually folks call attach/detach and hope that will take care of things. I don't think we should have to detach media at all. An important consideration is that removing / replacing source buffers is an async operation. 

### Resolves issues:
#2473

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
