### PR TITLE
Perform one append per segment per MPEG-2 TS elementary stream

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -131,6 +131,8 @@ export interface BufferAppendedData {
         video?: TimeRanges;
         audiovideo?: TimeRanges;
     };
+    // (undocumented)
+    type: SourceBufferName;
 }
 
 // Warning: (ae-missing-release-tag) "BufferAppendingData" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -143,6 +145,8 @@ export interface BufferAppendingData {
     data: Uint8Array;
     // (undocumented)
     frag: Fragment;
+    // (undocumented)
+    parent: PlaylistLevelType;
     // (undocumented)
     part: Part | null;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1359,9 +1359,9 @@ Full list of Events is available below:
   - data: { tracks : { audio? : `[Track]`, video? : `[Track]`, audiovideo?: `[Track]` } }
     interface Track { id: 'audio' | 'main', buffer?: SourceBuffer, container: string, codec?: string, initSegment?: Uint8Array, levelCodec?: string, metadata?: any }
 - `Hls.Events.BUFFER_APPENDING` - fired when we append a segment to the buffer
-- data: { type, data, frag, chunkMeta }
+- data: { parent, type, frag, part, chunkMeta, data }
 - `Hls.Events.BUFFER_APPENDED` - fired when we are done with appending a media segment to the buffer
-  - data: { frag, parent : playlist type triggered `BUFFER_APPENDING`, timeRanges : { video?: TimeRange, audio?: TimeRange, audiovideo?: TimeRange }, chunkMeta }
+  - data: { parent : playlist type triggered `BUFFER_APPENDING`, type, frag, part, chunkMeta, timeRanges : { video?: TimeRange, audio?: TimeRange, audiovideo?: TimeRange } }
 - `Hls.Events.BUFFER_EOS` - fired when the stream is finished and we want to notify the media buffer that there will be no more data
   - data: { type: SourceBufferName }
 - `Hls.Events.BUFFER_FLUSHING` - fired when the media buffer should be flushed

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -820,10 +820,11 @@ class AudioStreamController
     if (initSegment?.byteLength) {
       const segment: BufferAppendingData = {
         type: 'audio',
-        data: initSegment,
         frag,
         part: null,
         chunkMeta,
+        parent: frag.type,
+        data: initSegment,
       };
       this.hls.trigger(Events.BUFFER_APPENDING, segment);
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -661,10 +661,11 @@ export default class BaseStreamController
 
     const segment: BufferAppendingData = {
       type: data.type,
-      data: buffer,
       frag,
       part,
       chunkMeta,
+      parent: frag.type,
+      data: buffer,
     };
     this.hls.trigger(Events.BUFFER_APPENDING, segment);
 

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -363,11 +363,12 @@ export default class BufferController implements ComponentAPI {
         }
         this.appendError = 0;
         this.hls.trigger(Events.BUFFER_APPENDED, {
-          parent: frag.type,
-          timeRanges,
+          type,
           frag,
           part,
           chunkMeta,
+          parent: frag.type,
+          timeRanges,
         });
       },
       onError: (err) => {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1303,6 +1303,7 @@ export default class StreamController
           frag,
           part: null,
           chunkMeta,
+          parent: frag.type,
         });
       }
     });

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -249,7 +249,7 @@ class TSDemuxer implements Demuxer {
       this.remainderData = null;
     }
 
-    if (len < 188 && !flush) {
+    if ((len < 188 || !this.config.progressive) && !flush) {
       this.remainderData = data;
       return {
         audioTrack,

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -985,6 +985,8 @@ export default class MP4Remuxer implements Remuxer {
       nb: nbSamples,
     };
 
+    this.isAudioContiguous = true;
+
     console.assert(mdat.length, 'MDAT length must not be zero');
     return audioData;
   }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -41,16 +41,18 @@ export interface BufferCreatedData {
 
 export interface BufferAppendingData {
   type: SourceBufferName;
-  data: Uint8Array;
   frag: Fragment;
   part: Part | null;
   chunkMeta: ChunkMetadata;
+  parent: PlaylistLevelType;
+  data: Uint8Array;
 }
 
 export interface BufferAppendedData {
-  chunkMeta: ChunkMetadata;
+  type: SourceBufferName;
   frag: Fragment;
   part: Part | null;
+  chunkMeta: ChunkMetadata;
   parent: PlaylistLevelType;
   timeRanges: {
     audio?: TimeRanges;

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -9,7 +9,7 @@ import { BufferOperation, SourceBufferName } from '../../../src/types/buffer';
 import { BufferAppendingData } from '../../../src/types/events';
 import { Events } from '../../../src/events';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
-import { Fragment, ElementaryStreamTypes } from '../../../src/loader/fragment';
+import { ElementaryStreamTypes, Fragment } from '../../../src/loader/fragment';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
 import { LevelDetails } from '../../../src/loader/level-details';
@@ -173,6 +173,7 @@ describe('BufferController', function () {
         const frag = new Fragment(PlaylistLevelType.MAIN, '');
         const chunkMeta = new ChunkMetadata(0, 0, 0, 0);
         const data: BufferAppendingData = {
+          parent: PlaylistLevelType.MAIN,
           type: name,
           data: segmentData,
           frag,
@@ -200,6 +201,7 @@ describe('BufferController', function () {
           'BUFFER_APPENDED should be triggered upon completion of the operation'
         ).to.have.been.calledWith(Events.BUFFER_APPENDED, {
           parent: 'main',
+          type: name,
           timeRanges: {
             audio: buffers.audio.buffered,
             video: buffers.video.buffered,

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -569,6 +569,7 @@ function createBufferAppendedData(
     frag: new Fragment(PlaylistLevelType.MAIN, ''),
     part: null,
     parent: PlaylistLevelType.MAIN,
+    type: audio && video ? 'audiovideo' : video ? 'video' : 'audio',
     timeRanges: {
       video: createMockBuffer(video),
       audio: createMockBuffer(audio || video),


### PR DESCRIPTION
### This PR will...

- Only perform one append per segment per MPEG-2 TS elementary stream (in non-progressive mode)
- Normalize buffer append event properties
- Assume audio contiguity in the mp4-remuxer after remuxing has begun

### Why is this Pull Request needed?

The "progressive" refactor introduced a regression in the number of appends when in non-progressive mode. The transmuxer performs two appends for each elementary stream for each segment (one on loading-progress > push and one on loading-complete > flush). This happens because the ts-demuxer leaves unparsed PES packets until flush.

This change skips the demuxing of TS data on push and processes it all on flush. This removes a performance bottle-neck caused by the additional SourceBuffer blocking, controller state changes, and events all resulting from these additional appends. This also results in the FRAG_LOADED event firing consistently before append events in non-progressive mode as it does in v0.14. 

The contiguity change is to match a side-effect that the double-demux had which was to flip the remuxer to contiguous on the append of the last PES. This allows the remuxer to fill gaps between contiguous segments such as those found in the "PDTs with large gaps following discontinuities" test stream.  Ideally, audio and video contiguity in the remuxer would be managed by the transmuxer which has its own flag for this, but that can wait for feature support that requires that kind of cleanup (like filling video gaps, more audio gaps, and supporting X-EXT-GAP tags).

### Are there any points in the code the reviewer needs to double-check?

There are still two messages in and out of the worker ('demux' push and 'flush'). It would be nice to combine these so that we're not adding another roundtrip compared to previous versions. Not with this PR, but one day... 👼  

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
