### PR TITLE
Sample AES decryption with 48 AVC Closes: #3102

### DIFF
--- a/src/demux/sample-aes.js
+++ b/src/demux/sample-aes.js
@@ -105,7 +105,7 @@ class SampleAesDecrypter {
         }
 
         let curUnit = curUnits[unitIndex];
-        if (curUnit.length <= 48 || (curUnit.type !== 1 && curUnit.type !== 5)) {
+        if (curUnit.data.length <= 48 || (curUnit.type !== 1 && curUnit.type !== 5)) {
           continue;
         }
 


### PR DESCRIPTION
### This PR will fix Nals <= 48 going through decryption phase

### Why is this Pull Request needed?
Nals <= 48 go through decryption phase
Nothing is decrypted (too few data), but discardEPB is performed, which corrupts bitstream, which results in artifacts in playback, depending on target machine + browser this may also freeze the tab/browser, as corrupt data is fed to decoder
This error looks like a typo.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
#3102 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
