### PR TITLE
update sauce-connect action to a version with retries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,11 +308,12 @@ jobs:
           name: build
 
       - name: start SauceConnect tunnel
-        uses: saucelabs/sauce-connect-action@a0930f1
+        uses: tjenkinson/sauce-connect-action@be563c4
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
           tunnelIdentifier: ${{ github.run_id }}-${{ matrix.config }}
+          retryTimeout: 300
 
       - name: install
         run: |
@@ -402,11 +403,12 @@ jobs:
           name: build
 
       - name: start SauceConnect tunnel
-        uses: saucelabs/sauce-connect-action@a0930f1
+        uses: tjenkinson/sauce-connect-action@be563c4
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
           tunnelIdentifier: ${{ github.run_id }}-${{ matrix.config }}
+          retryTimeout: 300
 
       - name: install
         run: |


### PR DESCRIPTION
### This PR will...
Updates the sauce connection action to a [version that retries](https://github.com/saucelabs/sauce-connect-action/pull/20) and will actually error if the connection fails.

### Why is this Pull Request needed?
Current version does not error if connection fails or concurrent limit reached, meaning the build then fails at the integration test stage. With retries hitting the concurrent execution limit shouldn't cause a failure anymore, because we will keep retrying until there's room available.