### PR TITLE
Prevent back-buffer eviction callback from resetting active segment requests 

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -669,22 +669,14 @@ class AudioStreamController
     }
   }
 
-  onBufferFlushed(event: Events.BUFFER_FLUSHED, { type }: BufferFlushedData) {
-    /* after successful buffer flushing, filter flushed fragments from bufferedFrags
-      use mediaBuffered instead of media (so that we will check against video.buffered ranges in case of alt audio track)
-    */
-    const media = this.mediaBuffer ? this.mediaBuffer : this.media;
-    if (media && type === ElementaryStreamTypes.AUDIO) {
-      // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
-      this.fragmentTracker.detectEvictedFragments(
-        ElementaryStreamTypes.AUDIO,
-        BufferHelper.getBuffered(media)
-      );
+  private onBufferFlushed(
+    event: Events.BUFFER_FLUSHED,
+    { type }: BufferFlushedData
+  ) {
+    if (type === ElementaryStreamTypes.AUDIO) {
+      const media = this.mediaBuffer ? this.mediaBuffer : this.media;
+      this.afterBufferFlushed(media, type);
     }
-    // reset reference to frag
-    this.fragPrevious = null;
-    // move to IDLE once flush complete. this should trigger new fragment loading
-    this.state = State.IDLE;
   }
 
   private _handleTransmuxComplete(transmuxResult: TransmuxerResult) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -320,6 +320,7 @@ export default class BaseStreamController
           // This happens after handleTransmuxComplete when the worker or progressive is disabled
           if (this.state === State.BACKTRACKING) {
             this.fragmentTracker.backtrack(frag, data);
+            this.resetFragmentLoading(frag);
             return;
           }
         }
@@ -1078,7 +1079,7 @@ export default class BaseStreamController
     }
   }
 
-  private resetFragmentLoading(frag: Fragment) {
+  protected resetFragmentLoading(frag: Fragment) {
     if (!this.fragCurrent || !this.fragContextChanged(frag)) {
       this.state = State.IDLE;
     }

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -291,14 +291,20 @@ export class FragmentTracker implements ComponentAPI {
     return FragmentState.NOT_LOADED;
   }
 
-  public backtrack(frag: Fragment, data?: FragLoadedData) {
+  public backtrack(
+    frag: Fragment,
+    data?: FragLoadedData
+  ): FragLoadedData | null {
     const fragKey = getFragmentKey(frag);
     const fragmentEntity = this.fragments[fragKey];
     if (!fragmentEntity || fragmentEntity.backtrack) {
-      return;
+      return null;
     }
-    fragmentEntity.backtrack = data ? data : fragmentEntity.loaded;
+    const backtrack = (fragmentEntity.backtrack = data
+      ? data
+      : fragmentEntity.loaded);
     fragmentEntity.loaded = null;
+    return backtrack;
   }
 
   public getBacktrackData(fragment: Fragment): FragLoadedData | null {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -375,11 +375,15 @@ export default class StreamController
     }
   }
 
-  private getAppendedFrag(position) {
-    return this.fragmentTracker.getAppendedFrag(
+  private getAppendedFrag(position): Fragment | null {
+    const fragOrPart = this.fragmentTracker.getAppendedFrag(
       position,
       PlaylistLevelType.MAIN
     );
+    if (fragOrPart && 'fragment' in fragOrPart) {
+      return fragOrPart.fragment;
+    }
+    return fragOrPart;
   }
 
   private getBufferedFrag(position) {
@@ -477,6 +481,7 @@ export default class StreamController
     if (fragCurrent?.loader) {
       fragCurrent.loader.abort();
     }
+    this.nextLoadPosition = this.getLoadPosition();
     this.fragCurrent = null;
   }
 
@@ -836,6 +841,9 @@ export default class StreamController
           frag.level
         } finished buffering, but was aborted. state: ${this.state}`
       );
+      if (this.state === State.PARSED) {
+        this.state = State.IDLE;
+      }
       return;
     }
     const stats = part ? part.stats : frag.stats;
@@ -940,23 +948,13 @@ export default class StreamController
     event: Events.BUFFER_FLUSHED,
     { type }: BufferFlushedData
   ) {
-    /* after successful buffer flushing, filter flushed fragments from bufferedFrags
-      use mediaBuffered instead of media (so that we will check against video.buffered ranges in case of alt audio track)
-    */
-    const media =
-      (type === ElementaryStreamTypes.VIDEO
-        ? this.videoBuffer
-        : this.mediaBuffer) || this.media;
-    if (media && type !== ElementaryStreamTypes.AUDIO) {
-      this.fragmentTracker.detectEvictedFragments(
-        type,
-        BufferHelper.getBuffered(media)
-      );
+    if (type !== ElementaryStreamTypes.AUDIO) {
+      const media =
+        (type === ElementaryStreamTypes.VIDEO
+          ? this.videoBuffer
+          : this.mediaBuffer) || this.media;
+      this.afterBufferFlushed(media, type);
     }
-    // reset reference to frag
-    this.fragPrevious = null;
-    // move to IDLE once flush complete. this should trigger new fragment loading
-    this.state = State.IDLE;
   }
 
   private onLevelsUpdated(

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -407,6 +407,7 @@ export default class Hls implements HlsEventEmitter {
   set currentLevel(newLevel: number) {
     logger.log(`set currentLevel:${newLevel}`);
     this.loadLevel = newLevel;
+    this.abrController.clearTimer();
     this.streamController.immediateLevelSwitch();
   }
 

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -168,7 +168,7 @@ module.exports = {
   },
   pdtDuplicate: {
     url: 'https://playertest.longtailvideo.com/adaptive/artbeats/manifest.m3u8',
-    description: 'Stream with duplicate sequential PDT values',
+    description: 'Duplicate sequential PDT values',
     abr: false,
   },
   pdtLargeGap: {

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -244,17 +244,12 @@ describe('BufferController', function () {
 
   describe('onFragParsed', function () {
     it('should trigger FRAG_BUFFERED when all audio/video data has been buffered', function () {
-      const flushBackBufferSpy = sandbox.spy(
-        bufferController,
-        'flushBackBuffer'
-      );
       const frag = new Fragment(PlaylistLevelType.MAIN, '');
       frag.setElementaryStreamInfo(ElementaryStreamTypes.AUDIO, 0, 0, 0, 0);
       frag.setElementaryStreamInfo(ElementaryStreamTypes.VIDEO, 0, 0, 0, 0);
 
       bufferController.onFragParsed(Events.FRAG_PARSED, { frag });
       expect(queueAppendBlockerSpy).to.have.been.calledTwice;
-      expect(flushBackBufferSpy).to.have.been.calledOnce;
       return new Promise<void>((resolve, reject) => {
         hls.on(Events.FRAG_BUFFERED, (event, data) => {
           try {
@@ -426,7 +421,7 @@ describe('BufferController', function () {
       ).to.have.callCount(2);
     });
 
-    it('removes a maximum of one targetDuration from currentTime', function () {
+    it('removes a maximum of one targetDuration from currentTime at intervals of targetDuration', function () {
       mockMedia.currentTime = 25;
       hls.config.backBufferLength = 5;
       bufferController.flushBackBuffer();
@@ -436,7 +431,7 @@ describe('BufferController', function () {
           `BUFFER_FLUSHING should have been triggered for the ${name} SourceBuffer`
         ).to.have.been.calledWith(Events.BUFFER_FLUSHING, {
           startOffset: 0,
-          endOffset: 15,
+          endOffset: 10,
           type: name,
         });
       });


### PR DESCRIPTION
### This PR will...
- Prevent back-buffer `BUFFER_FLUSHED` callbacks from resetting stream state to `IDLE` while fragments are loading
- Set stream controller state to `IDLE` when the current fragment loading/parsing/appending is aborted or fails (not after it's replaced)
- Evict back-buffer on `FRAG_CHANGED` at target duration intervals making fewer MSE remove requests
- Emit `FRAG_CHANGED` where parts were loaded and fix other methods relying on `getAppendedFrag` for ranges where only parts were buffered (Resolves #3530)
- Only emit `LIVE_BACK_BUFFER_REACHED` in live streams


### Why is this Pull Request needed?
After uninterrupted playback for longer than 90 seconds (the default back-buffer length) hls.js starts clearing the back-buffer. `onBufferFlushed` stream controller callbacks will reset the loading state and begin fetching a new segment. If this happens while a segment is loading/parsing/appending that process will be aborted or interrupted before complete, which in the worse case, can result in interrupting streaming.

This also addresses issues with stream controller state getting stuck in `PARSED` or `FRAG_LOADING` state when mashing level settings (quickly changing `currentLevel`, `nextLevel`, and `loadLevel`).

### Resolves Issue(s)
#3564
#3530

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
