### PR TITLE
Low-Latency HLS Blocking Playlist Reload support

### DIFF
--- a/demo/chart/timeline-chart.ts
+++ b/demo/chart/timeline-chart.ts
@@ -212,7 +212,9 @@ export class TimelineChart {
     const { targetduration, totalduration, url } = details;
     const { datasets } = this.chart.data;
     // eslint-disable-next-line no-restricted-properties
-    const levelDataSet = arrayFind(datasets, dataset => dataset.url && dataset.url.toString() === url);
+    const deliveryDirectivePattern = /[?&]_HLS_(?:msn|part|skip)=[^?&]+/g;
+    const levelDataSet = arrayFind(datasets, dataset =>
+      dataset.url?.toString().replace(deliveryDirectivePattern, '') === url.replace(deliveryDirectivePattern, ''));
     if (!levelDataSet) {
       return;
     }

--- a/demo/main.js
+++ b/demo/main.js
@@ -1468,10 +1468,10 @@ function hideAllTabs () {
   $('.demo-tab').hide();
 }
 
-function toggleTab (btn) {
+function toggleTab (btn, dontHideOpenTabs) {
   const tabElId = $(btn).data('tab');
   // eslint-disable-next-line no-restricted-globals
-  const modifierPressed = window.event && (window.event.metaKey || window.event.shiftKey);
+  const modifierPressed = dontHideOpenTabs || window.event && (window.event.metaKey || window.event.shiftKey);
   if (!modifierPressed) {
     hideAllTabs();
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,20 +1,21 @@
 import AbrController from './controller/abr-controller';
 import AudioStreamController from './controller/audio-stream-controller';
 import AudioTrackController from './controller/audio-track-controller';
+import { SubtitleStreamController } from './controller/subtitle-stream-controller';
+import SubtitleTrackController from './controller/subtitle-track-controller';
 import BufferController from './controller/buffer-controller';
+import { TimelineController } from './controller/timeline-controller';
 import CapLevelController from './controller/cap-level-controller';
 import FPSController from './controller/fps-controller';
-
-import { TimelineController } from './controller/timeline-controller';
-import SubtitleTrackController from './controller/subtitle-track-controller';
 import EMEController from './controller/eme-controller';
-
 import XhrLoader from './utils/xhr-loader';
 import FetchLoader, { fetchSupported } from './utils/fetch-loader';
 import * as Cues from './utils/cues';
-import { SubtitleStreamController } from './controller/subtitle-stream-controller';
-import { requestMediaKeySystemAccess, MediaKeyFunc } from './utils/mediakeys-helper';
+import { requestMediaKeySystemAccess } from './utils/mediakeys-helper';
 import { logger } from './utils/logger';
+
+import type { MediaKeyFunc } from './utils/mediakeys-helper';
+import type { FragmentLoaderContext, Loader, LoaderContext, PlaylistLoaderContext } from './types/loader';
 
 type ABRControllerConfig = {
   abrEwmaFastLive: number,
@@ -53,7 +54,7 @@ export type EMEControllerConfig = {
 };
 
 type FragmentLoaderConfig = {
-  fLoader: any, // TODO(typescript-loader): Once Loader is typed fill this in
+  fLoader?: { new(confg: HlsConfig): Loader<FragmentLoaderContext> },
 
   fragLoadingTimeOut: number,
   fragLoadingMaxRetry: number,
@@ -77,7 +78,7 @@ export type MP4RemuxerConfig = {
 };
 
 type PlaylistLoaderConfig = {
-  pLoader: any, // TODO(typescript-loader): Once Loader is typed fill this in
+  pLoader?: { new(confg: HlsConfig): Loader<PlaylistLoaderContext> },
 
   manifestLoadingTimeOut: number,
   manifestLoadingMaxRetry: number,
@@ -140,7 +141,7 @@ export type HlsConfig =
     enableWorker: boolean,
     enableSoftwareAES: boolean,
     minAutoBitrate: number,
-    loader: any, // TODO(typescript-xhrloader): Type once XHR is done
+    loader: { new(confg: HlsConfig): Loader<LoaderContext> },
     xhrSetup?: (xhr: XMLHttpRequest, url: string) => void,
 
     // Alt Audio

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -297,7 +297,15 @@ class AudioTrackController extends BasePlaylistController {
   protected loadPlaylist (hlsUrlParameters?: HlsUrlParameters): void {
     const audioTrack = this.tracks[this.trackId];
     if (this.shouldLoadTrack(audioTrack)) {
-      const { url, id } = audioTrack;
+      const id = audioTrack.id;
+      let url = audioTrack.url;
+      if (hlsUrlParameters) {
+        try {
+          url = hlsUrlParameters.addDirectives(url);
+        } catch (error) {
+          logger.warn(`[audio-track-controller] Could not construct new URL with HLS Delivery Directives: ${error}`);
+        }
+      }
       // track not retrieved yet, or live playlist we need to (re)load it
       logger.log(`[audio-track-controller]: loading audio-track playlist for id: ${id}`);
       this.clearTimer();

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -1,0 +1,74 @@
+import Hls from '../hls';
+import { NetworkComponentAPI } from '../types/component-api';
+import { HlsUrlParameters } from '../types/level';
+import { computeReloadInterval } from './level-helper';
+import { logger } from '../utils/logger';
+import type LevelDetails from '../loader/level-details';
+import type { MediaPlaylist } from '../types/media-playlist';
+import type { AudioTrackLoadedData, LevelLoadedData, TrackLoadedData } from '../types/events';
+
+export default class BasePlaylistController implements NetworkComponentAPI {
+  protected hls: Hls;
+  protected timer: number = -1;
+  protected canLoad: boolean = false;
+
+  constructor (hls: Hls) {
+    this.hls = hls;
+  }
+
+  public destroy (): void {
+    this.clearTimer();
+  }
+
+  protected clearTimer (): void {
+    clearTimeout(this.timer);
+    this.timer = -1;
+  }
+
+  public startLoad (): void {
+    this.canLoad = true;
+    this.loadPlaylist();
+  }
+
+  public stopLoad (): void {
+    this.canLoad = false;
+    this.clearTimer();
+  }
+
+  protected loadPlaylist (hlsUrlParameters?: HlsUrlParameters): void {}
+
+  protected shouldLoadTrack (track: MediaPlaylist): boolean {
+    return this.canLoad && track && !!track.url && (!track.details || track.details.live);
+  }
+
+  protected playlistLoaded (index: number, data: LevelLoadedData | AudioTrackLoadedData | TrackLoadedData, previousDetails: LevelDetails | undefined) {
+    const { details, stats, deliveryDirectives } = data;
+
+    // if current playlist is a live playlist, arm a timer to reload it
+    if (details.live) {
+      if (deliveryDirectives) {
+        console.assert(deliveryDirectives.msn === details.endSN, `blocking reload result ${details.endSN}, requested ${deliveryDirectives.msn}`);
+      }
+      details.reloaded(previousDetails);
+      if (previousDetails) {
+        logger.log(`[${this.constructor?.name}] live playlist ${index} ${details.advanced ? 'REFRESHED' : 'MISSED'}`);
+      }
+      if (!this.canLoad) {
+        return;
+      }
+      // TODO: Do not use LL-HLS delivery directives if playlist "endSN" is stale
+      if (details.canBlockReload && details.endSN && details.advanced) {
+        // Load level with LL-HLS delivery directives
+        // TODO: LL-HLS Specify latest partial segment
+        // TODO: LL-HLS enable skip parameter for delta playlists independent of canBlockReload
+        this.loadPlaylist(new HlsUrlParameters(details.endSN + 1, 0, false));
+        return;
+      }
+      const reloadInterval = computeReloadInterval(details, stats);
+      logger.log(`[${this.constructor?.name}] reload live playlist ${index} in ${Math.round(reloadInterval)} ms`);
+      this.timer = self.setTimeout(() => this.loadPlaylist(), reloadInterval);
+    } else {
+      this.clearTimer();
+    }
+  }
+}

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -638,15 +638,16 @@ export default class BaseStreamController extends TaskLoop {
     this.log(`Fragment ${frag.sn} of level ${frag.level} was aborted, flushing transmuxer & resetting nextLoadPosition to ${this.nextLoadPosition}`);
   }
 
-  private updateLevelTiming (frag: Fragment, currentLevel: Level) {
-    const { details } = currentLevel;
+  private updateLevelTiming (frag: Fragment, level: Level) {
+    const details = level.details as LevelDetails;
+    console.assert(!!details, 'level.details must be defined');
     Object.keys(frag.elementaryStreams).forEach(type => {
       const info = frag.elementaryStreams[type];
       if (info) {
         const drift = LevelHelper.updateFragPTSDTS(details, frag, info.startPTS, info.endPTS, info.startDTS, info.endDTS);
         this.hls.trigger(Events.LEVEL_PTS_UPDATED, {
           details,
-          level: currentLevel,
+          level,
           drift,
           type,
           start: info.startPTS,

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -461,7 +461,7 @@ export default class LevelController extends BasePlaylistController {
     const level = this.currentLevelIndex;
     const currentLevel = this._levels[level];
 
-    if (this.canLoad && currentLevel?.url.length > 0) {
+    if (this.canLoad && currentLevel && currentLevel.url.length > 0) {
       const id = currentLevel.urlId;
       let url = currentLevel.url[id];
       if (hlsUrlParameters) {
@@ -473,8 +473,8 @@ export default class LevelController extends BasePlaylistController {
       }
 
       logger.log(`[level-controller]: Attempt loading level index ${level}${
-        hlsUrlParameters ? ' at sn ' + hlsUrlParameters.msn : ''
-      } with URL-id ${id}`);
+        hlsUrlParameters ? ' at sn ' + hlsUrlParameters.msn + ' part ' + hlsUrlParameters.part : ''
+      } with URL-id ${id} ${url}`);
 
       // console.log('Current audio track group ID:', this.hls.audioTracks[this.hls.audioTrack].groupId);
       // console.log('New video quality level audio group id:', levelObject.attrs.AUDIO, level);

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -135,11 +135,17 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
       newFrag.endPTS = oldFrag.endPTS;
       newFrag.startDTS = oldFrag.startDTS;
       newFrag.endDTS = oldFrag.endDTS;
+      newFrag.appendedPTS = oldFrag.appendedPTS;
+      newFrag.maxStartPTS = oldFrag.maxStartPTS;
+      newFrag.minEndPTS = oldFrag.minEndPTS;
       newFrag.duration = oldFrag.duration;
       newFrag.backtracked = oldFrag.backtracked;
       newFrag.dropped = oldFrag.dropped;
       PTSFrag = newFrag;
     }
+    newFrag.stats = oldFrag.stats;
+    newFrag.loader = oldFrag.loader;
+    newFrag.urlId = oldFrag.urlId;
     // PTS is known when there are overlapping segments
     newDetails.PTSKnown = true;
   });

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -159,7 +159,15 @@ class SubtitleTrackController extends BasePlaylistController {
   protected loadPlaylist (hlsUrlParameters?: HlsUrlParameters): void {
     const currentTrack = this.tracks[this.trackId];
     if (this.shouldLoadTrack(currentTrack)) {
-      const { url, id } = currentTrack;
+      const id = currentTrack.id;
+      let url = currentTrack.url;
+      if (hlsUrlParameters) {
+        try {
+          url = hlsUrlParameters.addDirectives(url);
+        } catch (error) {
+          logger.warn(`[subtitle-track-controller] Could not construct new URL with HLS Delivery Directives: ${error}`);
+        }
+      }
       logger.log(`[subtitle-track-controller]: Loading subtitle playlist for id ${id}`);
       this.hls.trigger(Events.SUBTITLE_TRACK_LOADING, {
         url,

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,51 @@
-import { ManifestLoadedData, ManifestLoadingData, MediaAttachedData, MediaAttachingData, LevelLoadingData, LevelLoadedData, ManifestParsedData, LevelUpdatedData, LevelsUpdatedData, FragParsingUserdataData, FragDecryptedData, FragLoadedData, InitPTSFoundData, CuesParsedData, SubtitleFragProcessedData, NonNativeTextTracksData, FragLoadingData, AudioTrackLoadingData, AudioTrackLoadedData, SubtitleTrackLoadedData, SubtitleTrackLoadingData, ErrorData, AudioTrackSwitchingData, AudioTrackSwitchedData, KeyLoadedData, KeyLoadingData, SubtitleTrackSwitchData, SubtitleTracksUpdatedData, LevelSwitchedData, FragChangedData, BufferAppendingData, BufferCodecsData, FragParsingMetadataData, FragParsingInitSegmentData, FragBufferedData, BufferFlushingData, BufferEOSData, LevelSwitchingData, FPSDropLevelCappingData, FPSDropData, BufferCreatedData, BufferAppendedData, LevelPTSUpdatedData, FragParsedData, AudioTracksUpdatedData, FragLoadEmergencyAbortedData, LiveBackBufferData } from './types/events';
+import {
+  ManifestLoadedData,
+  ManifestLoadingData,
+  MediaAttachedData,
+  MediaAttachingData,
+  LevelLoadingData,
+  LevelLoadedData,
+  ManifestParsedData,
+  LevelUpdatedData,
+  LevelsUpdatedData,
+  FragParsingUserdataData,
+  FragDecryptedData,
+  FragLoadedData,
+  InitPTSFoundData,
+  CuesParsedData,
+  SubtitleFragProcessedData,
+  NonNativeTextTracksData,
+  FragLoadingData,
+  AudioTrackLoadedData,
+  SubtitleTrackLoadedData,
+  ErrorData,
+  AudioTrackSwitchingData,
+  AudioTrackSwitchedData,
+  KeyLoadedData,
+  KeyLoadingData,
+  SubtitleTrackSwitchData,
+  SubtitleTracksUpdatedData,
+  LevelSwitchedData,
+  FragChangedData,
+  BufferAppendingData,
+  BufferCodecsData,
+  FragParsingMetadataData,
+  FragParsingInitSegmentData,
+  FragBufferedData,
+  BufferFlushingData,
+  BufferEOSData,
+  LevelSwitchingData,
+  FPSDropLevelCappingData,
+  FPSDropData,
+  BufferCreatedData,
+  BufferAppendedData,
+  LevelPTSUpdatedData,
+  FragParsedData,
+  AudioTracksUpdatedData,
+  FragLoadEmergencyAbortedData,
+  LiveBackBufferData,
+  TrackLoadingData
+} from './types/events';
 import { Tail } from './types/tuples';
 
 /**
@@ -144,12 +191,12 @@ export interface HlsListeners {
   [Events.AUDIO_TRACKS_UPDATED]: (event: Events.AUDIO_TRACKS_UPDATED, data: AudioTracksUpdatedData) => void
   [Events.AUDIO_TRACK_SWITCHING]: (event: Events.AUDIO_TRACK_SWITCHING, data: AudioTrackSwitchingData) => void
   [Events.AUDIO_TRACK_SWITCHED]: (event: Events.AUDIO_TRACK_SWITCHED, data: AudioTrackSwitchedData) => void
-  [Events.AUDIO_TRACK_LOADING]: (event: Events.AUDIO_TRACK_LOADING, data: AudioTrackLoadingData) => void
+  [Events.AUDIO_TRACK_LOADING]: (event: Events.AUDIO_TRACK_LOADING, data: TrackLoadingData) => void
   [Events.AUDIO_TRACK_LOADED]: (event: Events.AUDIO_TRACK_LOADED, data: AudioTrackLoadedData) => void
   [Events.SUBTITLE_TRACKS_UPDATED]: (event: Events.SUBTITLE_TRACKS_UPDATED, data: SubtitleTracksUpdatedData) => void
   [Events.SUBTITLE_TRACKS_CLEARED]: (event: Events.SUBTITLE_TRACKS_CLEARED) => void
   [Events.SUBTITLE_TRACK_SWITCH]: (event: Events.SUBTITLE_TRACK_SWITCH, data: SubtitleTrackSwitchData) => void
-  [Events.SUBTITLE_TRACK_LOADING]: (event: Events.SUBTITLE_TRACK_LOADING, data: SubtitleTrackLoadingData) => void
+  [Events.SUBTITLE_TRACK_LOADING]: (event: Events.SUBTITLE_TRACK_LOADING, data: TrackLoadingData) => void
   [Events.SUBTITLE_TRACK_LOADED]: (event: Events.SUBTITLE_TRACK_LOADED, data: SubtitleTrackLoadedData) => void
   [Events.SUBTITLE_FRAG_PROCESSED]: (event: Events.SUBTITLE_FRAG_PROCESSED, data: SubtitleFragProcessedData) => void
   [Events.CUES_PARSED]: (event: Events.CUES_PARSED, data: CuesParsedData) => void

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -244,9 +244,8 @@ export default class Hls implements HlsEventEmitter {
     logger.log('destroy');
     this.trigger(Events.DESTROYING);
     this.detachMedia();
-    this.coreComponents.concat(this.networkControllers).forEach(component => {
-      component.destroy();
-    });
+    this.networkControllers.forEach(component => component.destroy());
+    this.coreComponents.forEach(component => component.destroy());
     this.url = null;
     this.removeAllListeners();
     this._autoLevelCapping = -1;

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -20,7 +20,13 @@ export default class FragmentLoader {
 
   load (frag: Fragment, onProgress?: FragmentLoadProgressCallback, highWaterMark?: number): Promise<FragLoadSuccessResult | LoadError> {
     if (!frag.url) {
-      return Promise.reject(new LoadError(null, 'Fragment does not have a url'));
+      return Promise.reject(new LoadError({
+        type: ErrorTypes.NETWORK_ERROR,
+        details: ErrorDetails.FRAG_LOAD_ERROR,
+        fatal: true,
+        frag,
+        networkDetails: null
+      }, 'Fragment does not have a url'));
     }
 
     const config = this.config;
@@ -34,7 +40,7 @@ export default class FragmentLoader {
     }
 
     loader = this.loader = frag.loader =
-      config.fLoader ? new FragmentILoader(config) : new DefaultILoader(config);
+      FragmentILoader ? new FragmentILoader(config) : new DefaultILoader(config) as Loader<FragmentLoaderContext>;
 
     const loaderContext: FragmentLoaderContext = {
       frag,
@@ -125,7 +131,7 @@ export default class FragmentLoader {
 }
 
 export class LoadError extends Error {
-  private data: FragLoadFailResult | null;
+  private readonly data: FragLoadFailResult;
   constructor (data, ...params) {
     super(...params);
     this.data = data;
@@ -142,7 +148,7 @@ export interface FragLoadFailResult {
   details: string
   fatal: boolean
   frag: Fragment
-  networkDetails: XMLHttpRequest
+  networkDetails: any
 }
 
 export type FragmentLoadProgressCallback = (result: FragLoadSuccessResult) => void;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -4,7 +4,7 @@ import { logger } from '../utils/logger';
 import LevelKey from './level-key';
 import LoadStats from './load-stats';
 import AttrList from '../utils/attr-list';
-import type { Loader, LoaderContext, PlaylistLevelType } from '../types/loader';
+import type { FragmentLoaderContext, Loader, PlaylistLevelType } from '../types/loader';
 
 export enum ElementaryStreamTypes {
   AUDIO = 'audio',
@@ -98,7 +98,7 @@ export default class Fragment extends BaseSegment {
   // A string representing the fragment type
   public readonly type: PlaylistLevelType;
   // A reference to the loader. Set while the fragment is loading, and removed afterwards. Used to abort fragment loading
-  public loader: Loader<LoaderContext> | null = null;
+  public loader: Loader<FragmentLoaderContext> | null = null;
   // The level index to which the fragment belongs
   public level: number = -1;
   // The continuity counter of the fragment

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -6,7 +6,14 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import Hls from '../hls';
 import Fragment from './fragment';
-import { LoaderStats, LoaderResponse, LoaderContext, LoaderConfiguration, LoaderCallbacks } from '../types/loader';
+import {
+  LoaderStats,
+  LoaderResponse,
+  LoaderContext,
+  LoaderConfiguration,
+  LoaderCallbacks,
+  Loader, FragmentLoaderContext
+} from '../types/loader';
 import { ComponentAPI } from '../types/component-api';
 import { KeyLoadingData } from '../types/events';
 
@@ -67,7 +74,7 @@ export default class KeyLoader implements ComponentAPI {
         return;
       }
 
-      const fragLoader = frag.loader = this.loaders[type] = new config.loader(config);
+      const fragLoader = frag.loader = this.loaders[type] = new config.loader(config) as Loader<FragmentLoaderContext>;
       this.decrypturl = uri;
       this.decryptkey = null;
 

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -44,6 +44,7 @@ export default class LevelDetails {
       this.updated = true;
       return;
     }
+    // TODO: LL-HLS Set `updated` with delta playlist and partial segment changes taken into account
     const updated = (this.endSN !== previous.endSN || this.url !== previous.url);
     if (updated) {
       this.misses = Math.floor(previous.misses * 0.6);

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -34,6 +34,8 @@ export default class LevelDetails {
   public partTarget: number = 0;
   public preloadHint?: AttrList;
   public renditionReports?: AttrList[];
+  public endPart: number = 0;
+  public lastPart: boolean = true;
 
   constructor (baseUrl) {
     this.fragments = [];
@@ -46,15 +48,14 @@ export default class LevelDetails {
       this.updated = true;
       return;
     }
-    // TODO: LL-HLS Set `updated` with delta playlist and partial segment changes taken into account
-    const updated = (this.endSN !== previous.endSN || this.url !== previous.url);
+    const updated = (this.endSN !== previous.endSN || this.endPart !== previous.endPart);
     if (updated) {
       this.misses = Math.floor(previous.misses * 0.6);
     } else {
       this.misses = previous.misses + 1;
     }
     this.updated = updated;
-    this.advanced = this.endSN > previous.endSN;
+    this.advanced = this.endSN > previous.endSN || this.endPart > previous.endPart;
     this.availabilityDelay = previous.availabilityDelay;
   }
 

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -22,6 +22,7 @@ export default class LevelDetails {
   public totalduration: number = 0;
   public type: string | null = null;
   public updated: boolean = true;
+  public advanced: boolean = true;
   public misses: number = 0;
   public url: string;
   public version: number | null = null;
@@ -41,6 +42,7 @@ export default class LevelDetails {
 
   reloaded (previous: LevelDetails | undefined) {
     if (!previous) {
+      this.advanced = true;
       this.updated = true;
       return;
     }
@@ -52,6 +54,7 @@ export default class LevelDetails {
       this.misses = previous.misses + 1;
     }
     this.updated = updated;
+    this.advanced = this.endSN > previous.endSN;
     this.availabilityDelay = previous.availabilityDelay;
   }
 

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -393,6 +393,8 @@ export default class M3U8Parser {
         }
         case 'PART':
           frag.appendPart(new AttrList(value1));
+          // TODO: Append this incomplete fragment with its parts once the fragment-loader can handle it
+          // appendfragment();
           break;
         case 'PRELOAD-HINT': {
           const preloadHintAttrs = new AttrList(value1);
@@ -423,6 +425,9 @@ export default class M3U8Parser {
       const lastFragment = level.fragments[fragmentLength - 1];
       const lastSn = lastFragment.sn;
       level.endSN = lastSn !== 'initSegment' ? lastSn : 0;
+      level.endPart = lastFragment.partCount - 1;
+      // If we have a complete fragment url, then all parts are accounted for
+      level.lastPart = !!lastFragment.relurl;
       level.startCC = level.fragments[0].cc;
     } else {
       level.endSN = 0;

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -15,37 +15,22 @@ import { logger } from '../utils/logger';
 import { parseSegmentIndex } from '../utils/mp4-tools';
 import M3U8Parser from './m3u8-parser';
 import { getProgramDateTimeAtEndOfLastEncodedFragment } from '../controller/level-helper';
-import { HlsUrlParameters, LevelParsed } from '../types/level';
-import {
-  Loader,
-  LoaderContext,
-  LoaderResponse,
-  LoaderStats, PlaylistContextType,
-  PlaylistLevelType,
-  PlaylistLoaderContext
-} from '../types/loader';
+import { LevelParsed } from '../types/level';
+import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import LevelDetails from './level-details';
 import Fragment from './fragment';
 import Hls from '../hls';
 import AttrList from '../utils/attr-list';
 import type { ManifestLoadingData, LevelLoadingData, TrackLoadingData, ErrorData } from '../types/events';
+import type { Loader, LoaderContext, LoaderResponse, LoaderStats, PlaylistLoaderContext } from '../types/loader';
 
 const { performance } = self;
 
-/**
- * @param {PlaylistContextType} type
- * @returns {boolean}
- */
 function canHaveQualityLevels (type: PlaylistContextType): boolean {
   return (type !== PlaylistContextType.AUDIO_TRACK &&
     type !== PlaylistContextType.SUBTITLE_TRACK);
 }
 
-/**
- * Map context.type to LevelType
- * @param {{type: PlaylistContextType}} context
- * @returns {LevelType}
- */
 function mapContextToLevelType (context: PlaylistLoaderContext): PlaylistLevelType {
   const { type } = context;
 
@@ -70,19 +55,12 @@ function getResponseUrl (response: LoaderResponse, context: PlaylistLoaderContex
   return url;
 }
 
-/**
- * @constructor
- */
 class PlaylistLoader {
   private readonly hls: Hls;
   private readonly loaders: {
     [key: string]: Loader<LoaderContext>
   } = Object.create(null)
 
-  /**
-   * @constructs
-   * @param {Hls} hls
-   */
   constructor (hls: Hls) {
     this.hls = hls;
     this._registerListeners();
@@ -118,7 +96,7 @@ class PlaylistLoader {
     const Loader = config.loader;
     const InternalLoader = PLoader || Loader;
 
-    const loader = new InternalLoader(config);
+    const loader = new InternalLoader(config) as Loader<PlaylistLoaderContext>;
 
     context.loader = loader;
     this.loaders[context.type] = loader;

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -24,7 +24,7 @@ import {
   PlaylistLevelType,
   PlaylistLoaderContext
 } from '../types/loader';
-import { ManifestLoadingData, LevelLoadingData, AudioTrackLoadingData, SubtitleTrackLoadingData } from '../types/events';
+import { ManifestLoadingData, LevelLoadingData, TrackLoadingData } from '../types/events';
 import LevelDetails from './level-details';
 import Fragment from './fragment';
 import Hls from '../hls';
@@ -167,35 +167,38 @@ class PlaylistLoader {
   }
 
   private onLevelLoading (event: Events.LEVEL_LOADING, data: LevelLoadingData) {
-    const { id, level, url } = data;
+    const { id, level, url, deliveryDirectives } = data;
     this.load({
       id,
       level,
       responseType: 'text',
       type: PlaylistContextType.LEVEL,
-      url
+      url,
+      deliveryDirectives
     });
   }
 
-  private onAudioTrackLoading (event: Events.AUDIO_TRACK_LOADING, data: AudioTrackLoadingData) {
-    const { id, url } = data;
+  private onAudioTrackLoading (event: Events.AUDIO_TRACK_LOADING, data: TrackLoadingData) {
+    const { id, url, deliveryDirectives } = data;
     this.load({
       id,
       level: null,
       responseType: 'text',
       type: PlaylistContextType.AUDIO_TRACK,
-      url
+      url,
+      deliveryDirectives
     });
   }
 
-  private onSubtitleTrackLoading (event: Events.SUBTITLE_TRACK_LOADING, data: SubtitleTrackLoadingData) {
-    const { id, url } = data;
+  private onSubtitleTrackLoading (event: Events.SUBTITLE_TRACK_LOADING, data: TrackLoadingData) {
+    const { id, url, deliveryDirectives } = data;
     this.load({
       id,
       level: null,
       responseType: 'text',
       type: PlaylistContextType.SUBTITLE_TRACK,
-      url
+      url,
+      deliveryDirectives
     });
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,8 +1,8 @@
 import type Fragment from '../loader/fragment';
 import type LevelDetails from '../loader/level-details';
 import type { HlsUrlParameters, Level, LevelParsed } from './level';
-import type { MediaPlaylist } from './media-playlist';
-import type { LoaderStats, PlaylistLevelType } from './loader';
+import type { MediaPlaylist, MediaPlaylistType } from './media-playlist';
+import type { Loader, LoaderContext, LoaderResponse, LoaderStats, PlaylistLevelType, PlaylistLoaderContext } from './loader';
 import type { Track, TrackSet } from './track';
 import type { SourceBufferName } from './buffer';
 import type { ChunkMetadata } from './transmuxer';
@@ -10,6 +10,7 @@ import type LoadStats from '../loader/load-stats';
 import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type AttrList from '../utils/attr-list';
+import type { HlsListeners } from '../events';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement
@@ -74,6 +75,7 @@ export interface ManifestLoadedData {
 export interface ManifestParsedData {
   levels: Level[]
   audioTracks: MediaPlaylist[]
+  subtitleTracks: MediaPlaylist[]
   firstLevel: number
   stats: LoaderStats
   audio: boolean
@@ -86,7 +88,7 @@ export interface LevelSwitchingData extends Level {
 }
 
 export interface LevelSwitchedData {
-  level: any
+  level: number
 }
 
 export interface TrackLoadingData {
@@ -104,6 +106,7 @@ export interface TrackLoadedData {
   id: number
   networkDetails: any
   stats: LoaderStats
+  deliveryDirectives: HlsUrlParameters | null
 }
 
 export interface LevelLoadedData extends TrackLoadedData {
@@ -116,30 +119,25 @@ export interface LevelUpdatedData {
 }
 
 export interface LevelPTSUpdatedData {
-  details: any,
+  details: LevelDetails,
   level: Level,
   drift: number,
   type: string,
-  start: any,
-  end: any
+  start: number,
+  end: number
 }
 
 export interface AudioTrackSwitchingData {
-  url: any
-  type: any
-  id: any
+  url: string
+  type: MediaPlaylistType | 'main'
+  id: number
 }
 
 export interface AudioTrackSwitchedData {
-  id: any
+  id: number
 }
 
-export interface AudioTrackLoadedData {
-  details: LevelDetails;
-  id: number;
-  stats: LoaderStats;
-  networkDetails: unknown;
-}
+export interface AudioTrackLoadedData extends TrackLoadedData {}
 
 export interface AudioTracksUpdatedData {
   audioTracks: MediaPlaylist[]
@@ -153,12 +151,7 @@ export interface SubtitleTrackSwitchData {
   id: number
 }
 
-export interface SubtitleTrackLoadedData {
-  details: LevelDetails;
-  id: number | null;
-  stats: LoaderStats;
-  networkDetails: unknown;
-}
+export interface SubtitleTrackLoadedData extends TrackLoadedData {}
 
 export interface TrackSwitchedData {
   id: number
@@ -190,16 +183,17 @@ export interface ErrorData {
   fatal: boolean
   buffer?: number
   bytes?: number
-  context?: any
+  context?: PlaylistLoaderContext
   error?: Error
-  event?: any
+  event?: keyof HlsListeners | 'demuxerWorker'
   frag?: Fragment
-  level?: number
+  level?: number | undefined
   levelRetry?: boolean
+  loader?: Loader<LoaderContext>
   networkDetails?: any
   mimeType?: string
   reason?: string
-  response?: any
+  response?: LoaderResponse
   url?: string
   parent?: PlaylistLevelType
   err?: { // comes from transmuxer interface

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,15 +1,15 @@
-import Fragment from '../loader/fragment';
-import LevelDetails from '../loader/level-details';
-import { Level, LevelParsed } from './level';
-import { MediaPlaylist } from './media-playlist';
-import { LoaderStats, PlaylistLevelType } from './loader';
-import { Track, TrackSet } from './track';
-import { SourceBufferName } from './buffer';
-import { ChunkMetadata } from './transmuxer';
-import LoadStats from '../loader/load-stats';
-import { ErrorDetails, ErrorTypes } from '../errors';
-import { MetadataSample, UserdataSample } from './demuxer';
-import AttrList from '../utils/attr-list';
+import type Fragment from '../loader/fragment';
+import type LevelDetails from '../loader/level-details';
+import type { HlsUrlParameters, Level, LevelParsed } from './level';
+import type { MediaPlaylist } from './media-playlist';
+import type { LoaderStats, PlaylistLevelType } from './loader';
+import type { Track, TrackSet } from './track';
+import type { SourceBufferName } from './buffer';
+import type { ChunkMetadata } from './transmuxer';
+import type LoadStats from '../loader/load-stats';
+import type { ErrorDetails, ErrorTypes } from '../errors';
+import type { MetadataSample, UserdataSample } from './demuxer';
+import type AttrList from '../utils/attr-list';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement
@@ -92,6 +92,7 @@ export interface LevelSwitchedData {
 export interface TrackLoadingData {
   id: number
   url: string
+  deliveryDirectives: HlsUrlParameters | null
 }
 
 export interface LevelLoadingData extends TrackLoadingData {
@@ -133,11 +134,6 @@ export interface AudioTrackSwitchedData {
   id: any
 }
 
-export interface AudioTrackLoadingData {
-  url: string;
-  id: number | null;
-}
-
 export interface AudioTrackLoadedData {
   details: LevelDetails;
   id: number;
@@ -155,11 +151,6 @@ export interface SubtitleTracksUpdatedData {
 
 export interface SubtitleTrackSwitchData {
   id: number
-}
-
-export interface SubtitleTrackLoadingData {
-  url: string;
-  id: number | null;
 }
 
 export interface SubtitleTrackLoadedData {

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -37,6 +37,34 @@ export interface LevelAttributes extends AttrList {
   URI?: string
 }
 
+export class HlsUrlParameters {
+  msn: number;
+  part?: number;
+  skip?: boolean;
+
+  constructor (msn: number, part?: number, skip?: boolean) {
+    this.msn = msn;
+    this.part = part;
+    this.skip = skip;
+  }
+
+  addDirectives (uri: string): string | never {
+    const url: URL = new self.URL(uri);
+    const searchParams: URLSearchParams = url.searchParams;
+    searchParams.set('_HLS_msn', this.msn.toString());
+    if (this.part !== undefined) {
+      searchParams.set('_HLS_part', this.part.toString());
+    }
+    if (this.skip) {
+      // TODO: LL-HLS value is 'v2' when 'CAN-SKIP-DATERANGES=YES'
+      searchParams.set('_HLS_skip', 'YES');
+    }
+    searchParams.sort();
+    url.search = searchParams.toString();
+    return url.toString();
+  }
+}
+
 export class Level {
   public attrs: LevelAttributes;
   public audioCodec?: string;

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -158,5 +158,5 @@ export interface PlaylistLoaderContext extends LoaderContext {
   // internal representation of a parsed m3u8 level playlist
   levelDetails?: LevelDetails,
   // Blocking playlist request delivery directives (or null id none were added to playlist url
-  deliveryDirectives?: HlsUrlParameters | null
+  deliveryDirectives: HlsUrlParameters | null
 }

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -1,5 +1,6 @@
 import type Fragment from '../loader/fragment';
 import type LevelDetails from '../loader/level-details';
+import type { HlsUrlParameters } from './level';
 
 export interface LoaderContext {
   // target URL
@@ -154,6 +155,8 @@ export interface PlaylistLoaderContext extends LoaderContext {
   id: number | null
   // defines if the loader is handling a sidx request for the playlist
   isSidxRequest?: boolean
-  // internal reprsentation of a parsed m3u8 level playlist
-  levelDetails?: LevelDetails
+  // internal representation of a parsed m3u8 level playlist
+  levelDetails?: LevelDetails,
+  // Blocking playlist request delivery directives (or null id none were added to playlist url
+  deliveryDirectives?: HlsUrlParameters | null
 }

--- a/tests/unit/controller/audio-track-controller.js
+++ b/tests/unit/controller/audio-track-controller.js
@@ -205,6 +205,7 @@ describe('AudioTrackController', function () {
       audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
         level: 0
       });
+      audioTrackController.startLoad();
 
       expect(needsTrackLoading).to.have.been.calledOnce;
       expect(needsTrackLoading).to.have.been.calledWith(trackWithUrl);
@@ -232,6 +233,7 @@ describe('AudioTrackController', function () {
       audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
         level: 0
       });
+      audioTrackController.startLoad();
 
       expect(needsTrackLoading).to.have.been.calledOnce;
       expect(needsTrackLoading).to.have.been.calledWith(trackWithOutUrl);

--- a/tests/unit/controller/level-controller.js
+++ b/tests/unit/controller/level-controller.js
@@ -109,6 +109,7 @@ describe('LevelController', function () {
       expect(triggerSpy).to.have.been.calledWith(Events.MANIFEST_PARSED, {
         levels: data.levels.map(levelParsed => new Level(levelParsed)),
         audioTracks: [],
+        subtitleTracks: [],
         firstLevel: 0,
         stats: {},
         audio: false,
@@ -135,6 +136,7 @@ describe('LevelController', function () {
       expect(triggerSpy).to.have.been.calledWith(Events.MANIFEST_PARSED, {
         levels: data.levels.map(levelParsed => new Level(levelParsed)),
         audioTracks: data.audioTracks,
+        subtitleTracks: [],
         firstLevel: 0,
         stats: {},
         audio: false,
@@ -167,6 +169,7 @@ describe('LevelController', function () {
       expect(triggerSpy).to.have.been.calledWith(Events.MANIFEST_PARSED, {
         levels: data.levels.map(levelParsed => new Level(levelParsed)),
         audioTracks: data.audioTracks,
+        subtitleTracks: [],
         firstLevel: 0,
         stats: {},
         audio: true,
@@ -199,6 +202,7 @@ describe('LevelController', function () {
       expect(triggerSpy).to.have.been.calledWith(Events.MANIFEST_PARSED, {
         levels: data.levels.map(levelParsed => new Level(levelParsed)),
         audioTracks: data.audioTracks,
+        subtitleTracks: [],
         firstLevel: 0,
         stats: {},
         audio: true,

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -111,7 +111,11 @@ describe('SubtitleTrackController', function () {
       subtitleTrackController.subtitleTrack = 1;
 
       expect(triggerSpy).to.have.been.calledTwice;
-      expect(triggerSpy.secondCall).to.have.been.calledWith('hlsSubtitleTrackLoading', { url: 'bar', id: 1 });
+      expect(triggerSpy.secondCall).to.have.been.calledWith('hlsSubtitleTrackLoading', {
+        url: 'bar',
+        id: 1,
+        deliveryDirectives: null
+      });
     });
 
     it('should not trigger SUBTITLE_TRACK_LOADING if the track has details and is not live', function () {
@@ -138,7 +142,11 @@ describe('SubtitleTrackController', function () {
       subtitleTrackController.subtitleTrack = 2;
 
       expect(triggerSpy).to.have.been.calledTwice;
-      expect(triggerSpy.secondCall).to.have.been.calledWith('hlsSubtitleTrackLoading', { url: 'foo', id: 2 });
+      expect(triggerSpy.secondCall).to.have.been.calledWith('hlsSubtitleTrackLoading', {
+        url: 'foo',
+        id: 2,
+        deliveryDirectives: null
+      });
     });
 
     it('should do nothing if called with out of bound indices', function () {

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -32,12 +32,6 @@ describe('SubtitleTrackController', function () {
     sandbox.restore();
   });
 
-  describe('constructor', function () {
-    it('defaults stopped to true', function () {
-      expect(subtitleTrackController.stopped).to.be.true;
-    });
-  });
-
   describe('onTextTrackChanged', function () {
     it('should set subtitleTrack to -1 if disabled', function () {
       expect(subtitleTrackController.subtitleTrack).to.equal(-1);
@@ -96,7 +90,7 @@ describe('SubtitleTrackController', function () {
 
     it('should trigger SUBTITLE_TRACK_SWITCH', function () {
       const triggerSpy = sandbox.spy(subtitleTrackController.hls, 'trigger');
-      subtitleTrackController.stopped = false;
+      subtitleTrackController.canLoad = true;
       subtitleTrackController.trackId = 0;
       subtitleTrackController.subtitleTrack = 1;
 
@@ -106,7 +100,7 @@ describe('SubtitleTrackController', function () {
 
     it('should trigger SUBTITLE_TRACK_LOADING if the track has no details', function () {
       const triggerSpy = sandbox.spy(subtitleTrackController.hls, 'trigger');
-      subtitleTrackController.stopped = false;
+      subtitleTrackController.canLoad = true;
       subtitleTrackController.trackId = 0;
       subtitleTrackController.subtitleTrack = 1;
 
@@ -137,7 +131,7 @@ describe('SubtitleTrackController', function () {
 
     it('should trigger SUBTITLE_TRACK_LOADING if the track is live, even if it has details', function () {
       const triggerSpy = sandbox.spy(subtitleTrackController.hls, 'trigger');
-      subtitleTrackController.stopped = false;
+      subtitleTrackController.canLoad = true;
       subtitleTrackController.trackId = 0;
       subtitleTrackController.subtitleTrack = 2;
 
@@ -150,7 +144,7 @@ describe('SubtitleTrackController', function () {
     });
 
     it('should do nothing if called with out of bound indices', function () {
-      const clearReloadSpy = sandbox.spy(subtitleTrackController, '_clearReloadTimer');
+      const clearReloadSpy = sandbox.spy(subtitleTrackController, 'clearTimer');
       subtitleTrackController.subtitleTrack = 5;
       subtitleTrackController.subtitleTrack = -2;
 
@@ -187,38 +181,37 @@ describe('SubtitleTrackController', function () {
 
     describe('onSubtitleTrackLoaded', function () {
       it('exits early if the loaded track does not match the requested track', function () {
-        const tracks = subtitleTrackController.tracks;
-        const clearReloadSpy = sandbox.spy(subtitleTrackController, '_clearReloadTimer');
+        const playlistLoadedSpy = sandbox.spy(subtitleTrackController, 'playlistLoaded');
+        subtitleTrackController.canLoad = true;
         subtitleTrackController.trackId = 1;
 
         const mockLoadedEvent = { id: 999, details: { foo: 'bar' } };
         subtitleTrackController.onSubtitleTrackLoaded(Events.SUBTITLE_TRACK_LOADED, mockLoadedEvent);
-        expect(subtitleTrackController.timer).to.not.exist;
-        expect(clearReloadSpy).to.have.been.calledOnce;
+        expect(subtitleTrackController.timer).to.equal(-1);
+        expect(playlistLoadedSpy).to.have.not.been.called;
 
         mockLoadedEvent.id = 0;
         subtitleTrackController.onSubtitleTrackLoaded(Events.SUBTITLE_TRACK_LOADED, mockLoadedEvent);
-        expect(subtitleTrackController.timer).to.not.exist;
-        expect(clearReloadSpy).to.have.been.calledTwice;
+        expect(subtitleTrackController.timer).to.equal(-1);
+        expect(playlistLoadedSpy).to.have.not.been.called;
 
         mockLoadedEvent.id = 1;
         subtitleTrackController.onSubtitleTrackLoaded(Events.SUBTITLE_TRACK_LOADED, mockLoadedEvent);
-        tracks[1] = null;
-        expect(subtitleTrackController.timer).to.not.exist;
-        expect(clearReloadSpy).to.have.been.calledThrice;
+        expect(subtitleTrackController.timer).to.equal(-1);
+        expect(playlistLoadedSpy).to.have.been.calledOnce;
       });
 
-      it('does not set the reload timer if the stopped flag is set', function () {
+      it('does not set the reload timer if the canLoad flag is set to false', function () {
         const details = new LevelDetails('');
-        subtitleTrackController.stopped = true;
+        subtitleTrackController.canLoad = false;
         subtitleTrackController.trackId = 1;
         subtitleTrackController.onSubtitleTrackLoaded(Events.SUBTITLE_TRACK_LOADED, { id: 1, details, stats: new LoadStats() });
-        expect(subtitleTrackController.timer).to.not.exist;
+        expect(subtitleTrackController.timer).to.equal(-1);
       });
 
       it('sets the live reload timer if the level is live', function () {
         const details = new LevelDetails('');
-        subtitleTrackController.stopped = false;
+        subtitleTrackController.canLoad = true;
         subtitleTrackController.trackId = 1;
         subtitleTrackController.onSubtitleTrackLoaded(Events.SUBTITLE_TRACK_LOADED, { id: 1, details, stats: new LoadStats() });
         expect(subtitleTrackController.timer).to.exist;
@@ -230,24 +223,24 @@ describe('SubtitleTrackController', function () {
         subtitleTrackController.trackId = 1;
         subtitleTrackController.timer = self.setTimeout(() => {}, 0);
         subtitleTrackController.onSubtitleTrackLoaded(Events.SUBTITLE_TRACK_LOADED, { id: 1, details, stats: new LoadStats() });
-        expect(subtitleTrackController.timer).to.not.exist;
+        expect(subtitleTrackController.timer).to.equal(-1);
       });
     });
 
     describe('stopLoad', function () {
       it('stops loading', function () {
-        const clearReloadSpy = sandbox.spy(subtitleTrackController, '_clearReloadTimer');
+        const clearReloadSpy = sandbox.spy(subtitleTrackController, 'clearTimer');
         subtitleTrackController.stopLoad();
-        expect(subtitleTrackController.stopped).to.be.true;
+        expect(subtitleTrackController.canLoad).to.be.false;
         expect(clearReloadSpy).to.have.been.calledOnce;
       });
     });
 
     describe('startLoad', function () {
-      it('stops loading', function () {
-        const loadCurrentTrackSpy = sandbox.spy(subtitleTrackController, '_loadCurrentTrack');
+      it('starts loading', function () {
+        const loadCurrentTrackSpy = sandbox.spy(subtitleTrackController, 'loadPlaylist');
         subtitleTrackController.startLoad();
-        expect(subtitleTrackController.stopped).to.be.false;
+        expect(subtitleTrackController.canLoad).to.be.true;
         expect(loadCurrentTrackSpy).to.have.been.calledOnce;
       });
     });


### PR DESCRIPTION
### This PR will...
Adds support for Low-latency HLS Playlist Request Query Parameters (Delivery Directives). 

[6.2.5.  Delivery Directives Interface](https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-07#section-6.2.5)
> A server MAY provide a set of services to its clients by implementing support for Delivery Directives.  Delivery Directives are transmitted by the Client to the Server as Query Parameters in Playlist request URIs.
Servers advertise the availability of Delivery Directives using the EXT-X-SERVER-CONTROL tag (Section 4.4.3.8).
Currently-defined Delivery Directives are _HLS_skip, _HLS_msn and _HLS_part.

These changes introduce a `BasePlaylistController` class that acts as the base class for `LevelController`, `AudioTrackController` and `SubtitleTrackController`. It implements live playlist reload logic and timing, as well as use of delivery directives when signaled by the EXT-X-SERVER-CONTROL tag and attributes.
 
This PR builds on top of #2865 (LL-HLS manifest parsing).

### Why is this Pull Request needed?

[LL-HLS support](https://github.com/video-dev/hls.js/projects/7#card-41231116)

### Are there any points in the code the reviewer needs to double check?

The next PR in the series is [Low-Latency HLS Part Loading](https://github.com/video-dev/hls.js/pull/2977)

### Checklist

- [ ] changes have been done against ~master~ feature/ll-lhls-parse-server-control branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
