### PR TITLE
Add rule for abolishing `enum` 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,6 +97,14 @@ module.exports = {
       { property: 'find' } // Intended to block usage of Array.prototype.find
     ],
 
+    'no-restricted-syntax': [
+      2,
+      {
+        selector: 'TSEnumDeclaration',
+        message: 'Don\'t declare enums'
+      }
+    ],
+
     'standard/no-callback-literal': 1,
     'import/first': 1,
     'no-var': 1,

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -7,12 +7,14 @@ import { ComponentAPI } from '../types/component-api';
 import Hls from '../hls';
 import { BufferAppendedData, FragBufferedData, FragLoadedData } from '../types/events';
 
+/* eslint-disable no-restricted-syntax */
 export enum FragmentState {
   NOT_LOADED = 'NOT_LOADED',
   APPENDING = 'APPENDING',
   PARTIAL = 'PARTIAL',
   OK = 'OK'
 }
+/* eslint-enable no-restricted-syntax */
 
 export class FragmentTracker implements ComponentAPI {
   private activeFragment: Fragment | null = null;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 export enum ErrorTypes {
   // Identifier for a network error (loading error / timeout ...)
   NETWORK_ERROR = 'networkError',
@@ -75,3 +76,4 @@ export enum ErrorDetails {
   // Identifier for an internal call to abort a loader
   INTERNAL_ABORTED = 'aborted'
 }
+/* eslint-enable no-restricted-syntax */

--- a/src/events.ts
+++ b/src/events.ts
@@ -51,6 +51,7 @@ import {
  * @readonly
  * @enum {string}
  */
+/* eslint-disable no-restricted-syntax */
 export enum Events {
   // Fired before MediaSource is attaching to media element
   MEDIA_ATTACHING = 'hlsMediaAttaching',
@@ -221,6 +222,8 @@ export interface HlsListeners {
   [Events.KEY_LOADED]: (event: Events.KEY_LOADED, data: KeyLoadedData) => void
   [Events.LIVE_BACK_BUFFER_REACHED]: (event: Events.LIVE_BACK_BUFFER_REACHED, data: LiveBackBufferData) => void
 }
+/* eslint-enable no-restricted-syntax */
+
 export interface HlsEventEmitter {
   on<E extends keyof HlsListeners, Context = undefined> (event: E, listener: HlsListeners[E], context?: Context): void
   once<E extends keyof HlsListeners, Context = undefined> (event: E, listener: HlsListeners[E], context?: Context): void

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -6,11 +6,13 @@ import LoadStats from './load-stats';
 import AttrList from '../utils/attr-list';
 import type { FragmentLoaderContext, Loader, PlaylistLevelType } from '../types/loader';
 
+/* eslint-disable no-restricted-syntax */
 export enum ElementaryStreamTypes {
   AUDIO = 'audio',
   VIDEO = 'video',
   AUDIOVIDEO = 'audiovideo'
 }
+/* eslint-enable no-restricted-syntax */
 
 interface ElementaryStreamInfo {
   startPTS: number

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -37,11 +37,13 @@ export interface LevelAttributes extends AttrList {
   URI?: string
 }
 
+/* eslint-disable no-restricted-syntax */
 export enum HlsSkip {
   No = '',
   Yes = 'YES',
   v2 = 'v2'
 }
+/* eslint-enable no-restricted-syntax */
 
 export function getSkipValue (details: LevelDetails, msn: number): HlsSkip {
   const { canSkipUntil, canSkipDateRanges, endSN } = details;

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -126,6 +126,7 @@ export interface Loader<T extends LoaderContext> {
   stats: LoaderStats
 }
 
+/* eslint-disable no-restricted-syntax */
 export enum PlaylistContextType {
   MANIFEST = 'manifest',
   LEVEL = 'level',
@@ -138,6 +139,7 @@ export enum PlaylistLevelType {
   AUDIO = 'audio',
   SUBTITLE = 'subtitle'
 }
+/* eslint-enable no-restricted-syntax */
 
 export interface PlaylistLoaderContext extends LoaderContext {
   loader?: Loader<PlaylistLoaderContext>

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -164,6 +164,7 @@ const rowsHighCh2 = { 0x19: 2, 0x1A: 4, 0x1D: 6, 0x1E: 8, 0x1F: 10, 0x1B: 13, 0x
 
 const backgroundColors = ['white', 'green', 'blue', 'cyan', 'red', 'yellow', 'magenta', 'black', 'transparent'];
 
+/* eslint-disable no-restricted-syntax */
 enum VerboseLevel {
   ERROR = 0,
   TEXT = 1,
@@ -172,6 +173,7 @@ enum VerboseLevel {
   DEBUG = 3,
   DATA = 3,
 }
+/* eslint-enable no-restricted-syntax */
 
 class CaptionsLogger {
   public time: number | null = null;

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -1,10 +1,12 @@
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess
  */
+/* eslint-disable no-restricted-syntax */
 export enum KeySystems {
   WIDEVINE = 'com.widevine.alpha',
   PLAYREADY = 'com.microsoft.playready',
 }
+/* eslint-enable no-restricted-syntax */
 
 export type MediaKeyFunc = (keySystem: KeySystems, supportedConfigurations: MediaKeySystemConfiguration[]) => Promise<MediaKeySystemAccess>;
 const requestMediaKeySystemAccess = (function (): MediaKeyFunc | null {


### PR DESCRIPTION
### This PR will...

Add rule for abolishing `enum`.
Add comments for disabling ESLint to existing `enum` (Because of requiring to change many codes).

### Why is this Pull Request needed?

It is deprecated to use `enum` (if TypeScript version is greater than or equal to v3.0.4).
Therefore, it is recommended to use `union` type.

### Are there any points in the code the reviewer needs to double check?

N/A

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
