### PR TITLE
Only apply minimum ID3 cue duration when cue has none

### DIFF
--- a/src/controller/id3-track-controller.js
+++ b/src/controller/id3-track-controller.js
@@ -79,8 +79,8 @@ class ID3TrackController extends EventHandler {
         }
 
         const timeDiff = endTime - startTime;
-        if (timeDiff < MIN_CUE_DURATION) {
-          endTime += MIN_CUE_DURATION - timeDiff;
+        if (timeDiff <= 0) {
+          endTime = startTime + MIN_CUE_DURATION;
         }
 
         for (let j = 0; j < frames.length; j++) {


### PR DESCRIPTION
### This PR will...
Only apply minimum ID3 cue duration when cue does not have a valid duration.

### Why is this Pull Request needed?
ID3 cues found on the last sample of an ID3 track or cues in tracks with out-of-order PTS will have an end time that is equal or less than their start time, which is not valid.

This fixes a regression introduced in v0.14.8 with  #2951 where we applied a minimum duration 0.25s to all metadata cues, to ensure change events always fire, without considering the need to maintain the duration of cues intended to provide data relative to video frames (where the duration is more likely to be ~0.008-0.04s).

### Resolves issues:
#2963

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
