### PR TITLE
Switch to stable dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"
-    version_requirement_updates: "increase_versions_if_necessary"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99
+    versioning-strategy: increase-if-necessary

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,13 @@
+name: Auto Merge Dependency Updates
+
+on:
+  - pull_request
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tjenkinson/gh-action-auto-merge-dependency-updates@d053c2f
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allowed-actors: dependabot[bot]


### PR DESCRIPTION
### This PR will...
Switch to the stable version of dependabot which is managed by GitHub and configures an [auto merge action](https://github.com/tjenkinson/gh-action-auto-merge-dependency-updates) (disclaimer: I wrote it) to merge the dependency update PRs which don't contain major bumps.

### Why is this Pull Request needed?

Because the current dependabot is going away eventually. The auto merge action isn't needed, but if we make the travis step required, then it could be helpful if we have enough confidence in that to merge. The new dependabot doesn't support auto merging after an approval anymore.

### TODO
- [x] If we keep the auto merge action, we should make the travis step a required status check so that it only merges if the tests pass. (Admins can still override and merge PR's with that check failing)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
