### PR TITLE
Allow fragment loading error retries to run before level recovery

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -633,6 +633,11 @@ class AudioStreamController
             this.retryDate = performance.now() + delay;
             // retry loading state
             this.state = State.FRAG_LOADING_WAITING_RETRY;
+          } else if (data.levelRetry) {
+            // Fragment errors that result in a level switch or redundant fail-over
+            // should reset the audio stream controller state to idle
+            this.fragLoadError = 0;
+            this.state = State.IDLE;
           } else {
             logger.error(
               `${data.details} reaches max retry, redispatch as fatal ...`

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -575,7 +575,7 @@ class AudioStreamController
 
   onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
     const { frag, part } = data;
-    if (frag && frag.type !== 'audio') {
+    if (frag.type !== PlaylistLevelType.AUDIO) {
       return;
     }
     if (this.fragContextChanged(frag)) {
@@ -603,19 +603,19 @@ class AudioStreamController
       case ErrorDetails.FRAG_LOAD_ERROR:
       case ErrorDetails.FRAG_LOAD_TIMEOUT:
       case ErrorDetails.KEY_LOAD_ERROR:
-      case ErrorDetails.KEY_LOAD_TIMEOUT: {
+      case ErrorDetails.KEY_LOAD_TIMEOUT:
         if (!data.fatal) {
           const frag = data.frag;
-          const fragCurrent = this.fragCurrent;
           // don't handle frag error not related to audio fragment
-          if (!frag || frag.type !== 'audio') {
-            break;
+          if (!frag || frag.type !== PlaylistLevelType.AUDIO) {
+            return;
           }
+          const fragCurrent = this.fragCurrent;
           console.assert(
             fragCurrent &&
               frag.sn === fragCurrent.sn &&
               frag.level === fragCurrent.level &&
-              frag.urlId === fragCurrent.urlId,
+              frag.urlId === fragCurrent.urlId, // FIXME: audio-group id
             'Frag load error must match current frag to retry'
           );
           const config = this.config;
@@ -647,7 +647,6 @@ class AudioStreamController
           }
         }
         break;
-      }
       case ErrorDetails.AUDIO_TRACK_LOAD_ERROR:
       case ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
         //  when in ERROR state, don't switch back to IDLE state in case a non-fatal error is received

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -298,11 +298,11 @@ export default class BaseStreamController
       targetBufferTime,
       progressCallback
     ).then((data) => {
-      this.fragLoadError = 0;
       if (!data) {
         // if we're here we probably needed to backtrack or are waiting for more parts
         return;
       }
+      this.fragLoadError = 0;
       if (this.fragContextChanged(frag)) {
         if (
           this.state === State.FRAG_LOADING ||
@@ -1080,7 +1080,7 @@ export default class BaseStreamController
     const previousState = this._state;
     if (previousState !== nextState) {
       this._state = nextState;
-      // this.log(`${previousState}->${nextState}`);
+      this.log(`${previousState}->${nextState}`);
     }
   }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -674,6 +674,18 @@ export default class BaseStreamController
     }
   }
 
+  protected reduceMaxBufferLength(threshold?: number) {
+    const config = this.config;
+    const minLength = threshold || config.maxBufferLength;
+    if (config.maxMaxBufferLength >= minLength) {
+      // reduce max buffer length as it might be too high. we do this to avoid loop flushing ...
+      config.maxMaxBufferLength /= 2;
+      this.warn(`Reduce max buffer length to ${config.maxMaxBufferLength}s`);
+      return true;
+    }
+    return false;
+  }
+
   protected getNextFragment(
     pos: number,
     levelDetails: LevelDetails

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -16,9 +16,8 @@ import { Events } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { isCodecSupportedInMp4 } from '../utils/codecs';
 import { addGroupId, assignTrackIdsByGroup } from './level-helper';
-import Fragment from '../loader/fragment';
 import BasePlaylistController from './base-playlist-controller';
-import { PlaylistContextType } from '../types/loader';
+import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import type Hls from '../hls';
 import type { HlsUrlParameters, LevelParsed } from '../types/level';
 import type { MediaPlaylist } from '../types/media-playlist';
@@ -426,7 +425,7 @@ export default class LevelController extends BasePlaylistController {
 
   // reset errors on the successful load of a fragment
   protected onFragLoaded(event: Events.FRAG_LOADED, { frag }: FragLoadedData) {
-    if (frag !== undefined && frag.type === 'main') {
+    if (frag !== undefined && frag.type === PlaylistLevelType.MAIN) {
       const level = this._levels[frag.level];
       if (level !== undefined) {
         level.fragmentError = 0;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -825,7 +825,7 @@ export default class StreamController
 
   private onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
     const { frag, part } = data;
-    if (frag && frag.type !== 'main') {
+    if (frag && frag.type !== PlaylistLevelType.MAIN) {
       return;
     }
     if (this.fragContextChanged(frag)) {
@@ -854,11 +854,11 @@ export default class StreamController
       case ErrorDetails.KEY_LOAD_TIMEOUT:
         if (!data.fatal) {
           const frag = data.frag;
-          const fragCurrent = this.fragCurrent;
           // don't handle frag error not related to main fragment
-          if (!frag || frag.type !== 'main') {
+          if (!frag || frag.type !== PlaylistLevelType.MAIN) {
             return;
           }
+          const fragCurrent = this.fragCurrent;
           console.assert(
             fragCurrent &&
               frag.sn === fragCurrent.sn &&

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -887,12 +887,18 @@ export default class StreamController
             }
             this.fragLoadError++;
             this.state = State.FRAG_LOADING_WAITING_RETRY;
+          } else if (data.levelRetry) {
+            // Fragment errors that result in a level switch or redundant fail-over
+            // should reset the stream controller state to idle
+            this.fragLoadError = 0;
+            this.state = State.IDLE;
           } else {
             logger.error(
               `[stream-controller]: ${data.details} reaches max retry, redispatch as fatal ...`
             );
             // switch error to fatal
             data.fatal = true;
+            this.hls.stopLoad();
             this.state = State.ERROR;
           }
         }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -6,6 +6,7 @@ import type { FragmentTracker } from './fragment-tracker';
 import { FragmentState } from './fragment-tracker';
 import BaseStreamController, { State } from './base-stream-controller';
 import FragmentLoader from '../loader/fragment-loader';
+import { PlaylistLevelType } from '../types/loader';
 import { Level } from '../types/level';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type Hls from '../hls';
@@ -152,7 +153,7 @@ export class SubtitleStreamController
   onError(event: Events.ERROR, data: ErrorData) {
     const frag = data.frag;
     // don't handle error not related to subtitle fragment
-    if (!frag || frag.type !== 'subtitle') {
+    if (!frag || frag.type !== PlaylistLevelType.SUBTITLE) {
       return;
     }
 

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -15,6 +15,7 @@ import {
   InitPTSFoundData,
   SubtitleTracksUpdatedData,
 } from '../types/events';
+import { PlaylistLevelType } from '../types/loader';
 import type Hls from '../hls';
 import type { ComponentAPI } from '../types/component-api';
 import type { HlsConfig } from '../config';
@@ -419,7 +420,7 @@ export class TimelineController implements ComponentAPI {
       lastSn,
       unparsedVttFrags,
     } = this;
-    if (frag.type === 'main') {
+    if (frag.type === PlaylistLevelType.MAIN) {
       const sn = frag.sn;
       // if this frag isn't contiguous, clear the parser so cues with bad start/end times aren't added to the textTrack
       if (sn !== lastSn + 1) {
@@ -429,7 +430,7 @@ export class TimelineController implements ComponentAPI {
         }
       }
       this.lastSn = sn as number;
-    } else if (frag.type === 'subtitle') {
+    } else if (frag.type === PlaylistLevelType.SUBTITLE) {
       // If fragment is subtitle type, parse as WebVTT.
       if (payload.byteLength) {
         // We need an initial synchronisation PTS. Store fragments as long as none has arrived.
@@ -598,7 +599,7 @@ export class TimelineController implements ComponentAPI {
 
   onFragDecrypted(event: Events.FRAG_DECRYPTED, data: FragDecryptedData) {
     const { frag } = data;
-    if (frag.type === 'subtitle') {
+    if (frag.type === PlaylistLevelType.SUBTITLE) {
       if (!Number.isFinite(this.initPTS[frag.cc])) {
         this.unparsedVttFrags.push((data as unknown) as FragLoadedData);
         return;

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -75,16 +75,15 @@ export default class M3U8Parser {
   }
 
   static convertAVC1ToAVCOTI(codec) {
+    // Convert avc1 codec string from RFC-4281 to RFC-6381 for MediaSource.isTypeSupported
     const avcdata = codec.split('.');
-    let result;
     if (avcdata.length > 2) {
-      result = avcdata.shift() + '.';
+      let result = avcdata.shift() + '.';
       result += parseInt(avcdata.shift()).toString(16);
       result += ('000' + parseInt(avcdata.shift()).toString(16)).substr(-4);
-    } else {
-      result = codec;
+      return result;
     }
-    return result;
+    return codec;
   }
 
   static resolve(url, baseUrl) {

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -95,7 +95,7 @@ export class Level {
   public readonly unknownCodecs: string[] | undefined;
   public audioGroupIds?: string[];
   public details?: LevelDetails;
-  public fragmentError: boolean = false;
+  public fragmentError: number = 0;
   public loadError: number = 0;
   public loaded?: { bytes: number; duration: number };
   public realBitrate: number = 0;

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -69,15 +69,13 @@ const sampleEntryCodesISO = {
 
 export type CodecType = 'audio' | 'video';
 
-function isCodecType(codec: string, type: CodecType): boolean {
+export function isCodecType(codec: string, type: CodecType): boolean {
   const typeCodes = sampleEntryCodesISO[type];
   return !!typeCodes && typeCodes[codec.slice(0, 4)] === true;
 }
 
-function isCodecSupportedInMp4(codec: string, type: CodecType): boolean {
+export function isCodecSupportedInMp4(codec: string, type: CodecType): boolean {
   return MediaSource.isTypeSupported(
     `${type || 'video'}/mp4;codecs="${codec}"`
   );
 }
-
-export { isCodecType, isCodecSupportedInMp4 };

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -217,7 +217,12 @@ async function testSeekOnVOD(url, config) {
       self.startStream(url, config, callback);
       const video = self.video;
       video.ondurationchange = function () {
-        console.log('[test] > video  "durationchange": ' + video.duration);
+        console.log(
+          '[test] > video  "durationchange": ' +
+            video.duration +
+            ', currentTime: ' +
+            video.currentTime
+        );
       };
       video.onloadeddata = function () {
         console.log('[test] > video  "loadeddata"');
@@ -285,7 +290,9 @@ async function testSeekOnVOD(url, config) {
       };
 
       video.oncanplaythrough = video.onwaiting = function (e) {
-        console.log('[test] > video  "' + e.type + '"');
+        console.log(
+          '[test] > video  "' + e.type + '", currentTime: ' + video.currentTime
+        );
       };
     },
     url,

--- a/tests/unit/controller/level-controller.js
+++ b/tests/unit/controller/level-controller.js
@@ -82,7 +82,7 @@ describe('LevelController', function () {
       bitrate: 246440,
       codecSet: '',
       details: data.levels[1].details,
-      fragmentError: false,
+      fragmentError: 0,
       height: 0,
       id: 2,
       level: 1,


### PR DESCRIPTION
### This PR will...
- Allow fragment loading error retries to run before level recovery
- If level recovery fails for all levels, then make the fragment loading error fatal
- Fix the audio stream controller error handler (missing event type and object input parameters)

### Why is this Pull Request needed?

Fixes a conflict between stream-controller and level-controller fragment loading error handling. Any live stream in auto ABR mode would stall after a single fragment load timeout, waiting for a level update that never comes, and skipping fragment reload logic because of that level change.

To reproduce the issue, I used the following config with a multi variant live stream and throttled network performance after (or before) playback starts:
```js
{
  "debug": true,
  "enableWorker": false,
  "lowLatencyMode": false,
  "fragLoadingTimeOut": 1000,
  "fragLoadingRetryDelay": 500,
  "fragLoadingMaxRetryTimeout": 2000,
  "fragLoadingMaxRetry": 2,
  "abrEwmaDefaultEstimate": 500000,
  "startLevel": -1,
  "testBandwidth": false
}
```

With these changes, when fragment loading times out or errors, it will be retried up to `fragLoadingMaxRetry` times as long as nothing triggers a level change. When the number of retries has reached `fragLoadingMaxRetry` for a level, the level-controller will then apply redundant level fail-over  when available or, if in auto mode, cycle to another level. Once all levels have exhausted the maximum number of fragment error retries, then the next fragment error will be treated as fatal, and all loading will stop with a fatal error event.

### Resolves issues:
Fixes #3381

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
