### PR TITLE
Handle PTS rollover on initial sample of video or audio

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -52,7 +52,7 @@ class MP4Remuxer {
       } else {
         return sample.pts;
       }
-    }, videoSamples[0].pts);
+    }, PTSNormalize(videoSamples[0].pts, 0));
     if (rolloverDetected) {
       logger.debug('PTS rollover detected');
     }
@@ -76,7 +76,7 @@ class MP4Remuxer {
         // when providing timeOffset to remuxAudio / remuxVideo. if we don't do that, there might be a permanent / small
         // drift between audio and video streams
         const startPTS = this.getVideoStartPts(videoTrack.samples);
-        const tsDelta = audioTrack.samples[0].pts - startPTS;
+        const tsDelta = PTSNormalize(audioTrack.samples[0].pts, 0) - startPTS;
         const audiovideoTimestampDelta = tsDelta / videoTrack.inputTimeScale;
         audioTimeOffset += Math.max(0, audiovideoTimestampDelta);
         videoTimeOffset += Math.max(0, -audiovideoTimestampDelta);
@@ -190,7 +190,7 @@ class MP4Remuxer {
       if (computePTSDTS) {
         const startPTS = this.getVideoStartPts(videoSamples);
         const startOffset = Math.round(inputTimeScale * timeOffset);
-        initDTS = Math.min(initDTS, videoSamples[0].dts - startOffset);
+        initDTS = Math.min(initDTS, PTSNormalize(videoSamples[0].dts, 0) - startOffset);
         initPTS = Math.min(initPTS, startPTS - startOffset);
         this.observer.trigger(Event.INIT_PTS_FOUND, { initPTS });
       }


### PR DESCRIPTION
### This PR will...
Normalize first audio and video PTS/DTS when comparing the two and determining initPTS to ensure elementary media streams are aligned on start.

### Why is this Pull Request needed?
In a stream where the first video PTS is a wrapped unsigned integer as seen below, we don't want to base initPTS on this value and attempt to align audio to it.
```
videoTrack.samples
0: {key: true, pts: 8589933243, dts: 8589933243, units: Array(3), debug: "", …}
1: {key: false, pts: 1711, dts: 1711, units: Array(1), debug: "", …}
2: {key: false, pts: 4681, dts: 4681, units: Array(1), debug: "", …}
3: {key: false, pts: 7651, dts: 7651, units: Array(1), debug: "", …}
4: {key: false, pts: 10711, dts: 10711, units: Array(1), debug: "", …}
5: {key: false, pts: 13681, dts: 13681, units: Array(1), debug: "", …}
6: {key: false, pts: 16651, dts: 16651, units: Array(1), debug: "", …}
```
```
audioTrack.samples
0: {unit: Uint8Array(243), pts: 1, dts: 1}
1: {unit: Uint8Array(243), pts: 1921, dts: 1921}
2: {unit: Uint8Array(244), pts: 3841, dts: 3841}
3: {unit: Uint8Array(265), pts: 5761, dts: 5761}
4: {unit: Uint8Array(242), pts: 7681, dts: 7681}
5: {unit: Uint8Array(255), pts: 9601, dts: 9601}
6: {unit: Uint8Array(243), pts: 11521, dts: 11521}
```

### Resolves issues:
#3082

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
