### PR TITLE
Improve backtracking on level switch and repair gaps

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -479,8 +479,6 @@ export default class BufferController implements ComponentAPI {
       logger.warn(
         `Fragments must have at least one ElementaryStreamType set. type: ${frag.type} level: ${frag.level} sn: ${frag.sn}`
       );
-      Promise.resolve(onUnblocked);
-      return;
     }
 
     this.blockBuffers(onUnblocked, buffersAppendedTo);

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -159,8 +159,6 @@ export class FragmentTracker implements ComponentAPI {
     if (!fragmentEntity) {
       return;
     }
-    fragmentEntity.buffered = true;
-    fragmentEntity.backtrack = fragmentEntity.loaded = null;
     Object.keys(timeRanges).forEach((elementaryStream) => {
       const streamInfo = frag.elementaryStreams[elementaryStream];
       if (!streamInfo) {
@@ -175,6 +173,13 @@ export class FragmentTracker implements ComponentAPI {
         timeRange
       );
     });
+    fragmentEntity.backtrack = fragmentEntity.loaded = null;
+    if (Object.keys(fragmentEntity.range).length) {
+      fragmentEntity.buffered = true;
+    } else {
+      // remove fragment if nothing was appended
+      this.removeFragment(fragmentEntity.body);
+    }
   }
 
   private getBufferedTimes(

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -208,6 +208,15 @@ describe('FragmentTracker', function () {
         ),
       ];
       // load fragments to buffered
+      hls.trigger(
+        Events.BUFFER_APPENDED,
+        createBufferAppendedData([
+          {
+            startPTS: 0,
+            endPTS: 3,
+          },
+        ])
+      );
       fragments.forEach((fragment) => {
         triggerFragLoadedAndFragBuffered(hls, fragment);
       });
@@ -470,6 +479,15 @@ describe('FragmentTracker', function () {
         [ElementaryStreamTypes.AUDIO, ElementaryStreamTypes.VIDEO]
       );
       // load fragments to buffered
+      hls.trigger(
+        Events.BUFFER_APPENDED,
+        createBufferAppendedData([
+          {
+            startPTS: 0,
+            endPTS: 1,
+          },
+        ])
+      );
       triggerFragLoadedAndFragBuffered(hls, fragment);
       expect(fragmentTracker.hasFragment(fragment)).to.be.true;
       // Remove the fragment
@@ -524,18 +542,33 @@ describe('FragmentTracker', function () {
         ),
       ];
       // load fragments to buffered
+      hls.trigger(
+        Events.BUFFER_APPENDED,
+        createBufferAppendedData([
+          {
+            startPTS: 0,
+            endPTS: 3,
+          },
+        ])
+      );
       fragments.forEach((fragment) => {
         triggerFragLoadedAndFragBuffered(hls, fragment);
       });
       // before
       fragments.forEach((fragment) => {
-        expect(fragmentTracker.hasFragment(fragment)).to.be.true;
+        expect(
+          fragmentTracker.hasFragment(fragment),
+          'has fragments before removing'
+        ).to.be.true;
       });
       // Remove all fragments
       fragmentTracker.removeAllFragments();
       // after
       fragments.forEach((fragment) => {
-        expect(fragmentTracker.hasFragment(fragment)).to.be.false;
+        expect(
+          fragmentTracker.hasFragment(fragment),
+          'has not fragments after removing'
+        ).to.be.false;
       });
     });
   });


### PR DESCRIPTION
### This PR will...
- Prevent new backtracking logic from clearing the buffer at `currentTime`.
- When clearing the forward buffer for `nextLevel` only remove the buffer starting at the end of the upcoming segment we want to replace, this way we don't have to backtrack if the loaded media does not begin with a keyframe but still has one before the end of the segment.
- Only evict part of the forward buffer if there is a gap. The larger gap will allow rebuffering or backtracking to fill the gap.

### Why is this Pull Request needed?
Clearing the entire buffer up to a non-independent or partial segment (`this.flushMainBuffer(0, frag.start);`) allows the player to backtrack all the way to the first segment with a keyframe, but it can interrupt playback if the play head is in range.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
