### PR TITLE
on level load, check current level details as well as new when determ…

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -417,13 +417,13 @@ class AudioStreamController extends BaseStreamController {
     let newDetails = data.details,
       trackId = data.id,
       track = this.tracks[trackId],
+      curDetails = track.details,
       duration = newDetails.totalduration,
       sliding = 0;
 
     logger.log(`track ${trackId} loaded [${newDetails.startSN},${newDetails.endSN}],duration:${duration}`);
 
-    if (newDetails.live) {
-      let curDetails = track.details;
+    if (newDetails.live || (curDetails && curDetails.live)) {
       if (curDetails && newDetails.fragments.length > 0) {
         // we already have details for that level, merge them
         LevelHelper.mergeDetails(curDetails, newDetails);

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -783,7 +783,7 @@ class StreamController extends BaseStreamController {
 
     logger.log(`level ${newLevelId} loaded [${newDetails.startSN},${newDetails.endSN}],duration:${duration}`);
 
-    if (newDetails.live) {
+    if (newDetails.live || (curLevel.details && curLevel.details.live)) {
       let curDetails = curLevel.details;
       if (curDetails && newDetails.fragments.length > 0) {
         // we already have details for that level, merge them


### PR DESCRIPTION
### This PR will...

Improve playback when a stream switches to VOD (an ENDLIST tag is found)

### Why is this Pull Request needed?

Currently if 2 fragments come with an ENDLIST tag, hls.js will skip the first of the two chunks and play the last before going to VOD.

### Are there any points in the code the reviewer needs to double check?

I'm not certain if the same fix needs to be applied to subtitle tracks or audio tracks or not

### Resolves issues:

End of stream playback when 2 fragments + ENDLIST come in

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
