### PR TITLE
Check combined buffer before start seek

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1293,12 +1293,12 @@ class StreamController extends BaseStreamController {
   _checkBuffer () {
     const { media } = this;
     if (!media || media.readyState === 0) {
-      // Exit early if we don't have media or if the media hasn't bufferd anything yet (readyState 0)
+      // Exit early if we don't have media or if the media hasn't buffered anything yet (readyState 0)
       return;
     }
 
-    const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
-    const buffered = mediaBuffer.buffered;
+    // Check combined buffer
+    const buffered = media.buffered;
 
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;


### PR DESCRIPTION
### This PR will...
Use the combined buffer in gap controller and to signal when to seek to start position

### Why is this Pull Request needed?
So that when we seek to the start position we can adjust for any difference between the start of audio and video buffers that offsets the combined buffer.

### Other considerations
This will prevent stalls, but may cause the audio-stream-controller to load segments based on currentTime 0 after loading it's start segment, but before this check results in `_seekToStartPos()` being called. The problem is that each stream controller has its own rules for setting its `loadedmetadata` flag which determines if the search for the next fragment to be loaded should start from `currentTime` or `nextLoadPosition`.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
