### PR TITLE
Improve remuxing of non-independent segments and backtracking

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -189,7 +189,7 @@ export const hlsDefaultConfig: HlsConfig = {
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
-  maxBufferHole: 0.5, // used by stream-controller
+  maxBufferHole: 0.1, // used by stream-controller
   highBufferWatchdogPeriod: 2, // used by stream-controller
   nudgeOffset: 0.1, // used by stream-controller
   nudgeMaxRetry: 3, // used by stream-controller

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -507,7 +507,7 @@ export default class BufferController implements ComponentAPI {
     const mediaSource = this.mediaSource;
     const fragments = levelDetails.fragments;
     const len = fragments.length;
-    if (len && mediaSource?.setLiveSeekableRange) {
+    if (len && levelDetails.live && mediaSource?.setLiveSeekableRange) {
       const start = fragments[0].start;
       const end = start + levelDetails.totalduration;
       mediaSource.setLiveSeekableRange(start, end);

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -177,8 +177,6 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
       newFrag.minEndPTS = oldFrag.minEndPTS;
       newFrag.duration = (oldFrag.endPTS as number) - (oldFrag.startPTS as number);
 
-      newFrag.backtracked = oldFrag.backtracked;
-      newFrag.dropped = oldFrag.dropped;
       if (newFrag.duration) {
         PTSFrag = newFrag;
       }

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -197,8 +197,9 @@ export default class Transmuxer {
 
     const { audioTrack, avcTrack, id3Track, textTrack } = demuxer.flush(timeOffset);
     logger.log(`[transmuxer.ts]: Flushed fragment ${chunkMeta.sn}${chunkMeta.part > -1 ? ' p: ' + chunkMeta.part : ''} of level ${chunkMeta.level}`);
+    const remuxResult = remuxer.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset);
     transmuxResults.push({
-      remuxResult: remuxer.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset),
+      remuxResult,
       chunkMeta
     });
 
@@ -254,10 +255,11 @@ export default class Transmuxer {
     return result;
   }
 
-  private transmuxUnencrypted (data: Uint8Array, timeOffset: number, accurateTimeOffset: boolean, chunkMeta: ChunkMetadata) {
+  private transmuxUnencrypted (data: Uint8Array, timeOffset: number, accurateTimeOffset: boolean, chunkMeta: ChunkMetadata): TransmuxerResult {
     const { audioTrack, avcTrack, id3Track, textTrack } = this.demuxer!.demux(data, timeOffset, false);
+    const remuxResult = this.remuxer!.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset);
     return {
-      remuxResult: this.remuxer!.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset),
+      remuxResult,
       chunkMeta
     };
   }

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -16,6 +16,7 @@ interface ElementaryStreamInfo {
   endPTS: number
   startDTS: number
   endDTS: number
+  partial?: boolean
 }
 
 type ElementaryStreams = Record<ElementaryStreamTypes, ElementaryStreamInfo | null>;
@@ -115,8 +116,6 @@ export default class Fragment extends BaseSegment {
   public endDTS!: number;
   // The start time of the fragment, as listed in the manifest. Updated after transmux complete.
   public start: number = 0;
-  // Set when the fragment was loaded and transmuxed, but was stopped from buffering due to dropped frames.
-  public backtracked: boolean = false;
   // Set by `updateFragPTSDTS` in level-helper
   public deltaPTS?: number;
   // The maximum starting Presentation Time Stamp (audio/video PTS) of the fragment. Set after transmux complete.
@@ -129,8 +128,6 @@ export default class Fragment extends BaseSegment {
   public data?: Uint8Array;
   // A flag indicating whether the segment was downloaded in order to test bitrate, and was not buffered
   public bitrateTest: boolean = false;
-  // Total video frames dropped by the transmuxer
-  public dropped: number = 0;
   // #EXTINF  segment title
   public title: string | null = null;
 
@@ -232,7 +229,7 @@ export default class Fragment extends BaseSegment {
     return decryptdata;
   }
 
-  setElementaryStreamInfo (type: ElementaryStreamTypes, startPTS: number, endPTS: number, startDTS: number, endDTS: number) {
+  setElementaryStreamInfo (type: ElementaryStreamTypes, startPTS: number, endPTS: number, startDTS: number, endDTS: number, partial: boolean = false) {
     const { elementaryStreams } = this;
     const info = elementaryStreams[type];
     if (!info) {
@@ -240,7 +237,8 @@ export default class Fragment extends BaseSegment {
         startPTS,
         endPTS,
         startDTS,
-        endDTS
+        endDTS,
+        partial
       };
       return;
     }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -59,7 +59,7 @@ export interface BufferEOSData {
 export interface BufferFlushingData {
   startOffset: number
   endOffset: number
-  type: SourceBufferName
+  type: SourceBufferName | null
 }
 
 export interface BufferFlushedData {

--- a/src/types/fragment-tracker.ts
+++ b/src/types/fragment-tracker.ts
@@ -1,11 +1,17 @@
-import Fragment, { Part } from '../loader/fragment';
+// eslint-disable-next-line import/no-duplicates
+import type Fragment from '../loader/fragment';
+// eslint-disable-next-line import/no-duplicates
+import type { Part } from '../loader/fragment';
 import type { SourceBufferName } from './buffer';
+import type { FragLoadedData } from './events';
 
 export interface FragmentEntity {
   body: Fragment,
-  part: Part | null,
+  part: Part | null
+  loaded: FragLoadedData | null,
+  backtrack: FragLoadedData | null,
+  buffered: boolean,
   range: { [key in SourceBufferName]: FragmentBufferedRange }
-  buffered: boolean
 }
 
 export interface FragmentTimeRange {

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -31,6 +31,7 @@ export interface RemuxedTrack {
   type: SourceBufferName
   hasAudio: boolean
   hasVideo: boolean
+  independent?: boolean
   nb: number
   transferredData1?: ArrayBuffer
   transferredData2?: ArrayBuffer
@@ -51,6 +52,7 @@ export interface RemuxerResult {
   text?: RemuxedUserdata
   id3?: RemuxedMetadata
   initSegment?: InitSegmentData
+  independent?: boolean
 }
 
 export interface InitSegmentData {

--- a/tests/unit/controller/audio-track-controller.js
+++ b/tests/unit/controller/audio-track-controller.js
@@ -90,21 +90,6 @@ describe('AudioTrackController', function () {
         level: 0
       });
     });
-
-    it('should set the audioTracks contained in the event data (nullable) to an empty array and trigger AUDIO_TRACKS_UPDATED', function (done) {
-      hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, (event, data) => {
-        expect(data.audioTracks).to.be.empty;
-        expect(audioTrackController.tracks).to.be.empty;
-        done();
-      });
-
-      audioTrackController.onManifestParsed(Events.MANIFEST_PARSED, {
-        audioTracks: null
-      });
-      audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
-        level: 0
-      });
-    });
   });
 
   it('should select audioGroupId and trigger AUDIO_TRACK_SWITCHING', function (done) {

--- a/tests/unit/controller/base-stream-controller.js
+++ b/tests/unit/controller/base-stream-controller.js
@@ -42,11 +42,6 @@ describe('BaseStreamController', function () {
       expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be.false;
     });
 
-    it('returns false if fragCurrent has backtracked set to true', function () {
-      baseStreamController.fragCurrent = { backtracked: true };
-      expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be.false;
-    });
-
     it('returns false if fragCurrent is not the last fragment', function () {
       baseStreamController.fragCurrent = { sn: 9 };
       levelDetails.endSN = 10;

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -29,6 +29,8 @@ class MockMediaSource {
   addEventListener () {}
 
   removeEventListener () {}
+
+  endOfStream () {}
 }
 
 class MockSourceBuffer extends EventTarget {
@@ -58,6 +60,7 @@ class MockSourceBuffer extends EventTarget {
 class MockMediaElement {
   public currentTime: number = 0;
   public duration: number = Infinity;
+  public textTracks: any[] = [];
 }
 
 const queueNames: Array<SourceBufferName> = ['audio', 'video'];

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -88,7 +88,7 @@ describe('GapController', function () {
     });
 
     it('should not nudge when too far from the buffer end', function () {
-      const mockBufferInfo = { len: 0.25 };
+      const mockBufferInfo = { len: 0.09 };
       const mockStallDuration = (config.highBufferWatchdogPeriod + 1) * 1000;
       const nudgeStub = sandbox.stub(gapController, '_tryNudgeBuffer');
       gapController._tryFixBufferStall(mockBufferInfo, mockStallDuration);

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -182,13 +182,6 @@ describe('StreamController', function () {
       assertLoadingState(frag);
     });
 
-    it('should load a frag which has backtracked', function () {
-      fragStateStub(FragmentState.OK);
-      frag.backtracked = true;
-      streamController['loadFragment'](frag, levelDetails, 0);
-      assertLoadingState(frag);
-    });
-
     it('should not load a fragment which has completely & successfully loaded', function () {
       fragStateStub(FragmentState.OK);
       streamController['loadFragment'](frag, levelDetails, 0);


### PR DESCRIPTION
### This PR will...
- Load all previous segments until a keyframe is found when non-independent video segments are found in a new transmux session (backtracking after a seek or stream start).
- Loaded segment data that requires backtracking is kept in the fragment-tracker so that the segment is not reloaded after previous segments are.
- Segment duration and timeline are not modified when frames are dropped from segments containing but not starting with a keyframe.
- The back buffer is flushed when backtracking and when appending partial (dropped frames) segments. This ensures partially appended fragments are reloaded and buffered completely in sequence when necessary.
- Segments whose frames are dropped before being appended are always reported as `PARTIAL` by the fragment-tracker
- Changed default `maxBufferHole` to `0.1` so that `PARTIAL` buffered fragments with small gaps will be reloaded if a new transmux session runs over them, rebuffering and patching those holes that cause stalls.
- Adds a `BACKTRACKING` state to the stream-controller active from the time a transmux response signals non-independent data in a non-contiguous transmux state until the loading promise is complete, where we can cache the `FragLoadedData` in the fragment-tracker

### Why is this Pull Request needed?
Improves performance and prevents stalling and errors when seeking and level switching in streams with non-independent segments - especially those with sequences of several segments containing no AVC keyframes.

### Are there any points in the code the reviewer needs to double-check?
This work was done by testing against the single quality, video-only stream found in #2808. I also tested against an AV stream with keyframes not at the start of each segment to test against, which is not available for public use.

### Resolves issues:
Fixes #2808

### Checklist

- [x] changes have been done against the feature/v1.0.0 branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md