### PR TITLE
fix: duplicate 608/708 VTT lines

### DIFF
--- a/src/utils/cues.ts
+++ b/src/utils/cues.ts
@@ -10,6 +10,7 @@ interface VTTCue extends TextTrackCue {
   line: number
   align: string
   position: number
+  text: string
 }
 
 export function newCue (track: TextTrack | null, startTime: number, endTime: number, captionScreen: CaptionScreen): VTTCue[] {
@@ -62,15 +63,12 @@ export function newCue (track: TextTrack | null, startTime: number, endTime: num
   }
   if (track && result.length) {
     // Sort bottom cues in reverse order so that they render in line order when overlapping in Chrome
-    const sortedCues = result.sort((cueA, cueB) => {
+    return result.sort((cueA, cueB) => {
       if (cueA.line > 8 && cueB.line > 8) {
         return cueB.line - cueA.line;
       }
       return cueA.line - cueB.line;
     });
-    for (let i = 0; i < sortedCues.length; i++) {
-      track.addCue(sortedCues[i]);
-    }
   }
   return result;
 }

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -35,6 +35,12 @@ const hash = function (text) {
   return (hash >>> 0).toString();
 };
 
+// Create a unique hash id for a cue based on start/end times and text.
+// This helps timeline-controller to avoid showing repeated captions.
+export function generateCueId (startTime, endTime, text) {
+  return hash(startTime.toString()) + hash(endTime.toString()) + hash(text);
+}
+
 const calculateOffset = function (vttCCs, cc, presentationTime) {
   let currCC = vttCCs[cc];
   let prevCC = vttCCs[currCC.prevCC];
@@ -59,7 +65,7 @@ const calculateOffset = function (vttCCs, cc, presentationTime) {
   vttCCs.presentationOffset = presentationTime;
 };
 
-const WebVTTParser = {
+export const WebVTTParser = {
   parse: function (vttByteArray, initPTS, timescale, vttCCs, cc, callBack, errorCallBack) {
     // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
     let re = /\r\n|\n\r|\n|\r/g;
@@ -105,9 +111,7 @@ const WebVTTParser = {
         cue.endTime += cueOffset - localTime;
       }
 
-      // Create a unique hash id for a cue based on start/end times and text.
-      // This helps timeline-controller to avoid showing repeated captions.
-      cue.id = hash(cue.startTime.toString()) + hash(cue.endTime.toString()) + hash(cue.text);
+      cue.id = generateCueId(cue.startTime, cue.endTime, cue.text);
 
       // Fix encoding of special characters. TODO: Test with all sorts of weird characters.
       cue.text = decodeURIComponent(encodeURIComponent(cue.text));
@@ -172,5 +176,3 @@ const WebVTTParser = {
     parser.flush();
   }
 };
-
-export default WebVTTParser;


### PR DESCRIPTION
### This PR will...
fix duplicate 608 lines

### Why is this Pull Request needed?
On rendition switching the liones may get duplicated

### Are there any points in the code the reviewer needs to double check?
Reuse the hash function when creating the 608/708 VTTCues to assign them a unique id.
Extract the webvtt-parser callback function that adds text track cues and reuse it for adding the 608/708 cues.

Wasn't sure what is the best way to use the hash function - if to leave it in webvtt-aprser and expose or extract it to a seperate vtt utils function and import in both parser and cues modules.
I ended up exposing it from webvtt-parser and adding the id in timeline-controller, but it makes more sense to keep the logic near where VTTCue is created.
Let me know if you want to change this in anyway- open for comments.

In addition, added text field to VTTCue interface.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
