### PR TITLE
Fix audio track buffering in Safari

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -550,6 +550,7 @@ class AudioStreamController
 
   protected _handleFragmentLoadComplete(fragLoadedData: FragLoadedData) {
     if (this.waitingData) {
+      this.waitingData.complete = true;
       return;
     }
     super._handleFragmentLoadComplete(fragLoadedData);

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -749,18 +749,23 @@ export default class BufferController implements ComponentAPI {
     startOffset: number,
     endOffset: number
   ) {
-    const { media, operationQueue, sourceBuffer } = this;
+    const { media, mediaSource, operationQueue, sourceBuffer } = this;
     const sb = sourceBuffer[type];
-    if (!media || !sb) {
+    if (!media || !mediaSource || !sb) {
       logger.warn(
         `[buffer-controller]: Attempting to remove from the ${type} SourceBuffer, but it does not exist`
       );
       operationQueue.shiftAndExecuteNext(type);
       return;
     }
-
+    const mediaDuration = Number.isFinite(media.duration)
+      ? media.duration
+      : Infinity;
+    const msDuration = Number.isFinite(mediaSource.duration)
+      ? mediaSource.duration
+      : Infinity;
     const removeStart = Math.max(0, startOffset);
-    const removeEnd = Math.min(media.duration, endOffset);
+    const removeEnd = Math.min(endOffset, mediaDuration, msDuration);
     if (removeEnd > removeStart) {
       logger.log(
         `[buffer-controller]: Removing [${removeStart},${removeEnd}] from the ${type} SourceBuffer`

--- a/src/controller/buffer-operation-queue.ts
+++ b/src/controller/buffer-operation-queue.ts
@@ -29,7 +29,7 @@ export default class BufferOperationQueue {
   public insertAbort(operation: BufferOperation, type: SourceBufferName) {
     const queue = this.queues[type];
     queue.unshift(operation);
-    this.executeNext(type, true);
+    this.executeNext(type);
   }
 
   public appendBlocker(type: SourceBufferName): Promise<{}> {
@@ -48,14 +48,9 @@ export default class BufferOperationQueue {
     return promise;
   }
 
-  public executeNext(type: SourceBufferName, ignoreUpdating?: boolean) {
+  public executeNext(type: SourceBufferName) {
     const { buffers, queues } = this;
     const sb = buffers[type];
-    console.assert(
-      !sb || ignoreUpdating || !sb.updating,
-      `${type} sourceBuffer must exist, and must not be updating`
-    );
-
     const queue = queues[type];
     if (queue.length) {
       const operation: BufferOperation = queue[0];


### PR DESCRIPTION
### This PR will...
- Fix buffer flush when `media.duration` is `NaN`
- Set `complete` flag on audio-stream-controller `waitingData` to process fragment completely on INIT_PTS

### Why is this Pull Request needed?
Fixes a case where the audio-stream-controller gets stuck in a `PARSED` state after loading the first audio segment in Safari because `media.duration` is still `NaN` after setting `mediaSource.duration`.

Reproducible by loading fmp4 stream in Safari in v1.0.0-beta.2:
https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
