### PR TITLE
fix: duplicate segmented vtt lines

### DIFF
--- a/src/utils/webvtt-parser.ts
+++ b/src/utils/webvtt-parser.ts
@@ -145,12 +145,15 @@ export function parseWebVTT(
       cue.endTime = startTime + duration;
     }
 
+    //trim trailing webvtt block whitespaces
+    const text = cue.text.trim();
+
     // Fix encoding of special characters
-    cue.text = decodeURIComponent(encodeURIComponent(cue.text));
+    cue.text = decodeURIComponent(encodeURIComponent(text));
 
     // If the cue was not assigned an id from the VTT file (line above the content), create one.
     if (!cue.id) {
-      cue.id = generateCueId(cue.startTime, cue.endTime, cue.text);
+      cue.id = generateCueId(cue.startTime, cue.endTime, text);
     }
 
     if (cue.endTime > 0) {


### PR DESCRIPTION
### This PR will...
fix duplicate vtt lines for segmented vtt

### Why is this Pull Request needed?

When vtt file is sliced it sometimes may contain same caption line in both slices of the vtt file as the time range of it is crossing the slicing border.
If the line has a trailing whitespace it will be treated differently if it is in the end of the vtt slice or at the start(or middle) as we trim the entire vtt fragment we get but not the individual time blocks.

Example:
```
Frag1.vtt
WEB VTT

1
00:00:00.360 --> 00:00:01.520 
first line

2
00:00:01.600 --> 00:00:02.680 
second line ending with trailing whitespace 
```

```
Frag2.vtt
WEB VTT

3
00:00:01.600 --> 00:00:02.680 
second line ending with trailing whitespace 

4
00:00:03.400 --> 00:00:04.000
third line

```

In the first fragment we will clip the trailing whitespace cause we do it in webvtt-parser for the entire frag before we start line by line processing.
In the second fragment we won't clip it as it is in the middle of the string.

The end result is that we will create a different hash for each of these lines, and then they will appear duplicate.

Solution is to just clip each cue text as well.
I see this is basically what we do for 608 and ismc parsers.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
