### PR TITLE
Fix LL-HLS FRAG_CHANGED, LEVEL_SWITCHED and currentLevel

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -76,12 +76,13 @@ export class FragmentTracker implements ComponentAPI {
     if (!activeFragment) {
       return null;
     }
-    if (
-      activeFragment.appendedPTS !== undefined &&
-      activeFragment.start <= position &&
-      position <= activeFragment.appendedPTS
-    ) {
-      return activeFragment;
+    if (activeFragment.start <= position) {
+      const appendedPTS = this.activePart
+        ? this.activePart.end
+        : activeFragment.appendedPTS;
+      if (appendedPTS !== undefined && position <= appendedPTS) {
+        return activeFragment;
+      }
     }
     return this.getBufferedFrag(position, levelType);
   }


### PR DESCRIPTION
### This PR will...
Fix `FRAG_CHANGED` and `LEVEL_SWITCHED` events being skipped and `currentLevel` not changing when playing at the edge of an LL-HLS stream.

### Why is this Pull Request needed?
App integrations depend on these events to determine the current playback quality among other things.

### Resolves issues:
#3530

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
