### PR TITLE
Unblock remuxer on flush

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -120,6 +120,9 @@ class AudioTrackController extends BasePlaylistController {
 
       this.tracksInGroup = audioTracks;
       const audioTracksUpdated: AudioTracksUpdatedData = { audioTracks };
+      this.log(
+        `Updating audio tracks, ${audioTracks.length} track(s) found in "${audioGroupId}" group-id`
+      );
       this.hls.trigger(Events.AUDIO_TRACKS_UPDATED, audioTracksUpdated);
 
       this.selectInitialTrack();

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -671,7 +671,7 @@ export default class StreamController
 
     // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
     const accurateTimeOffset = details.PTSKnown || !details.live;
-    const initSegmentData = details.initSegment?.data || new Uint8Array(0);
+    const initSegmentData = details.initSegment?.data;
     const audioCodec = this._getAudioCodec(currentLevel);
 
     // transmux the MPEG-TS data to ISO-BMFF segments

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -168,7 +168,6 @@ export class SubtitleStreamController
     event: Events.SUBTITLE_TRACKS_UPDATED,
     { subtitleTracks }: SubtitleTracksUpdatedData
   ) {
-    logger.log('subtitle levels updated');
     this.tracksBuffered = [];
     this.levels = subtitleTracks.map(
       (mediaPlaylist) => new Level(mediaPlaylist)

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -12,6 +12,7 @@ import type {
 import type { MediaPlaylist } from '../types/media-playlist';
 import { ErrorData, LevelLoadingData } from '../types/events';
 import { PlaylistContextType } from '../types/loader';
+import { logger } from '../utils/logger';
 
 class SubtitleTrackController extends BasePlaylistController {
   private media: HTMLMediaElement | null = null;
@@ -184,6 +185,9 @@ class SubtitleTrackController extends BasePlaylistController {
       const subtitleTracksUpdated: SubtitleTracksUpdatedData = {
         subtitleTracks,
       };
+      this.log(
+        `Updating subtitle tracks, ${subtitleTracks.length} track(s) found in "${textGroupId}" group-id`
+      );
       this.hls.trigger(Events.SUBTITLE_TRACKS_UPDATED, subtitleTracksUpdated);
 
       if (initialTrackId !== -1) {
@@ -321,7 +325,7 @@ class SubtitleTrackController extends BasePlaylistController {
 
     // exit if track id as already set or invalid
     if (
-      (this.trackId === newId && tracks[newId]?.details) ||
+      (this.trackId === newId && (newId === -1 || tracks[newId]?.details)) ||
       newId < -1 ||
       newId >= tracks.length
     ) {

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -145,7 +145,7 @@ export default class TransmuxerInterface {
 
   push(
     data: ArrayBuffer,
-    initSegmentData: Uint8Array,
+    initSegmentData: Uint8Array | undefined,
     audioCodec: string | undefined,
     videoCodec: string | undefined,
     frag: Fragment,
@@ -192,7 +192,7 @@ export default class TransmuxerInterface {
       const config = new TransmuxConfig(
         audioCodec,
         videoCodec,
-        new Uint8Array(initSegmentData),
+        initSegmentData,
         duration,
         defaultInitPTS
       );

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -266,7 +266,8 @@ export default class Transmuxer {
       id3Track,
       textTrack,
       timeOffset,
-      accurateTimeOffset
+      accurateTimeOffset,
+      true
     );
     transmuxResults.push({
       remuxResult,
@@ -296,7 +297,7 @@ export default class Transmuxer {
   }
 
   resetInitSegment(
-    initSegmentData: Uint8Array,
+    initSegmentData: Uint8Array | undefined,
     audioCodec: string | undefined,
     videoCodec: string | undefined,
     duration: number
@@ -365,7 +366,8 @@ export default class Transmuxer {
       id3Track,
       textTrack,
       timeOffset,
-      accurateTimeOffset
+      accurateTimeOffset,
+      false
     );
     return {
       remuxResult,
@@ -389,7 +391,8 @@ export default class Transmuxer {
           demuxResult.id3Track,
           demuxResult.textTrack,
           timeOffset,
-          accurateTimeOffset
+          accurateTimeOffset,
+          false
         ),
         chunkMeta,
       })
@@ -481,14 +484,14 @@ export function isPromise<T>(p: Promise<T> | any): p is Promise<T> {
 export class TransmuxConfig {
   public audioCodec?: string;
   public videoCodec?: string;
-  public initSegmentData: Uint8Array;
+  public initSegmentData?: Uint8Array;
   public duration: number;
   public defaultInitPts?: number;
 
   constructor(
     audioCodec: string | undefined,
     videoCodec: string | undefined,
-    initSegmentData: Uint8Array,
+    initSegmentData: Uint8Array | undefined,
     duration: number,
     defaultInitPts?: number
   ) {

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -40,7 +40,7 @@ class PassThroughRemuxer implements Remuxer {
   }
 
   resetInitSegment(
-    initSegment: Uint8Array,
+    initSegment: Uint8Array | undefined,
     audioCodec: string | undefined,
     videoCodec: string | undefined
   ) {
@@ -50,7 +50,7 @@ class PassThroughRemuxer implements Remuxer {
     this.emitInitSegment = true;
   }
 
-  generateInitSegment(initSegment: Uint8Array): void {
+  generateInitSegment(initSegment: Uint8Array | undefined): void {
     let { audioCodec, videoCodec } = this;
     if (!initSegment || !initSegment.byteLength) {
       this.initTracks = undefined;
@@ -60,7 +60,7 @@ class PassThroughRemuxer implements Remuxer {
     const initData = (this.initData = parseInitSegment(initSegment));
 
     // default audio codec if nothing specified
-    // TODO : extract that from initsegment
+    // TODO : extract that from initSegment
     if (!audioCodec) {
       audioCodec = 'mp4a.40.5';
     }

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -15,10 +15,11 @@ export interface Remuxer {
     id3Track: DemuxedTrack,
     textTrack: DemuxedTrack,
     timeOffset: number,
-    accurateTimeOffset: boolean
+    accurateTimeOffset: boolean,
+    flush: boolean
   ): RemuxerResult;
   resetInitSegment(
-    initSegment: Uint8Array,
+    initSegment: Uint8Array | undefined,
     audioCodec: string | undefined,
     videoCodec: string | undefined
   ): void;


### PR DESCRIPTION
### This PR will...
- Fix remuxing of TS segments with audio elementary streams (PID) but no audio samples 
- Do not create empty `initSegment` arrays
- Improve audio and subtitle tracks update and change logging

### Why is this Pull Request needed?
This line was meant to wait for expected AV samples from the TS demuxer to be present before remuxing when streaming progressively.

```
const canRemuxAvc =
      ((!hasAudio || enoughAudioSamples) && (!hasVideo || enoughVideoSamples)) || this.ISGenerated;
```

In [this stream](https://playertest.longtailvideo.com/adaptive/eleph-audio/playlist.m3u8), that never happens because while the TS segments describe an audio track in the program map table, there are no audio samples in the TS segments (audio is delivered in AAC tracks). As a result, we are stuck with a remux result containing no context. The player never establishes initPTS. The audio track does not buffer. The first segment is reloaded... It isn't good.

The fix made here is to wait only until flush (end of the segment) for samples in all tracks. At that point, if a track has no samples, we process the demuxed content, as we have in past versions without progressive streaming support.

Test stream
https://playertest.longtailvideo.com/adaptive/eleph-audio/playlist.m3u8

### Checklist

- [x] changes have been done against the master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
