### PR TITLE
use full commit hashes in workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,7 +22,7 @@ jobs:
     if: needs.config.outputs.hasSecret == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: tjenkinson/gh-action-auto-merge-dependency-updates@1ff3f19
+      - uses: tjenkinson/gh-action-auto-merge-dependency-updates@1ff3f19509b1965cf1753c294c55e8cdb0528178
         with:
           repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
           allowed-actors: dependabot[bot]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,7 +312,7 @@ jobs:
           name: build
 
       - name: start SauceConnect tunnel
-        uses: saucelabs/sauce-connect-action@5c0cf29
+        uses: saucelabs/sauce-connect-action@5c0cf29805c7fe68f2dec68c6384332fb1ba73f9
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -402,7 +402,7 @@ jobs:
           name: build
 
       - name: start SauceConnect tunnel
-        uses: saucelabs/sauce-connect-action@5c0cf29
+        uses: saucelabs/sauce-connect-action@5c0cf29805c7fe68f2dec68c6384332fb1ba73f9
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
### This PR will...
Use full commit hashes in the workflows.

### Why is this Pull Request needed?
GitHub is gong to deprecate using the short hashes.
See: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions