### PR TITLE
fix webpack CLI usage (current scripts are not compatible with webpack versions in current package deps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "scripts": {
     "build": "webpack --progress",
     "build:ci": "webpack",
-    "build:debug": "webpack --progress --env.debug --env.demo",
-    "build:watch": "webpack --progress --env.debug --env.demo --watch",
+    "build:debug": "webpack --progress --env debug --env demo",
+    "build:watch": "webpack --progress --env debug --env demo --watch",
     "build:types": "tsc --emitDeclarationOnly",
-    "dev": "webpack-dev-server --progress --env.debug --env.demo --port 8000",
+    "dev": "webpack serve --progress --env debug --env demo --port 8000",
     "docs": "esdoc",
     "lint": "./scripts/lint.sh",
     "lint:fix": "./scripts/lint.sh --fix",


### PR DESCRIPTION
### This PR will...

fix the following issue on running `npm start` with the current combo of webpack vs webpack-dev-server versions in deps:

```
> webpack-dev-server --progress --env.debug --env.demo --port 8000

internal/modules/cjs/loader.js:800
    throw err;
    ^

Error: Cannot find module 'webpack-cli/bin/config-yargs'
```

As stated here: https://github.com/webpack/webpack-dev-server/issues/2759#issuecomment-706668920

> webpack-dev-server does not work with webpack-cli v4

### Why is this Pull Request needed?

fix the bug which probably was induced from an automatic update of deps.

in order to do that, we need to invoke the dev-server via `webpack serve ...`. 

this patch will also fix the `--env` arg usage. the dot-syntax is not supported anymore, but instead values are passed as in other standard CLI argument syntax.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

described above.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
