### PR TITLE
Fix stream duration update regression with discontinuities and misaligned AV

### DIFF
--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -46,7 +46,8 @@ export function updatePTS (fragments, fromIdx, toIdx) {
   } else {
     // we dont know startPTS[toIdx]
     if (toIdx > fromIdx) {
-      fragTo.start = fragFrom.start + (fragFrom.minEndPTS ? fragFrom.minEndPTS - fragFrom.start : fragFrom.duration);
+      const contiguous = fragFrom.cc === fragTo.cc;
+      fragTo.start = fragFrom.start + ((contiguous && fragFrom.minEndPTS) ? fragFrom.minEndPTS - fragFrom.start : fragFrom.duration);
     } else {
       fragTo.start = Math.max(fragFrom.start - fragTo.duration, 0);
     }


### PR DESCRIPTION
### This PR will...
Do not use shorter track duration when updating fragment timing at a discontinuity.

### Why is this Pull Request needed?
The first of audio and video tracks to end is used to determine the start of the next segment - but this should only be done when segments are contiguous and we expect the same track to start sooner. In the case of a discontinuity, we want the next segment to start after both tracks in the previous segment have ended.

In earlier releases and in Safari, this stream has a duration of ~40 seconds. These changes restore that duration which was being cut short by always using `minEndPTS` in the changes below.
  
http://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8


### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
