### PR TITLE
Include old WebKit based browsers in positive DTS gate 

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -325,7 +325,7 @@ class MP4Remuxer {
       }
     }
 
-    if (this.requiresPositiveDts) {
+    if (requiresPositiveDts) {
       firstDTS = Math.max(0, firstDTS);
     }
     let nbNalu = 0;

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -16,6 +16,8 @@ const MAX_SILENT_FRAME_DURATION_90KHZ = toMpegTsClockFromTimescale(10);
 const PTS_DTS_SHIFT_TOLERANCE_90KHZ = toMpegTsClockFromTimescale(0.2);
 
 let chromeVersion = null;
+let safariWebkitVersion = null;
+let requiresPositiveDts = false;
 
 class MP4Remuxer {
   constructor (observer, config, typeSupported, vendor) {
@@ -27,6 +29,11 @@ class MP4Remuxer {
       const result = navigator.userAgent.match(/Chrome\/(\d+)/i);
       chromeVersion = result ? parseInt(result[1]) : 0;
     }
+    if (safariWebkitVersion === null) {
+      const result = navigator.userAgent.match(/Safari\/(\d+)/i);
+      safariWebkitVersion = result ? parseInt(result[1]) : 0;
+    }
+    requiresPositiveDts = (chromeVersion && chromeVersion < 75) || (safariWebkitVersion && safariWebkitVersion < 600);
   }
 
   destroy () {
@@ -318,7 +325,7 @@ class MP4Remuxer {
       }
     }
 
-    if (chromeVersion && chromeVersion < 75) {
+    if (this.requiresPositiveDts) {
       firstDTS = Math.max(0, firstDTS);
     }
     let nbNalu = 0;


### PR DESCRIPTION
### This PR will...
Prevent us from using negative DTS values in AVC moof atoms in old webkit browsers.

### Why is this Pull Request needed?
Fixes a decode errors in 2017 Tizen Smart TVs in streams where we try to minimizing video start gaps by aligning video and audio as close to 0 as possible without changing initial CTS.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #3211

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
