### PR TITLE
Latency controller

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -1009,10 +1009,11 @@ function checkBuffer () {
 
     if ($('#statsDisplayTab').is(':visible')) {
       let log = `Duration: ${video.duration}\nBuffered: ${timeRangesToString(video.buffered)}\nSeekable: ${timeRangesToString(video.seekable)}\nPlayed: ${timeRangesToString(video.played)}\n`;
-
+      log += `Latency: ${hls.latency}\n`;
+      log += `Playback rate: ${video.playbackRate.toFixed(2)}\n`;
       if (hls.media) {
         for (const type in tracks) {
-          log += 'Buffer for ' + type + ' contains: ' + timeRangesToString(tracks[type].buffer.buffered) + '\n';
+          log += `Buffer for ${type} contains:${timeRangesToString(tracks[type].buffer.buffered)}\n`;
         }
 
         const videoPlaybackQuality = video.getVideoPlaybackQuality;

--- a/demo/main.js
+++ b/demo/main.js
@@ -1009,11 +1009,6 @@ function checkBuffer () {
 
     if ($('#statsDisplayTab').is(':visible')) {
       let log = `Duration: ${video.duration}\nBuffered: ${timeRangesToString(video.buffered)}\nSeekable: ${timeRangesToString(video.seekable)}\nPlayed: ${timeRangesToString(video.played)}\n`;
-      log += `Max Latency: ${hls.maxLatency}\n`;
-      log += `Target Latency: ${hls.targetLatency}\n`;
-      log += `Latency: ${hls.latency}\n`;
-      log += `Edge Stall: ${hls.latencyController.edgeStalled}\n`;
-      log += `Playback rate: ${video.playbackRate.toFixed(2)}\n`;
       if (hls.media) {
         for (const type in tracks) {
           log += `Buffer for ${type} contains:${timeRangesToString(tracks[type].buffer.buffered)}\n`;
@@ -1024,8 +1019,17 @@ function checkBuffer () {
           log += `Dropped frames: ${video.getVideoPlaybackQuality().droppedVideoFrames}\n`;
           log += `Corrupted frames: ${video.getVideoPlaybackQuality().corruptedVideoFrames}\n`;
         } else if (video.webkitDroppedFrameCount) {
-          log += `Dropped frames: ${video.webkitDroppedFrameCount}`;
+          log += `Dropped frames: ${video.webkitDroppedFrameCount}\n`;
         }
+      }
+
+      if (events.isLive) {
+        log += 'Live Stats:\n' +
+          `  Max Latency: ${hls.maxLatency}\n` +
+          `  Target Latency: ${hls.targetLatency}\n` +
+          `  Latency: ${hls.latency}\n` +
+          `  Edge Stall: ${hls.latencyController.edgeStalled}\n` +
+          `  Playback rate: ${video.playbackRate.toFixed(2)}\n`;
       }
 
       $('#bufferedOut').text(log);

--- a/demo/main.js
+++ b/demo/main.js
@@ -1009,7 +1009,10 @@ function checkBuffer () {
 
     if ($('#statsDisplayTab').is(':visible')) {
       let log = `Duration: ${video.duration}\nBuffered: ${timeRangesToString(video.buffered)}\nSeekable: ${timeRangesToString(video.seekable)}\nPlayed: ${timeRangesToString(video.played)}\n`;
+      log += `Max Latency: ${hls.maxLatency}\n`;
+      log += `Target Latency: ${hls.targetLatency}\n`;
       log += `Latency: ${hls.latency}\n`;
+      log += `Edge Stall: ${hls.latencyController.edgeStalled}\n`;
       log += `Playback rate: ${video.playbackRate.toFixed(2)}\n`;
       if (hls.media) {
         for (const type in tracks) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,6 +123,7 @@
   - [`hls.subtitleDisplay`](#hlssubtitledisplay)
 - [Live stream API](#live-stream-api)
   - [`hls.liveSyncPosition`](#hlslivesyncposition)
+  - [`hls.latency`](#hlslatency)
 - [Runtime Events](#runtime-events)
 - [Loader Composition](#loader-composition)
 - [Errors](#errors)
@@ -391,7 +392,7 @@ Configuration parameters could be provided to hls.js upon instantiation of `Hls`
 
 ### `Hls.DefaultConfig get/set`
 
-This getter/setter allows to retrieve and override Hls default configuration.
+This getter/setter allows retrieval and override of the Hls default configuration.
 This configuration will be applied by default to all instances.
 
 ### `capLevelToPlayerSize`
@@ -662,7 +663,7 @@ Disable this test if you'd like to provide your own estimate or use the default 
                   
 (default: `false`)
 
-Stream segment data with fetch loader.
+Enable streaming segment data with fetch loader (experimental).
 
 ### `lowLatencyMode`
                   
@@ -1304,6 +1305,10 @@ get/set : if set to true the active subtitle track mode will be set to `showing`
 ### `hls.liveSyncPosition`
 
 get : position of live sync point (ie edge of live position minus safety delay defined by ```hls.config.liveSyncDuration```)
+
+### `hls.latency`
+
+get : estimated position of live edge (ie edge of live playlist plus time sync playlist advanced)
 
 ## Runtime Events
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,8 @@
   - [`liveMaxLatencyDurationCount`](#livemaxlatencydurationcount)
   - [`liveSyncDuration`](#livesyncduration)
   - [`liveMaxLatencyDuration`](#livemaxlatencyduration)
+  - [`minLiveSyncPlaybackRate`](#minLiveSyncPlaybackRate)
+  - [`maxLiveSyncPlaybackRate`](#maxLiveSyncPlaybackRate)
   - [`liveDurationInfinity`](#livedurationinfinity)
   - [`liveBackBufferLength`](#livebackbufferlength)
   - [`enableWorker`](#enableworker)
@@ -124,6 +126,8 @@
 - [Live stream API](#live-stream-api)
   - [`hls.liveSyncPosition`](#hlslivesyncposition)
   - [`hls.latency`](#hlslatency)
+  - [`hls.maxLatency`](#hlsmaxlatency)
+  - [`hls.targetLatency`](#hlstargetlatency)
 - [Runtime Events](#runtime-events)
 - [Loader Composition](#loader-composition)
 - [Errors](#errors)
@@ -582,6 +586,20 @@ If defined in the configuration object, `liveMaxLatencyDuration` will take prece
 If set, this value must be stricly superior to `liveSyncDuration` which must be defined as well.
 You can't define this parameter and either `liveSyncDurationCount` or `liveMaxLatencyDurationCount` in your configuration object at the same time.
 A value too close from `liveSyncDuration` is likely to cause playback stalls.
+
+### `minLiveSyncPlaybackRate`
+
+(default: `0.75` min: `0.5` max: `1`)
+
+Decrease `video.playbackRate` down to this value when latency falls below target (`liveSyncDuration(Count)` or manifest (PART-)HOLD-BACK) in a live stream.
+Set both `minLiveSyncPlaybackRate` and `maxLiveSyncPlaybackRate` to `1` to disable setting of playback rate.
+
+### `maxLiveSyncPlaybackRate`
+
+(default: `1.5` min: `1` max: `2`)
+
+Increase `video.playbackRate` up to this value to catch up to target latency (`liveSyncDuration(Count)` or manifest (PART-)HOLD-BACK) in a live stream.
+Set both `minLiveSyncPlaybackRate` and `maxLiveSyncPlaybackRate` to `1` to disable setting of playback rate.
 
 ### `liveDurationInfinity`
 
@@ -1308,7 +1326,18 @@ get : position of live sync point (ie edge of live position minus safety delay d
 
 ### `hls.latency`
 
-get : estimated position of live edge (ie edge of live playlist plus time sync playlist advanced)
+get : estimated position (in seconds) of live edge (ie edge of live playlist plus time sync playlist advanced)
+returns 0 before first playlist is loaded
+
+### `hls.maxLatency`
+
+get : maximum distance from the edge before the player seeks forward to ```hls.liveSyncPosition```
+configured using ```liveMaxLatencyDurationCount``` (multiple of target duration) or ```liveMaxLatencyDuration```
+returns 0 before first playlist is loaded
+
+### `hls.targetLatency`
+
+get : target distance from the edge as calculated by the latency controller
 
 ## Runtime Events
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,20 +99,23 @@ type StreamControllerConfig = {
   maxBufferLength: number,
   maxBufferSize: number,
   maxBufferHole: number,
-
   highBufferWatchdogPeriod: number,
   nudgeOffset: number,
   nudgeMaxRetry: number,
   maxFragLookUpTolerance: number,
+  maxMaxBufferLength: number,
+  startFragPrefetch: boolean,
+  testBandwidth: boolean
+};
+
+type LatencyControllerConfig = {
   liveSyncDurationCount: number,
   liveMaxLatencyDurationCount: number,
   liveSyncDuration?: number,
   liveMaxLatencyDuration?: number,
-  maxMaxBufferLength: number,
-
-  startFragPrefetch: boolean,
-  testBandwidth: boolean
-};
+  maxLiveSyncPlaybackRate: number,
+  minLiveSyncPlaybackRate: number
+}
 
 type TimelineControllerConfig = {
   cueHandler: Cues.CuesInterface,
@@ -170,6 +173,7 @@ export type HlsConfig =
   MP4RemuxerConfig &
   PlaylistLoaderConfig &
   StreamControllerConfig &
+  LatencyControllerConfig &
   TimelineControllerConfig &
   TSDemuxerConfig;
 
@@ -191,10 +195,12 @@ export const hlsDefaultConfig: HlsConfig = {
   nudgeOffset: 0.1, // used by stream-controller
   nudgeMaxRetry: 3, // used by stream-controller
   maxFragLookUpTolerance: 0.25, // used by stream-controller
-  liveSyncDurationCount: 3, // used by stream-controller
-  liveMaxLatencyDurationCount: Infinity, // used by stream-controller
-  liveSyncDuration: void 0, // used by stream-controller
-  liveMaxLatencyDuration: void 0, // used by stream-controller
+  liveSyncDurationCount: 3, // used by latency-controller
+  liveMaxLatencyDurationCount: Infinity, // used by latency-controller
+  liveSyncDuration: void 0, // used by latency-controller
+  liveMaxLatencyDuration: void 0, // used by latency-controller
+  minLiveSyncPlaybackRate: 0.75, // used by latency-controller
+  maxLiveSyncPlaybackRate: 1.5, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
   liveBackBufferLength: Infinity, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -27,13 +27,13 @@ import { TrackSet } from '../types/track';
 import { Level } from '../types/level';
 import { PlaylistLevelType } from '../types/loader';
 import Hls from '../hls';
-import type { ComponentAPI } from '../types/component-api';
+import { NetworkComponentAPI } from '../types/component-api';
 
 const { performance } = self;
 
 const TICK_INTERVAL = 100; // how often to tick in ms
 
-class AudioStreamController extends BaseStreamController implements ComponentAPI {
+class AudioStreamController extends BaseStreamController implements NetworkComponentAPI {
   private retryDate: number = 0;
   private onvseeking: EventListener | null = null;
   private onvseeked: EventListener | null = null;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -129,12 +129,7 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
   }
 
   doTick () {
-    const { media } = this;
-
     switch (this.state) {
-    case State.ERROR:
-      // don't do anything in error state to avoid breaking further ...
-      break;
     case State.IDLE:
       this.doTickIdle();
       break;
@@ -153,7 +148,7 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
       const now = performance.now();
       const retryDate = this.retryDate;
       // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-      if (!retryDate || (now >= retryDate) || media?.seeking) {
+      if (!retryDate || (now >= retryDate) || this.media?.seeking) {
         this.log('RetryDate reached, switch back to IDLE state');
         this.state = State.IDLE;
       }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -568,7 +568,6 @@ export default class BaseStreamController extends TaskLoop implements NetworkCom
         this.log(`Start time offset found in playlist, adjust startPosition to ${startTimeOffset}`);
         this.startPosition = startTimeOffset;
       } else {
-        // if live playlist, set start position to be fragment N-this.config.liveSyncDurationCount (usually 3)
         if (details.live) {
           this.startPosition = this.hls.liveSyncPosition || sliding;
           this.log(`Configure startPosition to ${this.startPosition}`);

--- a/src/controller/fps-controller.ts
+++ b/src/controller/fps-controller.ts
@@ -15,7 +15,7 @@ class FPSController implements ComponentAPI {
   private hls: Hls;
   private isVideoPlaybackQualityAvailable: boolean = false;
   private timer?: number;
-  private video: HTMLVideoElement | null = null;
+  private media: HTMLVideoElement | null = null;
   private lastTime: any;
   private lastDroppedFrames: number = 0;
   private lastDecodedFrames: number = 0;
@@ -47,14 +47,15 @@ class FPSController implements ComponentAPI {
 
     this.unregisterListeners();
     this.isVideoPlaybackQualityAvailable = false;
+    this.media = null;
   }
 
   protected onMediaAttaching (event: Events.MEDIA_ATTACHING, data: MediaAttachingData) {
     const config = this.hls.config;
     if (config.capLevelOnFPSDrop) {
-      const video = data.media instanceof self.HTMLVideoElement ? data.media : null;
-      this.video = video;
-      if (video && typeof video.getVideoPlaybackQuality === 'function') {
+      const media = data.media instanceof self.HTMLVideoElement ? data.media : null;
+      this.media = media;
+      if (media && typeof media.getVideoPlaybackQuality === 'function') {
         this.isVideoPlaybackQualityAvailable = true;
       }
 
@@ -94,7 +95,7 @@ class FPSController implements ComponentAPI {
   }
 
   checkFPSInterval () {
-    const video = this.video;
+    const video = this.media;
     if (video) {
       if (this.isVideoPlaybackQualityAvailable) {
         const videoPlaybackQuality = video.getVideoPlaybackQuality();

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -1,0 +1,169 @@
+import LevelDetails from '../loader/level-details';
+import { ErrorDetails } from '../errors';
+import { Events } from '../events';
+import { ErrorData, LevelUpdatedData, MediaAttachingData } from '../types/events';
+import { logger } from '../utils/logger';
+import type { ComponentAPI } from '../types/component-api';
+import type Hls from '../hls';
+import type { HlsConfig } from '../config';
+
+// TODO: LatencyController config options:
+//  - maxLiveSyncPlaybackRate
+//  - minLiveSyncPlaybackRate
+//  - maxLevelUpdateAge (rename or existing option we could use?)
+//  - adjustLatencyOnErrorMax
+//  - liveSyncOnStallIncrease
+//  - maxLiveSyncOnStallIncrease
+const L = 1.5; // Change playback rate by up to 1.5x
+const k = 0.75;
+const sigmoid = (x, x0) => L / (1 + Math.exp(-k * (x - x0)));
+
+// TODO: LatencyController unit tests
+//  - latency estimate
+
+export default class LatencyController implements ComponentAPI {
+  private readonly hls: Hls;
+  private readonly config: HlsConfig;
+  private media: HTMLMediaElement | null = null;
+  private levelDetails: LevelDetails | null = null;
+  private currentTime: number = 0;
+  private stallCount: number = 0;
+  private _latency: number | null = null;
+  private timeupdateHandler = () => this.timeupdate();
+
+  constructor (hls: Hls) {
+    this.hls = hls;
+    this.config = hls.config;
+    this.registerListeners();
+  }
+
+  get latency (): number {
+    return this._latency || 0;
+  }
+
+  get liveSyncPosition (): number | null {
+    const liveEdge = this.estimateLiveEdge();
+    const targetLatency = this.computeTargetLatency();
+    if (liveEdge === null || targetLatency === null || this.levelDetails === null) {
+      return null;
+    }
+    const maxLevelUpdateAge = this.levelDetails.targetduration * 3;
+    const edgeStalled = Math.max(this.levelDetails.age - maxLevelUpdateAge, 0);
+    return Math.min(this.levelDetails.edge, liveEdge - targetLatency - edgeStalled);
+  }
+
+  public destroy (): void {
+    this.unregisterListeners();
+    this.onMediaDetaching();
+  }
+
+  private registerListeners () {
+    this.hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
+    this.hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+    this.hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
+    this.hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
+    this.hls.on(Events.ERROR, this.onError, this);
+  }
+
+  private unregisterListeners () {
+    this.hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached);
+    this.hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching);
+    this.hls.off(Events.MANIFEST_LOADING, this.onManifestLoading);
+    this.hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated);
+    this.hls.off(Events.ERROR, this.onError);
+  }
+
+  private onMediaAttached (event: Events.MEDIA_ATTACHED, data: MediaAttachingData) {
+    this.media = data.media;
+    this.media.addEventListener('timeupdate', this.timeupdateHandler);
+  }
+
+  private onMediaDetaching () {
+    if (this.media) {
+      this.media.removeEventListener('timeupdate', this.timeupdateHandler);
+      this.media = null;
+    }
+  }
+
+  private onManifestLoading () {
+    this.levelDetails = null;
+    this._latency = null;
+    this.stallCount = 0;
+  }
+
+  private onLevelUpdated (event: Events.LEVEL_UPDATED, { details }: LevelUpdatedData) {
+    this.levelDetails = details;
+    if (details.advanced) {
+      this.timeupdate();
+    }
+    if (!details.live && this.media) {
+      this.media.removeEventListener('timeupdate', this.timeupdateHandler);
+    }
+  }
+
+  private onError (event: Events.ERROR, data: ErrorData) {
+    if (data.details !== ErrorDetails.BUFFER_STALLED_ERROR) {
+      return;
+    }
+    this.stallCount++;
+    logger.warn('[playback-rate-controller]: Stall detected, adjusting target latency');
+  }
+
+  private timeupdate () {
+    const { media, levelDetails } = this;
+    if (!media || !levelDetails) {
+      return;
+    }
+    this.currentTime = media.currentTime;
+
+    const latency = this.computeLatency();
+    if (latency === null) {
+      return;
+    }
+    this._latency = latency;
+
+    const latencyTarget = this.computeTargetLatency();
+    if (latencyTarget === null) {
+      return;
+    }
+    const distance = latency - latencyTarget;
+    if (distance && levelDetails.live) {
+      media.playbackRate = Math.max(0.1, sigmoid(latency, latencyTarget));
+    } else if (media.playbackRate !== 1) {
+      media.playbackRate = 1;
+    }
+  }
+
+  private estimateLiveEdge (): number | null {
+    const { levelDetails } = this;
+    if (levelDetails === null) {
+      return null;
+    }
+    return levelDetails.edge + levelDetails.age;
+  }
+
+  private computeLatency (): number | null {
+    const liveEdge = this.estimateLiveEdge();
+    if (liveEdge === null) {
+      return null;
+    }
+    return liveEdge - this.currentTime;
+  }
+
+  private computeTargetLatency (): number | null {
+    const { levelDetails } = this;
+    if (levelDetails === null) {
+      return null;
+    }
+    const { holdBack, partHoldBack, targetduration } = levelDetails;
+    const { liveSyncDuration, liveSyncDurationCount, lowLatencyMode } = this.config;
+    const userConfig = this.hls.userConfig;
+    let targetLatency = lowLatencyMode ? partHoldBack || holdBack : holdBack;
+    if (userConfig.liveSyncDuration || userConfig.liveSyncDurationCount || targetLatency === 0) {
+      targetLatency = liveSyncDuration !== undefined ? liveSyncDuration : liveSyncDurationCount * targetduration;
+    }
+    const maxLiveSyncOnStallIncrease = levelDetails.targetduration;
+    const liveSyncOnStallIncrease = 1.0;
+    return targetLatency + Math.min(this.stallCount * liveSyncOnStallIncrease, maxLiveSyncOnStallIncrease);
+  }
+}

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -180,9 +180,9 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
     }
   }
 
+  const newFragments = newDetails.fragments;
   if (ccOffset) {
     logger.log('discontinuity sliding from playlist, take drift into account');
-    const newFragments = newDetails.fragments;
     for (let i = 0; i < newFragments.length; i++) {
       newFragments[i].cc += ccOffset;
     }
@@ -202,6 +202,10 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
     // also adjust sliding in case delta is 0 (we could have old=[50-60] and new=old=[50-61])
     // in that case we also need to adjust start offset of all fragments
     adjustSliding(oldDetails, newDetails);
+  }
+
+  if (newFragments.length) {
+    newDetails.totalduration = newDetails.edge - newFragments[0].start;
   }
 }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -596,9 +596,6 @@ export default class StreamController extends BaseStreamController implements Ne
         return;
       }
       sliding = this.alignPlaylists(newDetails, curLevel.details);
-      if (sliding) {
-        this._liveSyncPosition = this.computeLivePosition(sliding, newDetails);
-      }
     }
     // override level info
     curLevel.details = newDetails;
@@ -805,7 +802,7 @@ export default class StreamController extends BaseStreamController implements Ne
           // exponential backoff capped to config.fragLoadingMaxRetryTimeout
           const delay = Math.min(Math.pow(2, this.fragLoadError) * this.config.fragLoadingRetryDelay, this.config.fragLoadingMaxRetryTimeout);
           // @ts-ignore - frag is potentially null according to TS here
-          this.warn(`Fragment ${frag.sn} of level ${frag.level} failed to load, retrying in ${delay}ms`);
+          this.warn(`Fragment ${frag?.sn} of level ${frag?.level} failed to load, retrying in ${delay}ms`);
           this.retryDate = self.performance.now() + delay;
           // retry loading state
           // if loadedmetadata is not set, it means that we are emergency switch down on first frag
@@ -1058,17 +1055,19 @@ export default class StreamController extends BaseStreamController implements Ne
     }
 
     if (id3?.samples?.length) {
-      const emittedID3: FragParsingMetadataData = Object.assign({
+      const emittedID3: FragParsingMetadataData = {
         frag,
-        id
-      }, id3);
+        id,
+        samples: id3.samples
+      };
       hls.trigger(Events.FRAG_PARSING_METADATA, emittedID3);
     }
     if (text) {
-      const emittedText: FragParsingUserdataData = Object.assign({
+      const emittedText: FragParsingUserdataData = {
         frag,
-        id
-      }, text);
+        id,
+        samples: text.samples
+      };
       hls.trigger(Events.FRAG_PARSING_USERDATA, emittedText);
     }
   }
@@ -1180,10 +1179,6 @@ export default class StreamController extends BaseStreamController implements Ne
     }
   }
 
-  get liveSyncPosition () {
-    return this._liveSyncPosition;
-  }
-
   get nextLevel () {
     const frag = this.nextBufferedFrag;
     if (frag) {
@@ -1213,10 +1208,6 @@ export default class StreamController extends BaseStreamController implements Ne
     } else {
       return null;
     }
-  }
-
-  set liveSyncPosition (value) {
-    this._liveSyncPosition = value;
   }
 
   get forceStartLoad () {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -152,7 +152,7 @@ export default class StreamController extends BaseStreamController implements Ne
   doTick () {
     switch (this.state) {
     case State.IDLE:
-      this._doTickIdle();
+      this.doTickIdle();
       break;
     case State.WAITING_LEVEL: {
       const { levels, level } = this;
@@ -190,7 +190,7 @@ export default class StreamController extends BaseStreamController implements Ne
     this.checkFragmentChanged();
   }
 
-  _doTickIdle () {
+  private doTickIdle () {
     const { hls, levelLastLoaded, levels, media } = this;
     const { config, nextLoadLevel: level } = hls;
 

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -19,7 +19,7 @@ import {
 } from '../types/events';
 import { Level } from '../types/level';
 import LevelDetails from '../loader/level-details';
-import { ComponentAPI } from '../types/component-api';
+import { NetworkComponentAPI } from '../types/component-api';
 import Hls from '../hls';
 
 const { performance } = self;
@@ -31,7 +31,7 @@ interface TimeRange {
   end: number
 }
 
-export class SubtitleStreamController extends BaseStreamController implements ComponentAPI {
+export class SubtitleStreamController extends BaseStreamController implements NetworkComponentAPI {
   protected levels: Array<Level> = [];
 
   private currentTrackId: number = -1;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -722,9 +722,28 @@ export default class Hls implements HlsEventEmitter {
 
   /**
    * estimated position (in seconds) of live edge (ie edge of live playlist plus time sync playlist advanced)
+   * returns 0 before first playlist is loaded
    * @type {number}
    */
   get latency () {
     return this.latencyController.latency;
+  }
+
+  /**
+   * maximum distance from the edge before the player seeks forward to ```hls.liveSyncPosition```
+   * configured using ```liveMaxLatencyDurationCount``` (multiple of target duration) or ```liveMaxLatencyDuration```
+   * returns 0 before first playlist is loaded
+   * @type {number}
+   */
+  get maxLatency (): number {
+    return this.latencyController.maxLatency;
+  }
+
+  /**
+   * target distance from the edge as calculated by the latency controller
+   * @type {number}
+   */
+  get targetLatency (): number | null {
+    return this.latencyController.computeTargetLatency();
   }
 }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -744,6 +744,6 @@ export default class Hls implements HlsEventEmitter {
    * @type {number}
    */
   get targetLatency (): number | null {
-    return this.latencyController.computeTargetLatency();
+    return this.latencyController.targetLatency;
   }
 }

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -77,9 +77,19 @@ export default class LevelDetails {
     return this.averagetargetduration || this.targetduration || DEFAULT_TARGET_DURATION;
   }
 
+  get edge (): number {
+    if (this.partList?.length) {
+      return this.partList[this.partList.length - 1].end;
+    }
+    if (this.fragments?.length) {
+      return this.fragments[this.fragments.length - 1].end;
+    }
+    return 0;
+  }
+
   get age (): number {
     if (this.lastModified) {
-      return (Date.now() - this.lastModified) / 1000;
+      return Math.max(Date.now() - this.lastModified, 0) / 1000;
     }
     return 0;
   }

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -261,6 +261,7 @@ export default class M3U8Parser {
               fragments.unshift(null);
             }
             currentSN += skippedSegments;
+            totalduration += skippedSegments * level.targetduration;
           }
           const recentlyRemovedDateranges = skipAttrs.enumeratedString('RECENTLY-REMOVED-DATERANGES');
           if (recentlyRemovedDateranges) {

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -59,10 +59,10 @@ class PlaylistLoader {
 
   constructor (hls: Hls) {
     this.hls = hls;
-    this._registerListeners();
+    this.registerListeners();
   }
 
-  private _registerListeners () {
+  private registerListeners () {
     const { hls } = this;
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.LEVEL_LOADING, this.onLevelLoading, this);
@@ -70,7 +70,7 @@ class PlaylistLoader {
     hls.on(Events.SUBTITLE_TRACK_LOADING, this.onSubtitleTrackLoading, this);
   }
 
-  private _unregisterListeners () {
+  private unregisterListeners () {
     const { hls } = this;
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.LEVEL_LOADING, this.onLevelLoading, this);
@@ -120,7 +120,7 @@ class PlaylistLoader {
   }
 
   public destroy (): void {
-    this._unregisterListeners();
+    this.unregisterListeners();
     this.destroyInternalLoaders();
   }
 

--- a/tests/mocks/data.js
+++ b/tests/mocks/data.js
@@ -1,48 +1,52 @@
+import Fragment from '../../src/loader/fragment';
+import { PlaylistLevelType } from '../../src/types/loader';
+
+function fragment (options) {
+  const frag = new Fragment(PlaylistLevelType.MAIN, '');
+  Object.assign(frag, options);
+  return frag;
+}
+
 export const mockFragments = [
-  {
+  fragment({
     programDateTime: 1505502661523,
-    endProgramDateTime: 1505502666523,
     level: 2,
     duration: 5.000,
     start: 0,
     sn: 0,
     cc: 0
-  },
+  }),
   // Discontinuity with PDT 1505502671523 which does not exist in level 1 as per fragPrevious
-  {
+  fragment({
     programDateTime: 1505502671523,
-    endProgramDateTime: 1505502676523,
     level: 2,
     duration: 5.000,
     start: 5.000,
     sn: 1,
     cc: 1
-  },
-  {
+  }),
+  fragment({
     programDateTime: 1505502676523,
-    endProgramDateTime: 1505502681523,
     level: 2,
     duration: 5.000,
     start: 10.000,
     sn: 2,
     cc: 1
-  },
-  {
+  }),
+  fragment({
     programDateTime: 1505502681523,
-    endProgramDateTime: 1505502686523,
     level: 2,
     duration: 5.000,
     start: 15.000,
     sn: 3,
     cc: 1
-  },
-  {
+  }),
+  fragment({
     programDateTime: 1505502686523,
-    endProgramDateTime: 1505502691523,
     level: 2,
     duration: 5.000,
     start: 20.000,
     sn: 4,
     cc: 1
-  }
+  })
 ];

--- a/tests/unit/controller/latency-controller.ts
+++ b/tests/unit/controller/latency-controller.ts
@@ -1,0 +1,278 @@
+/* eslint-disable dot-notation */
+import LatencyController from '../../../src/controller/latency-controller';
+import Hls from '../../../src/hls';
+import { Events } from '../../../src/events';
+import LevelDetails from '../../../src/loader/level-details';
+import { LevelUpdatedData } from '../../../src/types/events';
+
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+// Write to .age and .edge getter stubs for testing LevelDetails in LatencyController
+interface TestLevelDetails extends LevelDetails { age: number, edge: number }
+
+describe('LatencyController', function () {
+  let latencyController: LatencyController;
+  let hls: Hls;
+  let media: { currentTime: number, playbackRate: number };
+  let levelDetails: TestLevelDetails;
+
+  beforeEach(function () {
+    hls = new Hls({});
+    latencyController = new LatencyController(hls);
+    levelDetails = new LevelDetails('');
+    levelDetails.live = true;
+    levelDetails.targetduration = 5;
+    const levelUpdatedData: LevelUpdatedData = {
+      details: levelDetails,
+      level: 0
+    };
+    const edgeStub = sinon.stub(levelDetails, 'edge');
+    edgeStub.get(() => 0);
+    edgeStub.set((value: number) => {
+      edgeStub.get(() => value);
+      latencyController['onLevelUpdated'](Events.LEVEL_UPDATED, levelUpdatedData);
+    });
+    const ageStub = sinon.stub(levelDetails, 'age');
+    ageStub.get(() => 0);
+    ageStub.set((value: number) => {
+      ageStub.get(() => value);
+      latencyController['onLevelUpdated'](Events.LEVEL_UPDATED, levelUpdatedData);
+    });
+    let currentTime = 0;
+    // @ts-ignore
+    media = latencyController['media'] = {
+      currentTime: 0,
+      playbackRate: 1
+    };
+    const currentTimeStub = sinon.stub(media, 'currentTime');
+    currentTimeStub.get(() => currentTime);
+    currentTimeStub.set((value: number) => {
+      currentTime = value;
+      latencyController['timeupdate']();
+    });
+  });
+
+  describe('latency', function () {
+    it('returns 0 when unknown / detached / prior to timeupdate', function () {
+      expect(latencyController.latency).to.equal(0);
+    });
+
+    it('is the distance between currentTime and the live edge plus playlist age', function () {
+      levelDetails.edge = 25;
+      expect(latencyController.latency).to.equal(25);
+      media.currentTime = 15;
+      expect(latencyController.latency).to.equal(10);
+      media.currentTime = 20;
+      expect(latencyController.latency).to.equal(5);
+      levelDetails.age = 1;
+      expect(latencyController.latency).to.equal(6);
+      levelDetails.edge = 30;
+      levelDetails.age = 0;
+      expect(latencyController.latency).to.equal(10);
+    });
+  });
+
+  describe('maxLatency', function () {
+    it('returns liveMaxLatencyDuration when set', function () {
+      latencyController['config'].liveMaxLatencyDuration = 30;
+      expect(latencyController.maxLatency).to.equal(30);
+    });
+
+    it('returns liveMaxLatencyDurationCount * targetduration after level update', function () {
+      latencyController['config'].liveMaxLatencyDurationCount = 3;
+      expect(latencyController.maxLatency).to.equal(0);
+      levelDetails.age = 0;
+      expect(latencyController.maxLatency).to.equal(15);
+    });
+  });
+
+  describe('targetLatency', function () {
+    it('returns null before level update', function () {
+      expect(latencyController.targetLatency).to.equal(null);
+    });
+
+    it('returns liveSyncDuration if set after level update', function () {
+      latencyController['config'].liveSyncDuration = 12;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(12);
+    });
+
+    it('returns targetduration * liveSyncDurationCount if set after level update', function () {
+      latencyController['config'].liveSyncDurationCount = 2;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(10);
+    });
+
+    it('returns holdBack when set in playlist after level update', function () {
+      levelDetails.holdBack = 8;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(8);
+    });
+
+    it('returns partHoldBack in lowLatencyMode when set in playlist after level update', function () {
+      levelDetails.holdBack = 8;
+      levelDetails.partHoldBack = 3;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(8);
+      latencyController['config'].lowLatencyMode = true;
+      expect(latencyController.targetLatency).to.equal(3);
+    });
+
+    it('liveSyncDuration overrides holdBack when set by user', function () {
+      hls.userConfig.liveSyncDuration = 12;
+      latencyController['config'].liveSyncDuration = 12;
+      levelDetails.holdBack = 8;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(12);
+    });
+
+    it('liveSyncDurationCount overrides holdBack when set by user', function () {
+      hls.userConfig.liveSyncDurationCount = 2;
+      latencyController['config'].liveSyncDurationCount = 2;
+      levelDetails.holdBack = 8;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(10);
+    });
+
+    it('adds a second of latency for each stall up to targetduration', function () {
+      latencyController['config'].lowLatencyMode = true;
+      levelDetails.targetduration = 3.5;
+      levelDetails.partHoldBack = 3;
+      levelDetails.age = 0;
+      expect(latencyController.targetLatency).to.equal(3);
+      latencyController['stallCount'] = 1;
+      expect(latencyController.targetLatency).to.equal(4);
+      latencyController['stallCount'] += 1;
+      expect(latencyController.targetLatency).to.equal(5);
+      latencyController['stallCount'] += 1;
+      expect(latencyController.targetLatency).to.equal(6);
+      latencyController['stallCount'] += 1;
+      expect(latencyController.targetLatency).to.equal(6.5);
+    });
+  });
+
+  describe('liveSyncPosition', function () {
+    it('returns null before level update', function () {
+      expect(latencyController.liveSyncPosition).to.equal(null);
+    });
+
+    it('returns target currentTime based on edge and targetLatency', function () {
+      latencyController['config'].liveSyncDuration = 12;
+      levelDetails.edge = 60;
+      expect(latencyController.liveSyncPosition).to.equal(48);
+    });
+
+    it('accounts for level update age up to 3 target durations', function () {
+      levelDetails.targetduration = 5;
+      levelDetails.holdBack = 15;
+      levelDetails.edge = 60;
+      expect(latencyController.liveSyncPosition).to.equal(45);
+      levelDetails.age = 5;
+      expect(latencyController.liveSyncPosition).to.equal(50);
+      levelDetails.age = 10;
+      expect(latencyController.liveSyncPosition).to.equal(55);
+      levelDetails.age = 20;
+      expect(latencyController.liveSyncPosition).to.equal(60);
+    });
+
+    it('accounts for level update age up to 3 part targets in low latency mode', function () {
+      latencyController['config'].lowLatencyMode = true;
+      levelDetails.partTarget = 1;
+      levelDetails.partHoldBack = 3;
+      levelDetails.edge = 60;
+      expect(latencyController.liveSyncPosition).to.equal(57);
+      levelDetails.age = 1;
+      expect(latencyController.liveSyncPosition).to.equal(58);
+      levelDetails.age = 2;
+      expect(latencyController.liveSyncPosition).to.equal(59);
+      levelDetails.age = 5;
+      expect(latencyController.liveSyncPosition).to.equal(60);
+    });
+  });
+
+  describe('edgeStalled', function () {
+    it('returns 0 before level update', function () {
+      expect(latencyController.edgeStalled).to.equal(0);
+    });
+
+    it('returns the age seconds past 3 target durations', function () {
+      levelDetails.targetduration = 5;
+      levelDetails.holdBack = 15;
+      levelDetails.age = 0;
+      expect(latencyController.edgeStalled).to.equal(0);
+      levelDetails.age = 1;
+      expect(latencyController.edgeStalled).to.equal(0);
+      levelDetails.age = 20;
+      expect(latencyController.edgeStalled).to.equal(5);
+      levelDetails.age = 25;
+      expect(latencyController.edgeStalled).to.equal(10);
+    });
+
+    it('returns the age seconds past 3 part targets in low latency mode', function () {
+      latencyController['config'].lowLatencyMode = true;
+      levelDetails.partTarget = 1;
+      levelDetails.partHoldBack = 3;
+      levelDetails.age = 0;
+      expect(latencyController.edgeStalled).to.equal(0);
+      levelDetails.age = 1;
+      expect(latencyController.edgeStalled).to.equal(0);
+      levelDetails.age = 5;
+      expect(latencyController.edgeStalled).to.equal(2);
+      levelDetails.age = 6;
+      expect(latencyController.edgeStalled).to.equal(3);
+    });
+  });
+
+  describe('when minLiveSyncPlaybackRate or maxLiveSyncPlaybackRate is set', function () {
+    beforeEach(function () {
+      latencyController['config'].minLiveSyncPlaybackRate = 0.5;
+      latencyController['config'].maxLiveSyncPlaybackRate = 2;
+    });
+
+    it('increases playbackRate when latency is greater than target latency on timeupdate', function () {
+      levelDetails.edge = 12;
+      levelDetails.holdBack = 6;
+      media.currentTime = 6;
+      expect(media.playbackRate).to.equal(1);
+      media.currentTime = 5;
+      expect(media.playbackRate).to.be.within(1.3, 1.4);
+      media.currentTime = 4;
+      expect(media.playbackRate).to.be.within(1.6, 1.7);
+      media.currentTime = 1;
+      expect(media.playbackRate).to.be.within(1.9, 2);
+    });
+
+    it('decreases playbackRate when latency is less than target latency on timeupdate', function () {
+      levelDetails.edge = 12;
+      levelDetails.holdBack = 6;
+      media.currentTime = 6;
+      expect(media.playbackRate).to.equal(1);
+      media.currentTime = 7;
+      expect(media.playbackRate).to.be.within(0.6, 0.7);
+      media.currentTime = 8;
+      expect(media.playbackRate).to.equal(0.5);
+    });
+
+    it('decreases playbackRate when playback is at risk of stalling on timeupdate', function () {
+      levelDetails.edge = 12;
+      levelDetails.holdBack = 6;
+      media.currentTime = 11;
+      expect(media.playbackRate).to.equal(0.5);
+      levelDetails.age = 1;
+      expect(media.playbackRate).to.equal(0.5);
+    });
+
+    it('resets latency estimates when a new manifest is loading', function () {
+      expect(latencyController.latency).to.equal(0);
+      levelDetails.edge = 25;
+      expect(latencyController.latency).to.equal(25);
+      latencyController['onManifestLoading']();
+      expect(latencyController.latency).to.equal(0);
+    });
+  });
+});

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -111,8 +111,8 @@ describe('StreamController', function () {
       expect(foundFragment).to.equal(mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
-    // TODO: This test fails if using a real instance of Hls
     it('PTS search choosing the right segment if fragPrevious is not available', function () {
+      streamController['fragPrevious'] = null;
       const foundFragment = streamController['getNextFragment'](bufferEnd, levelDetails);
       const resultSN = foundFragment ? foundFragment.sn : -1;
       expect(foundFragment).to.equal(mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -10,11 +10,11 @@ import LevelDetails from '../../../src/loader/level-details';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import AttrList from '../../../src/utils/attr-list';
+import { Level, LevelAttributes } from '../../../src/types/level';
 
 import * as sinon from 'sinon';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
-import { Level, LevelAttributes } from '../../../src/types/level';
 
 chai.use(sinonChai);
 const expect = chai.expect;


### PR DESCRIPTION
### This PR will...
Adjust playbackRate (1/2-2x) to maintain target latency
- Adds `latency` getter to API
- Adds `targetLatency ` getter to API
- Adds `maxLatency ` getter to API
- Moves responsibility for `liveSync...` options from stream-controller to latency-controller
- Show "Max Latency", "Target Latency", "Latency", "Edge Stall" and "Playback rate" in Buffer and statistics demo tab
- Adds `minLiveSyncPlaybackRate` and `maxLiveSyncPlaybackRate` config bounds to `playbackRate` adjustment

Target latency is determined by:

1. User defined configuration option `liveSyncDuration` or `liveSyncDurationCount`
2. HOLD-BACK (not Low-Latency) or PART-HOLD-BACK (LL-HLS) in v9+ HLS playlist
3. Default is TARGETDURATION * 3 (`DefaultConfig.liveSyncDurationCount`)

### Why is this Pull Request needed?
This controller will be responsible for hls.js's live streaming API. Playback rate control will help maintain a target latency and reduce under-buffer stalls. 

### Checklist

- [x] changes have been done against the feature/v1.0.0 branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
