### PR TITLE
Cleanup cues and track group switching

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -6,6 +6,7 @@ import {
   ErrorData,
   LevelLoadingData,
   AudioTrackLoadedData,
+  LevelSwitchingData,
 } from '../types/events';
 import BasePlaylistController from './base-playlist-controller';
 import { PlaylistContextType } from '../types/loader';
@@ -30,6 +31,7 @@ class AudioTrackController extends BasePlaylistController {
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.on(Events.LEVEL_LOADING, this.onLevelLoading, this);
+    hls.on(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     hls.on(Events.AUDIO_TRACK_LOADED, this.onAudioTrackLoaded, this);
     hls.on(Events.ERROR, this.onError, this);
   }
@@ -39,6 +41,7 @@ class AudioTrackController extends BasePlaylistController {
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.off(Events.LEVEL_LOADING, this.onLevelLoading, this);
+    hls.off(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     hls.off(Events.AUDIO_TRACK_LOADED, this.onAudioTrackLoaded, this);
     hls.off(Events.ERROR, this.onError, this);
   }
@@ -85,18 +88,22 @@ class AudioTrackController extends BasePlaylistController {
     }
   }
 
-  /**
-   * When a level is loading, if it has redundant audioGroupIds (in the same ordinality as it's redundant URLs)
-   * we are setting our audio-group ID internally to the one set, if it is different from the group ID currently set.
-   *
-   * If group-ID got update, we re-select the appropriate audio-track with this group-ID matching the currently
-   * selected one (based on NAME property).
-   */
   protected onLevelLoading(
     event: Events.LEVEL_LOADING,
     data: LevelLoadingData
   ): void {
-    const levelInfo = this.hls.levels[data.level];
+    this.switchLevel(data.level);
+  }
+
+  protected onLevelSwitching(
+    event: Events.LEVEL_SWITCHING,
+    data: LevelSwitchingData
+  ): void {
+    this.switchLevel(data.level);
+  }
+
+  private switchLevel(levelIndex: number) {
+    const levelInfo = this.hls.levels[levelIndex];
 
     if (!levelInfo?.audioGroupIds) {
       return;

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -2,7 +2,7 @@ import { Events } from '../events';
 import {
   sendAddTrackEvent,
   clearCurrentCues,
-  getCuesInRange,
+  removeCuesInRange,
 } from '../utils/texttrack-utils';
 import * as ID3 from '../demux/id3';
 import type {
@@ -138,12 +138,8 @@ class ID3TrackController implements ComponentAPI {
     if (!type || type === 'audio') {
       // id3 cues come from parsed audio only remove cues when audio buffer is cleared
       const { id3Track } = this;
-      if (!id3Track || !id3Track.cues || !id3Track.cues.length) {
-        return;
-      }
-      const cues = getCuesInRange(id3Track.cues, startOffset, endOffset);
-      for (let i = 0; i < cues.length; i++) {
-        id3Track.removeCue(cues[i]);
+      if (id3Track) {
+        removeCuesInRange(id3Track, startOffset, endOffset);
       }
     }
   }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -140,6 +140,7 @@ export class SubtitleStreamController
       return;
     }
     this.fragmentTracker.removeAllFragments();
+    this.fragPrevious = null;
     this.currentTrackId = -1;
     this.levels.forEach((level: Level) => {
       this.tracksBuffered[level.id] = [];
@@ -173,6 +174,8 @@ export class SubtitleStreamController
     this.levels = subtitleTracks.map(
       (mediaPlaylist) => new Level(mediaPlaylist)
     );
+    this.fragmentTracker.removeAllFragments();
+    this.fragPrevious = null;
     this.levels.forEach((level: Level) => {
       this.tracksBuffered[level.id] = [];
     });

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -8,6 +8,7 @@ import type {
   MediaAttachedData,
   SubtitleTracksUpdatedData,
   ManifestParsedData,
+  LevelSwitchingData,
 } from '../types/events';
 import type { MediaPlaylist } from '../types/media-playlist';
 import { ErrorData, LevelLoadingData } from '../types/events';
@@ -44,6 +45,7 @@ class SubtitleTrackController extends BasePlaylistController {
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.on(Events.LEVEL_LOADING, this.onLevelLoading, this);
+    hls.on(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     hls.on(Events.SUBTITLE_TRACK_LOADED, this.onSubtitleTrackLoaded, this);
     hls.on(Events.ERROR, this.onError, this);
   }
@@ -55,6 +57,7 @@ class SubtitleTrackController extends BasePlaylistController {
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.off(Events.LEVEL_LOADING, this.onLevelLoading, this);
+    hls.off(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     hls.off(Events.SUBTITLE_TRACK_LOADED, this.onSubtitleTrackLoaded, this);
     hls.off(Events.ERROR, this.onError, this);
   }
@@ -163,8 +166,18 @@ class SubtitleTrackController extends BasePlaylistController {
     event: Events.LEVEL_LOADING,
     data: LevelLoadingData
   ): void {
-    const levelInfo = this.hls.levels[data.level];
+    this.switchLevel(data.level);
+  }
 
+  protected onLevelSwitching(
+    event: Events.LEVEL_SWITCHING,
+    data: LevelSwitchingData
+  ): void {
+    this.switchLevel(data.level);
+  }
+
+  private switchLevel(levelIndex: number) {
+    const levelInfo = this.hls.levels[levelIndex];
     if (!levelInfo?.textGroupIds) {
       return;
     }

--- a/src/utils/imsc1-ttml-parser.ts
+++ b/src/utils/imsc1-ttml-parser.ts
@@ -3,6 +3,7 @@ import { parseTimeStamp } from './vttparser';
 import VTTCue from './vttcue';
 import { utf8ArrayToStr } from '../demux/id3';
 import { toTimescaleFromScale } from './timescale-conversion';
+import { generateCueId } from './webvtt-parser';
 
 export const IMSC1_CODEC = 'stpp.ttml.im1t';
 
@@ -91,6 +92,7 @@ function parseTTML(ttml: string, syncTime: number): Array<VTTCue> {
         endTime = startTime + duration;
       }
       const cue = new VTTCue(startTime - syncTime, endTime - syncTime, cueText);
+      cue.id = generateCueId(cue.startTime, cue.endTime, cue.text);
 
       const region = regionElements[cueElement.getAttribute('region')];
       const style = styleElements[cueElement.getAttribute('style')];


### PR DESCRIPTION
### This PR will...

- Do not append 608/WebVTT/IMSC cues that have already been appended (merges changes from #3321 into master, while maintaining that `config.cueHandler` must append cues to their supplied TextTrack)
- Fix 608 CC continuity when seeking and while its track is disabled
- Clear tracks when levels text group-id changes
- Update group-id on level switch, not just on level loading
- Remove 608 CC cues from the live back buffer
- Exit early after parsing duplicate 608 cues (reduce cue creation on level switch)
- Demo replaces the video element when playing a new source to remove subtitle and captions tracks that cannot be removed (🎻 no `removeTrack` 🎶  )
- Clear demo video event handlers (fixes demo performance/leak)

### Why is this Pull Request needed?
- Prevents the user from seeing duplicate cues (especially with multi-level streams containing 608 captions)
- Reduces the chance of OOM errors with long-running live streams containing 608 captions
- Loads/buffers audio and subtitles relative to the selected level (a bit more aggressively than Safari, but only in streams with alternate groups)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
