### PR TITLE
Limit ABR level selection to current codec set

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -413,7 +413,7 @@ function loadSelectedStream() {
   });
 
   hls.on(Hls.Events.MANIFEST_PARSED, function (eventName, data) {
-    logStatus('No of quality levels found: ' + hls.levels.length);
+    logStatus(`${hls.levels.length} quality levels found`);
     logStatus('Manifest successfully loaded');
     stats = {
       levelNb: data.levels.length,
@@ -1743,6 +1743,8 @@ function appendLog(textElId, message) {
   logText += newMessage;
   // update
   el.text(logText);
+  const element = el[0];
+  element.scrollTop = element.scrollHeight - element.clientHeight;
 }
 
 function logStatus(message) {

--- a/demo/style.css
+++ b/demo/style.css
@@ -187,13 +187,13 @@ select option {
 
 #statusOut {
   height: auto;
-  max-height: 4em;
+  max-height: calc((17px * 3) + 19px);
   overflow: auto;
 }
 
 #errorOut {
   height: auto;
-  max-height: 4em;
+  max-height: calc((17px * 3) + 19px);
   overflow: auto;
 }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -446,17 +446,12 @@ export default class BaseStreamController
 
   protected fragBufferedComplete(frag: Fragment, part: Part | null) {
     const media = this.mediaBuffer ? this.mediaBuffer : this.media;
-    const timestampInfo = frag.startPTS
-      ? `PTS:[${frag.startPTS},${frag.endPTS}],DTS:[${frag.startDTS}/${frag.endDTS}]`
-      : `start-end:[${frag.start}-${frag.end}]`;
     this.log(
       `Buffered ${frag.type} sn: ${frag.sn}${
         part ? ' part: ' + part.index : ''
       } of ${this.logPrefix === '[stream-controller]' ? 'level' : 'track'} ${
         frag.level
-      }. ${timestampInfo}, Buffered: ${TimeRanges.toString(
-        BufferHelper.getBuffered(media)
-      )}`
+      } ${TimeRanges.toString(BufferHelper.getBuffered(media))}`
     );
     this.state = State.IDLE;
     this.tick();
@@ -511,7 +506,7 @@ export default class BaseStreamController
               details.endSN
             }] parts [0-${partIndex}-${partList.length - 1}] ${
               this.logPrefix === '[stream-controller]' ? 'level' : 'track'
-            }: ${frag.level}, target buffer time: ${parseFloat(
+            }: ${frag.level}, target: ${parseFloat(
               targetBufferTime.toFixed(3)
             )}`
           );
@@ -542,7 +537,7 @@ export default class BaseStreamController
         details ? 'of [' + details.startSN + '-' + details.endSN + '] ' : ''
       }${this.logPrefix === '[stream-controller]' ? 'level' : 'track'}: ${
         frag.level
-      }, target buffer time: ${parseFloat(targetBufferTime.toFixed(3))}`
+      }, target: ${parseFloat(targetBufferTime.toFixed(3))}`
     );
 
     this.state = State.FRAG_LOADING;

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -117,7 +117,10 @@ export default class M3U8Parser {
           level.height = resolution.height;
         }
 
-        setCodecs([].concat((attrs.CODECS || '').split(/[ ,]+/)), level);
+        setCodecs(
+          (attrs.CODECS || '').split(/[ ,]+/).filter((c) => c),
+          level
+        );
 
         if (level.videoCodec && level.videoCodec.indexOf('avc1') !== -1) {
           level.videoCodec = M3U8Parser.convertAVC1ToAVCOTI(level.videoCodec);

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -83,30 +83,33 @@ export class HlsUrlParameters {
 }
 
 export class Level {
-  public attrs: LevelAttributes;
-  public audioCodec?: string;
+  public readonly attrs: LevelAttributes;
+  public readonly audioCodec: string | undefined;
+  public readonly bitrate: number;
+  public readonly codecSet: string;
+  public readonly height: number;
+  public readonly id: number;
+  public readonly name: string | undefined;
+  public readonly videoCodec: string | undefined;
+  public readonly width: number;
+  public readonly unknownCodecs: string[] | undefined;
   public audioGroupIds?: string[];
-  public bitrate: number;
   public details?: LevelDetails;
   public fragmentError: boolean = false;
-  public height: number;
-  public id: number;
   public loadError: number = 0;
   public loaded?: { bytes: number; duration: number };
-  public name: string | undefined;
   public realBitrate: number = 0;
   public textGroupIds?: string[];
   public url: string[];
-  public videoCodec?: string;
-  public width: number;
-  public unknownCodecs: string[] | undefined;
   private _urlId: number = 0;
 
   constructor(data: LevelParsed) {
     this.url = [data.url];
     this.attrs = data.attrs;
     this.bitrate = data.bitrate;
-    this.details = data.details;
+    if (data.details) {
+      this.details = data.details;
+    }
     this.id = data.id || 0;
     this.name = data.name;
     this.width = data.width || 0;
@@ -114,6 +117,10 @@ export class Level {
     this.audioCodec = data.audioCodec;
     this.videoCodec = data.videoCodec;
     this.unknownCodecs = data.unknownCodecs;
+    this.codecSet = [data.videoCodec, data.audioCodec]
+      .filter((c) => c)
+      .join(',')
+      .replace(/\.[^.,]+/g, '');
   }
 
   get maxBitrate(): number {

--- a/tests/unit/controller/level-controller.js
+++ b/tests/unit/controller/level-controller.js
@@ -80,6 +80,7 @@ describe('LevelController', function () {
       audioCodec: undefined,
       audioGroupIds: undefined,
       bitrate: 246440,
+      codecSet: '',
       details: data.levels[1].details,
       fragmentError: false,
       height: 0,


### PR DESCRIPTION
### This PR will...
Prevent ABR level switching to different codec sets that would break playback.

### Why is this Pull Request needed?
Improves support for streams with mixed codecs in browsers where MSE supports multiple audio and video codecs.

Example:

Apple's [Advanced stream (HEVC/H.264)](https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8 ) example contains AVC and HEVC video. It also contains AAC, AC-3, and  EC-3 audio. Since we do not yet support [codec changing on source buffers](https://googlechrome.github.io/samples/media/sourcebuffer-changetype.html), appending one type of video or audio after another can cause either an append or media error. This can still occur after a manual switch but should not in auto mode, where experiencing error recovery would disrupt the viewing experience. 

### Are there any points in the code the reviewer needs to double-check?

The codec set is created by simplifying video and audio STREAM-INF CODECS into a single string.
`avc1.64002a,mp4a.40.2` becomes `avc1,mp4a`,
`hvc1.2.4.L123.B0,ec-3` becomes `hvc1,ec-3`,
`mp4a.40.5` becomes `mp4a`
undefined CODECS results in an empty codec set

While implementing MSE `SourceBuffer.changeType` might be a better solution, this stop-gap is a lot simpler, stable, and can still be used when we look to implement it and configure [preferred codecs](https://github.com/video-dev/hls.js/blob/ebf2fdc20f43d90b7152213609d5416235329eee/src/loader/m3u8-parser.ts#L555). 
### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
