### PR TITLE
Always parse ID3 tags if type is present on the ID3 Frame

### DIFF
--- a/src/demux/id3.js
+++ b/src/demux/id3.js
@@ -186,10 +186,9 @@ class ID3 {
       return ID3._decodePrivFrame(frame);
     } else if (frame.type[0] === 'W') {
       return ID3._decodeURLFrame(frame);
-    } else if (frame.type) {
+    } else {
       return ID3._decodeTextFrame(frame);
     }
-    return undefined;
   }
 
   static _readTimeStamp (timeStampFrame) {

--- a/src/demux/id3.js
+++ b/src/demux/id3.js
@@ -184,12 +184,11 @@ class ID3 {
   static _decodeFrame (frame) {
     if (frame.type === 'PRIV') {
       return ID3._decodePrivFrame(frame);
-    } else if (frame.type[0] === 'T') {
-      return ID3._decodeTextFrame(frame);
     } else if (frame.type[0] === 'W') {
       return ID3._decodeURLFrame(frame);
+    } else if (frame.type) {
+      return ID3._decodeTextFrame(frame);
     }
-
     return undefined;
   }
 

--- a/src/demux/id3.js
+++ b/src/demux/id3.js
@@ -186,9 +186,9 @@ class ID3 {
       return ID3._decodePrivFrame(frame);
     } else if (frame.type[0] === 'W') {
       return ID3._decodeURLFrame(frame);
-    } else {
-      return ID3._decodeTextFrame(frame);
     }
+
+    return ID3._decodeTextFrame(frame);
   }
 
   static _readTimeStamp (timeStampFrame) {


### PR DESCRIPTION
### This PR will...
This PR updates our ID3 tag parsing to ensure that we always parse and surface the ID3 tags as long as the `type` is present on the frame.
### Why is this Pull Request needed?
Certain users, such as Yospace, have custom ID3 tags, like `YMID`, that were previously being dropped in the parsing step as they did not follow any of the expected patterns.

For an example, see the following test stream: http://playertest.longtailvideo.com/adaptive/yospace-id3/index.m3u8
### Are there any points in the code the reviewer needs to double check?
I don't believe so, but as this is my first contribution here, possibly!
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
