### PR TITLE
feat: add filter levels config

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -339,6 +339,7 @@ Configuration parameters could be provided to hls.js upon instantiation of `Hls`
       manifestLoadingRetryDelay: 1000,
       manifestLoadingMaxRetryTimeout: 64000,
       startLevel: undefined,
+      filterLevels: undefined, 
       levelLoadingTimeOut: 10000,
       levelLoadingMaxRetry: 4,
       levelLoadingRetryDelay: 1000,
@@ -613,6 +614,12 @@ Enable to use JavaScript version AES decryption for fallback of WebCrypto API.
 (default: `undefined`)
 
 When set, use this level as the default hls.startLevel. Keep in mind that the startLevel set with the API takes precedence over config.startLevel configuration parameter.
+
+### `filterLevels`
+
+(default: `undefined`)
+
+When set, use filtered levels as hls.levels.
 
 ### `fragLoadingTimeOut` / `manifestLoadingTimeOut` / `levelLoadingTimeOut`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,8 @@ type FPSControllerConfig = {
 };
 
 type LevelControllerConfig = {
-  startLevel?: number
+  startLevel?: number,
+  filterLevels?: (levels: any[]) => any[],
 };
 
 type MP4RemuxerConfig = {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -116,6 +116,10 @@ export default class LevelController extends EventHandler {
     levels = levels.filter(({ audioCodec, videoCodec }) => {
       return (!audioCodec || isCodecSupportedInMp4(audioCodec, 'audio')) && (!videoCodec || isCodecSupportedInMp4(videoCodec, 'video'));
     });
+    // filter levels by hls config
+    if (this.hls.config.filterLevels) {
+      levels = this.hls.config.filterLevels(levels);
+    }
 
     if (data.audioTracks) {
       audioTracks = data.audioTracks.filter(track => !track.audioCodec || isCodecSupportedInMp4(track.audioCodec, 'audio'));


### PR DESCRIPTION
### This PR will...

Add `filterLevels` to filter levels which not invalid. 

### Why is this Pull Request needed?

We don't want abr controller switch a level that invalid, so it provides a filter config to filter invalid levels when manifest parsed.

### Resolves issues:

https://github.com/video-dev/hls.js/issues/3039

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
