### PR TITLE
Fix audio remuxer out of sequence sample drop regression 

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -520,7 +520,7 @@ class MP4Remuxer {
 
         // If we're overlapping by more than a duration, drop this sample
         if (delta <= -maxAudioFramesDrift * inputSampleDuration) {
-          if (contiguous) {
+          if (contiguous || i > 0) {
             logger.warn(`Dropping 1 audio frame @ ${toMsFromMpegTsClock(nextPts, true) / 1000}s due to ${toMsFromMpegTsClock(delta, true)} ms overlap.`);
             inputSamples.splice(i, 1);
             // Don't touch nextPtsNorm or i


### PR DESCRIPTION
### This PR will...
Fix a regression introduced in v0.14.1, in the audio remuxer, where bad samples mid fragment were not being dropped.

### Why is this Pull Request needed?
Appending out of order samples results in stretching of audio track duration.

### Are there any points in the code the reviewer needs to double check?

Test stream (4 second segment with one out of sequence audio sample) https://playertest.longtailvideo.com/adaptive/audio-sample-out-of-sequence/main.m3u8

The video duration becomes 27 hours:
https://hls-js.netlify.app/demo/?src=https%3A%2F%2Fplayertest.longtailvideo.com%2Fadaptive%2Faudio-sample-out-of-sequence%2Fmain.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOnRydWUsImR1bXBmTVA0IjpmYWxzZSwibGV2ZWxDYXBwaW5nIjotMSwibGltaXRNZXRyaWNzIjotMX0=

### Resolves issues
#2959

### Checklist

- [x] changes have been done against master/patch branch, and PR does not conflict
- [x] unit / functional tests pass