### PR TITLE
LL-HLS RENDITION-REPORT playlist variant switching

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1354,7 +1354,7 @@ Full list of Events is available below:
   - `Hls.Events.MANIFEST_PARSED`  - fired after manifest has been parsed
     -  data: { levels : [ available quality levels ], firstLevel : index of first quality level appearing in Manifest, audioTracks, subtitleTracks, stats, audio: boolean, video: boolean, altAudio: boolean }
   - `Hls.Events.LEVEL_SWITCHING`  - fired when a level switch is requested
-    -  data: { `level` object (please see [below](#level) for more information) }
+    -  data: { `level` and Level object properties (please see [below](#level) for more information) }
   - `Hls.Events.LEVEL_SWITCHED`  - fired when a level switch is effective
     -  data: { level : id of new level }
   - `Hls.Events.LEVEL_LOADING`  - fired when a level playlist loading starts
@@ -1370,7 +1370,7 @@ Full list of Events is available below:
   - `Hls.Events.AUDIO_TRACKS_UPDATED`  - fired to notify that audio track lists has been updated
     -  data: { audioTracks : audioTracks }
   - `Hls.Events.AUDIO_TRACK_SWITCHING`  - fired when an audio track switching is requested
-    -  data: { id : audio track id }
+    -  data: { id : audio track id, type : playlist type ('AUDIO' | 'main'), url : audio track URL }
   - `Hls.Events.AUDIO_TRACK_SWITCHED`  - fired when an audio track switch actually occurs
     -  data: { id : audio track id }
   - `Hls.Events.AUDIO_TRACK_LOADING`  - fired when an audio track loading starts
@@ -1380,7 +1380,7 @@ Full list of Events is available below:
   - `Hls.Events.SUBTITLE_TRACKS_UPDATED`  - fired to notify that subtitle track lists has been updated
     -  data: { subtitleTracks : subtitleTracks }
   - `Hls.Events.SUBTITLE_TRACK_SWITCH`  - fired when a subtitle track switch occurs
-    -  data: { id : subtitle track id }
+    -  data: { id : subtitle track id, type? : playlist type ('SUBTITLES' | 'CLOSED-CAPTIONS'), url? : subtitle track URL  }
   - `Hls.Events.SUBTITLE_TRACK_LOADING`  - fired when a subtitle track loading starts
     -  data: { url : audio track URL, id : audio track id }
   - `Hls.Events.SUBTITLE_TRACK_LOADED`  - fired when a subtitle track loading finishes

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -240,29 +240,29 @@ class AudioTrackController extends BasePlaylistController {
   }
 
   private _setAudioTrack (newId: number): void {
+    const tracks = this.tracks;
     // noop on same audio track id as already set
-    if (this.trackId === newId && this.tracks[this.trackId].details) {
+    if (this.trackId === newId && tracks[newId]?.details) {
       return;
     }
 
     // check if level idx is valid
-    if (newId < 0 || newId >= this.tracks.length) {
+    if (newId < 0 || newId >= tracks.length) {
       logger.warn('[audio-track-controller]: Invalid id passed to audio-track controller');
       return;
     }
 
-    const audioTrack = this.tracks[newId];
-
-    logger.log(`[audio-track-controller]: Now switching to audio-track index ${newId}`);
-
     // stopping live reloading timer if any
     this.clearTimer();
-    this.trackId = newId;
 
-    const { url, type, id } = audioTrack;
+    const lastTrack = tracks[this.trackId];
+    const track = tracks[newId];
+    logger.log(`[audio-track-controller]: Now switching to audio-track index ${newId}`);
+    this.trackId = newId;
+    const { url, type, id } = track;
     this.hls.trigger(Events.AUDIO_TRACK_SWITCHING, { id, type, url });
-    // TODO: LL-HLS use RENDITION-REPORT if available
-    this.loadPlaylist();
+    const hlsUrlParameters = this.switchParams(track.url, lastTrack?.details);
+    this.loadPlaylist(hlsUrlParameters);
   }
 
   private _selectInitialAudioTrack (): void {

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -39,6 +39,29 @@ export default class BasePlaylistController implements NetworkComponentAPI {
     this.clearTimer();
   }
 
+  protected switchParams (playlistUri: string, previous?: LevelDetails): HlsUrlParameters | undefined {
+    const renditionReports = previous?.renditionReports;
+    if (renditionReports) {
+      for (let i = 0; i < renditionReports.length; i++) {
+        const attr = renditionReports[i];
+        const uri = '' + attr.URI;
+        if (uri === playlistUri.substr(-uri.length)) {
+          const msn = parseInt(attr['LAST-MSN']);
+          let part = parseInt(attr['LAST-PART']);
+          if (previous && this.hls.config.lowLatencyMode) {
+            const currentGoal = Math.min(previous.age - previous.partTarget, previous.targetduration);
+            if (part !== undefined && currentGoal > previous.partTarget) {
+              part += 1;
+            }
+          }
+          if (Number.isFinite(msn)) {
+            return new HlsUrlParameters(msn, Number.isFinite(part) ? part : undefined, HlsSkip.No);
+          }
+        }
+      }
+    }
+  }
+
   protected loadPlaylist (hlsUrlParameters?: HlsUrlParameters): void {}
 
   protected shouldLoadTrack (track: MediaPlaylist): boolean {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -155,6 +155,8 @@ export interface SubtitleTracksUpdatedData {
 }
 
 export interface SubtitleTrackSwitchData {
+  url?: string
+  type?: MediaPlaylistType | 'main'
   id: number
 }
 

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -119,4 +119,8 @@ export class Level {
   get maxBitrate (): number {
     return Math.max(this.realBitrate, this.bitrate);
   }
+
+  get uri (): string {
+    return this.url[this.urlId] || '';
+  }
 }

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -5,7 +5,13 @@ export interface AudioGroup {
   codec?: string;
 }
 
-export type MediaPlaylistType = 'AUDIO' | 'VIDEO' | 'SUBTITLES' | 'CLOSED-CAPTIONS';
+export type AudioPlaylistType = 'AUDIO';
+
+export type MainPlaylistType = AudioPlaylistType | 'VIDEO';
+
+export type SubtitlePlaylistType = 'SUBTITLES' | 'CLOSED-CAPTIONS';
+
+export type MediaPlaylistType = MainPlaylistType | SubtitlePlaylistType;
 
 // audioTracks, captions and subtitles returned by `M3U8Parser.parseMasterPlaylistMedia`
 export interface MediaPlaylist extends LevelParsed {

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -18,7 +18,32 @@ describe('SubtitleTrackController', function () {
     videoElement = document.createElement('video');
     subtitleTrackController = new SubtitleTrackController(hls);
     subtitleTrackController.media = videoElement;
-    subtitleTrackController.tracks = [{ id: 0, url: 'baz', details: { live: false } }, { id: 1, url: 'bar' }, { id: 2, details: { live: true }, url: 'foo' }];
+    subtitleTrackController.tracks = [{
+      id: 0,
+      groupId: 'default-text-group',
+      lang: 'en',
+      name: 'English',
+      type: 'SUBTITLES',
+      url: 'baz',
+      details: { live: false }
+    },
+    {
+      id: 1,
+      groupId: 'default-text-group',
+      lang: 'en',
+      name: 'English',
+      type: 'SUBTITLES',
+      url: 'bar'
+    },
+    {
+      id: 2,
+      groupId: 'default-text-group',
+      lang: 'en',
+      name: 'English',
+      type: 'SUBTITLES',
+      url: 'foo',
+      details: { live: true }
+    }];
 
     const textTrack1 = videoElement.addTextTrack('subtitles', 'English', 'en');
     const textTrack2 = videoElement.addTextTrack('subtitles', 'Swedish', 'se');
@@ -95,7 +120,7 @@ describe('SubtitleTrackController', function () {
       subtitleTrackController.subtitleTrack = 1;
 
       expect(triggerSpy).to.have.been.calledTwice;
-      expect(triggerSpy.firstCall).to.have.been.calledWith('hlsSubtitleTrackSwitch', { id: 1 });
+      expect(triggerSpy.firstCall).to.have.been.calledWith('hlsSubtitleTrackSwitch', { id: 1, type: 'SUBTITLES', url: 'bar' });
     });
 
     it('should trigger SUBTITLE_TRACK_LOADING if the track has no details', function () {
@@ -118,7 +143,7 @@ describe('SubtitleTrackController', function () {
       subtitleTrackController.subtitleTrack = 0;
 
       expect(triggerSpy).to.have.been.calledOnce;
-      expect(triggerSpy.firstCall).to.have.been.calledWith('hlsSubtitleTrackSwitch', { id: 0 });
+      expect(triggerSpy.firstCall).to.have.been.calledWith('hlsSubtitleTrackSwitch', { id: 0, type: 'SUBTITLES', url: 'baz' });
     });
 
     it('should trigger SUBTITLE_TRACK_SWITCH if passed -1', function () {


### PR DESCRIPTION
### This PR will...
- Use RENDITION-REPORT details to make blocking reload requests when switching level/audio/subtitle playlists
- Add `type` and `url` to "hlsSubtitleTrackSwitch" events switching to a track
  - Subtitle disabling switches to index `-1` continue to only contain `{ id }`

### Why is this Pull Request needed?
These changes allow us to make blocking playlist requests for variants that should be (close to) the latest already available on the origin and edge.

### Are there any points in the code the reviewer needs to double check?

These changes use the previous playlist report's LAST-MSN and LAST-PART attributes for the variant being switched to as parameters in the request for that playlist.

Improvements to low-latency switching like playlist/segment prefetching or variant latency/under-buffer estimates using these reports are not included in this change-set.

### Checklist

- [x] changes have been done against the feature/v1.0.0 branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
