### PR TITLE
Add onprogress listener to xhr-loader

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -89,6 +89,7 @@ class XhrLoader implements Loader<LoaderContext> {
     }
 
     xhr.onreadystatechange = this.readystatechange.bind(this);
+    xhr.onprogress = this.loadprogress.bind(this);
     xhr.responseType = context.responseType as XMLHttpRequestResponseType;
     // setup timeout before we perform request
     this.requestTimeout = self.setTimeout(this.loadtimeout.bind(this), (this.config as LoaderConfiguration).timeout);
@@ -171,6 +172,15 @@ class XhrLoader implements Loader<LoaderContext> {
     if (callbacks) {
       this.abortInternal();
       callbacks.onTimeout(this.stats, this.context, this.loader);
+    }
+  }
+
+  loadprogress (event: ProgressEvent): void {
+    const stats = this.stats;
+
+    stats.loaded = event.loaded;
+    if (event.lengthComputable) {
+      stats.total = event.total;
     }
   }
 


### PR DESCRIPTION
### This PR will...

Add the missing `onprogress` event listener to the `XMLHttpRequest` object inside the `xhr-loader`, and update `stats.loaded` & `stats.total` accordingly.

### Why is this Pull Request needed?

The ABR controller [relies](https://github.com/video-dev/hls.js/blob/feature/v1.0.0/src/controller/abr-controller.ts#L122) on the `.loaded` property of the `ProgressEvent` for accurate estimation of the remaining bytes to download.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
