### PR TITLE
Live start robustness with tracks and short sliding windows

### DIFF
--- a/demo/chart/timeline-chart.ts
+++ b/demo/chart/timeline-chart.ts
@@ -283,13 +283,11 @@ export class TimelineChart {
   updateLevelOrTrack(details: LevelDetails) {
     const { targetduration, totalduration, url } = details;
     const { datasets } = this.chart.data;
-    // eslint-disable-next-line no-restricted-properties
-    const deliveryDirectivePattern = /[?&]_HLS_(?:msn|part|skip)=[^?&]+/g;
     const levelDataSet = arrayFind(
       datasets,
       (dataset) =>
-        dataset.url?.toString().replace(deliveryDirectivePattern, '') ===
-        url.replace(deliveryDirectivePattern, '')
+        stripDeliveryDirectives(url) ===
+        stripDeliveryDirectives(dataset.url || '')
     );
     if (!levelDataSet) {
       return;
@@ -656,6 +654,19 @@ export class TimelineChart {
       ctx.lineTo(x, chartArea.bottom);
       ctx.stroke();
     }
+  }
+}
+
+function stripDeliveryDirectives(url: string): string {
+  try {
+    const webUrl: URL = new self.URL(url);
+    webUrl.searchParams.delete('_HLS_msn');
+    webUrl.searchParams.delete('_HLS_part');
+    webUrl.searchParams.delete('_HLS_skip');
+    webUrl.searchParams.sort();
+    return webUrl.href;
+  } catch (e) {
+    return url.replace(/[?&]_HLS_(?:msn|part|skip)=[^?&]+/g, '');
   }
 }
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -1583,7 +1583,7 @@ function addChartEventListeners(hls) {
     chart
   );
   hls.on(
-    Hls.Events.MANIFEST_LOADED,
+    Hls.Events.MANIFEST_PARSED,
     (eventName, data) => {
       const { levels } = data;
       chart.removeType('level');

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -697,6 +697,7 @@ class AudioStreamController
       this.warn(
         `The loading context changed while buffering fragment ${chunkMeta.sn} of level ${chunkMeta.level}. This chunk will not be buffered.`
       );
+      this.resetLiveStartWhenNotLoaded(chunkMeta.level);
       return;
     }
     const { frag, part } = context;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -590,10 +590,12 @@ class AudioStreamController
       );
       return;
     }
-    this.fragPrevious = frag;
-    if (this.audioSwitch && frag.sn !== 'initSegment') {
-      this.audioSwitch = false;
-      this.hls.trigger(Events.AUDIO_TRACK_SWITCHED, { id: this.trackId });
+    if (frag.sn !== 'initSegment') {
+      this.fragPrevious = frag;
+      if (this.audioSwitch) {
+        this.audioSwitch = false;
+        this.hls.trigger(Events.AUDIO_TRACK_SWITCHED, { id: this.trackId });
+      }
     }
     this.fragBufferedComplete(frag, part);
   }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -792,7 +792,8 @@ export default class BaseStreamController
           fragPrevious.endProgramDateTime,
           config.maxFragLookUpTolerance
         );
-      } else {
+      }
+      if (!frag) {
         // SN does not need to be accurate between renditions, but depending on the packaging it may be so.
         const targetSN = (fragPrevious.sn as number) + 1;
         if (

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -31,6 +31,7 @@ import {
 } from '../types/events';
 import Decrypter from '../crypt/decrypter';
 import TimeRanges from '../utils/time-ranges';
+import { PlaylistLevelType } from '../types/loader';
 import type { FragmentTracker } from './fragment-tracker';
 import type { Level } from '../types/level';
 import type { RemuxedTrack } from '../types/remuxer';
@@ -74,6 +75,7 @@ export default class BaseStreamController
   protected startPosition: number = 0;
   protected loadedmetadata: boolean = false;
   protected fragLoadError: number = 0;
+  protected retryDate: number = 0;
   protected levels: Array<Level> | null = null;
   protected fragmentLoader!: FragmentLoader;
   protected levelLastLoaded: number | null = null;
@@ -521,7 +523,7 @@ export default class BaseStreamController
             partList,
             partIndex,
             progressCallback
-          ).catch((error: LoadError) => this.handleFragError(error));
+          ).catch((error: LoadError) => this.handleFragLoadError(error));
         } else if (
           !frag.url ||
           this.loadedEndOfParts(partList, targetBufferTime)
@@ -545,7 +547,7 @@ export default class BaseStreamController
 
     return this.fragmentLoader
       .load(frag, progressCallback)
-      .catch((error: LoadError) => this.handleFragError(error));
+      .catch((error: LoadError) => this.handleFragLoadError(error));
   }
 
   private doFragPartsLoad(
@@ -583,7 +585,7 @@ export default class BaseStreamController
     );
   }
 
-  private handleFragError({ data }: LoadError) {
+  private handleFragLoadError({ data }: LoadError) {
     if (data && data.details === ErrorDetails.INTERNAL_ABORTED) {
       this.handleFragLoadAborted(data.frag, data.part);
     } else {
@@ -1046,6 +1048,74 @@ export default class BaseStreamController
           true
         )
       );
+    }
+  }
+
+  protected onFragmentOrKeyLoadError(
+    filterType: PlaylistLevelType,
+    data: ErrorData
+  ) {
+    if (data.fatal) {
+      return;
+    }
+    const frag = data.frag;
+    // Handle frag error related to caller's filterType
+    if (!frag || frag.type !== filterType) {
+      return;
+    }
+    const fragCurrent = this.fragCurrent;
+    console.assert(
+      fragCurrent &&
+        frag.sn === fragCurrent.sn &&
+        frag.level === fragCurrent.level &&
+        frag.urlId === fragCurrent.urlId,
+      'Frag load error must match current frag to retry'
+    );
+    const config = this.config;
+    // keep retrying until the limit will be reached
+    if (this.fragLoadError + 1 <= config.fragLoadingMaxRetry) {
+      // if loadedmetadata is not set, it means that we are emergency switch down on first frag
+      // in that case, reset startFragRequested flag
+      if (!this.loadedmetadata) {
+        this.startFragRequested = false;
+        const details = this.levels ? this.levels[frag.level].details : null;
+        if (details?.live) {
+          // We can't afford to retry after a delay in a live scenario. Update the start position and return to IDLE.
+          this.startPosition = -1;
+          this.setStartPosition(details, 0);
+          this.state = State.IDLE;
+          return;
+        }
+        this.nextLoadPosition = this.startPosition;
+      }
+      // exponential backoff capped to config.fragLoadingMaxRetryTimeout
+      const delay = Math.min(
+        Math.pow(2, this.fragLoadError) * config.fragLoadingRetryDelay,
+        config.fragLoadingMaxRetryTimeout
+      );
+      this.warn(
+        `Fragment ${frag.sn} of ${filterType} ${frag.level} failed to load, retrying in ${delay}ms`
+      );
+      this.retryDate = self.performance.now() + delay;
+      this.fragLoadError++;
+      this.state = State.FRAG_LOADING_WAITING_RETRY;
+    } else if (data.levelRetry) {
+      if (filterType === PlaylistLevelType.AUDIO) {
+        // Reset current fragment since audio track audio is essential and may not have a fail-over track
+        this.fragCurrent = null;
+      }
+      // Fragment errors that result in a level switch or redundant fail-over
+      // should reset the stream controller state to idle
+      this.fragLoadError = 0;
+      this.state = State.IDLE;
+    } else {
+      logger.error(
+        `${data.details} reaches max retry, redispatch as fatal ...`
+      );
+      // switch error to fatal
+      data.fatal = true;
+      this.hls.stopLoad();
+      this.state = State.ERROR;
     }
   }
 

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -78,16 +78,19 @@ export default class LatencyController implements ComponentAPI {
   get liveSyncPosition(): number | null {
     const liveEdge = this.estimateLiveEdge();
     const targetLatency = this.targetLatency;
-    if (
-      liveEdge === null ||
-      targetLatency === null ||
-      this.levelDetails === null
-    ) {
+    const levelDetails = this.levelDetails;
+    if (liveEdge === null || targetLatency === null || levelDetails === null) {
       return null;
     }
+    const edge = levelDetails.edge;
     return Math.min(
-      this.levelDetails.edge,
-      liveEdge - targetLatency - this.edgeStalled
+      Math.max(
+        edge - levelDetails.totalduration,
+        liveEdge - targetLatency - this.edgeStalled
+      ),
+      edge -
+        ((this.config.lowLatencyMode && levelDetails.partTarget) ||
+          levelDetails.targetduration)
     );
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1051,6 +1051,7 @@ export default class StreamController
       this.warn(
         `The loading context changed while buffering fragment ${chunkMeta.sn} of level ${chunkMeta.level}. This chunk will not be buffered.`
       );
+      this.resetLiveStartWhenNotLoaded(chunkMeta.level);
       return;
     }
     const { frag, part, level } = context;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -295,7 +295,6 @@ export default class StreamController
       targetBufferTime = bufferInfo.end;
       frag = this.getNextFragment(targetBufferTime, levelDetails);
       // Avoid loop loading by using nextLoadPosition set for backtracking
-      // TODO: this could be improved to simply pick next sn fragment
       if (
         frag &&
         this.fragmentTracker.getState(frag) === FragmentState.OK &&

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -490,6 +490,7 @@ export default class M3U8Parser {
       totalduration -= prevFrag.duration;
       level.fragmentHint = prevFrag;
     } else {
+      assignProgramDateTime(frag, prevFrag);
       level.fragmentHint = frag;
     }
     const fragmentLength = fragments.length;

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -148,7 +148,12 @@ module.exports = {
       description:
         'Shaka-packager Widevine DRM (EME) HLS-fMP4 - Angel One Demo',
       abr: true,
-      blacklist_ua: ['firefox', 'safari', 'internet explorer'],
+      blacklist_ua: [
+        'firefox',
+        'safari',
+        'internet explorer',
+        { name: 'chrome', version: '69.0' },
+      ],
     },
     {
       widevineLicenseUrl: 'https://cwip-shaka-proxy.appspot.com/no_auth',

--- a/tests/unit/controller/audio-track-controller.js
+++ b/tests/unit/controller/audio-track-controller.js
@@ -223,7 +223,7 @@ describe('AudioTrackController', function () {
       audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
         level: 0,
       });
-      audioTrackController.startLoad();
+      audioTrackController.startLoad(0);
 
       expect(shouldLoadTrack).to.have.been.calledTwice;
       expect(shouldLoadTrack).to.have.been.calledWith(trackWithUrl);
@@ -265,7 +265,7 @@ describe('AudioTrackController', function () {
       audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
         level: 0,
       });
-      audioTrackController.startLoad();
+      audioTrackController.startLoad(0);
 
       expect(shouldLoadTrack).to.have.been.calledTwice;
       expect(shouldLoadTrack).to.have.been.calledWith(trackWithOutUrl);

--- a/tests/unit/controller/latency-controller.ts
+++ b/tests/unit/controller/latency-controller.ts
@@ -35,6 +35,7 @@ describe('LatencyController', function () {
     levelDetails = new LevelDetails('');
     levelDetails.live = true;
     levelDetails.targetduration = 5;
+    levelDetails.totalduration = 15;
     const levelUpdatedData: LevelUpdatedData = {
       details: levelDetails,
       level: 0,
@@ -203,7 +204,7 @@ describe('LatencyController', function () {
       levelDetails.age = 10;
       expect(latencyController.liveSyncPosition).to.equal(55);
       levelDetails.age = 20;
-      expect(latencyController.liveSyncPosition).to.equal(60);
+      expect(latencyController.liveSyncPosition).to.equal(55);
     });
 
     it('accounts for level update age up to 3 part targets in low latency mode', function () {
@@ -217,7 +218,7 @@ describe('LatencyController', function () {
       levelDetails.age = 2;
       expect(latencyController.liveSyncPosition).to.equal(59);
       levelDetails.age = 5;
-      expect(latencyController.liveSyncPosition).to.equal(60);
+      expect(latencyController.liveSyncPosition).to.equal(59);
     });
   });
 


### PR DESCRIPTION
### This PR will...
- Set audio-track playlist start position after syncing with main playlist in live streams
(Fixes intermittent playback failure of Live  CMAF streams)
- Fix `getInitialLiveFragment` in scenarios where program-date-time was expected, but missing:
  - Do not set `fragPrevious` to the  "initSegment" as a sequence number is expected
  - Assign a PDT value to the level `fragmentHint` (the fragment object for LL parts in the playlist that do not yet form a complete segment)
  - Fallback to target SN if PDT is missing in live start frag lookup
- Reset start position for live streams when the first fragment request errors or transmuxing finished after the fragment was removed from the sliding window
- Fix demo timeline setup and updates of LL-HLS streams with query params
- Improve live stream start sync under constrained bandwidth conditions (fixes cases where stream controllers were unable to find a fragment to load after the playlist moved past the next load position)

### Why is this Pull Request needed?
These changes come from triaging playback of an LL-HLS stream that fails to play reliably in hls.js and Safari. Rendering the timeline and improving fragment selection should help.

There is still work to do improving recovery on fragment load errors before buffering or playback has started - especially in live streams with very short windows (less than 10 seconds) where segment availability is short. 

### Resolves issues:
#3473

### Checklist

- [x] changes have been done against master branch, and PR does not conflict