### PR TITLE
Remux audio-only streams contiguously

### DIFF
--- a/src/demux/base-audio-demuxer.ts
+++ b/src/demux/base-audio-demuxer.ts
@@ -2,9 +2,11 @@ import * as ID3 from '../demux/id3';
 import type {
   DemuxerResult,
   Demuxer,
-  DemuxedTrack,
   DemuxedAudioTrack,
   AppendedAudioFrame,
+  DemuxedMetadataTrack,
+  DemuxedAvcTrack,
+  DemuxedUserdataTrack,
 } from '../types/demuxer';
 import { dummyTrack } from './dummy-demuxed-track';
 import { appendUint8Array } from '../utils/mp4-tools';
@@ -12,7 +14,7 @@ import { sliceUint8 } from '../utils/typed-array';
 
 class BaseAudioDemuxer implements Demuxer {
   protected _audioTrack!: DemuxedAudioTrack;
-  protected _id3Track!: DemuxedTrack;
+  protected _id3Track!: DemuxedMetadataTrack;
   protected frameIndex: number = 0;
   protected cachedData: Uint8Array | null = null;
   protected initPTS: number | null = null;
@@ -59,7 +61,7 @@ class BaseAudioDemuxer implements Demuxer {
     const timestamp = id3Data ? ID3.getTimeStamp(id3Data) : undefined;
     const length = data.length;
 
-    if (this.initPTS === null) {
+    if (this.frameIndex === 0 || this.initPTS === null) {
       this.initPTS = initPTSFn(timestamp, timeOffset);
     }
 
@@ -106,9 +108,9 @@ class BaseAudioDemuxer implements Demuxer {
 
     return {
       audioTrack: track,
-      avcTrack: dummyTrack(),
+      avcTrack: dummyTrack() as DemuxedAvcTrack,
       id3Track,
-      textTrack: dummyTrack(),
+      textTrack: dummyTrack() as DemuxedUserdataTrack,
     };
   }
 
@@ -129,14 +131,13 @@ class BaseAudioDemuxer implements Demuxer {
     }
 
     this.frameIndex = 0;
-    this.initPTS = null;
     this.cachedData = null;
 
     return {
       audioTrack: this._audioTrack,
-      avcTrack: dummyTrack(),
+      avcTrack: dummyTrack() as DemuxedAvcTrack,
       id3Track: this._id3Track,
-      textTrack: dummyTrack(),
+      textTrack: dummyTrack() as DemuxedUserdataTrack,
     };
   }
 

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -25,6 +25,7 @@ import {
   DemuxerResult,
   AvcSample,
   DemuxedMetadataTrack,
+  DemuxedUserdataTrack,
 } from '../types/demuxer';
 import { appendUint8Array } from '../utils/mp4-tools';
 import { utf8ArrayToStr } from '../demux/id3';
@@ -66,8 +67,8 @@ class TSDemuxer implements Demuxer {
   private _avcTrack!: DemuxedAvcTrack;
   private _audioTrack!: DemuxedAudioTrack;
   private _id3Track!: DemuxedMetadataTrack;
-  private _txtTrack!: DemuxedTrack;
-  private aacOverFlow: any;
+  private _txtTrack!: DemuxedUserdataTrack;
+  private aacOverFlow: Uint8Array | null = null;
   private avcSample: AvcSample | null = null;
   private remainderData: Uint8Array | null = null;
 
@@ -141,10 +142,22 @@ class TSDemuxer implements Demuxer {
     this.pmtParsed = false;
     this._pmtId = -1;
 
-    this._avcTrack = TSDemuxer.createTrack('video', duration);
-    this._audioTrack = TSDemuxer.createTrack('audio', duration);
-    this._id3Track = TSDemuxer.createTrack('id3', duration);
-    this._txtTrack = TSDemuxer.createTrack('text', duration);
+    this._avcTrack = TSDemuxer.createTrack(
+      'video',
+      duration
+    ) as DemuxedAvcTrack;
+    this._audioTrack = TSDemuxer.createTrack(
+      'audio',
+      duration
+    ) as DemuxedAudioTrack;
+    this._id3Track = TSDemuxer.createTrack(
+      'id3',
+      duration
+    ) as DemuxedMetadataTrack;
+    this._txtTrack = TSDemuxer.createTrack(
+      'text',
+      duration
+    ) as DemuxedUserdataTrack;
     this._audioTrack.isAAC = true;
 
     // flush any partial content

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -15,7 +15,8 @@ import type {
 } from '../types/remuxer';
 import type {
   DemuxedAudioTrack,
-  DemuxedTrack,
+  DemuxedMetadataTrack,
+  DemuxedUserdataTrack,
   PassthroughVideoTrack,
 } from '../types/demuxer';
 
@@ -102,8 +103,8 @@ class PassThroughRemuxer implements Remuxer {
   remux(
     audioTrack: DemuxedAudioTrack,
     videoTrack: PassthroughVideoTrack,
-    id3Track: DemuxedTrack,
-    textTrack: DemuxedTrack,
+    id3Track: DemuxedMetadataTrack,
+    textTrack: DemuxedUserdataTrack,
     timeOffset: number
   ): RemuxerResult {
     let { initPTS, lastEndDTS } = this;

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -22,9 +22,9 @@ export interface Demuxer {
 
 export interface DemuxerResult {
   audioTrack: DemuxedAudioTrack;
-  avcTrack: DemuxedAvcTrack;
-  id3Track: DemuxedTrack;
-  textTrack: DemuxedTrack;
+  avcTrack: DemuxedVideoTrack;
+  id3Track: DemuxedMetadataTrack;
+  textTrack: DemuxedUserdataTrack;
 }
 
 export interface DemuxedTrack {
@@ -33,7 +33,12 @@ export interface DemuxedTrack {
   pid: number;
   inputTimeScale: number;
   sequenceNumber: number;
-  samples: any;
+  samples:
+    | AudioSample[]
+    | AvcSample[]
+    | MetadataSample[]
+    | UserdataSample[]
+    | Uint8Array;
   timescale?: number;
   container?: string;
   dropped: number;
@@ -43,11 +48,12 @@ export interface DemuxedTrack {
 }
 
 export interface DemuxedAudioTrack extends DemuxedTrack {
-  config?: Array<number>;
+  config?: number[];
   samplerate?: number;
   isAAC?: boolean;
   channelCount?: number;
   manifestCodec?: string;
+  samples: AudioSample[];
 }
 
 export interface DemuxedVideoTrack extends DemuxedTrack {
@@ -55,13 +61,14 @@ export interface DemuxedVideoTrack extends DemuxedTrack {
   height?: number;
   pixelRatio?: number;
   audFound?: boolean;
-  pps?: Array<number>;
-  sps?: Array<number>;
+  pps?: number[];
+  sps?: number[];
   naluState?: number;
+  samples: AvcSample[] | Uint8Array;
 }
 
 export interface DemuxedAvcTrack extends DemuxedVideoTrack {
-  samples: Array<AvcSample>;
+  samples: AvcSample[];
 }
 
 export interface PassthroughVideoTrack extends DemuxedVideoTrack {
@@ -79,7 +86,7 @@ export interface DemuxedUserdataTrack extends DemuxedTrack {
 export interface MetadataSample {
   pts: number;
   dts: number;
-  len: number;
+  len?: number;
   data: Uint8Array;
 }
 
@@ -93,7 +100,7 @@ export interface AvcSample {
   pts: number;
   key: boolean;
   frame: boolean;
-  units: Array<AvcSampleUnit>;
+  units: AvcSampleUnit[];
   debug: string;
   length: number;
 }
@@ -102,7 +109,7 @@ export interface AvcSampleUnit {
   data: Uint8Array;
 }
 
-type AudioSample = {
+export type AudioSample = {
   unit: Uint8Array;
   pts: number;
   dts: number;
@@ -114,6 +121,6 @@ export type AppendedAudioFrame = {
 };
 
 export interface ElementaryStreamData {
-  data: Array<Uint8Array>;
+  data: Uint8Array[];
   size: number;
 }

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -1,7 +1,9 @@
 import type { TrackSet } from './track';
 import {
   DemuxedAudioTrack,
+  DemuxedMetadataTrack,
   DemuxedTrack,
+  DemuxedUserdataTrack,
   DemuxedVideoTrack,
   MetadataSample,
   UserdataSample,
@@ -12,8 +14,8 @@ export interface Remuxer {
   remux(
     audioTrack: DemuxedAudioTrack,
     videoTrack: DemuxedVideoTrack,
-    id3Track: DemuxedTrack,
-    textTrack: DemuxedTrack,
+    id3Track: DemuxedMetadataTrack,
+    textTrack: DemuxedUserdataTrack,
     timeOffset: number,
     accurateTimeOffset: boolean,
     flush: boolean


### PR DESCRIPTION
### This PR will...
- Remux audio-only stream contiguously without dropping samples or inserting silence
- Strongly type demuxer and remuxer track input and output

### Why is this Pull Request needed?
Fixes support for audio-only playlist with ACC segments containing ID3 "com.apple.streaming.transportStreamTimestamp" that should be ignored:
https://playertest.longtailvideo.com/adaptive/id3/playlist.m3u8

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
