### PR TITLE
Fix regression in streams with PTS wrapping prior to DTS

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -222,14 +222,14 @@ class MP4Remuxer {
     // PTSNormalize will make PTS/DTS value monotonic, we use last known DTS value as reference value
     for (let i = 0; i < nbSamples; i++) {
       const sample = inputSamples[i];
+      sample.pts = PTSNormalize(sample.pts - initPTS, nextAvcDts);
+      sample.dts = PTSNormalize(sample.dts - initPTS, nextAvcDts);
       if (sample.dts > sample.pts) {
         ptsDtsShift = Math.max(Math.min(ptsDtsShift, sample.pts - sample.dts), -1 * PTS_DTS_SHIFT_TOLERANCE_90KHZ);
       }
       if (sample.dts < inputSamples[i > 0 ? i - 1 : i].dts) {
         sortSamples = true;
       }
-      sample.pts = PTSNormalize(sample.pts - initPTS, nextAvcDts);
-      sample.dts = PTSNormalize(sample.dts - initPTS, nextAvcDts);
     }
 
     // sort video samples by DTS then PTS then demux id order


### PR DESCRIPTION
### This PR will...
Compare set sort and shift flags after PTSNormalize is applied.

### Why is this Pull Request needed?
- Fixes false positive on the `sortSamples` flag when the last sample's dts was normalized but the current was not.
- Fixes false positive on the `ptsDtsShift` flag when `sample.pts` is less than `sample.dts` before `PTSNormalize` is applied.

### Resolves issues:
Relates to #1796

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
