### PR TITLE
DRM license request and response handlers

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -317,6 +317,7 @@ export enum ElementaryStreamTypes {
 // @public (undocumented)
 export type EMEControllerConfig = {
     licenseXhrSetup?: (xhr: XMLHttpRequest, url: string) => void;
+    licenseResponseCallback?: (xhr: XMLHttpRequest, url: string) => ArrayBuffer;
     emeEnabled: boolean;
     widevineLicenseUrl?: string;
     drmSystemOptions: DRMSystemOptions;
@@ -2108,16 +2109,16 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:155:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:156:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:158:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:159:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:160:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:162:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:164:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:165:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:166:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:167:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:156:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:157:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:159:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:160:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:161:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:163:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:165:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:166:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:167:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:168:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,6 +91,7 @@
   - [`emeEnabled`](#emeEnabled)
   - [`widevineLicenseUrl`](#widevineLicenseUrl)
   - [`licenseXhrSetup`](#licenseXhrSetup)
+  - [`licenseResponseCallback`](#licenseResponseCallback)
   - [`drmSystemOptions`](#drmSystemOptions)
   - [`requestMediaKeySystemAccessFunc`](#requestMediaKeySystemAccessFunc)
 - [Video Binding/Unbinding API](#video-bindingunbinding-api)
@@ -1147,6 +1148,12 @@ The Widevine license server URL.
 (default: `undefined`, type `(xhr: XMLHttpRequest, url: string) => void`)
 
 A pre-processor function for modifying the `XMLHttpRequest` and request url (using `xhr.open`) prior to sending the license request.
+
+### `licenseResponseCallback`
+
+(default: `undefined`, type `(xhr: XMLHttpRequest, url: string) => data: ArrayBuffer`)
+
+A post-processor function for modifying the license response before passing it to the key-session (`MediaKeySession.update`).
 
 ### `drmSystemOptions`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -90,6 +90,7 @@
   - [`minAutoBitrate`](#minautobitrate)
   - [`emeEnabled`](#emeEnabled)
   - [`widevineLicenseUrl`](#widevineLicenseUrl)
+  - [`licenseXhrSetup`](#licenseXhrSetup)
   - [`drmSystemOptions`](#drmSystemOptions)
   - [`requestMediaKeySystemAccessFunc`](#requestMediaKeySystemAccessFunc)
 - [Video Binding/Unbinding API](#video-bindingunbinding-api)
@@ -386,6 +387,7 @@ var config = {
   minAutoBitrate: 0,
   emeEnabled: false,
   widevineLicenseUrl: undefined,
+  licenseXhrSetup: undefined,
   drmSystemOptions: {},
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess,
 };
@@ -1139,6 +1141,12 @@ Set to `true` to enable DRM key system access and license retrieval.
 (default: `undefined`)
 
 The Widevine license server URL.
+
+### `licenseXhrSetup`
+
+(default: `undefined`, type `(xhr: XMLHttpRequest, url: string) => void`)
+
+A pre-processor function for modifying the `XMLHttpRequest` and request url (using `xhr.open`) prior to sending the license request.
 
 ### `drmSystemOptions`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export type DRMSystemOptions = {
 
 export type EMEControllerConfig = {
   licenseXhrSetup?: (xhr: XMLHttpRequest, url: string) => void;
+  licenseResponseCallback?: (xhr: XMLHttpRequest, url: string) => ArrayBuffer;
   emeEnabled: boolean;
   widevineLicenseUrl?: string;
   drmSystemOptions: DRMSystemOptions;
@@ -233,6 +234,7 @@ export const hlsDefaultConfig: HlsConfig = {
   pLoader: undefined, // used by playlist-loader
   xhrSetup: undefined, // used by xhr-loader
   licenseXhrSetup: undefined, // used by eme-controller
+  licenseResponseCallback: undefined, // used by eme-controller
   abrController: AbrController,
   bufferController: BufferController,
   capLevelController: CapLevelController,


### PR DESCRIPTION
### This PR will...
- Set license `xhr.responseType` and `onreadystatechange` before running ``licenseXhrSetup`
- Document `licenseXhrSetup` config option
- Add `licenseResponseCallback` to eme-controller config options
- Apply hls.js API instance context to eme-controller pre and post processor function calls

### Why is this Pull Request needed?
These options allow for pre and post-processing of WideVine license requests.

### Resolves issues:
#2016
#3494

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
