### PR TITLE
README: Swap logic for checking Hls.isSupported()

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
 <script>
   var video = document.getElementById('video');
   var videoSrc = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
+  if (Hls.isSupported()) {
+    var hls = new Hls();
+    hls.loadSource(videoSrc);
+    hls.attachMedia(video);
+    hls.on(Hls.Events.MANIFEST_PARSED, function() {
+      video.play();
+    });
+  }
+  // hls.js is not supported on platforms that do not have Media Source
+  // Extensions (MSE) enabled.
   //
   // When the browser has built-in HLS support (check using `canPlayType`),
   // we can provide an HLS manifest (i.e. .m3u8 URL) directly to the video
@@ -75,6 +85,35 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
   // video.src URL must be on the user-driven white-list before a 'canplay'
   // event will be emitted; the last video event that can be reliably
   // listened-for when the URL is not on the white-list is 'loadedmetadata'.
+  else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+    video.src = videoSrc;
+    video.addEventListener('loadedmetadata', function() {
+      video.play();
+    });
+  }
+</script>
+```
+
+#### Alternative setup
+
+Note that the example code above will check for hls.js support _first_ and then
+fallback to check if the browser natively supports HLS. If you want to check for
+native browser support first, and then fallback to Hls.js you will want to swap
+those conditionals.
+
+The order of these checks depends on if you want to use hls.js whenever possible
+see [this comment](https://github.com/video-dev/hls.js/pull/2954#issuecomment-670021358) to understand some of the tradeoffs.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+<!-- Or if you want a more recent alpha version -->
+<!-- <script src="https://cdn.jsdelivr.net/npm/hls.js@alpha"></script> -->
+<video id="video"></video>
+<script>
+  var video = document.getElementById('video');
+  var videoSrc = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
+  //
+  // First check for native browser HLS support
   //
   if (video.canPlayType('application/vnd.apple.mpegurl')) {
     video.src = videoSrc;
@@ -82,8 +121,7 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
       video.play();
     });
   //
-  // hls.js is not supported on platforms that do not have Media Source
-  // Extensions (MSE) enabled.
+  // If no native HLS support, check if hls.js is supported
   //
   } else if (Hls.isSupported()) {
     var hls = new Hls();

--- a/README.md
+++ b/README.md
@@ -64,16 +64,6 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
 <script>
   var video = document.getElementById('video');
   var videoSrc = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
-  if (Hls.isSupported()) {
-    var hls = new Hls();
-    hls.loadSource(videoSrc);
-    hls.attachMedia(video);
-    hls.on(Hls.Events.MANIFEST_PARSED, function() {
-      video.play();
-    });
-  }
-  // hls.js is not supported on platforms that do not have Media Source
-  // Extensions (MSE) enabled.
   //
   // When the browser has built-in HLS support (check using `canPlayType`),
   // we can provide an HLS manifest (i.e. .m3u8 URL) directly to the video
@@ -85,9 +75,21 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
   // video.src URL must be on the user-driven white-list before a 'canplay'
   // event will be emitted; the last video event that can be reliably
   // listened-for when the URL is not on the white-list is 'loadedmetadata'.
-  else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+  //
+  if (video.canPlayType('application/vnd.apple.mpegurl')) {
     video.src = videoSrc;
     video.addEventListener('loadedmetadata', function() {
+      video.play();
+    });
+  //
+  // hls.js is not supported on platforms that do not have Media Source
+  // Extensions (MSE) enabled.
+  //
+  } else if (Hls.isSupported()) {
+    var hls = new Hls();
+    hls.loadSource(videoSrc);
+    hls.attachMedia(video);
+    hls.on(Hls.Events.MANIFEST_PARSED, function() {
       video.play();
     });
   }


### PR DESCRIPTION
### This PR will...

Update README for checking browser HLS support.

### Why is this Pull Request needed?

Before Safari supported MSE then this recommendation in the README worked well because `Hls.isSupported()` would return `false`. Now that changed and it returns `true`.

I typically think it's a best practice to use the browser's native HLS support if it's available, otherwise fallback to `hls.js`

### Checklist

n/a - only a README update
