### PR TITLE
Bugfix: 608 captions displayed in reverse order

### DIFF
--- a/src/utils/cues.ts
+++ b/src/utils/cues.ts
@@ -53,14 +53,7 @@ export function newCue (track: TextTrack | null, startTime: number, endTime: num
         indent++;
       }
 
-      // VTTCue.line get's flakey when using controls, so let's now include line 13&14
-      // also, drop line 1 since it's to close to the top
-      if (navigator.userAgent.match(/Firefox\//)) {
-        cue.line = r + 1;
-      } else {
-        cue.line = (r > 7 ? r - 2 : r + 1);
-      }
-
+      cue.line = r + 1;
       cue.align = 'left';
       // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
       cue.position = Math.max(0, Math.min(100, 100 * (indent / 32)));
@@ -68,8 +61,15 @@ export function newCue (track: TextTrack | null, startTime: number, endTime: num
     }
   }
   if (track && result.length) {
-    for (let i = result.length; i--;) {
-      track.addCue(result[i]);
+    // Sort bottom cues in reverse order so that they render in line order when overlapping in Chrome
+    const sortedCues = result.sort((cueA, cueB) => {
+      if (cueA.line > 8 && cueB.line > 8) {
+        return cueB.line - cueA.line;
+      }
+      return cueA.line - cueB.line;
+    });
+    for (let i = 0; i < sortedCues.length; i++) {
+      track.addCue(sortedCues[i]);
     }
   }
   return result;


### PR DESCRIPTION
### This PR will...
Fix sorting of appended VTT cues with line numbers for Chrome's handling of overlapping cues.

### Why is this Pull Request needed?
Adjacent WebVTT cues rendered in Chrome tend to overlap by default, or don't fit in the viewport - at least when controls are displayed, which can lead to a cue with a greater line number being moved above one with a lower line number near the bottom of the screen.

To account for this, cues with a line number of 8 or higher are appended in reverse order. This makes them render in the correct order, unless the styling of cues is changed such that the cues no longer overlap (at which point they would be very small and difficult to read).

Lines at the top of the media element viewport must be appended in order, otherwise with snapToLine, the first line can be moved below the second, and so on. 

https://www.w3.org/TR/webvtt1/#processing-model

### Resolves issues:
#3097
#3070

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
