### PR TITLE
prefix dependabot commits with [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    commit-message:
+      # prevent netlify build
+      prefix: "[skip ci]"
     open-pull-requests-limit: 99
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
### This PR will...
Prefix dependabot commits with [skip ci]

### Why is this Pull Request needed?

Should stop netlify builds for dependabot PR's, which are using build minutes.
