### PR TITLE
Fix stalling on discontinuity with audio track

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -179,7 +179,7 @@ class AudioStreamController extends BaseStreamController {
           end = fragments[fragLen - 1].start + fragments[fragLen - 1].duration,
           frag;
 
-          // When switching audio track, reload audio as close as possible to currentTime
+        // When switching audio track, reload audio as close as possible to currentTime
         if (audioSwitch) {
           if (trackDetails.live && !trackDetails.PTSKnown) {
             logger.log('switching audiotrack, live stream, unknown PTS,load first fragment');
@@ -306,13 +306,13 @@ class AudioStreamController extends BaseStreamController {
           this.state = State.FRAG_LOADING;
           this.onFragLoaded(waitingFrag);
         } else if (!this.fragPrevious) {
-          logger.warn(`Waiting fragment CC (${waitingFragCC}) cancelled because of continuity change`);
+          logger.log(`Waiting fragment cc (${waitingFragCC}) cancelled because of continuity change`);
           this.clearWaitingFragment();
         } else {
           const bufferInfo = BufferHelper.bufferInfo(this.mediaBuffer, this.media.currentTime, config.maxBufferHole);
           const waitingFragmentAtPosition = fragmentWithinToleranceTest(bufferInfo.end, config.maxFragLookUpTolerance, waitingFrag.frag);
           if (waitingFragmentAtPosition !== 0) {
-            logger.warn(`Waiting fragment CC (${waitingFragCC}) @ ${waitingFrag.frag.start} cancelled because another fragment at ${bufferInfo.end} is needed`);
+            logger.log(`Waiting fragment cc (${waitingFragCC}) @ ${waitingFrag.frag.start} cancelled because another fragment at ${bufferInfo.end} is needed`);
             this.clearWaitingFragment();
           }
         }
@@ -514,7 +514,7 @@ class AudioStreamController extends BaseStreamController {
           let accurateTimeOffset = false; // details.PTSKnown || !details.live;
           this.demuxer.push(data.payload, initSegmentData, audioCodec, null, fragCurrent, duration, accurateTimeOffset, initPTS);
         } else {
-          logger.log(`unknown video PTS for continuity counter ${cc}, waiting for video PTS before demuxing audio frag ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
+          logger.log(`Unknown video PTS for cc ${cc}, waiting for video PTS before demuxing audio frag ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
           this.waitingFragment = data;
           this.state = State.WAITING_INIT_PTS;
         }


### PR DESCRIPTION
### This PR will...
Improve the handling of audio-stream-controller `waitingFrag` by:
- Always removing the waiting fragment from the fragment tracker when clearing it before it's appended
- Use fragment-finders `fragmentWithinToleranceTest` in audio-stream-controller
- Parse waiting fragment when fragment cc initPTS is known (so that we establish sync with video)
- Drop waiting fragment when:
  - video cc has changed since waiting fragment was set but not to the cc needed to parse waiting cc 
  - The waiting fragment is no longer the audio fragment that needs to be buffered

### Why is this Pull Request needed?
The audio-stream-controller got stuck on discontinuities for because the waiting was not used when it should be and it's status was not managed correctly: 

1. `videoTrackCC` is only updated once `initPTS[waitingFragCC]` is available, which caused the waiting fragment to be cleared before `onInitPtsFound` could fire. Using `videoTrackCC` to see if we still needed the waiting fragment simply did not work.
2. `waitingFrag` was set to `null` in several places, requiring that fragment to be reloaded, but without clearing it's status from the fragment-tracker, so it would not reload. 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolved #2913, #2545
Related to #2832

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
