### PR TITLE
use the hlsjs PAT for auto merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
       - uses: tjenkinson/gh-action-auto-merge-dependency-updates@1ff3f19
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
           allowed-actors: dependabot[bot]


### PR DESCRIPTION
### This PR will...
Use the hls.js personal access token for auto merge.

### Why is this Pull Request needed?
Because otherwise after the merge the actions don't run on master, because the `secrets.GITHUB_TOKEN` is not allowed to trigger other actions, which is why canary's and netlify builds aren't being published from the auto merges.