### PR TITLE
Demo Dark-Mode

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -22,6 +22,66 @@ select option {
   float: right;
 }
 
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #ddd;
+    background-color: #111;
+  }
+
+  button, optgroup, select {
+    background-color: rgb(0, 40, 70);
+  }
+
+  input, textarea {
+    background-color: #222;
+  }
+
+  label {
+    font-weight: initial;
+  }
+
+  a {
+    color: #337ab7;
+  }
+
+  pre {
+    background-color: #050505;
+    border-color: #333;
+    color: #ccc;
+  }
+
+  .ace-github {
+    background: #000;
+    color: #fff;
+  }
+
+  .ace-github .ace_gutter {
+    background: #181818;
+    color: #888;
+  }
+
+  .ace-github .ace_marker-layer .ace_active-line {
+    background: #111;
+  }
+
+  .ace-github.ace_focus .ace_marker-layer .ace_active-line {
+    background: #321;
+  }
+
+  div.config-editor-commands {
+    background-color: #444;
+    border-color: #333;
+  }
+
+  button.btn {
+    color: #050505;
+  }
+
+  canvas {
+    background: #bbb;
+  }
+}
+
 #controls {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### This PR will...
Add dark-mode styles to demo page applied with system/browser preferred color scheme.

### Why is this Pull Request needed?
It's easier on my eyes. 

With these new styles, and General > Appearance: "Dark" enabled on my mac, the demo looks like this:

<img width="863" alt="Screen Shot 2020-10-27 at 4 13 24 PM" src="https://user-images.githubusercontent.com/333258/97357074-98dd2b80-186f-11eb-9d7e-db4d2985bf2c.png">

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
