### PR TITLE
Correctly abort request when destroyed

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -21,9 +21,8 @@ class XhrLoader implements Loader<LoaderContext> {
   }
 
   destroy (): void {
-    this.loader =
-      this.callbacks = null;
     this.abortInternal();
+    this.loader = this.callbacks = null;
   }
 
   abortInternal (): void {


### PR DESCRIPTION
### This PR will...

Change the order of commands in xhr-loader `.destroy()` call to make sure an active request is aborted.

### Why is this Pull Request needed?

Otherwise its possible to have destroyed loaders with active requests

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
