### PR TITLE
Add EME Clear Key support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8907,7 +8907,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -10527,7 +10527,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -10540,7 +10540,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -11209,7 +11209,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -20930,7 +20930,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -22378,7 +22378,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "sinon": "^9.0.1",
     "sinon-chai": "^3.5.0",
     "typescript": "^3.7.4",
-    "webpack": "^4.27.1",
+    "webpack": "^4.44.0",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.2.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,10 +47,17 @@ export type DRMSystemOptions = {
   videoRobustness?: string,
 }
 
+export interface KeyidValue {
+  [keyid: string] : string;
+}
+
 export type EMEControllerConfig = {
   licenseXhrSetup?: (xhr: XMLHttpRequest, url: string) => void,
   emeEnabled: boolean,
   widevineLicenseUrl?: string,
+  clearkey: boolean,
+  clearkeyServerUrl?: string,
+  clearkeyPair: KeyidValue,
   drmSystemOptions: DRMSystemOptions,
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null,
 };
@@ -245,6 +252,9 @@ export const hlsDefaultConfig: HlsConfig = {
   maxLoadingDelay: 4, // used by abr-controller
   minAutoBitrate: 0, // used by hls
   emeEnabled: false, // used by eme-controller
+  clearkeyServerUrl: void 0,
+  clearkey: false,
+  clearkeyPair: {},
   widevineLicenseUrl: void 0, // used by eme-controller
   drmSystemOptions: {}, // used by eme-controller
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -75,13 +75,11 @@ const createClearkeyMediaKeySystemConfigurations = function (
   });
 
   videoCodecs.forEach((codec) => {
-    logger.log(codec);
+    // logger.log(codec);
     baseConfig.videoCapabilities!.push({
       contentType: `video/mp4; codecs="${codec}"`
     });
   });
-  logger.log(baseConfig.audioCapabilities);
-  logger.log(baseConfig.videoCapabilities);
   return [
     baseConfig
   ];
@@ -291,14 +289,14 @@ class EMEController extends EventHandler {
     // Instead, we will generate the license synchronously on the client, using
     // the hard-coded KEY.
     if (this._clearkeyPair == null) {
-      console.error('Failed to load the keys');
+      logger.error('Failed to load the keys');
     }
 
     let license = this._generateLicense(message);
 
     keySession.update(license).catch(
       function (error) {
-        console.error('Failed to update the session', error);
+        logger.error('Failed to update the session', error);
       }
     );
     logger.log(`Received license data (length: ${license ? license.byteLength : license}), updating key-session`);
@@ -314,12 +312,10 @@ class EMEController extends EventHandler {
       k?: string
     }
 
-    logger.log(JSON.stringify(request.kids));
     let keyarray: responseFormat[] = [];
-    logger.log(`clearkey pair: ${JSON.stringify(this._clearkeyPair)}`);
     for (let id of request.kids) {
       let decodedBase64 = this.base64ToHex(id);
-      logger.log(`decodedBase64: ${decodedBase64}`);
+      // logger.log(`decodedBase64: ${decodedBase64}`);
       if (!this._clearkeyPair.hasOwnProperty(decodedBase64)) {
         logger.error('No pair key, please use lower case');
       }

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -355,7 +355,6 @@ class EMEController extends EventHandler {
     while (end > start && encodedBase64[end - 1] === '=') {
       --end;
     }
-      
     return (start > 0 || end < encodedBase64.length) ? encodedBase64.substring(start, end) : encodedBase64;
   }
 

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -4,6 +4,7 @@
 export enum KeySystems {
   WIDEVINE = 'com.widevine.alpha',
   PLAYREADY = 'com.microsoft.playready',
+  CLEARKEY = 'org.w3.clearkey',
 }
 
 export type MediaKeyFunc = (keySystem: KeySystems, supportedConfigurations: MediaKeySystemConfiguration[]) => Promise<MediaKeySystemAccess>;


### PR DESCRIPTION
### This PR will...
This PR will add the check of `org.w3.clearkey` and define the usage of the Clear Key. 

the config will add :
  * clearkey: boolean,
  * clearkeyServerUrl?: string,
  * clearkeyPair: KeyidValue,

Users can specify the KeyID-Key pair in their configuration. `hls.js` will synchronously generate the license on the client following the [spec](https://www.w3.org/TR/encrypted-media/#clear-key-license-format). The usage is like:
```
clearkey: true,
clearkeyPair: { keyid (128 HEX) : key (128 HEX) } 
```
Users can also specify a Clear Key server URL through clearkeyServerUrl
   
### Why is this Pull Request needed?
We currently only support Widevine, which requires us to establish a license server. There isn't a clear path to use Clear Key with hls.js according to #2901 . From the [spec,](https://www.w3.org/2016/03/EME-factsheet#:~:text=The%20EME%20API%20does%20not,be%20built%20into%20the%20browser.) all browsers supporting EME must implement Clear Key. That allows us to play the encrypted video by providing the Key. 

The `org.w3.clearkey` Key System uses plain-text clear key(s) to decrypt the source. It is also handy for testing EME implementations, and applications using EME, without the need to request a content key from a complicated license server. 

### Are there any points in the code the reviewer needs to double check?
I am new to Typescript and welcome to any suggestions for the code

### Resolves issues:
#2901 

### Checklist
- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
