### PR TITLE
Fix resuming of live streams after calling stopLoad() and startLoad()

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -50,10 +50,6 @@ export default class LevelController extends EventHandler {
     if (levels) {
       levels.forEach(level => {
         level.loadError = 0;
-        const levelDetails = level.details;
-        if (levelDetails && levelDetails.live) {
-          level.details = undefined;
-        }
       });
     }
     // speed up live playlist refresh if timer exists

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -792,7 +792,7 @@ class StreamController extends BaseStreamController {
         this.liveSyncPosition = this.computeLivePosition(sliding, curDetails);
         if (newDetails.PTSKnown && Number.isFinite(sliding)) {
           logger.log(`live playlist sliding:${sliding.toFixed(3)}`);
-        } else {
+        } else if (!sliding) {
           logger.log('live playlist - outdated PTS, unknown sliding');
           alignStream(this.fragPrevious, lastLevel, newDetails);
         }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1297,8 +1297,8 @@ class StreamController extends BaseStreamController {
       return;
     }
 
-    // Check combined buffer
-    const buffered = media.buffered;
+    const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
+    const buffered = mediaBuffer.buffered;
 
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -114,7 +114,7 @@ class SubtitleTrackController extends EventHandler {
     }
 
     logger.log(`subtitle track ${id} loaded`);
-    if (details.live) {
+    if (details.live && !this.stopped) {
       const reloadInterval = computeReloadInterval(currentTrack.details, details, data.stats.trequest);
       logger.log(`Reloading live subtitle playlist in ${reloadInterval}ms`);
       this.timer = setTimeout(() => {
@@ -163,7 +163,7 @@ class SubtitleTrackController extends EventHandler {
   _loadCurrentTrack () {
     const { trackId, tracks, hls } = this;
     const currentTrack = tracks[trackId];
-    if (trackId < 0 || !currentTrack || (currentTrack.details && !currentTrack.details.live)) {
+    if (this.stopped || trackId < 0 || !currentTrack || (currentTrack.details && !currentTrack.details.live)) {
       return;
     }
     logger.log(`Loading subtitle track ${trackId}`);

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -91,6 +91,7 @@ describe('SubtitleTrackController', function () {
 
     it('should trigger SUBTITLE_TRACK_SWITCH', function () {
       const triggerSpy = sandbox.spy(subtitleTrackController.hls, 'trigger');
+      subtitleTrackController.stopped = false;
       subtitleTrackController.trackId = 0;
       subtitleTrackController.subtitleTrack = 1;
 
@@ -100,6 +101,7 @@ describe('SubtitleTrackController', function () {
 
     it('should trigger SUBTITLE_TRACK_LOADING if the track has no details', function () {
       const triggerSpy = sandbox.spy(subtitleTrackController.hls, 'trigger');
+      subtitleTrackController.stopped = false;
       subtitleTrackController.trackId = 0;
       subtitleTrackController.subtitleTrack = 1;
 
@@ -126,6 +128,7 @@ describe('SubtitleTrackController', function () {
 
     it('should trigger SUBTITLE_TRACK_LOADING if the track is live, even if it has details', function () {
       const triggerSpy = sandbox.spy(subtitleTrackController.hls, 'trigger');
+      subtitleTrackController.stopped = false;
       subtitleTrackController.trackId = 0;
       subtitleTrackController.subtitleTrack = 2;
 


### PR DESCRIPTION
### This PR will...
- Fix resuming of live streams after calling `stopLoad()` and `startLoad()`
- Stop loading subtitle track playlists after `stopLoad()`  is called
- Do not adjust for live playlist sliding twice
- Reverse 6a3f6a8 which requires audio, subtitle and main stream controllers to use the same startPosition logic

### Why is this Pull Request needed?
We should be able to resume live stream loading after stopping it.
All live playlist reloading should stop after `stopLoad()`  is called.

### Resolves issues:
#2994

### Known issues
Audio tracks continue to load after `stopLoad()` is called because the implementation was changes to a taskLoop. This is fixed in feature/v1.0.0 and will not be addressed here.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
