### PR TITLE
Convert sample-aes.js to typescript. Improve typescript types in tsdemuxer.

### DIFF
--- a/src/demux/base-audio-demuxer.ts
+++ b/src/demux/base-audio-demuxer.ts
@@ -7,6 +7,7 @@ import type {
   DemuxedMetadataTrack,
   DemuxedAvcTrack,
   DemuxedUserdataTrack,
+  KeyData,
 } from '../types/demuxer';
 import { dummyTrack } from './dummy-demuxed-track';
 import { appendUint8Array } from '../utils/mp4-tools';
@@ -116,7 +117,7 @@ class BaseAudioDemuxer implements Demuxer {
 
   demuxSampleAes(
     data: Uint8Array,
-    decryptData: Uint8Array,
+    keyData: KeyData,
     timeOffset: number
   ): Promise<DemuxerResult> {
     return Promise.reject(

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -4,11 +4,11 @@
 import {
   Demuxer,
   DemuxerResult,
-  DemuxedTrack,
   PassthroughVideoTrack,
   DemuxedAudioTrack,
   DemuxedUserdataTrack,
   DemuxedMetadataTrack,
+  KeyData,
 } from '../types/demuxer';
 import {
   findBox,
@@ -84,7 +84,7 @@ class MP4Demuxer implements Demuxer {
 
   demuxSampleAes(
     data: Uint8Array,
-    decryptData: Uint8Array,
+    keyData: KeyData,
     timeOffset: number
   ): Promise<DemuxerResult> {
     return Promise.reject(

--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -5,7 +5,7 @@
 import { HlsConfig } from '../config';
 import Decrypter from '../crypt/decrypter';
 import { HlsEventEmitter } from '../events';
-import {
+import type {
   AudioSample,
   AvcSample,
   AvcSampleUnit,
@@ -171,7 +171,7 @@ class SampleAesDecrypter {
     callback: () => void
   ) {
     if (samples instanceof Uint8Array) {
-      throw new Error('Cannot decrypte samples of type Uint8Array');
+      throw new Error('Cannot decrypt samples of type Uint8Array');
     }
 
     for (; ; sampleIndex++, unitIndex = 0) {

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -66,6 +66,7 @@ interface PES {
 export interface TypeSupported {
   mpeg: boolean;
   mp3: boolean;
+  mp4: boolean;
 }
 
 class TSDemuxer implements Demuxer {

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -6,7 +6,7 @@ export interface Demuxer {
   ): DemuxerResult;
   demuxSampleAes(
     data: Uint8Array,
-    decryptData: Uint8Array,
+    keyData: KeyData,
     timeOffset: number
   ): Promise<DemuxerResult>;
   flush(timeOffset?: number): DemuxerResult;
@@ -59,7 +59,7 @@ export interface DemuxedAudioTrack extends DemuxedTrack {
 export interface DemuxedVideoTrack extends DemuxedTrack {
   width?: number;
   height?: number;
-  pixelRatio?: number;
+  pixelRatio?: [number, number];
   audFound?: boolean;
   pps?: number[];
   sps?: number[];
@@ -107,6 +107,7 @@ export interface AvcSample {
 
 export interface AvcSampleUnit {
   data: Uint8Array;
+  type: number;
 }
 
 export type AudioSample = {
@@ -123,4 +124,10 @@ export type AppendedAudioFrame = {
 export interface ElementaryStreamData {
   data: Uint8Array[];
   size: number;
+}
+
+export interface KeyData {
+  method: string;
+  key: Uint8Array;
+  iv: Uint8Array;
 }


### PR DESCRIPTION
### This PR will...

Convert sample-aes.js to typescript, and improve typescript types in tsdemuxer.ts.

`decryptData` in demuxer code was of type `Uint8Array`, which was incorrect - this should have been a LevelKey.  But, LevelKey has a `key` and `iv` which can be null, and all of this code in demuxer will break if these are null.  So, I created a new type `KeyData` which is essentially a limited subset of [`LevelKey`](https://github.com/video-dev/hls.js/blob/master/src/loader/level-key.ts#L3) but where values can't be null, and with only the data that the demuxers need to do their job.  `transmuxer.ts#getEncryptionType()` was already checking to verify that the `key` was set on the LevelKey, but didn't bother to check if `iv` was set (even though we'll crash later when we try to dereference it, if it is not) so it now checks this, and instead of just returning the encryption type it now returns a KeyData object.  Now we can be sure that these values will not be null without having to check them.

`DemuxedVideoTrack.pixelRatio` was defined as a `number`, but it's actually being assigned a `[number, number]`, and I think this is correct, so I fixed it.  `DemuxedVideoTrack.pps` and `.sps` are defined as `number[]`, but when we create one in tsdemuxer, we're assigning a `Uint8Array[]`.  I added a TODO here and cast these as `any` for now, but something is amiss here, and I don't know enough to know what it's supposed to be.  :P  If I just change it to `Uint8Array[]`, then nothing seems to break...

Finally, `PES` has a `pts` and `dts`, which are a `number | undefined`, but callers of `parsePES()` assume they will never be undefined (or are happy to end up with a NaN), so for now I set these to `any` to get around this, and added a TODO.

### Why is this Pull Request needed?

![image](https://user-images.githubusercontent.com/1771003/104758666-c037ec00-572c-11eb-9501-0bdc39f77ad3.png)

### Resolves issues:

Related to #2070

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
