### PR TITLE
Backtrack partial segments

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -319,11 +319,9 @@ export default class BaseStreamController
         this.hls.trigger(Events.FRAG_LOADED, data);
 
         // Tracker backtrack must be called after onFragLoaded to update the fragment entity state to BACKTRACKED
+        // This happens after handleTransmuxComplete when the worker or progressive is disabled
         if (this.state === State.BACKTRACKING) {
-          this.flushMainBuffer(0, frag.start);
-          this.fragmentTracker.backtrack(data);
-          this.fragPrevious = null;
-          this.nextLoadPosition = frag.start;
+          this.fragmentTracker.backtrack(frag, data);
           return;
         }
       }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1143,6 +1143,12 @@ export default class StreamController
             endDTS,
           };
         } else if (video.dropped && video.independent) {
+          // Backtrack if dropped frames create a gap at currentTime
+          const pos = this.getLoadPosition() + this.config.maxBufferHole;
+          if (pos > frag.start && pos < startPTS) {
+            this.backtrack();
+            return;
+          }
           // Set video stream start to fragment start so that truncated samples do not distort the timeline, and mark it partial
           frag.setElementaryStreamInfo(
             video.type as ElementaryStreamTypes,


### PR DESCRIPTION
### This PR will...
Prevent playback from getting stuck when seeking to the start of a segment containing keyframe(s) after the start. 

### Why is this Pull Request needed?

Seeking to duration - 3 of https://playertest.longtailvideo.com/adaptive/artbeats/manifest.m3u8 reproduces the issue / fails functional tests:
```
should seek 3s from end and receive video ended event for Stream with duplicate sequential PDT values with 2 or less buffered ranges:
Error: Timeout of 40000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. 
```

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
