### PR TITLE
LL-HLS Part Loading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,11 +97,11 @@ module.exports = {
       { property: 'find' } // Intended to block usage of Array.prototype.find
     ],
 
-    'standard/no-callback-literal': 1,
+    'standard/no-callback-literal': 0,
     'import/first': 1,
     'no-var': 1,
     'no-empty': 1,
-    'no-mixed-operators': 1,
+    'no-mixed-operators': 2,
     'no-unused-vars': 2,
     'no-console': [
       1,
@@ -114,13 +114,13 @@ module.exports = {
     'no-irregular-whitespace': 1,
     'no-self-assign': 1,
     'new-cap': 1,
-    'no-undefined': 1,
+    'no-undefined': 0,
     'no-global-assign': 2,
     'prefer-const': 2,
     'dot-notation': 2,
     'array-bracket-spacing': 2,
     'quote-props': 2,
-    'no-void': 0,
+    'no-void': 2,
     'no-useless-catch': 2,
     'lines-between-class-members': 2,
     'no-prototype-builtins': 0

--- a/demo/canvas.js
+++ b/demo/canvas.js
@@ -328,7 +328,7 @@ function canvasBitrateEventUpdate (canvas, minTime, maxTime, windowMinTime, wind
   var event; var maxLevel; var minLevel; var sumLevel; var maxBitrate; var minBitrate; var sumDuration;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  if (levelEvents.length === 0) {
+  if (levelEvents.length === 0 || bitrateEvents.length === 0) {
     return;
   }
 

--- a/demo/canvas.js
+++ b/demo/canvas.js
@@ -530,6 +530,9 @@ function canvasDrawLoadEvent (ctx, yoffset, event, minTime, maxTime) {
   if (event.id2 !== undefined) {
     legend += ' ' + event.id2;
   }
+  if (event.id3 !== undefined) {
+    legend += '/' + event.id3;
+  }
   if (event.id !== undefined) {
     if (event.type.indexOf('fragment') !== -1) {
       legend += ' @';

--- a/demo/chart/chartjs-horizontal-bar.ts
+++ b/demo/chart/chartjs-horizontal-bar.ts
@@ -103,6 +103,10 @@ Chart.controllers.horizontalBar.prototype.draw = function () {
         if (!stats) {
           stats = {};
         }
+        if (isPart) {
+          ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+          ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
+        }
         if (stats.aborted) {
           ctx.fillStyle = 'rgba(100, 0, 0, 0.3)';
           ctx.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);

--- a/demo/index.html
+++ b/demo/index.html
@@ -50,14 +50,22 @@
 
           <input id="streamURL" class="innerControls" type=text value=""/>
 
-          <label class="innerControls">
+          <label class="innerControls"
+                 title="Uncheck this to disable loading of streams selected from the drop-down above.">
             Enable streaming:
             <input id="enableStreaming" type=checkbox checked/>
           </label>
 
-          <label class="innerControls">
+          <label class="innerControls"
+                 title="When a media error occurs, attempt to recover playback by calling `hls.recoverMediaError()`.">
             Auto-recover media-errors:
             <input id="autoRecoverError" type=checkbox checked/>
+          </label>
+
+          <label class="innerControls"
+                 title="Stop loading and playback if playback under-buffer stalls. This can help debug stall errors.">
+            Stop on first stall:
+            <input id="stopOnStall" type=checkbox unchecked/>
           </label>
 
           <label class="innerControls">

--- a/demo/main.js
+++ b/demo/main.js
@@ -479,9 +479,10 @@ function loadSelectedStream () {
 
   hls.on(Hls.Events.FRAG_BUFFERED, function (eventName, data) {
     const event = {
-      type: data.frag.type + ' fragment',
+      type: data.frag.type + (data.part ? ' part' : ' fragment'),
       id: data.frag.level,
       id2: data.frag.sn,
+      id3: data.part ? data.part.index : undefined,
       time: data.stats.loading.start - events.t0,
       latency: data.stats.loading.first - data.stats.loading.start,
       load: data.stats.loading.end - data.stats.loading.first,
@@ -798,10 +799,10 @@ function loadSelectedStream () {
   video.addEventListener('loadeddata', handleVideoEvent);
   video.addEventListener('durationchange', handleVideoEvent);
   video.addEventListener('volumechange', (evt) => {
-      localStorage.setItem(STORAGE_KEYS.volume, JSON.stringify({
-        muted: video.muted,
-        volume: video.volume
-      }));
+    localStorage.setItem(STORAGE_KEYS.volume, JSON.stringify({
+      muted: video.muted,
+      volume: video.volume
+    }));
   });
 }
 
@@ -1023,7 +1024,6 @@ function checkBuffer () {
         for (const type in tracks) {
           log += `Buffer for ${type} contains:${timeRangesToString(tracks[type].buffer.buffered)}\n`;
         }
-
         const videoPlaybackQuality = video.getVideoPlaybackQuality;
         if (videoPlaybackQuality && typeof (videoPlaybackQuality) === typeof (Function)) {
           log += `Dropped frames: ${video.getVideoPlaybackQuality().droppedVideoFrames}\n`;
@@ -1032,7 +1032,7 @@ function checkBuffer () {
           log += `Dropped frames: ${video.webkitDroppedFrameCount}\n`;
         }
       }
-
+      log += `Bandwidth Estimate: ${hls.bandwidthEstimate.toFixed(3)}\n`;
       if (events.isLive) {
         log += 'Live Stats:\n' +
           `  Max Latency: ${hls.maxLatency}\n` +
@@ -1517,7 +1517,7 @@ function toggleTabClick (btn) {
 function toggleTab (btn, dontHideOpenTabs) {
   const tabElId = $(btn).data('tab');
   // eslint-disable-next-line no-restricted-globals
-  const modifierPressed = dontHideOpenTabs || self.event && (self.event.metaKey || self.event.shiftKey);
+  const modifierPressed = dontHideOpenTabs || (self.event && (self.event.metaKey || self.event.shiftKey));
   if (!modifierPressed) {
     hideAllTabs();
   }

--- a/demo/main.js
+++ b/demo/main.js
@@ -37,6 +37,7 @@ let autoRecoverError = getDemoConfigPropOrDefault('autoRecoverError', true);
 let levelCapping = getDemoConfigPropOrDefault('levelCapping', -1);
 let limitMetrics = getDemoConfigPropOrDefault('limitMetrics', -1);
 let dumpfMP4 = getDemoConfigPropOrDefault('dumpfMP4', false);
+let stopOnStall = getDemoConfigPropOrDefault('stopOnStall', false);
 
 let bufferingIdx = -1;
 let selectedTestStream = null;
@@ -138,6 +139,11 @@ $(document).ready(function () {
     onDemoConfigChanged();
   });
 
+  $('#stopOnStall').click(function () {
+    stopOnStall = this.checked;
+    onDemoConfigChanged();
+  });
+
   $('#dumpfMP4').click(function () {
     dumpfMP4 = this.checked;
     $('.btn-dump').toggle(dumpfMP4);
@@ -157,6 +163,7 @@ $(document).ready(function () {
   $('#limitMetrics').val(limitMetrics);
   $('#enableStreaming').prop('checked', enableStreaming);
   $('#autoRecoverError').prop('checked', autoRecoverError);
+  $('#stopOnStall').prop('checked', stopOnStall);
   $('#dumpfMP4').prop('checked', dumpfMP4);
   $('#levelCapping').val(levelCapping);
 
@@ -703,6 +710,10 @@ function loadSelectedStream () {
       break;
     case Hls.ErrorDetails.BUFFER_STALLED_ERROR:
       logError('Buffer stalled error');
+      if (stopOnStall) {
+        hls.stopLoad();
+        video.pause();
+      }
       break;
     default:
       break;
@@ -1259,6 +1270,7 @@ function onDemoConfigChanged () {
   demoConfig = {
     enableStreaming,
     autoRecoverError,
+    stopOnStall,
     dumpfMP4,
     levelCapping,
     limitMetrics

--- a/docs/API.md
+++ b/docs/API.md
@@ -354,7 +354,7 @@ Configuration parameters could be provided to hls.js upon instantiation of `Hls`
       startFragPrefetch: false,
       testBandwidth: true,
       progressive: false,
-      lowLatencyMode: false,
+      lowLatencyMode: true,
       fpsDroppedMonitoringPeriod: 5000,
       fpsDroppedMonitoringThreshold: 0.2,
       appendErrorMaxRetry: 3,
@@ -685,7 +685,7 @@ Enable streaming segment data with fetch loader (experimental).
 
 ### `lowLatencyMode`
                   
-(default: `false`)
+(default: `true`)
 
 Enable Low-Latency HLS part playlist and segment loading, and start live streams at playlist PART-HOLD-BACK rather than HOLD-BACK.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "./scripts/lint.sh --fix",
     "lint:quiet": "./scripts/lint.sh --quiet",
     "pretest": "npm run lint",
-    "sanity-check": "npm run lint && npm run docs && npm run type-check && npm run build:types && npm run build && npm run test:unit",
+    "sanity-check": "npm run lint && npm run type-check && npm run docs && npm run build:types && npm run build && npm run test:unit",
     "start": "npm run dev",
     "test": "npm run test:unit && npm run test:func",
     "test:unit": "karma start karma.conf.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -253,7 +253,7 @@ export const hlsDefaultConfig: HlsConfig = {
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
   testBandwidth: true,
   progressive: false,
-  lowLatencyMode: false,
+  lowLatencyMode: true,
 
   // Dynamic Modules
   ...timelineConfig(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -183,7 +183,7 @@ export type HlsConfig =
 export const hlsDefaultConfig: HlsConfig = {
   autoStartLoad: true, // used by stream-controller
   startPosition: -1, // used by stream-controller
-  defaultAudioCodec: void 0, // used by stream-controller
+  defaultAudioCodec: undefined, // used by stream-controller
   debug: false, // used by logger
   capLevelOnFPSDrop: false, // used by fps-controller
   capLevelToPlayerSize: false, // used by cap-level-controller
@@ -197,8 +197,8 @@ export const hlsDefaultConfig: HlsConfig = {
   maxFragLookUpTolerance: 0.25, // used by stream-controller
   liveSyncDurationCount: 3, // used by latency-controller
   liveMaxLatencyDurationCount: Infinity, // used by latency-controller
-  liveSyncDuration: void 0, // used by latency-controller
-  liveMaxLatencyDuration: void 0, // used by latency-controller
+  liveSyncDuration: undefined, // used by latency-controller
+  liveMaxLatencyDuration: undefined, // used by latency-controller
   minLiveSyncPlaybackRate: 0.75, // used by latency-controller
   maxLiveSyncPlaybackRate: 1.5, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
@@ -210,7 +210,7 @@ export const hlsDefaultConfig: HlsConfig = {
   manifestLoadingMaxRetry: 1, // used by playlist-loader
   manifestLoadingRetryDelay: 1000, // used by playlist-loader
   manifestLoadingMaxRetryTimeout: 64000, // used by playlist-loader
-  startLevel: void 0, // used by level-controller
+  startLevel: undefined, // used by level-controller
   levelLoadingTimeOut: 10000, // used by playlist-loader
   levelLoadingMaxRetry: 4, // used by playlist-loader
   levelLoadingRetryDelay: 1000, // used by playlist-loader
@@ -225,11 +225,10 @@ export const hlsDefaultConfig: HlsConfig = {
   appendErrorMaxRetry: 3, // used by buffer-controller
   loader: XhrLoader,
   // loader: FetchLoader,
-  fLoader: void 0, // used by fragment-loader
-  pLoader: void 0, // used by playlist-loader
-  xhrSetup: void 0, // used by xhr-loader
-  licenseXhrSetup: void 0, // used by eme-controller
-  // fetchSetup: void 0,
+  fLoader: undefined, // used by fragment-loader
+  pLoader: undefined, // used by playlist-loader
+  xhrSetup: undefined, // used by xhr-loader
+  licenseXhrSetup: undefined, // used by eme-controller
   abrController: AbrController,
   bufferController: BufferController,
   capLevelController: CapLevelController,
@@ -249,7 +248,7 @@ export const hlsDefaultConfig: HlsConfig = {
   maxLoadingDelay: 4, // used by abr-controller
   minAutoBitrate: 0, // used by hls
   emeEnabled: false, // used by eme-controller
-  widevineLicenseUrl: void 0, // used by eme-controller
+  widevineLicenseUrl: undefined, // used by eme-controller
   drmSystemOptions: {}, // used by eme-controller
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
   testBandwidth: true,
@@ -258,12 +257,12 @@ export const hlsDefaultConfig: HlsConfig = {
 
   // Dynamic Modules
   ...timelineConfig(),
-  subtitleStreamController: (__USE_SUBTITLES__) ? SubtitleStreamController : void 0,
-  subtitleTrackController: (__USE_SUBTITLES__) ? SubtitleTrackController : void 0,
-  timelineController: (__USE_SUBTITLES__) ? TimelineController : void 0,
-  audioStreamController: (__USE_ALT_AUDIO__) ? AudioStreamController : void 0,
-  audioTrackController: (__USE_ALT_AUDIO__) ? AudioTrackController : void 0,
-  emeController: (__USE_EME_DRM__) ? EMEController : void 0
+  subtitleStreamController: (__USE_SUBTITLES__) ? SubtitleStreamController : undefined,
+  subtitleTrackController: (__USE_SUBTITLES__) ? SubtitleTrackController : undefined,
+  timelineController: (__USE_SUBTITLES__) ? TimelineController : undefined,
+  audioStreamController: (__USE_ALT_AUDIO__) ? AudioStreamController : undefined,
+  audioTrackController: (__USE_ALT_AUDIO__) ? AudioTrackController : undefined,
+  emeController: (__USE_EME_DRM__) ? EMEController : undefined
 };
 
 function timelineConfig (): TimelineControllerConfig {
@@ -284,16 +283,16 @@ function timelineConfig (): TimelineControllerConfig {
   };
 }
 
-export function mergeConfig (defaultConfig: HlsConfig, userConfig: any): HlsConfig {
+export function mergeConfig (defaultConfig: HlsConfig, userConfig: Partial<HlsConfig>): HlsConfig {
   if ((userConfig.liveSyncDurationCount || userConfig.liveMaxLatencyDurationCount) && (userConfig.liveSyncDuration || userConfig.liveMaxLatencyDuration)) {
     throw new Error('Illegal hls.js config: don\'t mix up liveSyncDurationCount/liveMaxLatencyDurationCount and liveSyncDuration/liveMaxLatencyDuration');
   }
 
-  if (userConfig.liveMaxLatencyDurationCount !== void 0 && userConfig.liveMaxLatencyDurationCount <= userConfig.liveSyncDurationCount) {
+  if (userConfig.liveMaxLatencyDurationCount !== undefined && (userConfig.liveSyncDurationCount === undefined || userConfig.liveMaxLatencyDurationCount <= userConfig.liveSyncDurationCount)) {
     throw new Error('Illegal hls.js config: "liveMaxLatencyDurationCount" must be greater than "liveSyncDurationCount"');
   }
 
-  if (userConfig.liveMaxLatencyDuration !== void 0 && (userConfig.liveMaxLatencyDuration <= userConfig.liveSyncDuration || userConfig.liveSyncDuration === void 0)) {
+  if (userConfig.liveMaxLatencyDuration !== undefined && (userConfig.liveSyncDuration === undefined || userConfig.liveMaxLatencyDuration <= userConfig.liveSyncDuration)) {
     throw new Error('Illegal hls.js config: "liveMaxLatencyDuration" must be greater than "liveSyncDuration"');
   }
 

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -481,7 +481,7 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
     if (frag && frag.type !== 'audio') {
       return;
     }
-    if (this._fragLoadAborted(frag)) {
+    if (this.fragContextChanged(frag)) {
       // If a level switch was requested while a fragment was buffering, it will emit the FRAG_BUFFERED event upon completion
       // Avoid setting state back to IDLE or concluding the audio switch; otherwise, the switched-to track will not buffer
       this.warn(`Fragment ${frag.sn} of level ${frag.level} finished buffering, but was aborted. state: ${this.state}, audioSwitch: ${this.audioSwitch}`);
@@ -612,7 +612,7 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
 
     // Check if the current fragment has been aborted. We check this by first seeing if we're still playing the current level.
     // If we are, subsequently check if the currently loading fragment (fragCurrent) has changed.
-    if (this._fragLoadAborted(frag)) {
+    if (this.fragContextChanged(frag)) {
       return;
     }
 

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -33,8 +33,6 @@ import type {
   BufferFlushedData
 } from '../types/events';
 
-const { performance } = self;
-
 const TICK_INTERVAL = 100; // how often to tick in ms
 
 class AudioStreamController extends BaseStreamController implements NetworkComponentAPI {
@@ -191,8 +189,6 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
         this.state = State.IDLE;
       }
     }
-    default:
-      break;
     }
 
     this.onTickEnd();
@@ -256,46 +252,50 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
       return;
     }
 
-    const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : this.media;
-    const videoBuffer = this.videoBuffer ? this.videoBuffer : this.media;
-    const maxBufferHole = pos < config.maxBufferHole ? Math.max(MAX_START_GAP_JUMP, config.maxBufferHole) : config.maxBufferHole;
-    const bufferInfo = BufferHelper.bufferInfo(mediaBuffer, pos, maxBufferHole);
-    const mainBufferInfo = BufferHelper.bufferInfo(videoBuffer, pos, maxBufferHole);
-    const bufferLen = bufferInfo.len;
-    const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
-    const maxBufLen = Math.max(maxConfigBuffer, mainBufferInfo.len);
-    const audioSwitch = this.audioSwitch;
+    let frag = trackDetails.initSegment;
+    let targetBufferTime = 0;
+    if (!frag || frag.data) {
+      const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : this.media;
+      const videoBuffer = this.videoBuffer ? this.videoBuffer : this.media;
+      const maxBufferHole = pos < config.maxBufferHole ? Math.max(MAX_START_GAP_JUMP, config.maxBufferHole) : config.maxBufferHole;
+      const bufferInfo = BufferHelper.bufferInfo(mediaBuffer, pos, maxBufferHole);
+      const mainBufferInfo = BufferHelper.bufferInfo(videoBuffer, pos, maxBufferHole);
+      const bufferLen = bufferInfo.len;
+      const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
+      const maxBufLen = Math.max(maxConfigBuffer, mainBufferInfo.len);
+      const audioSwitch = this.audioSwitch;
 
-    // if buffer length is less than maxBufLen try to load a new fragment
-    if (bufferLen >= maxBufLen && !audioSwitch) {
-      return;
-    }
+      // if buffer length is less than maxBufLen try to load a new fragment
+      if (bufferLen >= maxBufLen && !audioSwitch) {
+        return;
+      }
 
-    if (!audioSwitch && this._streamEnded(bufferInfo, trackDetails)) {
-      hls.trigger(Events.BUFFER_EOS, { type: 'audio' });
-      this.state = State.ENDED;
-      return;
-    }
+      if (!audioSwitch && this._streamEnded(bufferInfo, trackDetails)) {
+        hls.trigger(Events.BUFFER_EOS, { type: 'audio' });
+        this.state = State.ENDED;
+        return;
+      }
 
-    const fragments = trackDetails.fragments;
-    const start = fragments[0].start;
-    let targetBufferTime = bufferInfo.end;
+      const fragments = trackDetails.fragments;
+      const start = fragments[0].start;
+      targetBufferTime = bufferInfo.end;
 
-    if (audioSwitch) {
-      targetBufferTime = pos;
-      // if currentTime (pos) is less than alt audio playlist start time, it means that alt audio is ahead of currentTime
-      if (trackDetails.PTSKnown && pos < start) {
-        // if everything is buffered from pos to start or if audio buffer upfront, let's seek to start
-        if (bufferInfo.end > start || bufferInfo.nextStart) {
-          this.log('Alt audio track ahead of main track, seek to start of alt audio track');
-          media.currentTime = start + 0.05;
+      if (audioSwitch) {
+        targetBufferTime = pos;
+        // if currentTime (pos) is less than alt audio playlist start time, it means that alt audio is ahead of currentTime
+        if (trackDetails.PTSKnown && pos < start) {
+          // if everything is buffered from pos to start or if audio buffer upfront, let's seek to start
+          if (bufferInfo.end > start || bufferInfo.nextStart) {
+            this.log('Alt audio track ahead of main track, seek to start of alt audio track');
+            media.currentTime = start + 0.05;
+          }
         }
       }
-    }
 
-    const frag = this.getNextFragment(targetBufferTime, trackDetails);
-    if (!frag) {
-      return;
+      frag = this.getNextFragment(targetBufferTime, trackDetails);
+      if (!frag) {
+        return;
+      }
     }
 
     if (frag.decryptdata?.keyFormat === 'identity' && !frag.decryptdata?.key) {
@@ -303,15 +303,7 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
       this.state = State.KEY_LOADING;
       hls.trigger(Events.KEY_LOADING, { frag });
     } else {
-      // only load if fragment is not loaded or if in audio switch
-      // we force a frag loading in audio switch as fragment tracker might not have evicted previous frags in case of quick audio switch
-      const fragState = this.fragmentTracker.getState(frag);
-      if (this.audioSwitch || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
-        this.log(`Loading ${frag.sn}, cc: ${frag.cc} of [${trackDetails.startSN}-${trackDetails.endSN}], track ${trackId}, ${
-          this.loadedmetadata ? 'currentTime' : 'nextLoadPosition'
-        }: ${pos.toFixed(3)}-${targetBufferTime.toFixed(3)}`);
-        this.loadFragment(frag, targetBufferTime);
-      }
+      this.loadFragment(frag, trackDetails, targetBufferTime);
     }
   }
 
@@ -396,6 +388,9 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
     const track = levels[trackId];
     let sliding = 0;
     if (newDetails.live || track.details?.live) {
+      if (!newDetails.fragments[0]) {
+        newDetails.deltaUpdateFailed = true;
+      }
       if (newDetails.deltaUpdateFailed) {
         return;
       }
@@ -418,7 +413,7 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
   }
 
   _handleFragmentLoadProgress (data: FragLoadedData) {
-    const { frag, payload } = data;
+    const { frag, part, payload } = data;
     const { config, trackId, levels } = this;
     if (!levels) {
       this.warn(`Audio tracks were reset while fragment load was in progress. Fragment ${frag.sn} of level ${frag.level} will not be buffered`);
@@ -445,8 +440,10 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
       // this.log(`Transmuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
       // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
       const accurateTimeOffset = false; // details.PTSKnown || !details.live;
-      const chunkMeta = new ChunkMetadata(frag.level, frag.sn, frag.stats.chunkCount, payload.byteLength);
-      transmuxer.push(payload, initSegmentData, audioCodec, '', frag, details.totalduration, accurateTimeOffset, chunkMeta, initPTS);
+      const partIndex = part ? part.index : -1;
+      const partial = partIndex !== -1;
+      const chunkMeta = new ChunkMetadata(frag.level, frag.sn as number, frag.stats.chunkCount, payload.byteLength, partIndex, partial);
+      transmuxer.push(payload, initSegmentData, audioCodec, '', frag, part, details.totalduration, accurateTimeOffset, chunkMeta, initPTS);
     } else {
       logger.log(`Unknown video PTS for cc ${frag.cc}, waiting for video PTS before demuxing audio frag ${frag.sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
       const { cache } = this.waitingData = this.waitingData || { frag, cache: new ChunkCache(), complete: false };
@@ -610,8 +607,14 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
       this.warn(`The loading context changed while buffering fragment ${chunkMeta.sn} of level ${chunkMeta.level}. This chunk will not be buffered.`);
       return;
     }
-    const { frag } = context;
+    const { frag, part } = context;
     const { audio, text, id3, initSegment } = remuxResult;
+
+    // Check if the current fragment has been aborted. We check this by first seeing if we're still playing the current level.
+    // If we are, subsequently check if the currently loading fragment (fragCurrent) has changed.
+    if (this._fragLoadAborted(frag)) {
+      return;
+    }
 
     this.state = State.PARSING;
     if (this.audioSwitch && audio) {
@@ -624,7 +627,11 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
       // Only flush audio from old audio tracks when PTS is known on new audio track
     }
     if (audio) {
-      frag.setElementaryStreamInfo(ElementaryStreamTypes.AUDIO, audio.startPTS, audio.endPTS, audio.startDTS, audio.endDTS);
+      const { startPTS, endPTS, startDTS, endDTS } = audio;
+      if (part) {
+        part.elementaryStreams[ElementaryStreamTypes.AUDIO] = { startPTS, endPTS, startDTS, endDTS };
+      }
+      frag.setElementaryStreamInfo(ElementaryStreamTypes.AUDIO, startPTS, endPTS, startDTS, endDTS);
       this.bufferFragmentData(audio, frag, chunkMeta);
     }
 
@@ -672,17 +679,27 @@ class AudioStreamController extends BaseStreamController implements NetworkCompo
     this.tick();
   }
 
-  protected loadFragment (frag: Fragment, targetBufferTime: number) {
+  protected loadFragment (frag: Fragment, trackDetails: LevelDetails, targetBufferTime: number) {
+    // only load if fragment is not loaded or if in audio switch
+    const fragState = this.fragmentTracker.getState(frag);
     this.fragCurrent = frag;
-    if (frag.sn === 'initSegment') {
-      this._loadInitSegment(frag);
-    } else if (Number.isFinite(this.initPTS[frag.cc])) {
-      this.startFragRequested = true;
-      this.nextLoadPosition = frag.start + frag.duration;
-      super.loadFragment(frag, targetBufferTime);
-    } else {
-      this.log(`Unknown video PTS for continuity counter ${frag.cc}, waiting for video PTS before loading audio fragment ${frag.sn} of level ${this.trackId}`);
-      this.state = State.WAITING_INIT_PTS;
+
+    // we force a frag loading in audio switch as fragment tracker might not have evicted previous frags in case of quick audio switch
+    if (this.audioSwitch || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
+      this.log(`Loading ${frag.sn}, cc: ${frag.cc} of [${trackDetails.startSN}-${trackDetails.endSN}], track ${
+        frag.level
+      }, target buffer time: ${parseFloat(targetBufferTime.toFixed(3))}`);
+
+      if (frag.sn === 'initSegment') {
+        this._loadInitSegment(frag);
+      } else if (Number.isFinite(this.initPTS[frag.cc])) {
+        this.startFragRequested = true;
+        this.nextLoadPosition = frag.start + frag.duration;
+        super.loadFragment(frag, trackDetails, targetBufferTime);
+      } else {
+        this.log(`Unknown video PTS for continuity counter ${frag.cc}, waiting for video PTS before loading audio fragment ${frag.sn} of level ${this.trackId}`);
+        this.state = State.WAITING_INIT_PTS;
+      }
     }
   }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -325,19 +325,20 @@ export default class BaseStreamController extends TaskLoop implements NetworkCom
     if (!this.levels) {
       throw new Error('frag load aborted, missing levels');
     }
-
     targetBufferTime = Math.max(frag.start, targetBufferTime || 0);
-    const partList = details?.partList;
-    if (partList && progressCallback) {
-      const partIndex = this.getNextPart(partList, frag, targetBufferTime);
-      if (partIndex > -1) {
-        this.state = State.FRAG_LOADING;
-        this.hls.trigger(Events.FRAG_LOADING, { frag, part: partList[partIndex], targetBufferTime });
-        return this.doFragPartsLoad(frag, partList, partIndex, progressCallback)
-          .catch((error: LoadError) => this.handleFragError(error));
-      } else if (!frag.url || this.loadedEndOfParts(partList, targetBufferTime)) {
-        // Fragment hint has no parts
-        return Promise.resolve(null);
+    if (this.config.lowLatencyMode) {
+      const partList = details?.partList;
+      if (partList && progressCallback) {
+        const partIndex = this.getNextPart(partList, frag, targetBufferTime);
+        if (partIndex > -1) {
+          this.state = State.FRAG_LOADING;
+          this.hls.trigger(Events.FRAG_LOADING, { frag, part: partList[partIndex], targetBufferTime });
+          return this.doFragPartsLoad(frag, partList, partIndex, progressCallback)
+            .catch((error: LoadError) => this.handleFragError(error));
+        } else if (!frag.url || this.loadedEndOfParts(partList, targetBufferTime)) {
+          // Fragment hint has no parts
+          return Promise.resolve(null);
+        }
       }
     }
 

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -261,7 +261,7 @@ export default class BufferController implements ComponentAPI {
           timeRanges[type] = BufferHelper.getBuffered(sourceBuffer[type]);
         }
         this.appendError = 0;
-        this.hls.trigger(Events.BUFFER_APPENDED, { parent: frag.type, timeRanges, frag, chunkMeta });
+        this.hls.trigger(Events.BUFFER_APPENDED, { parent: frag.type, timeRanges, frag, part, chunkMeta });
       },
       onError: (err) => {
         // in case any error occured while appending, put back segment in segments table
@@ -690,16 +690,16 @@ export default class BufferController implements ComponentAPI {
   // upon completion, since we already do it here
   private blockBuffers (onUnblocked: Function, buffers: Array<SourceBufferName> = this.getSourceBufferTypes()) {
     if (!buffers.length) {
-      // logger.log('[buffer-controller]: Blocking operation requested, but no SourceBuffers exist');
-      onUnblocked();
+      logger.log('[buffer-controller]: Blocking operation requested, but no SourceBuffers exist');
+      Promise.resolve(onUnblocked);
       return;
     }
     const { operationQueue } = this;
 
-    // logger.log(`[buffer-controller]: Blocking ${buffers} SourceBuffer`);
+    // logger.debug(`[buffer-controller]: Blocking ${buffers} SourceBuffer`);
     const blockingOperations = buffers.map(type => operationQueue.appendBlocker(type as SourceBufferName));
     Promise.all(blockingOperations).then(() => {
-      // logger.log(`[buffer-controller]: Blocking operation resolved; unblocking ${buffers} SourceBuffer`);
+      // logger.debug(`[buffer-controller]: Blocking operation resolved; unblocking ${buffers} SourceBuffer`);
       onUnblocked();
       buffers.forEach(type => {
         const sb = this.sourceBuffer[type];

--- a/src/controller/cap-level-controller.ts
+++ b/src/controller/cap-level-controller.ts
@@ -198,7 +198,7 @@ class CapLevelController implements ComponentAPI {
     let pixelRatio = 1;
     try {
       pixelRatio = self.devicePixelRatio;
-    } catch (e) {}
+    } catch (e) { /* no-op */ }
     return pixelRatio;
   }
 

--- a/src/controller/fps-controller.ts
+++ b/src/controller/fps-controller.ts
@@ -1,15 +1,9 @@
-/*
- * FPS Controller
-*/
-
 import { Events } from '../events';
 import { logger } from '../utils/logger';
 import { ComponentAPI } from '../types/component-api';
 import Hls from '../hls';
 import { MediaAttachingData } from '../types/events';
 import StreamController from './stream-controller';
-
-const { performance } = self;
 
 class FPSController implements ComponentAPI {
   private hls: Hls;

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -249,7 +249,8 @@ export class FragmentTracker implements ComponentAPI {
     const { frag } = data;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
-    if (frag.sn === 'initSegment' || frag.bitrateTest) {
+    // FIXME: don't track frag parts (yet)
+    if (frag.sn === 'initSegment' || frag.bitrateTest || data.part) {
       return;
     }
 

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -1,5 +1,5 @@
 import { Events } from '../events';
-import Fragment from '../loader/fragment';
+import Fragment, { Part } from '../loader/fragment';
 import { SourceBufferName } from '../types/buffer';
 import { FragmentBufferedRange, FragmentEntity, FragmentTimeRange } from '../types/fragment-tracker';
 import { PlaylistLevelType } from '../types/loader';
@@ -16,6 +16,7 @@ export enum FragmentState {
 
 export class FragmentTracker implements ComponentAPI {
   private activeFragment: Fragment | null = null;
+  private activePart: Part | null = null;
   private fragments: Partial<Record<string, FragmentEntity>> = Object.create(null);
   private timeRanges: {
     [key in SourceBufferName]: TimeRanges
@@ -54,7 +55,7 @@ export class FragmentTracker implements ComponentAPI {
    * Return a Fragment with an appended range that matches the position and levelType.
    * If not found any Fragment, return null
    */
-  getAppendedFrag (position: number, levelType: PlaylistLevelType) : Fragment | null {
+  public getAppendedFrag (position: number, levelType: PlaylistLevelType) : Fragment | null {
     const { activeFragment } = this;
     if (!activeFragment) {
       return null;
@@ -70,7 +71,7 @@ export class FragmentTracker implements ComponentAPI {
    * A buffered Fragment is one whose loading, parsing and appending is done (completed or "partial" meaning aborted).
    * If not found any Fragment, return null
    */
-  getBufferedFrag (position: number, levelType: PlaylistLevelType) : Fragment | null {
+  public getBufferedFrag (position: number, levelType: PlaylistLevelType) : Fragment | null {
     const { fragments } = this;
     const keys = Object.keys(fragments);
     for (let i = keys.length; i--;) {
@@ -90,7 +91,7 @@ export class FragmentTracker implements ComponentAPI {
    * The browser will unload parts of the buffer to free up memory for new buffer data
    * Fragments will need to be reloaded when the buffer is freed up, removing partial fragments will allow them to reload(since there might be parts that are still playable)
    */
-  detectEvictedFragments (elementaryStream: SourceBufferName, timeRange: TimeRanges) {
+  public detectEvictedFragments (elementaryStream: SourceBufferName, timeRange: TimeRanges) {
     // Check if any flagged fragments have been unloaded
     Object.keys(this.fragments).forEach(key => {
       const fragmentEntity = this.fragments[key];
@@ -116,33 +117,34 @@ export class FragmentTracker implements ComponentAPI {
    * Checks if the fragment passed in is loaded in the buffer properly
    * Partially loaded fragments will be registered as a partial fragment
    */
-  detectPartialFragments (fragment: Fragment) {
-    const { timeRanges, fragments } = this;
-    if (!timeRanges || fragment.sn === 'initSegment') {
+  private detectPartialFragments (data: FragBufferedData) {
+    const timeRanges = this.timeRanges;
+    const { frag, part } = data;
+    if (!timeRanges || frag.sn === 'initSegment') {
       return;
     }
 
-    const fragKey = getFragmentKey(fragment);
-    const fragmentEntity = fragments[fragKey];
+    const fragKey = getFragmentKey(frag);
+    const fragmentEntity = this.fragments[fragKey];
     if (!fragmentEntity) {
       return;
     }
     fragmentEntity.buffered = true;
     Object.keys(timeRanges).forEach(elementaryStream => {
-      if (!fragment.elementaryStreams[elementaryStream]) {
+      if (!frag.elementaryStreams[elementaryStream]) {
         return;
       }
-      fragmentEntity.range[elementaryStream] = this.getBufferedTimes(fragment, timeRanges[elementaryStream]);
+      fragmentEntity.range[elementaryStream] = this.getBufferedTimes(frag, part, timeRanges[elementaryStream]);
     });
   }
 
-  getBufferedTimes (fragment: Fragment, timeRange: TimeRanges): FragmentBufferedRange {
+  private getBufferedTimes (fragment: Fragment, part: Part | null, timeRange: TimeRanges): FragmentBufferedRange {
     const buffered: FragmentBufferedRange = {
       time: [],
-      partial: false
+      partial: part !== null
     };
-    const startPTS = fragment.start;
-    const endPTS = fragment.end;
+    const startPTS = part ? part.start : fragment.start;
+    const endPTS = part ? part.end : fragment.end;
     const minEndPTS = fragment.minEndPTS || endPTS;
     const maxStartPTS = fragment.maxStartPTS || startPTS;
     for (let i = 0; i < timeRange.length; i++) {
@@ -175,7 +177,7 @@ export class FragmentTracker implements ComponentAPI {
   /**
    * Gets the partial fragment for a certain time
    */
-  getPartialFragment (time: number): Fragment | null {
+  public getPartialFragment (time: number): Fragment | null {
     let bestFragment: Fragment | null = null;
     let timePadding: number;
     let startTime: number;
@@ -206,7 +208,7 @@ export class FragmentTracker implements ComponentAPI {
   /**
    *  Return the fragment state when a fragment never loaded or if it partially loaded
    */
-  getState (fragment: Fragment): FragmentState {
+  public getState (fragment: Fragment): FragmentState {
     const fragKey = getFragmentKey(fragment);
     const fragmentEntity = this.fragments[fragKey];
 
@@ -223,7 +225,7 @@ export class FragmentTracker implements ComponentAPI {
     return FragmentState.NOT_LOADED;
   }
 
-  isTimeBuffered (startPTS: number, endPTS: number, timeRange: TimeRanges): boolean {
+  private isTimeBuffered (startPTS: number, endPTS: number, timeRange: TimeRanges): boolean {
     let startTime;
     let endTime;
     for (let i = 0; i < timeRange.length; i++) {
@@ -245,17 +247,18 @@ export class FragmentTracker implements ComponentAPI {
   /**
    * Fires when a fragment loading is completed
    */
-  onFragLoaded (event: Events.FRAG_LOADED, data: FragLoadedData): void {
-    const { frag } = data;
+  private onFragLoaded (event: Events.FRAG_LOADED, data: FragLoadedData): void {
+    const { frag, part } = data;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
     // FIXME: don't track frag parts (yet)
-    if (frag.sn === 'initSegment' || frag.bitrateTest || data.part) {
+    if (frag.sn === 'initSegment' || frag.bitrateTest || part) {
       return;
     }
 
     this.fragments[getFragmentKey(frag)] = {
       body: frag,
+      part,
       range: Object.create(null),
       buffered: false
     };
@@ -264,16 +267,19 @@ export class FragmentTracker implements ComponentAPI {
   /**
    * Fires when the buffer is updated
    */
-  onBufferAppended (event: Events.BUFFER_APPENDED, data: BufferAppendedData): void {
-    const { frag, timeRanges } = data;
+  private onBufferAppended (event: Events.BUFFER_APPENDED, data: BufferAppendedData): void {
+    const { frag, part, timeRanges } = data;
     this.activeFragment = frag;
+    this.activePart = part;
     // Store the latest timeRanges loaded in the buffer
     this.timeRanges = timeRanges as { [key in SourceBufferName]: TimeRanges };
     Object.keys(timeRanges).forEach((elementaryStream: SourceBufferName) => {
       const timeRange = timeRanges[elementaryStream] as TimeRanges;
       this.detectEvictedFragments(elementaryStream, timeRange);
-      for (let i = 0; i < timeRange.length; i++) {
-        frag.appendedPTS = Math.max(timeRange.end(i), frag.appendedPTS || 0);
+      if (!part) {
+        for (let i = 0; i < timeRange.length; i++) {
+          frag.appendedPTS = Math.max(timeRange.end(i), frag.appendedPTS || 0);
+        }
       }
     });
   }
@@ -281,14 +287,14 @@ export class FragmentTracker implements ComponentAPI {
   /**
    * Fires after a fragment has been loaded into the source buffer
    */
-  onFragBuffered (event: Events.FRAG_BUFFERED, data: FragBufferedData): void {
-    this.detectPartialFragments(data.frag);
+  private onFragBuffered (event: Events.FRAG_BUFFERED, data: FragBufferedData): void {
+    this.detectPartialFragments(data);
   }
 
   /**
    * Return true if fragment tracker has the fragment.
    */
-  hasFragment (fragment: Fragment): boolean {
+  private hasFragment (fragment: Fragment): boolean {
     const fragKey = getFragmentKey(fragment);
     return !!this.fragments[fragKey];
   }
@@ -296,15 +302,17 @@ export class FragmentTracker implements ComponentAPI {
   /**
    * Remove a fragment from fragment tracker until it is loaded again
    */
-  removeFragment (fragment: Fragment): void {
+  public removeFragment (fragment: Fragment): void {
     const fragKey = getFragmentKey(fragment);
+    fragment.stats.loaded = 0;
+    fragment.clearElementaryStreamInfo();
     delete this.fragments[fragKey];
   }
 
   /**
    * Remove all fragments from fragment tracker.
    */
-  removeAllFragments (): void {
+  public removeAllFragments (): void {
     this.fragments = Object.create(null);
   }
 }

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -46,9 +46,6 @@ class ID3TrackController implements ComponentAPI {
   // Add ID3 metatadata text track.
   protected onMediaAttached (event: Events.MEDIA_ATTACHED, data: MediaAttachedData): void {
     this.media = data.media;
-    if (!this.media) {
-
-    }
   }
 
   protected onMediaDetaching (): void {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -391,6 +391,9 @@ export default class LevelController extends BasePlaylistController {
 
     if (!curLevel) {
       logger.warn('[level-controller]: Invalid level index:', level);
+      if (data.deliveryDirectives?.skip) {
+        details.deltaUpdateFailed = true;
+      }
       return;
     }
     logger.log(`[level-controller]: level ${level} loaded [${details.startSN}-${details.endSN}]`);
@@ -403,6 +406,9 @@ export default class LevelController extends BasePlaylistController {
         this.retryCount = 0;
       }
       this.playlistLoaded(level, data, curLevel.details);
+    } else if (data.deliveryDirectives?.skip) {
+      // received a delta playlist update that cannot be merged
+      details.deltaUpdateFailed = true;
     }
   }
 

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -4,10 +4,13 @@
  * */
 
 import { logger } from '../utils/logger';
-import Fragment from '../loader/fragment';
+import Fragment, { Part } from '../loader/fragment';
 import LevelDetails from '../loader/level-details';
 import { Level } from '../types/level';
 import { LoaderStats } from '../types/loader';
+
+type FragmentIntersection = (oldFrag: Fragment, newFrag: Fragment) => void;
+type PartIntersection = (oldPart: Part, newPart: Part) => void;
 
 export function addGroupId (level: Level, type: string, id: string): void {
   switch (type) {
@@ -83,9 +86,10 @@ export function updateFragPTSDTS (details: LevelDetails | undefined, frag: Fragm
 
     maxStartPTS = Math.max(startPTS, fragStartPts);
     startPTS = Math.min(startPTS, fragStartPts);
+    startDTS = Math.min(startDTS, frag.startDTS);
+
     minEndPTS = Math.min(endPTS, fragEndPts);
     endPTS = Math.max(endPTS, fragEndPts);
-    startDTS = Math.min(startDTS, frag.startDTS);
     endDTS = Math.max(endDTS, frag.endDTS);
   }
 
@@ -139,39 +143,46 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
     newDetails.initSegment = oldDetails.initSegment;
   }
 
+  if (oldDetails.fragmentHint) {
+    // prevent PTS and duration from being adjusted on the next hint
+    delete oldDetails.fragmentHint.endPTS;
+  }
   // check if old/new playlists have fragments in common
   // loop through overlapping SN and update startPTS , cc, and duration if any found
   let ccOffset = 0;
   let PTSFrag;
-  mapFragmentIntersection(oldDetails, newDetails, (oldFrag, newFrag) => {
+  mapFragmentIntersection(oldDetails, newDetails, (oldFrag: Fragment, newFrag: Fragment) => {
     ccOffset = oldFrag.cc - newFrag.cc;
     if (Number.isFinite(oldFrag.startPTS) && Number.isFinite(oldFrag.endPTS)) {
-      newFrag.start = newFrag.startPTS = oldFrag.startPTS;
+      newFrag.start = newFrag.startPTS = oldFrag.startPTS as number;
       newFrag.startDTS = oldFrag.startDTS;
       newFrag.appendedPTS = oldFrag.appendedPTS;
       newFrag.maxStartPTS = oldFrag.maxStartPTS;
-      if (!oldFrag.hasParts) {
-        newFrag.endPTS = oldFrag.endPTS;
-        newFrag.endDTS = oldFrag.endDTS;
-        newFrag.minEndPTS = oldFrag.minEndPTS;
-        newFrag.duration = oldFrag.endPTS - oldFrag.startPTS;
-      }
+
+      newFrag.endPTS = oldFrag.endPTS;
+      newFrag.endDTS = oldFrag.endDTS;
+      newFrag.minEndPTS = oldFrag.minEndPTS;
+      newFrag.duration = (oldFrag.endPTS as number) - (oldFrag.startPTS as number);
+
       newFrag.backtracked = oldFrag.backtracked;
       newFrag.dropped = oldFrag.dropped;
-      PTSFrag = newFrag;
+      if (newFrag.duration) {
+        PTSFrag = newFrag;
+      }
 
       // PTS is known when any segment has startPTS and endPTS
       newDetails.PTSKnown = newDetails.alignedSliding = true;
     }
-    newFrag.stats = oldFrag.stats;
+    newFrag.elementaryStreams = oldFrag.elementaryStreams;
     newFrag.loader = oldFrag.loader;
+    newFrag.stats = oldFrag.stats;
     newFrag.urlId = oldFrag.urlId;
   });
 
   if (newDetails.skippedSegments) {
     newDetails.deltaUpdateFailed = newDetails.fragments.some(frag => !frag);
     if (newDetails.deltaUpdateFailed) {
-      logger.warn(`[${this.constructor.name}] Previous playlist missing segments skipped in delta playlist`);
+      logger.warn('[level-helper] Previous playlist missing segments skipped in delta playlist');
       for (let i = newDetails.skippedSegments; i--;) {
         newDetails.fragments.shift();
       }
@@ -194,6 +205,12 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
     newDetails.startCC = newDetails.fragments[0].cc;
   }
 
+  // Merge parts
+  mapPartIntersection(oldDetails.partList, newDetails.partList, (oldPart: Part, newPart: Part) => {
+    newPart.elementaryStreams = oldPart.elementaryStreams;
+    newPart.stats = oldPart.stats;
+  });
+
   // if at least one fragment contains PTS info, recompute PTS information for all fragments
   if (PTSFrag) {
     updateFragPTSDTS(newDetails, PTSFrag, PTSFrag.startPTS, PTSFrag.endPTS, PTSFrag.startDTS, PTSFrag.endDTS);
@@ -209,21 +226,39 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
   }
 }
 
-export function mapFragmentIntersection (oldDetails: LevelDetails, newDetails: LevelDetails, intersectionFn): void {
+export function mapPartIntersection (oldParts: Part[] | null, newParts: Part[] | null, intersectionFn: PartIntersection) {
+  if (oldParts && newParts) {
+    let delta = 0;
+    for (let i = 0, len = oldParts.length; i <= len; i++) {
+      const oldPart = oldParts[i];
+      const newPart = newParts[i + delta];
+      if (oldPart && newPart && oldPart.index === newPart.index && oldPart.fragment.sn === newPart.fragment.sn) {
+        intersectionFn(oldPart, newPart);
+      } else {
+        delta--;
+      }
+    }
+  }
+}
+
+export function mapFragmentIntersection (oldDetails: LevelDetails, newDetails: LevelDetails, intersectionFn: FragmentIntersection): void {
   const skippedSegments = newDetails.skippedSegments;
   const start = Math.max(oldDetails.startSN, newDetails.startSN) - newDetails.startSN;
-  const end = (skippedSegments ? newDetails.endSN : Math.min(oldDetails.endSN, newDetails.endSN)) - newDetails.startSN;
+  const end = (oldDetails.fragmentHint ? 1 : 0) +
+    (skippedSegments ? newDetails.endSN : Math.min(oldDetails.endSN, newDetails.endSN)) - newDetails.startSN;
   const delta = newDetails.startSN - oldDetails.startSN;
+  const newFrags = newDetails.fragmentHint ? newDetails.fragments.concat(newDetails.fragmentHint) : newDetails.fragments;
+  const oldFrags = oldDetails.fragmentHint ? oldDetails.fragments.concat(oldDetails.fragmentHint) : oldDetails.fragments;
 
   for (let i = start; i <= end; i++) {
-    const oldFrag = oldDetails.fragments[delta + i];
-    let newFrag = newDetails.fragments[i];
+    const oldFrag = oldFrags[delta + i];
+    let newFrag = newFrags[i];
     if (skippedSegments && !newFrag && i < skippedSegments) {
       // Fill in skipped segments in delta playlist
       newFrag = newDetails.fragments[i] = oldFrag;
     }
     if (oldFrag && newFrag) {
-      intersectionFn(oldFrag, newFrag, i);
+      intersectionFn(oldFrag, newFrag);
     }
   }
 }
@@ -251,7 +286,7 @@ export function computeReloadInterval (newDetails: LevelDetails, stats: LoaderSt
   const reloadIntervalAfterMiss = reloadInterval / 2;
   const timeSinceLastModified = newDetails.lastModified ? +new Date() - newDetails.lastModified : 0;
   const useLastModified = timeSinceLastModified > 0 && timeSinceLastModified < reloadInterval * 3;
-  const roundTrip = stats ? stats.loading.end - stats.loading.start : 0;
+  const roundTrip = stats.loading.end - stats.loading.start;
 
   let estimatedTimeUntilUpdate = reloadInterval;
   let availabilityDelay = newDetails.availabilityDelay;
@@ -298,5 +333,29 @@ export function getFragmentWithSN (level: Level, sn: number): Fragment | null {
     return null;
   }
   const levelDetails = level.details;
-  return levelDetails.fragments[sn - levelDetails.startSN];
+  let fragment: Fragment | undefined = levelDetails.fragments[sn - levelDetails.startSN];
+  if (fragment) {
+    return fragment;
+  }
+  fragment = levelDetails.fragmentHint;
+  if (fragment && fragment.sn === sn) {
+    return fragment;
+  }
+  return null;
+}
+
+export function getPartWith (level: Level, sn: number, partIndex: number): Part | null {
+  if (!level || !level.details) {
+    return null;
+  }
+  const partList = level.details.partList;
+  if (partList) {
+    for (let i = partList.length; i--;) {
+      const part = partList[i];
+      if (part.index === partIndex && part.fragment.sn === sn) {
+        return part;
+      }
+    }
+  }
+  return null;
 }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -984,7 +984,12 @@ export default class StreamController extends BaseStreamController implements Ne
         const stats = frag.stats;
         // Bitrate tests fragments are neither parsed nor buffered
         stats.parsing.start = stats.parsing.end = stats.buffering.start = stats.buffering.end = self.performance.now();
-        hls.trigger(Events.FRAG_BUFFERED, { stats, frag, id: 'main' });
+        hls.trigger(Events.FRAG_BUFFERED, {
+          stats,
+          frag,
+          part: null,
+          id: 'main'
+        });
         this.tick();
       });
   }
@@ -1040,7 +1045,7 @@ export default class StreamController extends BaseStreamController implements Ne
           part.elementaryStreams[video.type] = { startPTS, endPTS, startDTS, endDTS };
         }
         frag.setElementaryStreamInfo(video.type as ElementaryStreamTypes, startPTS, endPTS, startDTS, endDTS);
-        this.bufferFragmentData(video, frag, chunkMeta);
+        this.bufferFragmentData(video, frag, part, chunkMeta);
       }
     }
 
@@ -1050,7 +1055,7 @@ export default class StreamController extends BaseStreamController implements Ne
         part.elementaryStreams[ElementaryStreamTypes.AUDIO] = { startPTS, endPTS, startDTS, endDTS };
       }
       frag.setElementaryStreamInfo(ElementaryStreamTypes.AUDIO, startPTS, endPTS, startDTS, endDTS);
-      this.bufferFragmentData(audio, frag, chunkMeta);
+      this.bufferFragmentData(audio, frag, part, chunkMeta);
     }
 
     if (id3?.samples?.length) {
@@ -1122,7 +1127,13 @@ export default class StreamController extends BaseStreamController implements Ne
       const initSegment = track.initSegment;
       this.log(`Main track:${trackName},container:${track.container},codecs[level/parsed]=[${track.levelCodec}/${track.codec}]`);
       if (initSegment) {
-        this.hls.trigger(Events.BUFFER_APPENDING, { type: trackName as SourceBufferName, data: initSegment, frag, chunkMeta });
+        this.hls.trigger(Events.BUFFER_APPENDING, {
+          type: trackName as SourceBufferName,
+          data: initSegment,
+          frag,
+          part: null,
+          chunkMeta
+        });
       }
     });
     // trigger handler right now

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -13,10 +13,10 @@ import FragmentLoader from '../loader/fragment-loader';
 import { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import { Level } from '../types/level';
 import { PlaylistLevelType } from '../types/loader';
-import LevelDetails from '../loader/level-details';
-import { TrackSet } from '../types/track';
 import { SourceBufferName } from '../types/buffer';
-import Hls from '../hls';
+import type Hls from '../hls';
+import type LevelDetails from '../loader/level-details';
+import type { TrackSet } from '../types/track';
 import type {
   LevelLoadedData,
   ManifestParsedData,
@@ -73,7 +73,6 @@ export default class StreamController extends BaseStreamController implements Ne
     hls.on(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.on(Events.LEVEL_LOADING, this.onLevelLoading, this);
     hls.on(Events.LEVEL_LOADED, this.onLevelLoaded, this);
-    hls.on(Events.KEY_LOADED, this.onKeyLoaded, this);
     hls.on(Events.FRAG_LOAD_EMERGENCY_ABORTED, this.onFragLoadEmergencyAborted, this);
     hls.on(Events.ERROR, this.onError, this);
     hls.on(Events.AUDIO_TRACK_SWITCHING, this.onAudioTrackSwitching, this);
@@ -91,7 +90,6 @@ export default class StreamController extends BaseStreamController implements Ne
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.off(Events.LEVEL_LOADED, this.onLevelLoaded, this);
-    hls.off(Events.KEY_LOADED, this.onKeyLoaded, this);
     hls.off(Events.FRAG_LOAD_EMERGENCY_ABORTED, this.onFragLoadEmergencyAborted, this);
     hls.off(Events.ERROR, this.onError, this);
     hls.off(Events.AUDIO_TRACK_SWITCHING, this.onAudioTrackSwitching, this);
@@ -291,7 +289,7 @@ export default class StreamController extends BaseStreamController implements Ne
     this.hls.trigger(Events.KEY_LOADING, { frag });
   }
 
-  private loadFragment (frag: Fragment, targetBufferTime: number) {
+  protected loadFragment (frag: Fragment, targetBufferTime: number) {
     // Check if fragment is not loaded
     const fragState = this.fragmentTracker.getState(frag);
     this.fragCurrent = frag;
@@ -310,7 +308,7 @@ export default class StreamController extends BaseStreamController implements Ne
         this._loadBitrateTestFrag(frag);
       } else {
         this.startFragRequested = true;
-        this._loadFragForPlayback(frag, targetBufferTime);
+        super.loadFragment(frag, targetBufferTime);
       }
     } else if (fragState === FragmentState.APPENDING) {
       // Lower the buffer size and try again
@@ -617,13 +615,6 @@ export default class StreamController extends BaseStreamController implements Ne
 
     // trigger handler right now
     this.tick();
-  }
-
-  onKeyLoaded () {
-    if (this.state === State.KEY_LOADING) {
-      this.state = State.IDLE;
-      this.tick();
-    }
   }
 
   _handleFragmentLoadProgress (data: FragLoadedData) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -763,7 +763,7 @@ export default class StreamController extends BaseStreamController implements Ne
     if (frag && frag.type !== 'main') {
       return;
     }
-    if (this._fragLoadAborted(frag)) {
+    if (this.fragContextChanged(frag)) {
       // If a level switch was requested while a fragment was buffering, it will emit the FRAG_BUFFERED event upon completion
       // Avoid setting state back to IDLE, since that will interfere with a level switch
       this.warn(`Fragment ${frag.sn} of level ${frag.level} finished buffering, but was aborted. state: ${this.state}`);
@@ -973,7 +973,7 @@ export default class StreamController extends BaseStreamController implements Ne
     this._doFragLoad(frag)
       .then((data) => {
         const { hls } = this;
-        if (!data || hls.nextLoadLevel || this._fragLoadAborted(frag)) {
+        if (!data || hls.nextLoadLevel || this.fragContextChanged(frag)) {
           return;
         }
         this.fragLoadError = 0;
@@ -1006,7 +1006,7 @@ export default class StreamController extends BaseStreamController implements Ne
 
     // Check if the current fragment has been aborted. We check this by first seeing if we're still playing the current level.
     // If we are, subsequently check if the currently loading fragment (fragCurrent) has changed.
-    if (this._fragLoadAborted(frag)) {
+    if (this.fragContextChanged(frag)) {
       return;
     }
 

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -19,8 +19,6 @@ import type {
   TrackSwitchedData
 } from '../types/events';
 
-const { performance } = self;
-
 const TICK_INTERVAL = 500; // how often to tick in ms
 
 interface TimeRange {
@@ -284,14 +282,14 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
         this.hls.trigger(Events.KEY_LOADING, { frag: foundFrag });
       } else if (foundFrag && fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED) {
         // only load if fragment is not loaded
-        this.loadFragment(foundFrag, targetBufferTime);
+        this.loadFragment(foundFrag, trackDetails, targetBufferTime);
       }
     }
   }
 
-  protected loadFragment (frag: Fragment, targetBufferTime: number) {
+  protected loadFragment (frag: Fragment, levelDetails: LevelDetails, targetBufferTime: number) {
     this.fragCurrent = frag;
-    super.loadFragment(frag, targetBufferTime);
+    super.loadFragment(frag, levelDetails, targetBufferTime);
   }
 
   stopLoad () {

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -215,7 +215,7 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     const decryptData = frag.decryptdata;
     const hls = this.hls;
 
-    if (this._fragLoadAborted(frag)) {
+    if (this.fragContextChanged(frag)) {
       return;
     }
     // check to see if the payload needs to be decrypted

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -1,7 +1,3 @@
-/**
- * @class SubtitleStreamController
- */
-
 import { Events } from '../events';
 import { logger } from '../utils/logger';
 import { BufferHelper } from '../utils/buffer-helper';
@@ -9,7 +5,12 @@ import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import { FragmentState, FragmentTracker } from './fragment-tracker';
 import BaseStreamController, { State } from './base-stream-controller';
 import FragmentLoader from '../loader/fragment-loader';
-import {
+import { Level } from '../types/level';
+import { NetworkComponentAPI } from '../types/component-api';
+import type Hls from '../hls';
+import type LevelDetails from '../loader/level-details';
+import type Fragment from '../loader/fragment';
+import type {
   ErrorData, FragLoadedData,
   MediaAttachedData,
   SubtitleFragProcessed,
@@ -17,10 +18,6 @@ import {
   TrackLoadedData,
   TrackSwitchedData
 } from '../types/events';
-import { Level } from '../types/level';
-import LevelDetails from '../loader/level-details';
-import { NetworkComponentAPI } from '../types/component-api';
-import Hls from '../hls';
 
 const { performance } = self;
 
@@ -56,7 +53,6 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
     hls.on(Events.ERROR, this.onError, this);
-    hls.on(Events.KEY_LOADED, this.onKeyLoaded, this);
     hls.on(Events.SUBTITLE_TRACKS_UPDATED, this.onSubtitleTracksUpdated, this);
     hls.on(Events.SUBTITLE_TRACK_SWITCH, this.onSubtitleTrackSwitch, this);
     hls.on(Events.SUBTITLE_TRACK_LOADED, this.onSubtitleTrackLoaded, this);
@@ -68,7 +64,6 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
     hls.off(Events.ERROR, this.onError, this);
-    hls.off(Events.KEY_LOADED, this.onKeyLoaded, this);
     hls.off(Events.SUBTITLE_TRACKS_UPDATED, this.onSubtitleTracksUpdated, this);
     hls.off(Events.SUBTITLE_TRACK_SWITCH, this.onSubtitleTrackSwitch, this);
     hls.off(Events.SUBTITLE_TRACK_LOADED, this.onSubtitleTrackLoaded, this);
@@ -217,12 +212,6 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     this.setInterval(TICK_INTERVAL);
   }
 
-  onKeyLoaded () {
-    if (this.state === State.KEY_LOADING) {
-      this.state = State.IDLE;
-    }
-  }
-
   _handleFragmentLoadComplete (fragLoadedData: FragLoadedData) {
     const { frag, payload } = fragLoadedData;
     const decryptData = frag.decryptdata;
@@ -295,10 +284,14 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
         this.hls.trigger(Events.KEY_LOADING, { frag: foundFrag });
       } else if (foundFrag && fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED) {
         // only load if fragment is not loaded
-        this.fragCurrent = foundFrag;
-        this._loadFragForPlayback(foundFrag, targetBufferTime);
+        this.loadFragment(foundFrag, targetBufferTime);
       }
     }
+  }
+
+  protected loadFragment (frag: Fragment, targetBufferTime: number) {
+    this.fragCurrent = frag;
+    super.loadFragment(frag, targetBufferTime);
   }
 
   stopLoad () {

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -35,7 +35,7 @@ export default class Decrypter {
         } else {
           this.config.enableSoftwareAES = true;
         }
-      } catch (e) {}
+      } catch (e) { /* no-op */ }
     }
   }
 

--- a/src/demux/adts.js
+++ b/src/demux/adts.js
@@ -69,9 +69,9 @@ export function getAudioConfig (observer, data, offset, audioCodec) {
     } else {
       // if (manifest codec is AAC) AND (frequency less than 24kHz AND nb channel is 1) OR (manifest codec not specified and mono audio)
       // Chrome fails to play back with low frequency AAC LC mono when initialized with HE-AAC.  This is not a problem with stereo.
-      if (audioCodec && audioCodec.indexOf('mp4a.40.2') !== -1 && ((adtsSampleingIndex >= 6 && adtsChanelConfig === 1) ||
-            /vivaldi/i.test(userAgent)) ||
-        (!audioCodec && adtsChanelConfig === 1)) {
+      if ((audioCodec && audioCodec.indexOf('mp4a.40.2') !== -1 &&
+          ((adtsSampleingIndex >= 6 && adtsChanelConfig === 1) || /vivaldi/i.test(userAgent))) ||
+          (!audioCodec && adtsChanelConfig === 1)) {
         adtsObjectType = 2;
         config = new Array(2);
       }

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -5,7 +5,7 @@ import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { getMediaSource } from '../utils/mediasource-helper';
 import { EventEmitter } from 'eventemitter3';
-import Fragment from '../loader/fragment';
+import Fragment, { Part } from '../loader/fragment';
 import { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import type Hls from '../hls';
 import type { HlsEventEmitter } from '../events';
@@ -18,6 +18,7 @@ export default class TransmuxerInterface {
   private id: PlaylistLevelType;
   private observer: HlsEventEmitter;
   private frag?: Fragment;
+  private part: Part | undefined;
   private worker: any;
   private onwmsg?: Function;
   private transmuxer: Transmuxer | null = null;
@@ -101,20 +102,22 @@ export default class TransmuxerInterface {
     this.observer = null;
   }
 
-  push (data: ArrayBuffer, initSegmentData: Uint8Array, audioCodec: string | undefined, videoCodec: string | undefined, frag: Fragment, duration: number, accurateTimeOffset: boolean, chunkMeta: ChunkMetadata, defaultInitPTS?: number): void {
+  push (data: ArrayBuffer, initSegmentData: Uint8Array, audioCodec: string | undefined, videoCodec: string | undefined, frag: Fragment, part: Part | undefined, duration: number, accurateTimeOffset: boolean, chunkMeta: ChunkMetadata, defaultInitPTS?: number): void {
+    chunkMeta.transmuxing.start = self.performance.now();
     const { currentTransmuxSession, transmuxer, worker } = this;
-    const timeOffset = frag.start;
+    const timeOffset = part ? part.start : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
 
     if (startingNewTransmuxSession(currentTransmuxSession, chunkMeta)) {
-      frag.stats.parsing.start = performance.now();
+      frag.stats.parsing.start = self.performance.now();
       const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));
-      const trackSwitch = !(lastFrag && (frag.level === lastFrag.level));
-      const nextSN = !!(lastFrag && (frag.sn === (lastFrag.sn as number + 1)));
-      const contiguous = !trackSwitch && nextSN;
+      const trackSwitch = !(lastFrag && (chunkMeta.level === lastFrag.level));
+      const snDiff = lastFrag ? chunkMeta.sn - (lastFrag.sn as number) : -1;
+      const partDiff = this.part ? (chunkMeta.part - this.part.index) : -1;
+      const contiguous = !trackSwitch && (snDiff === 1 || (snDiff === 0 && partDiff === 1));
 
-      logger.log(`[transmuxer-interface, ${frag.type}]: Starting new transmux session for fragment ${frag.sn}, of level ${frag.level}:
+      logger.log(`[transmuxer-interface, ${frag.type}]: Starting new transmux session for sn: ${chunkMeta.sn} p: ${chunkMeta.part} level: ${chunkMeta.level} id: ${chunkMeta.id}
         discontinuity: ${discontinuity}
         trackSwitch: ${trackSwitch}
         contiguous: ${contiguous}
@@ -127,6 +130,8 @@ export default class TransmuxerInterface {
     }
 
     this.frag = frag;
+    this.part = part;
+
     // Frags with sn of 'initSegment' are not transmuxed
     if (worker) {
       // post fragment payload as transferable objects for ArrayBuffer (no copy)
@@ -149,9 +154,9 @@ export default class TransmuxerInterface {
   }
 
   flush (chunkMeta: ChunkMetadata) {
+    chunkMeta.transmuxing.start = self.performance.now();
     const { transmuxer, worker } = this;
     this.currentTransmuxSession = null;
-    chunkMeta.transmuxing.start = performance.now();
     if (worker) {
       worker.postMessage({
         cmd: 'flush',
@@ -221,7 +226,7 @@ export default class TransmuxerInterface {
   }
 
   private handleTransmuxComplete (result: TransmuxerResult) {
-    result.chunkMeta.transmuxing.end = performance.now();
+    result.chunkMeta.transmuxing.end = self.performance.now();
     this.onTransmuxComplete(result);
   }
 }

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -288,12 +288,14 @@ export default class Transmuxer {
     // so let's check that current remuxer and demuxer are still valid
     let demuxer = this.demuxer;
     let remuxer = this.remuxer;
-    if (!remuxer || !(remuxer instanceof mux.remux)) {
-      remuxer = this.remuxer = new mux.remux(observer, config, typeSupported, vendor);
+    const Remuxer = mux.remux;
+    const Demuxer = mux.demux;
+    if (!remuxer || !(remuxer instanceof Remuxer)) {
+      remuxer = this.remuxer = new Remuxer(observer, config, typeSupported, vendor);
     }
-    if (!demuxer || !(demuxer instanceof mux.demux)) {
-      demuxer = this.demuxer = new mux.demux(observer, config, typeSupported);
-      this.probe = mux.demux.probe;
+    if (!demuxer || !(demuxer instanceof Demuxer)) {
+      demuxer = this.demuxer = new Demuxer(observer, config, typeSupported);
+      this.probe = Demuxer.probe;
     }
     // Ensure that muxers are always initialized with an initSegment
     this.resetInitSegment(initSegmentData, audioCodec, videoCodec, duration);

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -195,7 +195,7 @@ export default class Transmuxer {
     }
 
     const { audioTrack, avcTrack, id3Track, textTrack } = demuxer.flush(timeOffset);
-    logger.log(`[transmuxer.ts]: Flushed fragment ${chunkMeta.sn} of level ${chunkMeta.level}`);
+    logger.log(`[transmuxer.ts]: Flushed fragment ${chunkMeta.sn}${chunkMeta.part > -1 ? ' p: ' + chunkMeta.part : ''} of level ${chunkMeta.level}`);
     transmuxResults.push({
       remuxResult: remuxer.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset),
       chunkMeta

--- a/src/empty.js
+++ b/src/empty.js
@@ -1,3 +1,3 @@
 // This file is inserted as a shim for modules which we do not want to include into the distro.
 // This replacement is done in the "resolve" section of the webpack config.
-module.exports = void 0;
+module.exports = undefined;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -105,8 +105,6 @@ export default class Hls implements HlsEventEmitter {
     enableLogs(config.debug);
 
     this._autoLevelCapping = -1;
-    // Try to enable progressive streaming by default. Whether it will be enabled depends on API support
-    this.progressive = config.progressive;
 
     // core controllers and network loaders
     const abrController = this.abrController = new config.abrController(this); // eslint-disable-line new-cap

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -43,20 +43,20 @@ export default class FragmentLoader {
     const config = this.config;
     const FragmentILoader = config.fLoader;
     const DefaultILoader = config.loader;
-    const loader = this.loader = frag.loader =
-      FragmentILoader ? new FragmentILoader(config) : new DefaultILoader(config) as Loader<FragmentLoaderContext>;
-    const loaderContext = createLoaderContext(frag);
-    const loaderConfig: LoaderConfiguration = {
-      timeout: config.fragLoadingTimeOut,
-      maxRetry: 0,
-      retryDelay: 0,
-      maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-      highWaterMark: MIN_CHUNK_SIZE
-    };
 
     return new Promise((resolve, reject) => {
+      const loader = this.loader = frag.loader =
+        FragmentILoader ? new FragmentILoader(config) : new DefaultILoader(config) as Loader<FragmentLoaderContext>;
+      const loaderContext = createLoaderContext(frag);
+      const loaderConfig: LoaderConfiguration = {
+        timeout: config.fragLoadingTimeOut,
+        maxRetry: 0,
+        retryDelay: 0,
+        maxRetryDelay: config.fragLoadingMaxRetryTimeout,
+        highWaterMark: MIN_CHUNK_SIZE
+      };
       // Assign frag stats to the loader's stats reference
-      loader.stats = frag.stats;
+      frag.stats = loader.stats;
       loader.load(loaderContext, loaderConfig, {
         onSuccess: (response, stats, context, networkDetails) => {
           this.resetLoader(frag, loader);
@@ -116,19 +116,20 @@ export default class FragmentLoader {
     const config = this.config;
     const FragmentILoader = config.fLoader;
     const DefaultILoader = config.loader;
-    const loader = this.loader = frag.loader =
-      FragmentILoader ? new FragmentILoader(config) : new DefaultILoader(config) as Loader<FragmentLoaderContext>;
-    const loaderConfig: LoaderConfiguration = {
-      timeout: config.fragLoadingTimeOut,
-      maxRetry: 0,
-      retryDelay: 0,
-      maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-      highWaterMark: MIN_CHUNK_SIZE
-    };
+
     return new Promise((resolve, reject) => {
+      const loader = this.loader = frag.loader =
+        FragmentILoader ? new FragmentILoader(config) : new DefaultILoader(config) as Loader<FragmentLoaderContext>;
       const loaderContext = createLoaderContext(frag, part);
+      const loaderConfig: LoaderConfiguration = {
+        timeout: config.fragLoadingTimeOut,
+        maxRetry: 0,
+        retryDelay: 0,
+        maxRetryDelay: config.fragLoadingMaxRetryTimeout,
+        highWaterMark: MIN_CHUNK_SIZE
+      };
       // Assign part stats to the loader's stats reference
-      loader.stats = part.stats;
+      part.stats = loader.stats;
       loader.load(loaderContext, loaderConfig, {
         onSuccess: (response, stats, context, networkDetails) => {
           this.resetLoader(frag, loader);

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -191,17 +191,19 @@ export default class FragmentLoader {
       const estLoadedParts = Math.round(fragStats.loaded / partTotal);
       const estTotalParts = Math.round(frag.duration / part.duration);
       const estRemainingParts = estTotalParts - estLoadedParts;
-      fragStats.total = fragStats.loaded + partStats.total + estRemainingParts * Math.round(fragStats.loaded / estLoadedParts);
+      const estRemainingBytes = estRemainingParts * Math.round(fragStats.loaded / estLoadedParts);
+      fragStats.total = fragStats.loaded + estRemainingBytes;
     }
     const fragLoading = fragStats.loading;
+    const partLoading = partStats.loading;
     if (fragLoading.start) {
       // add to fragment loader latency
-      fragLoading.first += partStats.loading.first - partStats.loading.start;
+      fragLoading.first += partLoading.first - partLoading.start;
     } else {
-      fragLoading.start = partStats.loading.start;
-      fragLoading.first = partStats.loading.first;
+      fragLoading.start = partLoading.start;
+      fragLoading.first = partLoading.first;
     }
-    fragLoading.end = partStats.loading.end;
+    fragLoading.end = partLoading.end;
   }
 
   private resetLoader (frag: Fragment, loader: Loader<FragmentLoaderContext>) {

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -62,6 +62,7 @@ export default class FragmentLoader {
           this.resetLoader(frag, loader);
           resolve({
             frag,
+            part: null,
             payload: response.data as ArrayBuffer,
             networkDetails
           });
@@ -101,6 +102,7 @@ export default class FragmentLoader {
           if (onProgress) {
             onProgress({
               frag,
+              part: null,
               payload: data as ArrayBuffer,
               networkDetails
             });

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -190,11 +190,13 @@ export default class FragmentLoader {
     const partTotal = partStats.total;
     fragStats.loaded += partStats.loaded;
     if (partTotal) {
-      const estLoadedParts = Math.round(fragStats.loaded / partTotal);
       const estTotalParts = Math.round(frag.duration / part.duration);
+      const estLoadedParts = Math.min(Math.round(fragStats.loaded / partTotal), estTotalParts);
       const estRemainingParts = estTotalParts - estLoadedParts;
       const estRemainingBytes = estRemainingParts * Math.round(fragStats.loaded / estLoadedParts);
       fragStats.total = fragStats.loaded + estRemainingBytes;
+    } else {
+      fragStats.total = Math.max(fragStats.loaded, fragStats.total);
     }
     const fragLoading = fragStats.loading;
     const partLoading = partStats.loading;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -100,7 +100,7 @@ export default class Fragment extends BaseSegment {
   public readonly type: PlaylistLevelType;
   // A reference to the loader. Set while the fragment is loading, and removed afterwards. Used to abort fragment loading
   public loader: Loader<FragmentLoaderContext> | null = null;
-  // The level index to which the fragment belongs
+  // The level/track index to which the fragment belongs
   public level: number = -1;
   // The continuity counter of the fragment
   public cc: number = 0;
@@ -250,6 +250,13 @@ export default class Fragment extends BaseSegment {
     info.endPTS = Math.max(info.endPTS, endPTS);
     info.startDTS = Math.min(info.startDTS, startDTS);
     info.endDTS = Math.max(info.endDTS, endDTS);
+  }
+
+  clearElementaryStreamInfo () {
+    const { elementaryStreams } = this;
+    elementaryStreams[ElementaryStreamTypes.AUDIO] = null;
+    elementaryStreams[ElementaryStreamTypes.VIDEO] = null;
+    elementaryStreams[ElementaryStreamTypes.AUDIOVIDEO] = null;
   }
 }
 

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -73,8 +73,8 @@ export default class KeyLoader implements ComponentAPI {
         logger.warn('key uri is falsy');
         return;
       }
-
-      const fragLoader = frag.loader = this.loaders[type] = new config.loader(config) as Loader<FragmentLoaderContext>;
+      const Loader = config.loader;
+      const fragLoader = frag.loader = this.loaders[type] = new Loader(config) as Loader<FragmentLoaderContext>;
       this.decrypturl = uri;
       this.decryptkey = null;
 

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -78,9 +78,17 @@ export default class LevelDetails {
   }
 
   get edge (): number {
+    return this.partEnd || this.fragmentEnd;
+  }
+
+  get partEnd (): number {
     if (this.partList?.length) {
       return this.partList[this.partList.length - 1].end;
     }
+    return 0;
+  }
+
+  get fragmentEnd (): number {
     if (this.fragments?.length) {
       return this.fragments[this.fragments.length - 1].end;
     }

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -85,7 +85,7 @@ export default class LevelDetails {
     if (this.partList?.length) {
       return this.partList[this.partList.length - 1].end;
     }
-    return 0;
+    return this.fragmentEnd;
   }
 
   get fragmentEnd (): number {

--- a/src/loader/load-stats.ts
+++ b/src/loader/load-stats.ts
@@ -11,13 +11,3 @@ export default class LoadStats implements LoaderStats {
   parsing: HlsPerformanceTiming = { start: 0, end: 0 };
   buffering: HlsProgressivePerformanceTiming = { start: 0, first: 0, end: 0 };
 }
-
-export function reset (stats: LoaderStats) {
-  stats.loading = { start: 0, first: 0, end: 0 };
-  stats.parsing = { start: 0, end: 0 };
-  stats.buffering = { start: 0, first: 0, end: 0 };
-  stats.loaded = 0;
-  stats.aborted = false;
-  stats.retry = 0;
-  stats.chunkCount = 0;
-}

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -261,7 +261,6 @@ export default class M3U8Parser {
               fragments.unshift(null);
             }
             currentSN += skippedSegments;
-            totalduration += skippedSegments * level.targetduration;
           }
           const recentlyRemovedDateranges = skipAttrs.enumeratedString('RECENTLY-REMOVED-DATERANGES');
           if (recentlyRemovedDateranges) {
@@ -428,6 +427,7 @@ export default class M3U8Parser {
     const fragmentLength = fragments.length;
     const firstFragment = fragments[0];
     const lastFragment = fragments[fragmentLength - 1];
+    totalduration += level.skippedSegments * level.targetduration;
     if (totalduration > 0 && fragmentLength && lastFragment) {
       level.averagetargetduration = totalduration / fragmentLength;
       const lastSn = lastFragment.sn;

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -298,8 +298,7 @@ export default class M3U8Parser {
           break;
         case 'KEY': {
           // https://tools.ietf.org/html/rfc8216#section-4.3.2.4
-          const decryptparams = value1;
-          const keyAttrs = new AttrList(decryptparams);
+          const keyAttrs = new AttrList(value1);
           const decryptmethod = keyAttrs.enumeratedString('METHOD');
           const decrypturi = keyAttrs.URI;
           const decryptiv = keyAttrs.hexadecimalInteger('IV');

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -23,8 +23,6 @@ import Hls from '../hls';
 import AttrList from '../utils/attr-list';
 import type { ErrorData, LevelLoadingData, ManifestLoadingData, TrackLoadingData } from '../types/events';
 
-const { performance } = self;
-
 function mapContextToLevelType (context: PlaylistLoaderContext): PlaylistLevelType {
   const { type } = context;
 

--- a/src/performance/performance-monitor.ts
+++ b/src/performance/performance-monitor.ts
@@ -8,7 +8,6 @@
  */
 
 import { Events } from '../events';
-import Fragment from '../loader/fragment';
 import { logger } from '../utils/logger';
 import Hls from '../hls';
 import { FragBufferedData } from '../types/events';
@@ -26,18 +25,19 @@ export default class PerformanceMonitor {
   }
 
   onFragBuffered (event: Events.FRAG_BUFFERED, data: FragBufferedData) {
-    logFragStats(data.frag);
+    logFragStats(data);
   }
 }
 
-function logFragStats (frag: Fragment) {
-  const stats = frag.stats;
+function logFragStats (data: FragBufferedData) {
+  const { frag, part } = data;
+  const stats = part ? part.stats : frag.stats;
   const tLoad = stats.loading.end - stats.loading.start;
   const tBuffer = stats.buffering.end - stats.buffering.start;
   const tParse = stats.parsing.end - stats.parsing.start;
   const tTotal = stats.buffering.end - stats.loading.start;
 
-  logger.log(`[performance-monitor]: Stats for fragment ${frag.sn} of level ${frag.level}:
+  logger.log(`[performance-monitor]: Stats for fragment ${frag.sn} ${part ? (' part ' + part.index) : ''} of level ${frag.level}:
         Size:                       ${((stats.total / 1024)).toFixed(3)} kB
         Chunk Count:                ${stats.chunkCount}
 

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -112,7 +112,7 @@ export default class MP4Remuxer implements Remuxer {
     const hasVideo = videoTrack.pid > -1;
     const enoughAudioSamples = audioTrack.samples.length > 0;
     const enoughVideoSamples = videoTrack.samples.length > 1;
-    const canRemuxAvc = (!hasAudio || enoughAudioSamples) && (!hasVideo || enoughVideoSamples) || this.ISGenerated;
+    const canRemuxAvc = ((!hasAudio || enoughAudioSamples) && (!hasVideo || enoughVideoSamples)) || this.ISGenerated;
 
     if (canRemuxAvc) {
       if (!this.ISGenerated) {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -36,6 +36,7 @@ export interface BufferAppendingData {
   type: SourceBufferName;
   data: Uint8Array;
   frag: Fragment;
+  part: Part | null;
   chunkMeta: ChunkMetadata
 }
 
@@ -255,7 +256,7 @@ export interface FragLoadEmergencyAbortedData {
 
 export interface FragLoadedData {
   frag: Fragment
-  part?: Part
+  part: Part | null
   payload: ArrayBuffer
   networkDetails: unknown
 }
@@ -297,7 +298,8 @@ export interface FragParsedData {
 
 export interface FragBufferedData {
   stats: LoadStats
-  frag: Fragment
+  frag: Fragment,
+  part: Part | null
   id: string
 }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -261,8 +261,9 @@ export interface FragLoadedData {
   networkDetails: unknown
 }
 
-export interface FragLoadedEndData {
+export interface PartsLoadedData {
   frag: Fragment
+  part: Part | null
   partsLoaded?: FragLoadedData[]
 }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -244,6 +244,7 @@ export interface InitPTSFoundData {
 
 export interface FragLoadingData {
   frag: Fragment,
+  part?: Part,
   targetBufferTime: number | null
 }
 
@@ -256,7 +257,12 @@ export interface FragLoadedData {
   frag: Fragment
   part?: Part
   payload: ArrayBuffer
-  networkDetails: any
+  networkDetails: unknown
+}
+
+export interface FragLoadedEndData {
+  frag: Fragment
+  partsLoaded?: FragLoadedData[]
 }
 
 export interface FragDecryptedData {
@@ -286,7 +292,7 @@ export interface FragParsingMetadataData {
 
 export interface FragParsedData {
   frag: Fragment,
-  partIndex: number
+  part: Part | null
 }
 
 export interface FragBufferedData {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -33,16 +33,17 @@ export interface BufferCreatedData {
 }
 
 export interface BufferAppendingData {
-  type: SourceBufferName;
-  data: Uint8Array;
-  frag: Fragment;
-  part: Part | null;
+  type: SourceBufferName
+  data: Uint8Array
+  frag: Fragment
+  part: Part | null
   chunkMeta: ChunkMetadata
 }
 
 export interface BufferAppendedData {
   chunkMeta: ChunkMetadata
   frag: Fragment
+  part: Part | null
   parent: PlaylistLevelType
   timeRanges: {
     audio?: TimeRanges
@@ -244,13 +245,14 @@ export interface InitPTSFoundData {
 }
 
 export interface FragLoadingData {
-  frag: Fragment,
-  part?: Part,
+  frag: Fragment
+  part?: Part
   targetBufferTime: number | null
 }
 
 export interface FragLoadEmergencyAbortedData {
   frag: Fragment
+  part: Part | null
   stats: LoaderStats
 }
 

--- a/src/types/fragment-tracker.ts
+++ b/src/types/fragment-tracker.ts
@@ -1,8 +1,9 @@
-import Fragment from '../loader/fragment';
+import Fragment, { Part } from '../loader/fragment';
 import { SourceBufferName } from './buffer';
 
 export interface FragmentEntity {
-  body: Fragment
+  body: Fragment,
+  part: Part | null,
   range: { [key in SourceBufferName]: FragmentBufferedRange }
   buffered: boolean
 }

--- a/src/types/transmuxer.ts
+++ b/src/types/transmuxer.ts
@@ -8,25 +8,27 @@ export interface TransmuxerResult {
 }
 
 export class ChunkMetadata {
-    public level: number;
-    public sn: number;
-    public part: number;
-    public id: number;
-    public size: number;
-    public transmuxing: HlsChunkPerformanceTiming = getNewPerformanceTiming();
-    public buffering: { [key in SourceBufferName]: HlsChunkPerformanceTiming } = {
-      audio: getNewPerformanceTiming(),
-      video: getNewPerformanceTiming(),
-      audiovideo: getNewPerformanceTiming()
-    };
+  public readonly level: number;
+  public readonly sn: number;
+  public readonly part: number;
+  public readonly id: number;
+  public readonly size: number;
+  public readonly partial: boolean;
+  public readonly transmuxing: HlsChunkPerformanceTiming = getNewPerformanceTiming();
+  public readonly buffering: { [key in SourceBufferName]: HlsChunkPerformanceTiming } = {
+    audio: getNewPerformanceTiming(),
+    video: getNewPerformanceTiming(),
+    audiovideo: getNewPerformanceTiming()
+  };
 
-    constructor (level, sn, id, size = 0, part = -1) {
-      this.level = level;
-      this.sn = sn;
-      this.id = id;
-      this.size = size;
-      this.part = part;
-    }
+  constructor (level: number, sn: number, id: number, size = 0, part = -1, partial = false) {
+    this.level = level;
+    this.sn = sn;
+    this.id = id;
+    this.size = size;
+    this.part = part;
+    this.partial = partial;
+  }
 }
 
 function getNewPerformanceTiming (): HlsChunkPerformanceTiming {

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -6,7 +6,7 @@ import {
   LoaderConfiguration,
   LoaderOnProgress
 } from '../types/loader';
-import LoadStats, { reset } from '../loader/load-stats';
+import LoadStats from '../loader/load-stats';
 import ChunkCache from '../demux/chunk-cache';
 
 export function fetchSupported () {
@@ -26,7 +26,7 @@ class FetchLoader implements Loader<LoaderContext> {
   private response!: Response;
   private controller: AbortController;
   public context!: LoaderContext;
-  private config?: LoaderConfiguration;
+  private config: LoaderConfiguration | null = null;
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public stats: LoaderStats;
   public loader: Response | null = null;
@@ -57,7 +57,9 @@ class FetchLoader implements Loader<LoaderContext> {
 
   load (context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<LoaderContext>): void {
     const stats = this.stats;
-    reset(stats);
+    if (stats.loading.start) {
+      throw new Error('Loader can only be used once.');
+    }
     stats.loading.start = self.performance.now();
 
     const initParams = getRequestParameters(context, this.controller.signal);

--- a/src/utils/vttcue.ts
+++ b/src/utils/vttcue.ts
@@ -291,7 +291,7 @@ export default (function () {
      */
 
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state
-    cue.displayState = void 0;
+    cue.displayState = undefined;
   }
 
   /**

--- a/src/utils/vttparser.js
+++ b/src/utils/vttparser.js
@@ -377,7 +377,7 @@ VTTParser.prototype = {
           // 35 - If we have the special substring '-->' then report the cue,
           // but do not collect the line as we need to process the current
           // one as a new cue.
-          if (!line || hasSubstring && (alreadyCollectedLine = true)) {
+          if (!line || (hasSubstring && (alreadyCollectedLine = true))) {
             // We are done parsing self cue.
             if (_this.oncue) {
               _this.oncue(_this.cue);

--- a/src/utils/webvtt-parser.ts
+++ b/src/utils/webvtt-parser.ts
@@ -91,7 +91,7 @@ export function parseWebVTT (
 
     // Update offsets for new discontinuities
     if (currCC?.new) {
-      if (localTime !== void 0) {
+      if (localTime !== undefined) {
         // When local time is provided, offset = discontinuity start time - local time
         cueOffset = vttCCs.ccOffset = currCC.start;
       } else {

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -1,13 +1,13 @@
 import { logger } from '../utils/logger';
 import { LoaderCallbacks, LoaderContext, LoaderStats, Loader, LoaderConfiguration } from '../types/loader';
-import LoadStats, { reset } from '../loader/load-stats';
+import LoadStats from '../loader/load-stats';
 
 class XhrLoader implements Loader<LoaderContext> {
   private xhrSetup: Function | null;
   private requestTimeout?: number;
   private retryTimeout?: number | undefined;
   private retryDelay: number;
-  private config?: LoaderConfiguration;
+  private config: LoaderConfiguration | null = null;
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public context!: LoaderContext;
 
@@ -24,6 +24,7 @@ class XhrLoader implements Loader<LoaderContext> {
     this.callbacks = null;
     this.abortInternal();
     this.loader = null;
+    this.config = null;
   }
 
   abortInternal (): void {
@@ -46,11 +47,13 @@ class XhrLoader implements Loader<LoaderContext> {
   }
 
   load (context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<LoaderContext>): void {
+    if (this.stats.loading.start) {
+      throw new Error('Loader can only be used once.');
+    }
+    this.stats.loading.start = self.performance.now();
     this.context = context;
     this.config = config;
     this.callbacks = callbacks;
-    reset(this.stats);
-    this.stats.loading.start = self.performance.now();
     this.retryDelay = config.retryDelay;
     this.loadInternal();
   }

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -21,15 +21,15 @@ class XhrLoader implements Loader<LoaderContext> {
   }
 
   destroy (): void {
-    this.loader =
-      this.callbacks = null;
+    this.callbacks = null;
     this.abortInternal();
+    this.loader = null;
   }
 
   abortInternal (): void {
-    this.stats.aborted = true;
     const loader = this.loader;
     if (loader && loader.readyState !== 4) {
+      this.stats.aborted = true;
       loader.abort();
     }
     self.clearTimeout(this.requestTimeout);
@@ -50,7 +50,7 @@ class XhrLoader implements Loader<LoaderContext> {
     this.config = config;
     this.callbacks = callbacks;
     reset(this.stats);
-    this.stats.loading.start = performance.now();
+    this.stats.loading.start = self.performance.now();
     this.retryDelay = config.retryDelay;
     this.loadInternal();
   }
@@ -112,14 +112,14 @@ class XhrLoader implements Loader<LoaderContext> {
       // clear xhr timeout and rearm it if readyState less than 4
       self.clearTimeout(this.requestTimeout);
       if (stats.loading.first === 0) {
-        stats.loading.first = Math.max(performance.now(), stats.loading.start);
+        stats.loading.first = Math.max(self.performance.now(), stats.loading.start);
       }
 
       if (readyState === 4) {
         const status = xhr.status;
         // http status between 200 to 299 are all successful
         if (status >= 200 && status < 300) {
-          stats.loading.end = Math.max(performance.now(), stats.loading.first);
+          stats.loading.end = Math.max(self.performance.now(), stats.loading.first);
           let data;
           let len : number;
           if (context.responseType === 'arraybuffer') {

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -179,7 +179,7 @@ async function testSeekOnVOD (url, config) {
         video.onseeked = function () {
           self.setTimeout(function () {
             const { currentTime, paused } = video;
-            if (video.currentTime === 0 || video.paused) {
+            if (currentTime === 0 || paused) {
               callback({ code: 'paused', currentTime, paused, duration, logs: self.logString });
             }
           }, 5000);

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -149,6 +149,7 @@ describe('BufferController SourceBuffer operation queueing', function () {
           type: name,
           data: segmentData,
           frag,
+          part: null,
           chunkMeta
         };
 

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -166,6 +166,7 @@ describe('BufferController SourceBuffer operation queueing', function () {
             video: buffers.video.buffered
           },
           frag,
+          part: null,
           chunkMeta
         });
         expect(shiftAndExecuteNextSpy, 'The queue should have been cycled').to.have.callCount(i + 1);

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -447,14 +447,16 @@ function createFragBufferedData (frag: Fragment, aborted?: boolean): FragBuffere
   }
   return {
     stats,
-    id: frag.type,
-    frag
+    frag,
+    part: null,
+    id: frag.type
   };
 }
 
 function createFragLoadedData (frag: Fragment): FragLoadedData {
   return {
     frag,
+    part: null,
     payload: new ArrayBuffer(0),
     networkDetails: null
   };

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -432,6 +432,7 @@ function createBufferAppendedData (video: PtsTimeRanges, audio?: PtsTimeRanges):
   return {
     chunkMeta: new ChunkMetadata(0, 0, 0, 0),
     frag: new Fragment(PlaylistLevelType.MAIN, ''),
+    part: null,
     parent: PlaylistLevelType.MAIN,
     timeRanges: {
       video: createMockBuffer(video),

--- a/tests/unit/controller/latency-controller.ts
+++ b/tests/unit/controller/latency-controller.ts
@@ -118,6 +118,7 @@ describe('LatencyController', function () {
       levelDetails.holdBack = 8;
       levelDetails.partHoldBack = 3;
       levelDetails.age = 0;
+      latencyController['config'].lowLatencyMode = false;
       expect(latencyController.targetLatency).to.equal(8);
       latencyController['config'].lowLatencyMode = true;
       expect(latencyController.targetLatency).to.equal(3);

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -143,6 +143,7 @@ describe('StreamController', function () {
 
     let triggerSpy;
     let frag;
+    let levelDetails;
     beforeEach(function () {
       const attrs: LevelAttributes = new AttrList({});
       streamController['levels'] = [new Level({
@@ -155,6 +156,8 @@ describe('StreamController', function () {
       frag = new Fragment(PlaylistLevelType.MAIN, '');
       frag.level = 0;
       frag.url = 'file';
+      levelDetails = new LevelDetails('');
+      levelDetails.fragments.push(frag);
     });
 
     function assertLoadingState (frag) {
@@ -169,32 +172,32 @@ describe('StreamController', function () {
 
     it('should load a complete fragment which has not been previously appended', function () {
       fragStateStub(FragmentState.NOT_LOADED);
-      streamController['loadFragment'](frag, 0);
+      streamController['loadFragment'](frag, levelDetails, 0);
       assertLoadingState(frag);
     });
 
     it('should load a partial fragment', function () {
       fragStateStub(FragmentState.PARTIAL);
-      streamController['loadFragment'](frag, 0);
+      streamController['loadFragment'](frag, levelDetails, 0);
       assertLoadingState(frag);
     });
 
     it('should load a frag which has backtracked', function () {
       fragStateStub(FragmentState.OK);
       frag.backtracked = true;
-      streamController['loadFragment'](frag, 0);
+      streamController['loadFragment'](frag, levelDetails, 0);
       assertLoadingState(frag);
     });
 
     it('should not load a fragment which has completely & successfully loaded', function () {
       fragStateStub(FragmentState.OK);
-      streamController['loadFragment'](frag, 0);
+      streamController['loadFragment'](frag, levelDetails, 0);
       assertNotLoadingState();
     });
 
     it('should not load a fragment while it is appending', function () {
       fragStateStub(FragmentState.APPENDING);
-      streamController['loadFragment'](frag, 0);
+      streamController['loadFragment'](frag, levelDetails, 0);
       assertNotLoadingState();
     });
   });

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -88,7 +88,7 @@ describe('TransmuxerInterface tests', function () {
     newFrag.level = 1;
     newFrag.start = 1000;
     newFrag.startPTS = 1000;
-
+    const part = undefined;
     const data = new ArrayBuffer(8);
     const initSegmentData = new Uint8Array(0);
     const audioCodec = '';
@@ -99,7 +99,7 @@ describe('TransmuxerInterface tests', function () {
 
     const stub = sinon.stub(transmuxerInterfacePrivates.worker, 'postMessage');
 
-    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, newFrag, duration, accurateTimeOffset, chunkMeta);
+    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, newFrag, part, duration, accurateTimeOffset, chunkMeta);
 
     expect(stub).to.have.been.calledTwice;
     const firstCall = stub.args[0][0];
@@ -140,7 +140,7 @@ describe('TransmuxerInterface tests', function () {
     newFrag.sn = 5;
     newFrag.level = 2;
     newFrag.start = 1000;
-
+    const part = undefined;
     const data = new Uint8Array(new ArrayBuffer(8));
     const initSegmentData = new Uint8Array(0);
     const audioCodec = '';
@@ -152,7 +152,7 @@ describe('TransmuxerInterface tests', function () {
     const configureStub = sinon.stub(transmuxerInterfacePrivates.transmuxer, 'configure');
     const pushStub = sinon.stub(transmuxerInterfacePrivates.transmuxer, 'push');
     pushStub.returns(Promise.reject(new Error('Stubbed transmux result')));
-    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, newFrag, duration, accurateTimeOffset, chunkMeta);
+    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, newFrag, part, duration, accurateTimeOffset, chunkMeta);
 
     const tConfig = new TransmuxConfig('', '', initSegmentData, 0);
     const state = new TransmuxState(true, false, true, true, 1000);

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -88,7 +88,7 @@ describe('TransmuxerInterface tests', function () {
     newFrag.level = 1;
     newFrag.start = 1000;
     newFrag.startPTS = 1000;
-    const part = undefined;
+    const part = null;
     const data = new ArrayBuffer(8);
     const initSegmentData = new Uint8Array(0);
     const audioCodec = '';
@@ -140,7 +140,7 @@ describe('TransmuxerInterface tests', function () {
     newFrag.sn = 5;
     newFrag.level = 2;
     newFrag.start = 1000;
-    const part = undefined;
+    const part = null;
     const data = new Uint8Array(new ArrayBuffer(8));
     const initSegmentData = new Uint8Array(0);
     const audioCodec = '';

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -75,6 +75,7 @@ describe('TransmuxerInterface tests', function () {
     const id = PlaylistLevelType.MAIN;
     const transmuxerInterface = new TransmuxerInterface(hls, id, onTransmuxComplete, onFlush);
     const transmuxerInterfacePrivates = transmuxerInterface as any;
+    const stub = sinon.stub(transmuxerInterfacePrivates.worker, 'postMessage');
     const currentFrag = new Fragment(PlaylistLevelType.MAIN, '');
     currentFrag.cc = 100;
     currentFrag.sn = 5;
@@ -82,12 +83,6 @@ describe('TransmuxerInterface tests', function () {
     // Config for push
     transmuxerInterfacePrivates.frag = currentFrag;
 
-    const newFrag = new Fragment(PlaylistLevelType.MAIN, '');
-    newFrag.cc = 100;
-    newFrag.sn = 6;
-    newFrag.level = 1;
-    newFrag.start = 1000;
-    newFrag.startPTS = 1000;
     const part = null;
     const data = new ArrayBuffer(8);
     const initSegmentData = new Uint8Array(0);
@@ -95,23 +90,36 @@ describe('TransmuxerInterface tests', function () {
     const videoCodec = '';
     const duration = 0;
     const accurateTimeOffset = true;
-    const chunkMeta = new ChunkMetadata(newFrag.level, newFrag.sn, 0);
-
-    const stub = sinon.stub(transmuxerInterfacePrivates.worker, 'postMessage');
-
-    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, newFrag, part, duration, accurateTimeOffset, chunkMeta);
+    let chunkMeta = new ChunkMetadata(currentFrag.level, currentFrag.sn, 0);
+    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, currentFrag, part, duration, accurateTimeOffset, chunkMeta);
 
     expect(stub).to.have.been.calledTwice;
     const firstCall = stub.args[0][0];
     const secondCall = stub.args[1][0];
-
-    expect(firstCall, 'Configure call').to.deep.equal({
+    expect(firstCall, 'Configure call ' + JSON.stringify(firstCall, null, 2)).to.deep.equal({
       cmd: 'configure',
       config: new TransmuxConfig('', '', initSegmentData, 0),
-      state: new TransmuxState(false, true, true, false, 1000)
+      state: new TransmuxState(false, false, true, false, 0)
+    });
+    expect(secondCall, 'Demux call 1' + JSON.stringify(secondCall, null, 2)).to.deep.equal({
+      cmd: 'demux',
+      data,
+      decryptdata: currentFrag.decryptdata,
+      chunkMeta
     });
 
-    expect(secondCall, 'Demux call').to.deep.equal({
+    const newFrag = new Fragment(PlaylistLevelType.MAIN, '');
+    newFrag.cc = 100;
+    newFrag.sn = 6;
+    newFrag.level = 1;
+    newFrag.start = 1000;
+    newFrag.startPTS = 1000;
+    chunkMeta = new ChunkMetadata(newFrag.level, newFrag.sn, 0);
+    transmuxerInterface.push(data, initSegmentData, audioCodec, videoCodec, currentFrag, part, duration, accurateTimeOffset, chunkMeta);
+
+    expect(stub).to.have.been.calledThrice;
+    const thirdCall = stub.args[2][0];
+    expect(thirdCall, 'Demux call 2' + JSON.stringify(thirdCall, null, 2)).to.deep.equal({
       cmd: 'demux',
       data,
       decryptdata: newFrag.decryptdata,

--- a/tests/unit/loader/fragment-loader.ts
+++ b/tests/unit/loader/fragment-loader.ts
@@ -75,6 +75,7 @@ describe('FragmentLoader tests', function () {
         .then(data => {
           expect(data).to.deep.equal({
             frag,
+            part: null,
             payload: response.data,
             networkDetails
           });
@@ -84,6 +85,7 @@ describe('FragmentLoader tests', function () {
           expect(onProgress).to.have.been.calledOnce;
           expect(onProgress).to.have.been.calledWith({
             frag,
+            part: null,
             payload: response.data,
             networkDetails
           });


### PR DESCRIPTION
### This PR will...
Buffer HLS `EXT-X-PART` segments in `lowLatencyMode`, starting at the first available segment.

### Why is this Pull Request needed?
Low-Latency HLS support.

### Are there any points in the code the reviewer needs to double check?
Part loading uses the same path in the stream controller that fragment loading uses. Parts are buffered using the progressive streaming progress handlers. When we reach the last available part before the next fragment is available (meaning the current one is still incomplete) fragment loading is aborted so that the controller state can return to idle and continue on the next level update.
