### PR TITLE
Bugfix for subtitle loading after hls.stopload() was used

### DIFF
--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -40,6 +40,10 @@ export class SubtitleStreamController extends BaseStreamController {
     this._onMediaSeeking = this.onMediaSeeking.bind(this);
   }
 
+  startLoad () {
+    this.state = State.IDLE;
+  }
+
   onSubtitleFragProcessed (data) {
     const { frag, success } = data;
     this.fragPrevious = frag;

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -263,9 +263,6 @@ export class SubtitleStreamController extends BaseStreamController {
   }
 
   onMediaSeeking () {
-    // if (this.state === State.FRAG_LOADING) {
-    // WIP not reliable as the loader is active in State.IDLE
-
     if (this.fragCurrent) {
       const currentTime = this.media ? this.media.currentTime : null;
       const tolerance = this.config.maxFragLookUpTolerance;

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -42,10 +42,14 @@ export class SubtitleStreamController extends BaseStreamController {
 
   startLoad () {
     this.stopLoad();
-    this.setInterval(TICK_INTERVAL);
-
     this.state = State.IDLE;
-    this.tick();
+
+    // Check if we already have a track with necessary details to load fragments
+    const currentTrack = this.tracks[this.currentTrackId];
+    if (currentTrack && currentTrack.details) {
+      this.setInterval(TICK_INTERVAL);
+      this.tick();
+    }
   }
 
   onSubtitleFragProcessed (data) {

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -41,7 +41,11 @@ export class SubtitleStreamController extends BaseStreamController {
   }
 
   startLoad () {
+    this.stopLoad();
+    this.setInterval(TICK_INTERVAL);
+
     this.state = State.IDLE;
+    this.tick();
   }
 
   onSubtitleFragProcessed (data) {

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -38,7 +38,6 @@ export class SubtitleStreamController extends BaseStreamController {
     // lastAVStart stores the time in seconds for the start time of a level load
     this.lastAVStart = 0;
     this._onMediaSeeking = this.onMediaSeeking.bind(this);
-    this._onMediaSeeked = this.onMediaSeeked.bind(this);
   }
 
   startLoad () {
@@ -92,7 +91,6 @@ export class SubtitleStreamController extends BaseStreamController {
   onMediaAttached ({ media }) {
     this.media = media;
     media.addEventListener('seeking', this._onMediaSeeking);
-    media.addEventListener('seeked', this._onMediaSeeked);
     this.state = State.IDLE;
   }
 
@@ -101,7 +99,6 @@ export class SubtitleStreamController extends BaseStreamController {
       return;
     }
     this.media.removeEventListener('seeking', this._onMediaSeeking);
-    this.media.removeEventListener('seeked', this._onMediaSeeked);
     this.fragmentTracker.removeAllFragments();
     this.currentTrackId = -1;
     this.tracks.forEach((track) => {
@@ -261,10 +258,18 @@ export class SubtitleStreamController extends BaseStreamController {
   }
 
   onMediaSeeking () {
-    this.stopLoad();
-  }
+    let frag = this.fragCurrent;
+    if (frag) {
+      if (frag.loader) {
+        frag.loader.abort();
+      }
+      this.fragmentTracker.removeFragment(frag);
+    }
 
-  onMediaSeeked () {
-    this.startLoad();
+    this.fragCurrent = null;
+    this.fragPrevious = null;
+
+    this.state = State.IDLE;
+    this.tick();
   }
 }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -115,6 +115,11 @@ export class SubtitleStreamController extends BaseStreamController {
     if (!frag || frag.type !== 'subtitle') {
       return;
     }
+
+    if (this.fragCurrent && this.fragCurrent.loader) {
+      this.fragCurrent.loader.abort();
+    }
+
     this.state = State.IDLE;
   }
 

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -38,6 +38,7 @@ export class SubtitleStreamController extends BaseStreamController {
     // lastAVStart stores the time in seconds for the start time of a level load
     this.lastAVStart = 0;
     this._onMediaSeeking = this.onMediaSeeking.bind(this);
+    this._onMediaSeeked = this.onMediaSeeked.bind(this);
   }
 
   startLoad () {
@@ -91,6 +92,7 @@ export class SubtitleStreamController extends BaseStreamController {
   onMediaAttached ({ media }) {
     this.media = media;
     media.addEventListener('seeking', this._onMediaSeeking);
+    media.addEventListener('seeked', this._onMediaSeeked);
     this.state = State.IDLE;
   }
 
@@ -99,6 +101,7 @@ export class SubtitleStreamController extends BaseStreamController {
       return;
     }
     this.media.removeEventListener('seeking', this._onMediaSeeking);
+    this.media.removeEventListener('seeked', this._onMediaSeeked);
     this.fragmentTracker.removeAllFragments();
     this.currentTrackId = -1;
     this.tracks.forEach((track) => {
@@ -249,6 +252,7 @@ export class SubtitleStreamController extends BaseStreamController {
 
   stopLoad () {
     this.lastAVStart = 0;
+    this.fragPrevious = null;
     super.stopLoad();
   }
 
@@ -257,6 +261,10 @@ export class SubtitleStreamController extends BaseStreamController {
   }
 
   onMediaSeeking () {
-    this.fragPrevious = null;
+    this.stopLoad();
+  }
+
+  onMediaSeeked () {
+    this.startLoad();
   }
 }


### PR DESCRIPTION
### This PR will...
- fix the subtitle controller to work after `hls.stopLoad()` and `hls.startLoad()` was used #3053 
- fix an incorrect subtitle file loading order after initial seek in some very rare cases #3053 

### Why is this Pull Request needed?
The german tv-station ZDF uses the api `hls.stopLoad()`and `hls.startLoad()` in their player and needs to provide WebVTT for their clips. This also fixes the example code to work where `hls.loadSource` is called inside the `MEDIA_ATTACHED` event: https://github.com/video-dev/hls.js/blob/master/docs/API.md#third-step-load-a-manifest

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
- #3053 

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
