### PR TITLE
Add support for AVC fmp4 fragments found in Apple Advanced HEVC/H.264 stream

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -112,14 +112,14 @@ class PassThroughRemuxer implements Remuxer {
       this.emitInitSegment = false;
     }
 
-    if (!Number.isFinite(initPTS as number)) {
-      this.initPTS = initSegment.initPTS = initPTS = computeInitPTS(initData, data, timeOffset);
+    if (!Number.isFinite(initPTS!)) {
+      this.initPTS = initSegment.initPTS = initPTS = computeInitPTS(initData, data, lastEndDTS);
     }
 
     const duration = getDuration(data, initData);
     const startDTS = lastEndDTS as number;
     const endDTS = duration + startDTS;
-    offsetStartDTS(initData, data, initPTS);
+    offsetStartDTS(initData, data, initPTS as number);
 
     if (duration > 0) {
       this.lastEndDTS = endDTS;

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -210,6 +210,11 @@ module.exports = {
     // abr: true,
     startSeek: true
   },
+  AppleAdvancedHevcAvcHls: {
+    url: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8',
+    description: 'Advanced stream (HEVC/H.264, AC-3/AAC,  WebVTT, fMP4 segments)',
+    live: true
+  },
   AppleLowLatencyHls: {
     url: 'https://ll-hls-test.apple.com/master.m3u8',
     description: 'Apple Low-Latency HLS sample (TS segments)',


### PR DESCRIPTION
### This PR will...
Add support for AVC fmp4 fragments found in Apple Advanced HEVC/H.264 stream

### Why is this Pull Request needed?
Playback of https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8 without JavaScript exceptions.

When playing this stream, mp4-tool functions such as `getStartDTS`, `offsetStartDTS `, and `getDuration` would throw exceptions when encountering track fragment boxes for unknown track types* not accounted for in the init data (`initData[id]` is `undefined`).

These changes ignore those track fragments so that we only deal with the audio and video fragments we're parsing time/duration for.

*Track types added to init data:
```
const type: HdlrType = { soun: ElementaryStreamTypes.AUDIO, vide: ElementaryStreamTypes.VIDEO }[hdlrType];
if (type) {
```

### Are there any points in the code the reviewer needs to double check?
Replaced some array methods where appropriate (`map` > `reduce` or  `forEach`).

This is also broken in v0.x, so a patch in master should be made for v0.15.

### Demo:
https://deploy-preview-3274--hls-js-dev.netlify.app/demo/?src=https%3A%2F%2Fdevstreaming-cdn.apple.com%2Fvideos%2Fstreaming%2Fexamples%2Fbipbop_adv_example_hevc%2Fmaster.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOnRydWUsInN0b3BPblN0YWxsIjpmYWxzZSwiZHVtcGZNUDQiOmZhbHNlLCJsZXZlbENhcHBpbmciOi0xLCJsaW1pdE1ldHJpY3MiOi0xfQ==

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
