### PR TITLE
MediaSource.changeType Support and MP3 Buffering Fixed

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -823,7 +823,7 @@ class AudioStreamController
     );
     this.hls.trigger(Events.BUFFER_CODECS, tracks);
     const initSegment = track.initSegment;
-    if (initSegment) {
+    if (initSegment?.byteLength) {
       const segment: BufferAppendingData = {
         type: 'audio',
         data: initSegment,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1068,6 +1068,7 @@ export default class BaseStreamController
           level,
           drift,
           type,
+          frag,
           start: info.startPTS,
           end: info.endPTS,
         });

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -81,7 +81,6 @@ export default class BufferController implements ComponentAPI {
     hls.on(Events.BUFFER_CODECS, this.onBufferCodecs, this);
     hls.on(Events.BUFFER_EOS, this.onBufferEos, this);
     hls.on(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
-    hls.on(Events.LEVEL_PTS_UPDATED, this.onLevelPtsUpdated, this);
     hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
     hls.on(Events.FRAG_PARSED, this.onFragParsed, this);
   }
@@ -96,7 +95,6 @@ export default class BufferController implements ComponentAPI {
     hls.off(Events.BUFFER_CODECS, this.onBufferCodecs, this);
     hls.off(Events.BUFFER_EOS, this.onBufferEos, this);
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
-    hls.off(Events.LEVEL_PTS_UPDATED, this.onLevelPtsUpdated, this);
     hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
     hls.off(Events.FRAG_PARSED, this.onFragParsed, this);
   }
@@ -252,24 +250,47 @@ export default class BufferController implements ComponentAPI {
     event: Events.BUFFER_APPENDING,
     eventData: BufferAppendingData
   ) {
-    const { hls, operationQueue } = this;
+    const { hls, operationQueue, tracks } = this;
     const { data, type, frag, part, chunkMeta } = eventData;
     const chunkStats = chunkMeta.buffering[type];
 
-    const start = self.performance.now();
-    chunkStats.start = start;
+    const bufferAppendingStart = self.performance.now();
+    chunkStats.start = bufferAppendingStart;
     const fragBuffering = frag.stats.buffering;
     const partBuffering = part ? part.stats.buffering : null;
     if (fragBuffering.start === 0) {
-      fragBuffering.start = start;
+      fragBuffering.start = bufferAppendingStart;
     }
     if (partBuffering && partBuffering.start === 0) {
-      partBuffering.start = start;
+      partBuffering.start = bufferAppendingStart;
     }
+
+    // TODO: Only update timestampOffset when audio/mpeg fragment or part is not contiguous with previously appended
+    // Adjusting `SourceBuffer.timestampOffset` (desired point in the timeline where the next frames should be appended)
+    // in Chrome browser when we detect MPEG audio container and time delta between level PTS and `SourceBuffer.timestampOffset`
+    // is greater than 100ms (this is enough to handle seek for VOD or level change for LIVE videos).
+    // More info here: https://github.com/video-dev/hls.js/issues/332#issuecomment-257986486
+    const audioTrack = tracks.audio;
+    const checkTimestampOffset =
+      type === 'audio' &&
+      chunkMeta.id === 1 &&
+      audioTrack?.container === 'audio/mpeg';
 
     const operation: BufferOperation = {
       execute: () => {
         chunkStats.executeStart = self.performance.now();
+        if (checkTimestampOffset) {
+          const sb = this.sourceBuffer[type];
+          if (sb) {
+            const delta = frag.start - sb.timestampOffset;
+            if (Math.abs(delta) >= 0.1) {
+              logger.log(
+                `[buffer-controller]: Updating audio SourceBuffer timestampOffset to ${frag.start} (delta: ${delta}) sn: ${frag.sn})`
+              );
+              sb.timestampOffset = frag.start;
+            }
+          }
+        }
         this.appendExecutor(data, type);
       },
       onStart: () => {
@@ -453,75 +474,6 @@ export default class BufferController implements ComponentAPI {
       this.blockBuffers(this.updateMediaElementDuration.bind(this));
     } else {
       this.updateMediaElementDuration();
-    }
-  }
-
-  // Adjusting `SourceBuffer.timestampOffset` (desired point in the timeline where the next frames should be appended)
-  // in Chrome browser when we detect MPEG audio container and time delta between level PTS and `SourceBuffer.timestampOffset`
-  // is greater than 100ms (this is enough to handle seek for VOD or level change for LIVE videos). At the time of change we issue
-  // `SourceBuffer.abort()` and adjusting `SourceBuffer.timestampOffset` if `SourceBuffer.updating` is false or awaiting `updateend`
-  // event if SB is in updating state.
-  // More info here: https://github.com/video-dev/hls.js/issues/332#issuecomment-257986486
-  protected onLevelPtsUpdated(
-    event: Events.LEVEL_PTS_UPDATED,
-    data: LevelPTSUpdatedData
-  ) {
-    const { operationQueue, sourceBuffer, tracks } = this;
-    const type = data.type;
-    const audioTrack = tracks.audio;
-
-    if (
-      type !== 'audio' ||
-      (audioTrack && audioTrack.container !== 'audio/mpeg')
-    ) {
-      return;
-    }
-    const audioBuffer = sourceBuffer[type];
-    if (!audioBuffer) {
-      return;
-    }
-    const start = data.start;
-    const delta = Math.abs(audioBuffer.timestampOffset - start);
-    if (delta < 0.1) {
-      return;
-    }
-    // SourceBuffers can be aborted while the updating flag is true, but only if it is because of an append operation -
-    // aborting during a remove will throw an InvalidStateError. It's safer to enqueue aborts and execute them only if
-    // updating is false
-    if (audioBuffer.updating) {
-      const operation = {
-        execute() {
-          logger.log(`[buffer-controller]: Aborting the ${type} SourceBuffer`);
-          audioBuffer.abort();
-        },
-        onStart() {
-          logger.debug(
-            `[buffer-controller]: Starting abort on source buffer ${type}`
-          );
-        },
-        onComplete() {
-          logger.log(
-            `[buffer-controller]: Updating audio SourceBuffer timestampOffset to ${start}`
-          );
-          audioBuffer.timestampOffset = start;
-        },
-        onError(error) {
-          logger.warn(
-            '[buffer-controller]: Failed to abort the audio SourceBuffer',
-            error
-          );
-        },
-      };
-      operationQueue.insertAbort(operation, type);
-    } else {
-      logger.log(
-        `[buffer-controller]: Updating audio SourceBuffer timestampOffset to ${start}`
-      );
-      audioBuffer.timestampOffset = start;
-    }
-
-    if (this.hls.config.liveDurationInfinity) {
-      this.updateSeekableRange(data.details);
     }
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1,4 +1,5 @@
 import BaseStreamController, { State } from './base-stream-controller';
+import { changeTypeSupported } from '../is-supported';
 import type { NetworkComponentAPI } from '../types/component-api';
 import { Events } from '../events';
 import { BufferHelper } from '../utils/buffer-helper';
@@ -561,7 +562,7 @@ export default class StreamController
         }
       }
     });
-    this.audioCodecSwitch = aac && heaac;
+    this.audioCodecSwitch = aac && heaac && !changeTypeSupported();
     if (this.audioCodecSwitch) {
       this.log(
         'Both AAC/HE-AAC audio found in levels; declaring level codec as HE-AAC'

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1293,7 +1293,7 @@ export default class StreamController
     Object.keys(tracks).forEach((trackName) => {
       const track = tracks[trackName];
       const initSegment = track.initSegment;
-      if (initSegment) {
+      if (initSegment?.byteLength) {
         this.hls.trigger(Events.BUFFER_APPENDING, {
           type: trackName as SourceBufferName,
           data: initSegment,

--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -1,13 +1,16 @@
 import { getMediaSource } from './utils/mediasource-helper';
+import { ExtendedSourceBuffer } from './types/buffer';
+
+function getSourceBuffer(): typeof self.SourceBuffer {
+  return self.SourceBuffer || (self as any).WebKitSourceBuffer;
+}
 
 export function isSupported(): boolean {
   const mediaSource = getMediaSource();
   if (!mediaSource) {
     return false;
   }
-  const sourceBuffer =
-    self.SourceBuffer || ((self as any).WebKitSourceBuffer as SourceBuffer); // eslint-disable-line no-restricted-globals
-
+  const sourceBuffer = getSourceBuffer();
   const isTypeSupported =
     mediaSource &&
     typeof mediaSource.isTypeSupported === 'function' &&
@@ -21,4 +24,12 @@ export function isSupported(): boolean {
       typeof sourceBuffer.prototype.appendBuffer === 'function' &&
       typeof sourceBuffer.prototype.remove === 'function');
   return !!isTypeSupported && !!sourceBufferValidAPI;
+}
+
+export function changeTypeSupported(): boolean {
+  const sourceBuffer = getSourceBuffer();
+  return (
+    typeof (sourceBuffer?.prototype as ExtendedSourceBuffer)?.changeType ===
+    'function'
+  );
 }

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -3,6 +3,7 @@ export type SourceBufferName = 'video' | 'audio' | 'audiovideo';
 // eslint-disable-next-line no-restricted-globals
 export type ExtendedSourceBuffer = SourceBuffer & {
   ended?: boolean;
+  changeType?: (type: string) => void;
 };
 
 export type SourceBuffers = Partial<

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -149,6 +149,7 @@ export interface LevelPTSUpdatedData {
   level: Level;
   drift: number;
   type: string;
+  frag: Fragment;
   start: number;
   end: number;
 }


### PR DESCRIPTION
### This PR will...

- Update audio/mpeg SourceBuffer timestampOffset before appending first fragment/part bytes
- Include frag in Level PTS Updated event
- Add `MediaSource.changeType` support

### Why is this Pull Request needed?
MP3 chunks were being dropped on LEVEL_PTS_UPDATED when it fires before the last segment is completely appended. Also, the expectation was that it fires before any append, but that is no longer the case since bytes are always appended on loading progress (even if there is only one progress event). LEVEL_PTS_UPDATED happens after loading is complete. Including the fragment object in LEVEL_PTS_UPDATED helps make it clearer why the event was fired.

`MediaSource.changeType` support allows for transitions between AAC with and without SBR, as well as audio and video codec changes in the latest version of Chrome and Safari. hls.js can now switch from AVC to HEVC in Safari: https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8

### Resolves issues:
#3323
#3151

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md


