### PR TITLE
hls.js fix for stream-controller levelCodec log

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -968,16 +968,23 @@ class StreamController extends BaseStreamController {
         track.levelCodec = audioCodec;
         track.id = data.id;
       }
+
       track = tracks.video;
       if (track) {
         track.levelCodec = this.levels[this.level].videoCodec;
+        track.id = data.id;
+      }
+
+      track = tracks.audiovideo;
+      if (track && this.levels[this.level]) {
         track.id = data.id;
       }
       this.hls.trigger(Event.BUFFER_CODECS, tracks);
       // loop through tracks that are going to be provided to bufferController
       for (trackName in tracks) {
         track = tracks[trackName];
-        logger.log(`main track:${trackName},container:${track.container},codecs[level/parsed]=[${track.levelCodec}/${track.codec}]`);
+        const levelCodec = trackName === 'audiovideo' ? this.levels[this.level].attrs.CODECS : this.levels[this.level][`${trackName}Codec`];
+        logger.log(`main track:${trackName},container:${track.container},codecs[level/parsed]=[${levelCodec}/${track.codec}]`);
         let initSegment = track.initSegment;
         if (initSegment) {
           this.appended = true;


### PR DESCRIPTION
### This PR will fix ...
the "undefined" log text in onFragParsingInitSegment(data) logging.

Example of current behavior:
`[log] > main track:audiovideo,container:video/mp4,codecs[level/parsed]=[undefined/mp4a.40.2,avc1.640015]`

Example of desired behavior:
`[log] > main track:audiovideo,container:video/mp4,codecs[level/parsed]=[avc1.640014/mp4a.40.2,avc1.640015]`

### Why is this Pull Request needed?
This pull is needed because it's helpful to see the video levelCodec in the logging for the audiovideo track during frag parsing instead of the "undefined" text.

### Are there any points in the code the reviewer needs to double check?
No.

### Resolves issues:
It is related to issue #3068 which asks how "audiovideo" track is related to the TrackSet, which only includes video and audio track types. Instead of the 3 types of audio, video, audiovideo used in onFragParsingInitSegment(data).

### Checklist

- [ x] changes have been done against master branch, and PR does not conflict
- [ n/a] new unit / functional tests have been added (whenever applicable)
- [n/a ] API or design changes are documented in API.md

Example of "audiovideo" track in the onFragParsingInitSegment(data) method.

![image](https://user-images.githubusercontent.com/1331728/94953301-51a08c80-04b5-11eb-9ac6-333d09299df7.png)

