### PR TITLE
do not run automerge action if secret not available

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,7 +4,22 @@ on:
   - pull_request
 
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      hasSecret: ${{ steps.check_secret_access.outputs.result == 'true' }}
+    steps:
+      - name: check secret access
+        id: check_secret_access
+        run: |
+          if ! [[ -z "$SECRET" ]]; then
+            echo "::set-output name=result::true"
+          fi
+        env:
+          SECRET: ${{ secrets.CI_GITHUB_TOKEN }}
   run:
+    needs: config
+    if: needs.config.outputs.hasSecret == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: tjenkinson/gh-action-auto-merge-dependency-updates@1ff3f19


### PR DESCRIPTION
### This PR will...
Not run the automerge action on forks, where the secret is not available.

### Why is this Pull Request needed?
Currently it runs and fails on forks.