### PR TITLE
do not fail test_functional_optional workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
   test_functional_optional:
     needs: test_functional_required
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       max-parallel: 8


### PR DESCRIPTION
### This PR will...
Make it so that the `test_functional_optional` workflow always passes. The individual jobs can still fail.

### Why is this Pull Request needed?
Means the owner won't get an email showing a failure on the overall check run if only an optional test fails.
