### PR TITLE
Add support for multiple EXT-X-MAP tags

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -199,11 +199,7 @@ class AudioStreamController extends BaseStreamController {
             }
           }
         }
-        if (trackDetails.initSegment && !trackDetails.initSegment.data) {
-          frag = trackDetails.initSegment;
-        } // eslint-disable-line brace-style
-        // if bufferEnd before start of playlist, load first fragment
-        else if (bufferEnd <= start) {
+        if (bufferEnd <= start) {
           frag = fragments[0];
           if (this.videoTrackCC !== null && frag.cc !== this.videoTrackCC) {
             // Ensure we find a fragment which matches the continuity of the video track
@@ -262,6 +258,9 @@ class AudioStreamController extends BaseStreamController {
           } else {
             // only load if fragment is not loaded or if in audio switch
             // we force a frag loading in audio switch as fragment tracker might not have evicted previous frags in case of quick audio switch
+            if (trackDetails.initSegments[frag.initSegment] && !trackDetails.initSegments[frag.initSegment].data) {
+              frag = trackDetails.initSegments[frag.initSegment].fragment;
+            }
             this.fragCurrent = frag;
             if (audioSwitch || this.fragmentTracker.getState(frag) === FragmentState.NOT_LOADED) {
               logger.log(`Loading ${frag.sn}, cc: ${frag.cc} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}, ${
@@ -500,7 +499,7 @@ class AudioStreamController extends BaseStreamController {
         this.state = State.IDLE;
 
         stats.tparsed = stats.tbuffered = performance.now();
-        details.initSegment.data = data.payload;
+        details.initSegments[data.frag.relurl].data = data.payload;
         this.hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: fragCurrent, id: 'audio' });
         this.tick();
       } else {
@@ -514,7 +513,7 @@ class AudioStreamController extends BaseStreamController {
         // Check if we have video initPTS
         // If not we need to wait for it
         let initPTS = this.initPTS[cc];
-        let initSegmentData = details.initSegment ? details.initSegment.data : [];
+        const initSegmentData = details.initSegments[fragCurrent.initSegment] ? details.initSegments[fragCurrent.initSegment].data : [];
         if (initPTS !== undefined) {
           this.pendingBuffering = true;
           logger.log(`Demuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -119,6 +119,13 @@ export function mergeDetails (oldDetails, newDetails) {
     newDetails.initSegment = oldDetails.initSegment;
   }
 
+  if (newDetails.initSegments && oldDetails.initSegments) {
+    newDetails.initSegments = {
+      ...newDetails.initSegments,
+      ...oldDetails.initSegments
+    };
+  }
+
   // check if old/new playlists have fragments in common
   // loop through overlapping SN and update startPTS , cc, and duration if any found
   let ccOffset = 0;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -245,27 +245,23 @@ class StreamController extends BaseStreamController {
       bufferEnd = bufferInfo.end,
       frag;
 
-    if (levelDetails.initSegment && !levelDetails.initSegment.data) {
-      frag = levelDetails.initSegment;
-    } else {
-      // in case of live playlist we need to ensure that requested position is not located before playlist start
-      if (levelDetails.live) {
-        let initialLiveManifestSize = this.config.initialLiveManifestSize;
-        if (fragLen < initialLiveManifestSize) {
-          logger.warn(`Can not start playback of a level, reason: not enough fragments ${fragLen} < ${initialLiveManifestSize}`);
-          return;
-        }
+    // in case of live playlist we need to ensure that requested position is not located before playlist start
+    if (levelDetails.live) {
+      let initialLiveManifestSize = this.config.initialLiveManifestSize;
+      if (fragLen < initialLiveManifestSize) {
+        logger.warn(`Can not start playback of a level, reason: not enough fragments ${fragLen} < ${initialLiveManifestSize}`);
+        return;
+      }
 
-        frag = this._ensureFragmentAtLivePoint(levelDetails, bufferEnd, start, end, fragPrevious, fragments);
-        // if it explicitely returns null don't load any fragment and exit function now
-        if (frag === null) {
-          return;
-        }
-      } else {
-        // VoD playlist: if bufferEnd before start of playlist, load first fragment
-        if (bufferEnd < start) {
-          frag = fragments[0];
-        }
+      frag = this._ensureFragmentAtLivePoint(levelDetails, bufferEnd, start, end, fragPrevious, fragments);
+      // if it explicitely returns null don't load any fragment and exit function now
+      if (frag === null) {
+        return;
+      }
+    } else {
+      // VoD playlist: if bufferEnd before start of playlist, load first fragment
+      if (bufferEnd < start) {
+        frag = fragments[0];
       }
     }
     if (!frag) {
@@ -273,6 +269,14 @@ class StreamController extends BaseStreamController {
     }
 
     if (frag) {
+      if (levelDetails.initSegments[frag.initSegment]) {
+        levelDetails.initSegment = levelDetails.initSegments[frag.initSegment].fragment;
+      }
+
+      if (levelDetails.initSegments[frag.initSegment] && !levelDetails.initSegments[frag.initSegment].data) {
+        frag = levelDetails.initSegments[frag.initSegment].fragment;
+      }
+
       if (frag.encrypted) {
         this._loadKey(frag, levelDetails);
       } else {
@@ -878,7 +882,7 @@ class StreamController extends BaseStreamController {
       } else if (fragLoaded.sn === 'initSegment') {
         this.state = State.IDLE;
         stats.tparsed = stats.tbuffered = window.performance.now();
-        details.initSegment.data = data.payload;
+        details.initSegments[data.frag.relurl].data = data.payload;
         hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: fragCurrent, id: 'main' });
         this.tick();
       } else {
@@ -898,7 +902,7 @@ class StreamController extends BaseStreamController {
 
         // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live) and if media is not seeking (this is to overcome potential timestamp drifts between playlists and fragments)
         const accurateTimeOffset = !(media && media.seeking) && (details.PTSKnown || !details.live);
-        const initSegmentData = details.initSegment ? details.initSegment.data : [];
+        const initSegmentData = details.initSegments[fragCurrent.initSegment] ? details.initSegments[fragCurrent.initSegment].data : [];
         const audioCodec = this._getAudioCodec(currentLevel);
 
         // transmux the MPEG-TS data to ISO-BMFF segments

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -57,6 +57,10 @@ export default class Fragment {
   // _decryptdata will set the IV for this segment based on the segment number in the fragment
   public levelkey?: LevelKey;
 
+  // initSegment is the relurl of the initsegment associated with the fragment which can be found
+  // on level details
+  public initSegment?: string;
+
   // TODO(typescript-xhrloader)
   public loader: any;
 

--- a/src/loader/init-segment.ts
+++ b/src/loader/init-segment.ts
@@ -1,0 +1,10 @@
+import Fragment from './fragment';
+
+export default class InitSegment {
+  public fragment: Fragment;
+  public data: ArrayBuffer | null = null;
+
+  constructor (fragment: Fragment) {
+    this.fragment = fragment;
+  }
+}

--- a/src/loader/level.js
+++ b/src/loader/level.js
@@ -5,6 +5,7 @@ export default class Level {
     this.endSN = 0;
     this.fragments = [];
     this.initSegment = null;
+    this.initSegments = { };
     this.live = true;
     this.needSidxRanges = false;
     this.startCC = 0;

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -1,6 +1,7 @@
 import * as URLToolkit from 'url-toolkit';
 
 import Fragment from './fragment';
+import InitSegment from './init-segment';
 import Level from './level';
 import LevelKey from './level-key';
 
@@ -196,6 +197,7 @@ export default class M3U8Parser {
     let result: RegExpExecArray | RegExpMatchArray | null;
     let i: number;
     let levelkey: LevelKey | undefined;
+    let initSegment: InitSegment | null = null;
 
     let firstPdtIndex = null;
 
@@ -222,6 +224,9 @@ export default class M3U8Parser {
           frag.cc = discontinuityCounter;
           frag.urlId = levelUrlId;
           frag.baseurl = baseurl;
+          if (initSegment) {
+            frag.initSegment = initSegment.fragment.relurl;
+          }
           // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
           frag.relurl = (' ' + result[3]).slice(1);
           assignProgramDateTime(frag, prevFrag);
@@ -335,7 +340,11 @@ export default class M3U8Parser {
           frag.level = id;
           frag.type = type;
           frag.sn = 'initSegment';
-          level.initSegment = frag;
+          if (!level.initSegment) {
+            level.initSegment = frag;
+          }
+          initSegment = new InitSegment(frag);
+          level.initSegments[frag.relurl] = initSegment;
           frag = new Fragment();
           frag.rawProgramDateTime = level.initSegment.rawProgramDateTime;
           break;

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -773,6 +773,29 @@ main.mp4`;
     expect(result.initSegment.sn).to.equal('initSegment');
   });
 
+  it('parses multiple #EXT-X-MAP URI', function () {
+    let level = `#EXTM3U
+#EXT-X-TARGETDURATION:6
+#EXT-X-VERSION:7
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-INDEPENDENT-SEGMENTS
+#EXT-X-MAP:URI="main.mp4"
+#EXTINF:6.00600,
+frag1.mp4
+#EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="alt.mp4"
+#EXTINF:4.0
+frag2.mp4
+`;
+    let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+    expect(result.initSegment.url).to.equal('http://video.example.com/main.mp4');
+    expect(result.initSegment.sn).to.equal('initSegment');
+
+    expect(result.initSegments['main.mp4'].fragment.url).to.equal('http://video.example.com/main.mp4');
+    expect(result.initSegments['alt.mp4'].fragment.url).to.equal('http://video.example.com/alt.mp4');
+  });
+
   describe('PDT calculations', function () {
     it('if playlists contains #EXT-X-PROGRAM-DATE-TIME switching will be applied by PDT', function () {
       let level = `#EXTM3U


### PR DESCRIPTION
### This PR will...

Support multiple `EXT-X-MAP` tags (a slightly updated version of https://github.com/video-dev/hls.js/pull/2279)

### Why is this Pull Request needed?

To fix https://github.com/video-dev/hls.js/issues/1990 and support playlists that have multiple `EXT-X-MAP` tags.

I've verified with some private streams and also using the demo stream from the original issue (~12 seconds time offset): https://storage.googleapis.com/gaetan/hls.js/master-fmp4-bug.m3u8

### Are there any points in the code the reviewer needs to double check?

Per the old PR there was a [comment](https://github.com/video-dev/hls.js/pull/2279#pullrequestreview-450899652) regarding keeping the `levelDetails.initSegment` property up to date. I've addressed what I believe the feedback to be, but may have missed the intent of the comment.

### Resolves issues:

https://github.com/video-dev/hls.js/issues/1990

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
