### PR TITLE
Do not pause on immediate switch

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1190,7 +1190,7 @@ It is also possible to manually control quality swith using below API.
 ### `hls.currentLevel`
 
 - get: Return current playback quality level.
-- set: Trigger an immediate quality level switch to new quality level. This will pause the video if it was playing, flush the whole buffer, and fetch fragment matching with current position and requested quality level. Then resume the video if needed once fetched fragment will have been buffered.
+- set: Trigger an immediate quality level switch to new quality level. This will abort the current fragment request if any, flush the whole buffer, and fetch fragment matching with current position and requested quality level.
 
 Set to `-1` for automatic level selection.
 

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -78,7 +78,7 @@ describe('StreamController', function () {
       );
       // load levels data
       const levels = levelsParsed.map((levelParsed) => new Level(levelParsed));
-      streamController.onManifestParsed(Events.MANIFEST_PARSED, {
+      streamController['onManifestParsed'](Events.MANIFEST_PARSED, {
         altAudio: false,
         audio: false,
         audioTracks: [],
@@ -262,6 +262,7 @@ describe('StreamController', function () {
     });
 
     it('should seek to start pos when metadata has not yet been loaded', function () {
+      // @ts-ignore
       const seekStub = sandbox.stub(streamController, '_seekToStartPos');
       streamController['loadedmetadata'] = false;
       streamController['checkBuffer']();
@@ -270,6 +271,7 @@ describe('StreamController', function () {
     });
 
     it('should not seek to start pos when metadata has been loaded', function () {
+      // @ts-ignore
       const seekStub = sandbox.stub(streamController, '_seekToStartPos');
       streamController['loadedmetadata'] = true;
       streamController['checkBuffer']();
@@ -278,6 +280,7 @@ describe('StreamController', function () {
     });
 
     it('should not seek to start pos when nothing has been buffered', function () {
+      // @ts-ignore
       const seekStub = sandbox.stub(streamController, '_seekToStartPos');
       streamController['media'].buffered.length = 0;
       streamController['checkBuffer']();
@@ -285,28 +288,17 @@ describe('StreamController', function () {
       expect(streamController['loadedmetadata']).to.be.false;
     });
 
-    it('should complete the immediate switch if signalled', function () {
-      const levelSwitchStub = sandbox.stub(
-        streamController,
-        'immediateLevelSwitchEnd'
-      );
-      streamController['loadedmetadata'] = true;
-      streamController['immediateSwitch'] = true;
-      streamController['checkBuffer']();
-      expect(levelSwitchStub).to.have.been.calledOnce;
-    });
-
     describe('_seekToStartPos', function () {
       it('should seek to startPosition when startPosition is not buffered & the media is not seeking', function () {
         streamController['startPosition'] = 5;
-        streamController._seekToStartPos();
+        streamController['_seekToStartPos']();
         expect(streamController['media'].currentTime).to.equal(5);
       });
 
       it('should not seek to startPosition when it is buffered', function () {
         streamController['startPosition'] = 5;
         streamController['media'].currentTime = 5;
-        streamController._seekToStartPos();
+        streamController['_seekToStartPos']();
         expect(streamController['media'].currentTime).to.equal(5);
       });
     });


### PR DESCRIPTION
### This PR will...
- Remove pause and nudge on immediate level switch
- Immediate level switch simply aborts current frag and flushed the entire buffer

### Why is this Pull Request needed?
Prevents hls.js behavior (emergency down switch) and manual quality selection implementations from triggering a "pause". Hls.js may stall as a result when implementing a manual switch with `hls.currentLevel`. This can be addressed by toggling playback rate `video.playbackRate = 0` or pause before setting `hls.currentLevel`, and after the forward buffer is full.

### Resolves issues:
Fixes #3336

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
