### PR TITLE
Set live seekable range when `liveDurationInfinity` is enabled

### DIFF
--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -89,6 +89,9 @@ export default class GapController {
       // Jump start gaps within jump threshold
       const startJump = Math.max(nextStart, bufferInfo.start || 0) - currentTime;
 
+      // When joining a live stream with audio tracks, account for live playlist window sliding by allowing
+      // a larger jump over start gaps caused by the audio-stream-controller buffering a start fragment
+      // that begins over 1 target duration after the video start position.
       const level = this.hls.levels ? this.hls.levels[this.hls.currentLevel] : null;
       const isLive = level?.details?.live;
       const maxStartGapJump = isLive ? level.details.targetduration * 2 : MAX_START_GAP_JUMP;

--- a/src/controller/gap-controller.js
+++ b/src/controller/gap-controller.js
@@ -88,7 +88,11 @@ export default class GapController {
     if (!this.moved && this.stalled) {
       // Jump start gaps within jump threshold
       const startJump = Math.max(nextStart, bufferInfo.start || 0) - currentTime;
-      if (startJump > 0 && startJump <= MAX_START_GAP_JUMP) {
+
+      const level = this.hls.levels ? this.hls.levels[this.hls.currentLevel] : null;
+      const isLive = level?.details?.live;
+      const maxStartGapJump = isLive ? level.details.targetduration * 2 : MAX_START_GAP_JUMP;
+      if (startJump > 0 && startJump <= maxStartGapJump) {
         this._trySkipBufferHole(null);
         return;
       }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -106,9 +106,9 @@ class StreamController extends BaseStreamController {
       this._doTickIdle();
       break;
     case State.WAITING_LEVEL:
-      var level = this.levels[this.level];
-      // check if playlist is already loaded
-      if (level && level.details) {
+      var details = this.levels[this.level]?.details;
+      // check if playlist is already loaded (must be current level for live)
+      if (details && (!details.live || this.levelLastLoaded === this.level)) {
         this.state = State.IDLE;
       }
 
@@ -301,7 +301,7 @@ class StreamController extends BaseStreamController {
       let liveSyncPosition = this.liveSyncPosition = this.computeLivePosition(start, levelDetails);
       bufferEnd = liveSyncPosition;
       if (media && !media.paused && media.readyState && media.duration > liveSyncPosition && liveSyncPosition > media.currentTime) {
-        logger.log(`buffer end: ${bufferEnd.toFixed(3)} is located too far from the end of live sliding playlist, reset currentTime to : ${liveSyncPosition.toFixed(3)}`);
+        logger.warn(`buffer end: ${bufferEnd.toFixed(3)} is located too far from the end of live sliding playlist, reset currentTime to : ${liveSyncPosition.toFixed(3)}`);
         media.currentTime = liveSyncPosition;
       }
 
@@ -831,7 +831,7 @@ class StreamController extends BaseStreamController {
       }
       this.nextLoadPosition = this.startPosition;
     }
-    // only switch batck to IDLE state if we were waiting for level to start downloading a new fragment
+    // only switch back to IDLE state if we were waiting for level to start downloading a new fragment
     if (this.state === State.WAITING_LEVEL) {
       this.state = State.IDLE;
     }


### PR DESCRIPTION
### This PR will...
- Set live seekable range when `liveDurationInfinity` is enabled
- Skip large start gaps (target duration * 2)  in live streams 

### Why is this Pull Request needed?
When level loading in a live stream fails, and we perform an immediate switch the buffer is flushed. This also removes all `seekable` ranges and when the media's duration is `Infinity` this prevents seeking when setting `currentTime`. Since updating `currentTime` and seeking is essential to catchup to the live playlist so that buffering can resume, setting the seekable range with `setLiveSeekableRange` fixes this.

With these changes, when `liveDurationInfinity` is set to `true` the media element's `duration` and `seekable` properties should match those of Safari when buffering live content. `duration` will be `Infinity` and `seekable` TimeRange will match the live playlist window.

### Other considerations
The gap controller change accounts for segment sized deltas between where video and audio tracks begin buffering. Greater care could be taken to align the audio-stream-controller's start fragment to the (eventual) start of the video buffer and startPosition/currentTime, but that is outside of the scope of these changes.

### Resolves issues:
#1625

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
