### PR TITLE
Log parsed codec details before BUFFER_CODECS is triggered

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -817,10 +817,10 @@ class AudioStreamController
 
     track.levelCodec = track.codec;
     track.id = 'audio';
-    this.hls.trigger(Events.BUFFER_CODECS, tracks);
     this.log(
-      `Audio, container:${track.container}, codecs[level/parsed]=[${track.levelCodec}/${track.codec}]`
+      `Init audio buffer, container:${track.container}, codecs[parsed]=[${track.codec}]`
     );
+    this.hls.trigger(Events.BUFFER_CODECS, tracks);
     const initSegment = track.initSegment;
     if (initSegment) {
       const segment: BufferAppendingData = {

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -12,7 +12,6 @@ import type {
 import type { MediaPlaylist } from '../types/media-playlist';
 import { ErrorData, LevelLoadingData } from '../types/events';
 import { PlaylistContextType } from '../types/loader';
-import { logger } from '../utils/logger';
 
 class SubtitleTrackController extends BasePlaylistController {
   private media: HTMLMediaElement | null = null;


### PR DESCRIPTION
### This PR will...
1. Improve init buffer codecs logging so that it logs:

- the manifest audio codec even when a different one is selected.
- the manifest CODECS when buffering muxed "audiovideo" segments.
- before BUFFER_CODECS is triggered and buffer-controller logs `"creating sourceBuffer"` message.

2. Tidy up "Swapping audio codec" logs

### Resolves issues:
Closes #3069
Resolves #3068 (TrackSet includes "audiovideo")

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
