### PR TITLE
Add a test stream with non-independent segments

### DIFF
--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -240,6 +240,13 @@ module.exports = {
     // abr: true,
     startSeek: true,
   },
+  nonIndependentSegments: {
+    url:
+      'https://playertest.longtailvideo.com/adaptive/bipbop_16x9/bipbop_16x9_variant.m3u8',
+    description:
+      'Non-independent segments (missing key-frame at start) triggers backtracking',
+    abr: true,
+  },
   AppleAdvancedHevcAvcHls: {
     url:
       'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8',


### PR DESCRIPTION
### This PR will...
Add a multi-variant test stream with non-independent segments for functional test coverage of backtracking. 

### Why is this Pull Request needed?
This will help prevent regressions like one that was found and fixed recently in #3524.

When segments in a stream are non-independent, missing a key-frame at the start, frames prior to the first i-frame are dropped when buffered non-contiguously (seeking or switching to that segment in an unbuffered region or new quality).

We only have one other test stream with this "feature" but it only drops a frame in a few segments. It's not uncommon for some encoders to not segment on keyframe boundaries. This stream has a good portion of video frames before each initial key-frame. This makes it a great test candidate for exposing how hls.js backtracks or clears parts of the buffer to allow for "next frag to load" logic to load previous segments to find earlier keyframes and fill gaps without being destructive to the buffer range near the play head.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
