### PR TITLE
Chrome 74 and lower mp4-remuxer fix

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -15,12 +15,18 @@ import { logger } from '../utils/logger';
 const MAX_SILENT_FRAME_DURATION_90KHZ = toMpegTsClockFromTimescale(10);
 const PTS_DTS_SHIFT_TOLERANCE_90KHZ = toMpegTsClockFromTimescale(0.2);
 
+let chromeVersion = null;
+
 class MP4Remuxer {
   constructor (observer, config, typeSupported, vendor) {
     this.observer = observer;
     this.config = config;
     this.typeSupported = typeSupported;
     this.ISGenerated = false;
+    if (chromeVersion === null) {
+      const result = navigator.userAgent.match(/Chrome\/(\d+)/i);
+      chromeVersion = result ? parseInt(result[1]) : 0;
+    }
   }
 
   destroy () {
@@ -308,6 +314,9 @@ class MP4Remuxer {
       }
     }
 
+    if (chromeVersion && chromeVersion < 75) {
+      firstDTS = Math.max(0, firstDTS);
+    }
     let nbNalu = 0;
     let naluLen = 0;
     for (let i = 0; i < nbSamples; i++) {


### PR DESCRIPTION
### This PR will...
Fix mp4-remuxer `CHUNK_DEMUXER_ERROR_APPEND_FAILED` in Chrome 74 and lower, as well as Chromium based browsers like Opera 58.

### Why is this Pull Request needed?

Older versions of Chrome error when appending mp4 fragments with negative base decode times. Using these values works in other browsers and allows us to append video as close to `0` and the first audio sample as possible, reducing start gaps at the beginning of video with large composition times (pts-dts delta).

> The video playback was aborted due to a corruption problem or because the video used features your browser did not support - CHUNK_DEMUXER_ERROR_APPEND_FAILED: video frame with PTS 40000us has negative DTS -40000us after applying timestampOffset, handling any discontinuity, and filtering against append window

Negative DTS were allows in v0.14.4 which introduced improved stability for Safari without AVC sample workarounds for that user agent, and prevents AVC samples from being shifted around when they shouldn't be. While a broad number of browsers were tested, older Chrome was missed. Also this issue only affects streams with large composition times for the first frame not matched with corresponding audio.

### Checklist

- [x] changes have been done against patch branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
