### PR TITLE
Workaround stream-controller stuck in PARSED state

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -948,6 +948,10 @@ export default class BaseStreamController
       ) {
         if (!this.loadedmetadata) {
           this.nextLoadPosition = liveSyncPosition;
+          if (this.state === State.PARSED) {
+            logger.warn('Could not append media in sync with live stream');
+            this.state = State.IDLE;
+          }
         }
         if (media.readyState) {
           this.warn(

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -533,6 +533,11 @@ export default class BufferController implements ComponentAPI {
       return;
     }
 
+    const sourceBufferTypes = this.getSourceBufferTypes();
+    if (!sourceBufferTypes.length) {
+      return;
+    }
+
     // Support for deprecated liveBackBufferLength
     const backBufferLength =
       details.live && hls.config.liveBackBufferLength !== null
@@ -546,7 +551,7 @@ export default class BufferController implements ComponentAPI {
     const currentTime = media.currentTime;
     const targetBackBufferPosition =
       currentTime - Math.max(backBufferLength, details.levelTargetDuration);
-    this.getSourceBufferTypes().forEach((type: SourceBufferName) => {
+    sourceBufferTypes.forEach((type: SourceBufferName) => {
       const sb = sourceBuffer[type];
       if (sb) {
         const buffered = BufferHelper.getBuffered(sb);


### PR DESCRIPTION
### This PR will...
- Unblock fragment loading when stream controller cannot leave the PARSED state
- Exit early when flushing the back buffer when source buffers have not been created  

### Why is this Pull Request needed?
As a follow up to #3504, puts the stream controller back into an IDLE state if it changed to PARSED before source buffers were created, blocking live streams from starting under very constrained conditions

### Resolves issues:
#3473

### Checklist

- [x] changes have been done against master branch, and PR does not conflict