### PR TITLE
Display 608 captions in correct order

### DIFF
--- a/src/utils/cues.ts
+++ b/src/utils/cues.ts
@@ -65,9 +65,11 @@ export function newCue (track: TextTrack | null, startTime: number, endTime: num
       // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
       cue.position = Math.max(0, Math.min(100, 100 * (indent / 32)));
       result.push(cue);
-      if (track) {
-        track.addCue(cue);
-      }
+    }
+  }
+  if (track && result.length) {
+    for (let i = result.length; i--;) {
+      track.addCue(result[i]);
     }
   }
   return result;


### PR DESCRIPTION
### This PR will...
Add VTTCues with matching start time in reverse order for correct CSS layout.

### Why is this Pull Request needed?
Chrome will display cues with identical time ranges from the bottom up when controls overlap lines.

### Resolves issues:
#3070

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
