### PR TITLE
Fix ID3 WXXX URL parsing

### DIFF
--- a/src/demux/id3.js
+++ b/src/demux/id3.js
@@ -270,7 +270,7 @@ class ID3 {
       }
 
       let index = 1;
-      const description = ID3._utf8ArrayToStr(frame.data.subarray(index));
+      const description = ID3._utf8ArrayToStr(frame.data.subarray(index), true);
 
       index += description.length + 1;
       const value = ID3._utf8ArrayToStr(frame.data.subarray(index));


### PR DESCRIPTION
### This PR will...
Merge changes from v0.14.x into master

### Why is this Pull Request needed?
Includes a fix for ID3 parsing, splitting `WXXX` info and value on NULL delimiter to extract URL.

As a result TextTrack metadata cues added by hls.js for these ID3 tags should match those added by Safari using the same stream with video.src=m3u8 playback.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
