### PR TITLE
Fix SAMPLE-AES MPEG-TS streaming

### DIFF
--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -12,20 +12,14 @@ import type {
   DemuxedVideoTrack,
   KeyData,
 } from '../types/demuxer';
+import { discardEPB } from './tsdemuxer';
 
 class SampleAesDecrypter {
   private keyData: KeyData;
-  private discardEPB: (data: Uint8Array) => Uint8Array;
   private decrypter: Decrypter;
 
-  constructor(
-    observer: HlsEventEmitter,
-    config: HlsConfig,
-    keyData: KeyData,
-    discardEPB: (data: Uint8Array) => Uint8Array
-  ) {
+  constructor(observer: HlsEventEmitter, config: HlsConfig, keyData: KeyData) {
     this.keyData = keyData;
-    this.discardEPB = discardEPB;
     this.decrypter = new Decrypter(observer, config, {
       removePKCS7Padding: false,
     });
@@ -144,7 +138,7 @@ class SampleAesDecrypter {
     curUnit: AvcSampleUnit,
     sync: boolean
   ) {
-    const decodedData = this.discardEPB(curUnit.data);
+    const decodedData = discardEPB(curUnit.data);
     const encryptedData = this.getAvcEncryptedData(decodedData);
     const localthis = this;
 

--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -31,13 +31,11 @@ class SampleAesDecrypter {
     });
   }
 
-  // TODO: Fix callback return type.
   decryptBuffer(
-    encryptedData: Uint8Array | ArrayBufferLike,
-    callback: (decryptedData: any) => void
+    encryptedData: Uint8Array | ArrayBuffer,
+    callback: (decryptedData: ArrayBuffer) => void
   ) {
-    // TODO: `this.decrypter` is an instance of `Decrypter`, which has no function named decrypt!?
-    (this.decrypter as any).decrypt(
+    this.decrypter.decrypt(
       encryptedData,
       this.keyData.key.buffer,
       this.keyData.iv.buffer,
@@ -46,7 +44,7 @@ class SampleAesDecrypter {
   }
 
   // AAC - encrypt all full 16 bytes blocks starting from offset 16
-  decryptAacSample(
+  private decryptAacSample(
     samples: AudioSample[],
     sampleIndex: number,
     callback: () => void,
@@ -63,8 +61,8 @@ class SampleAesDecrypter {
     );
 
     const localthis = this;
-    this.decryptBuffer(encryptedBuffer, function (decryptedData) {
-      decryptedData = new Uint8Array(decryptedData);
+    this.decryptBuffer(encryptedBuffer, (decryptedBuffer: ArrayBuffer) => {
+      const decryptedData = new Uint8Array(decryptedBuffer);
       curUnit.set(decryptedData, 16);
 
       if (!sync) {
@@ -150,18 +148,24 @@ class SampleAesDecrypter {
     const encryptedData = this.getAvcEncryptedData(decodedData);
     const localthis = this;
 
-    this.decryptBuffer(encryptedData.buffer, function (decryptedData) {
-      curUnit.data = localthis.getAvcDecryptedUnit(decodedData, decryptedData);
-
-      if (!sync) {
-        localthis.decryptAvcSamples(
-          samples,
-          sampleIndex,
-          unitIndex + 1,
-          callback
+    this.decryptBuffer(
+      encryptedData.buffer,
+      function (decryptedBuffer: ArrayBuffer) {
+        curUnit.data = localthis.getAvcDecryptedUnit(
+          decodedData,
+          decryptedBuffer
         );
+
+        if (!sync) {
+          localthis.decryptAvcSamples(
+            samples,
+            sampleIndex,
+            unitIndex + 1,
+            callback
+          );
+        }
       }
-    });
+    );
   }
 
   decryptAvcSamples(

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -9,7 +9,7 @@ export interface Demuxer {
     keyData: KeyData,
     timeOffset: number
   ): Promise<DemuxerResult>;
-  flush(timeOffset?: number): DemuxerResult;
+  flush(timeOffset?: number): DemuxerResult | Promise<DemuxerResult>;
   destroy(): void;
   resetInitSegment(
     audioCodec: string | undefined,


### PR DESCRIPTION
### This PR will...
- Fixes SAMPLE-AES streaming. Fix developed and tested against sample stream from https://demo.unified-streaming.com/keyrotation/
- MPEG-TS Demuxer PES timestamp TypeScript cleanup; ID3 and MP3 PES with no PTS are dropped. AVC and AVC samples use previous PTS where available.

### Why is this Pull Request needed?
Follow up from #3384
Fixes a regression introduced in 6836ef3e40ee2ed72553856cc1bd6f35f806bf1d
Adds more type safety to `TSDemuxer`

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
