### PR TITLE
Low-Latency HLS Delta Playlist support

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -1,6 +1,6 @@
 import Hls from '../hls';
 import { NetworkComponentAPI } from '../types/component-api';
-import { HlsUrlParameters } from '../types/level';
+import { getSkipValue, HlsUrlParameters } from '../types/level';
 import { computeReloadInterval } from './level-helper';
 import { logger } from '../utils/logger';
 import type LevelDetails from '../loader/level-details';
@@ -81,8 +81,7 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           }
           details.tuneInGoal = currentGoal;
         }
-        // TODO: LL-HLS enable skip parameter for delta playlists independent of canBlockReload
-        const skip = false;
+        const skip = getSkipValue(details);
         this.loadPlaylist(new HlsUrlParameters(msn, part, skip));
         return;
       }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -532,7 +532,7 @@ export default class BaseStreamController extends TaskLoop {
     const lastLevel: Level | null = (levelLastLoaded !== null) ? levels![levelLastLoaded] : null;
 
     let sliding = 0;
-    if (oldDetails?.PTSKnown && newDetails.fragments.length > 0) {
+    if (oldDetails && newDetails.fragments.length > 0) {
       // we already have details for that level, merge them
       LevelHelper.mergeDetails(oldDetails, newDetails);
       // Update fragmentLoader if it's loading fragment parts

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -29,6 +29,8 @@ export default class LevelDetails {
   public canBlockReload: boolean = false;
   public canSkipUntil: number = 0;
   public canSkipDateRanges: boolean = false;
+  public skippedSegments?: number;
+  public recentlyRemovedDateranges?: string[];
   public partHoldBack: number = 0;
   public holdBack: number = 0;
   public partTarget: number = 0;

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -37,12 +37,29 @@ export interface LevelAttributes extends AttrList {
   URI?: string
 }
 
+enum HlsSkip {
+  No = '',
+  Yes = 'YES',
+  v2 = 'v2'
+}
+
+export function getSkipValue (details: LevelDetails): HlsSkip {
+  const { canSkipUntil, canSkipDateRanges } = details;
+  if (canSkipUntil) {
+    if (canSkipDateRanges) {
+      return HlsSkip.v2;
+    }
+    return HlsSkip.Yes;
+  }
+  return HlsSkip.No;
+}
+
 export class HlsUrlParameters {
   msn: number;
   part?: number;
-  skip?: boolean;
+  skip?: HlsSkip;
 
-  constructor (msn: number, part?: number, skip?: boolean) {
+  constructor (msn: number, part?: number, skip?: HlsSkip) {
     this.msn = msn;
     this.part = part;
     this.skip = skip;
@@ -56,8 +73,7 @@ export class HlsUrlParameters {
       searchParams.set('_HLS_part', this.part.toString());
     }
     if (this.skip) {
-      // TODO: When 'CAN-SKIP-DATERANGES=YES' then use _HLS_skip=v2 https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-07#section-6.3.7
-      searchParams.set('_HLS_skip', 'YES');
+      searchParams.set('_HLS_skip', this.skip);
     }
     searchParams.sort();
     url.search = searchParams.toString();

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -202,6 +202,14 @@ module.exports = {
     // abr: true,
     startSeek: true
   },
+  AppleLowLatencyHls: {
+    url: 'https://ll-hls-test.apple.com/master.m3u8',
+    description: 'Apple Low-Latency HLS sample (TS segments)'
+  },
+  AppleLowLatencyCmafHls: {
+    url: 'https://ll-hls-test.apple.com/cmaf/master.m3u8',
+    description: 'Apple Low-Latency HLS sample (fMP4 segments)'
+  },
   AppleLowLatencyHlsHoldBack: {
     url: 'https://playertest.longtailvideo.com/adaptive/low-latency-hls/archived/hold-back-8s.m3u8',
     description: 'Apple Low-Latency HLS archived sample. No blocking, no delta, PART-HOLD-BACK=2.004,HOLD-BACK=8, Safari MediaError 4',


### PR DESCRIPTION
### This PR will...
Adds support for requesting and parsing LL-HLS delta playlists - with and without skipped dateranges.

### Why is this Pull Request needed?
Playlist requests for Low Latency HLS streams should be made with delta updates to reduce response size and allow for faster roundtrip playlist updates.

### Are there any points in the code the reviewer needs to double check?
I'm not actively removing skipped dateranges. The m3u8 parser associates DATERANGE tags with fragments, so when skipped, we recover them from previously parsed segments. If not skipped, we might end up associating tags with with the first non-skipped segment. This is incorrect. hls.js does not keep a map of DATERANGE tags by id or create VTTCues for the tags (yet). 

TODO: Add tests to both the m3u8 parser and to stream controllers / level utils for merging live playlists.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
