### PR TITLE
Fix WebVTT X-TIMESTAMP-MAP handling and handle PTS rollover in cues

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -516,6 +516,7 @@ export class TimelineController implements ComponentAPI {
       this.timescale[frag.cc],
       vttCCs,
       frag.cc,
+      frag.start,
       (cues) => {
         this._appendCues(cues, frag.level);
         hls.trigger(Events.SUBTITLE_FRAG_PROCESSED, {

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -1079,7 +1079,7 @@ export default class MP4Remuxer implements Remuxer {
   }
 }
 
-function PTSNormalize(value: number, reference: number | null): number {
+export function PTSNormalize(value: number, reference: number | null): number {
   let offset;
   if (reference === null) {
     return value;


### PR DESCRIPTION
### This PR will...
- Fix WebVTT X-TIMESTAMP-MAP handling 
- handle PTS rollover in VTT cues

### Why is this Pull Request needed?
WebVTT with timestamp maps were not being parsed correctly. This stream, for example, has three cues:
https://playertest.longtailvideo.com/adaptive/live-webvtt/webvttTest/playlist.m3u8

In Safari, the first cue starts at 4.96s. The cue time calculation in v0.14.x was off because this code mistook the difference between the MPEGTS map time of 0 and the cue local time as a wrapped value when it has nothing to do with that.

```
 // Calculate subtitle offset in milliseconds.	
if (Math.abs(syncPTS - (vttCCs[cc].start * 90000 || 0)) > 4294967296) {	
  syncPTS += 8589934592;	
}
```

These changes rename the timestamp map variables and handle all calculations in `parser.oncue`. `PTSNormalize` is used on the final cue start time, comparing it to the fragment start time to deal with any 33-bit wrapping.

### Resolves issues:
#3311

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
