### PR TITLE
Fix MPEG-2 TS part loading regression

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -249,7 +249,7 @@ class TSDemuxer implements Demuxer {
       this.remainderData = null;
     }
 
-    if ((len < 188 || !this.config.progressive) && !flush) {
+    if (len < 188 && !flush) {
       this.remainderData = data;
       return {
         audioTrack,
@@ -403,12 +403,14 @@ class TSDemuxer implements Demuxer {
     audioTrack.pesData = audioData;
     id3Track.pesData = id3Data;
 
-    return {
+    const demuxResult: DemuxerResult = {
       audioTrack,
       avcTrack,
       id3Track,
       textTrack: this._txtTrack,
     };
+    this.extractRemainingSamples(demuxResult);
+    return demuxResult;
   }
 
   public flush(): DemuxerResult | Promise<DemuxerResult> {


### PR DESCRIPTION
### This PR will...
Fix MPEG-2 TS part loading regression

### Why is this Pull Request needed?
#3489 introduced a regression in LL-HLS part loading. The tsdemuxer depends on data to be demuxed on push. Moving this to flush prevented all parts except the last from being transmuxed.

While this change means that FRAG_LOADED will be dispatched after parse and append events when the worker is disabled, this is expected in progressive mode and with parts.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
