### PR TITLE
Fix remuxing of AVC with bad PTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ sudo: required
 # don't connect to sauce labs unless running functional tests
 before_install: if [ "${TRAVIS_MODE}" != "funcTests" ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 script: ./scripts/travis.sh
-after_script: if [ "${TRAVIS_MODE}" = "funcTests" ]; then echo -n "travis_fold:start:sauce_logs\nSauce connect log:\n" && cat /home/travis/sauce-connect.log && echo -n "\ntravis_fold:end:sauce_logs\n"; fi
-env:
-  global:
-    - SAUCE_USERNAME=mangui
 stages:
   - buildAndTest
   - releaseAlpha
@@ -52,25 +48,18 @@ jobs:
       env:   TRAVIS_MODE=funcTests UA=chrome              OS="Windows 10"
     # Optional Func tests
     - stage: testFuncOptional
+      env:   TRAVIS_MODE=funcTests UA=safari              OS="OS X 10.15"
+    - stage: testFuncOptional
       env:   TRAVIS_MODE=funcTests UA=firefox             OS="Windows 10"
     - stage: testFuncOptional
-      env:   TRAVIS_MODE=funcTests UA=chrome              OS="Windows 7"
-    - stage: testFuncOptional
-      env:   TRAVIS_MODE=funcTests UA=firefox             OS="Windows 7"
+      env:   TRAVIS_MODE=funcTests UA=chrome              OS="OS X 10.11"  UA_VERSION="79.0"
     # - stage: testFuncOptional
     #  env:   TRAVIS_MODE=funcTests UA=MicrosoftEdge       OS="Windows 10"
     - stage: testFuncOptional
-      env:   TRAVIS_MODE=funcTests UA="internet explorer" OS="Windows 8.1"  UA_VERSION="11.0"
-    - stage: testFuncOptional
       env:   TRAVIS_MODE=funcTests UA="internet explorer" OS="Windows 10"
     - stage: testFuncOptional
-      env:   TRAVIS_MODE=funcTests UA=chrome              OS="OS X 10.11"
-    # - stage: testFuncOptional
-    #  env:   TRAVIS_MODE=funcTests UA=firefox     OS="OS X 10.11"
+      env:   TRAVIS_MODE=funcTests UA="internet explorer" OS="Windows 8.1" UA_VERSION="11.0"
     - stage: testFuncOptional
-      env:   TRAVIS_MODE=funcTests UA=safari              OS="OS X 10.12" UA_VERSION="10.1"
-addons:
-  sauce_connect:
-    tunnel_domains: localhost
-  jwt:
-    secure: TxJT041jqRf4raCwtNJRb0rz2gGvEaADZjWO41UQND2+YIZ//S9qB2C4YyrL1BBsn8/ebdHr0cd18PwCzoBSEmoCdoAWXmqBaaLvM1DOeQkKJbU3+pFmWtv1qGqRXJLEAysNvzhG0sLdvBc0M7a/CWxqRfx1O3lGhLnTlAW33LlQndjJ8vh3SGQm8HxFR1503ujPd7V1jGwduVwaQp4zbAKTnQ4MLugmJf6UKiTc+YILMrVWOwipOIyYHh2GqbChd/v1PXff26XCNJXcaRZKJ8JosWyBpq5t4zlPO0qDfHpqbEuYK44xm4vzbZS94P/KF8BYzdtxQYLrxoS1UlnUYU7RmzqgL3y3AM7nzX/cXvJcoNXfUK2BpsB754XNyQfRmXOdRiHoC8+wwPqGkH/KCrmS4UIOqv4THfmDbrtewfcDTgKOzHxGcT1IsUq9BTxMNtxSwpHTHUXTXrzpS/UBDvrlc+9qPTqf+e6QL1aG+JT5sOg5REm2hMy0j18/Kr+HLXkehxEgJ6JrybyHUkkJrfcuWgVDu7Lv3cxlrtSMXi7TIwSB75NMoM8AE71GEVjXwpOw/0giwnmGsJNNi01ztod0UFe2V2rS+yPI1WNZIJ7Fw66U0oOKJ1rb4Iksl86n5Y2snHsxK8q5jhKaAaiWgGK5kVTAgF89t/GXYyNH6cI=
+      env:   TRAVIS_MODE=funcTests UA=chrome              OS="Windows 7"   UA_VERSION="69.0"
+    - stage: testFuncOptional
+      env:   TRAVIS_MODE=funcTests UA=safari              OS="OS X 10.12"  UA_VERSION="10.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6477,6 +6477,12 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
+    "adm-zip": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "dev": true
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -19532,6 +19538,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sauce-connect-launcher": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
+      "integrity": "sha512-wf0coUlidJ7rmeClgVVBh6Kw55/yalZCY/Un5RgjSnTXRAeGqagnTsTYpZaqC4dCtrY4myuYpOAZXCdbO7lHfQ==",
+      "dev": true,
+      "requires": {
+        "adm-zip": "~0.4.3",
+        "async": "^2.1.2",
+        "https-proxy-agent": "^5.0.0",
+        "lodash": "^4.16.6",
+        "rimraf": "^2.5.4"
+      }
     },
     "sax": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:unit": "karma start karma.conf.js",
     "test:unit:watch": "karma start karma.conf.js --auto-watch --no-single-run",
     "test:func": "BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
+    "test:func:sauce": "SAUCE=1 UA=MicrosoftEdge OS='Windows 10' BABEL_ENV=development mocha tests/functional/auto/setup.js --timeout 40000 --exit",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch"
   },
@@ -95,6 +96,7 @@
     "karma-webpack": "^4.0.2",
     "mocha": "^8.0.1",
     "netlify-cli": "^2.36.0",
+    "sauce-connect-launcher": "^1.3.2",
     "selenium-webdriver": "^3.1.0",
     "semver": "^7.3.2",
     "sinon": "^9.0.1",

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -23,7 +23,7 @@ if [ "${TRAVIS_MODE}" = "build" ]; then
 elif [ "${TRAVIS_MODE}" = "unitTests" ]; then
   npm run test:unit
 elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
-  npm run build
+  npm run build:ci
   n=0
   maxRetries=1
   until [ $n -ge ${maxRetries} ]

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -1,14 +1,15 @@
 /* eslint-disable no-console */
 
+const sauceConnectLauncher = require('sauce-connect-launcher');
 const webdriver = require('selenium-webdriver');
 const By = webdriver.By;
 const until = webdriver.until;
 // requiring this automatically adds the chromedriver binary to the PATH
-// eslint-disable-next-line
-const chromedriver = require('chromedriver');
+require('chromedriver');
 const HttpServer = require('http-server');
 const streams = require('../../test-streams');
 const onTravis = !!process.env.TRAVIS;
+const useSauce = !!process.env.SAUCE || onTravis;
 const chai = require('chai');
 const expect = chai.expect;
 
@@ -25,7 +26,7 @@ let stream;
 let printDebugLogs = false;
 
 // Setup browser config data from env vars
-if (onTravis) {
+if (useSauce) {
   let UA = process.env.UA;
   if (!UA) {
     throw new Error('No test browser name.');
@@ -47,15 +48,15 @@ if (onTravis) {
 
 let browserDescription = browserConfig.name;
 
-if (browserConfig.version) {
-  browserDescription += ` (${browserConfig.version})`;
+if (browserConfig.version && browserConfig.version !== 'latest') {
+  browserDescription += ` ${browserConfig.version}`;
 }
 
 if (browserConfig.platform) {
   browserDescription += `, ${browserConfig.platform}`;
 }
 
-let hostname = onTravis ? 'localhost' : '127.0.0.1';
+let hostname = useSauce ? 'localhost' : '127.0.0.1';
 
 // Launch static server
 HttpServer.createServer({
@@ -278,6 +279,36 @@ async function testSeekBackToStart (url, config) {
   expect(result, stringifyResult(result)).to.have.property('playing').which.is.true;
 }
 
+let sauceConnectProcess;
+async function sauceConnect (tunnelIdentifier) {
+  return new Promise(function (resolve, reject) {
+    console.log(`Running sauce-connect-launcher. Tunnel id: ${tunnelIdentifier}`);
+    sauceConnectLauncher({
+      tunnelIdentifier
+    }, function (err, sauceConnectProcess) {
+      if (err) {
+        console.error(err.message);
+        reject(err);
+        return;
+      }
+      console.log('Sauce Connect ready');
+      resolve(sauceConnectProcess);
+    });
+  });
+}
+
+async function sauceDisconnect () {
+  return new Promise(function (resolve) {
+    if (!sauceConnectProcess) {
+      resolve();
+    }
+    sauceConnectProcess.close(function () {
+      console.log('Closed Sauce Connect process');
+      resolve();
+    });
+  });
+}
+
 describe(`testing hls.js playback in the browser on "${browserDescription}"`, function () {
   before(async function () {
     // high timeout because sometimes getSession() takes a while
@@ -286,8 +317,9 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
       throw new Error('Stream not defined');
     }
 
+    const labelBranch = process.env.TRAVIS_BRANCH || 'unknown';
     let capabilities = {
-      name: `"${stream.description}" on "${browserDescription}"`,
+      name: `hls.js@${labelBranch} on "${browserDescription}"`,
       browserName: browserConfig.name,
       platform: browserConfig.platform,
       version: browserConfig.version,
@@ -307,10 +339,16 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
     if (onTravis) {
       capabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;
       capabilities.build = 'HLSJS-' + process.env.TRAVIS_BUILD_NUMBER;
+    } else if (useSauce) {
+      capabilities['tunnel-identifier'] = `local-${Date.now()}`;
+    }
+    if (useSauce) {
+      sauceConnectProcess = await sauceConnect(capabilities['tunnel-identifier']);
       capabilities.username = process.env.SAUCE_USERNAME;
       capabilities.accessKey = process.env.SAUCE_ACCESS_KEY;
       capabilities.avoidProxy = true;
-      browser = browser.usingServer(`http://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@ondemand.saucelabs.com:80/wd/hub`);
+      capabilities['record-screenshots'] = 'false';
+      browser = browser.usingServer(`https://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@ondemand.us-west-1.saucelabs.com:443/wd/hub`);
     }
 
     browser = browser.withCapabilities(capabilities).build();
@@ -325,13 +363,14 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
           browser.getSession()
         ]);
         console.log(`Retrieved session in ${Date.now() - start}ms`);
-        if (onTravis) {
+        if (useSauce) {
           console.log(`Job URL: https://saucelabs.com/jobs/${session.getId()}`);
         } else {
           console.log(`WebDriver SessionID: ${session.getId()}`);
         }
       });
     } catch (err) {
+      await sauceDisconnect();
       throw new Error(`failed setting up session: ${err}`);
     }
   });
@@ -371,16 +410,29 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
   });
 
   afterEach(async function () {
-    if (printDebugLogs || this.currentTest.isFailed()) {
+    const failed = this.currentTest.isFailed();
+    if (printDebugLogs || failed) {
       const logString = await browser.executeScript('return logString');
       console.log(`${onTravis ? 'travis_fold:start:debug_logs' : ''}\n${logString}\n${onTravis ? 'travis_fold:end:debug_logs' : ''}`);
+      if (failed && useSauce) {
+        browser.executeScript('sauce:job-result=failed');
+      }
     }
   });
 
   after(async function () {
+    if (useSauce && this.currentTest && this.currentTest.parent) {
+      const tests = this.currentTest.parent.tests;
+      if (tests && tests.length && tests.every(test => test.isPassed())) {
+        browser.executeScript('sauce:job-result=passed');
+      }
+    }
     console.log('Quitting browser...');
     await browser.quit();
     console.log('Browser quit.');
+    if (useSauce) {
+      await sauceDisconnect();
+    }
   });
 
   for (let name in streams) {


### PR DESCRIPTION
### This PR will...

Fix handling of AVC sample where sample contain PTS that is less than DTS and the PTS does not always increase like the DTS:

```js
0: {key: true, pts: 0, dts: 0, units: Array(4), debug: "", …}
1: {key: false, pts: 12003, dts: 3003, units: Array(1), debug: "", …}
2: {key: false, pts: 6006, dts: 6006, units: Array(1), debug: "", …}
3: {key: false, pts: 2979, dts: 9009, units: Array(1), debug: "", …} // PTS < DTS and < previous PTS
4: {key: false, pts: 9042, dts: 12012, units: Array(1), debug: "", …} // PTS < DTS
5: {key: false, pts: 24015, dts: 15015, units: Array(1), debug: "", …}
6: {key: false, pts: 18018, dts: 18018, units: Array(1), debug: "", …}
7: {key: false, pts: 14991, dts: 21021, units: Array(1), debug: "", …} // PTS < DTS and < previous PTS
8: {key: false, pts: 21054, dts: 24024, units: Array(1), debug: "", …} // PTS < DTS
9: {key: false, pts: 36027, dts: 27027, units: Array(1), debug: "", …}
10: {key: false, pts: 30030, dts: 30030, units: Array(1), debug: "", …}
11: {key: false, pts: 27003, dts: 33033, units: Array(1), debug: "", …} // PTS < DTS and < previous PTS
```

### Why is this Pull Request needed?

The current workaround will set DTS to an offset of PTS if the largest "PTS < DTS" discrepancy exceeds two average sample durations. This is a problem when PTS is not always increasing, since it results in out-of-order DTS in our samples.

The second method of adjusting all DTS evenly does not work in Safari with such a large offset which is why we have methods of adjusting timestamps. These changes just ensure that we maintain increasing DTS values with PTS that is never less than DTS with minimal impact to CTS (the difference between PTS and DTS).