### PR TITLE
Fix issue that causes DISCONTINUITY values to be reassigned incorrectly

### DIFF
--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -182,7 +182,12 @@ export function mergeDetails(
     oldDetails,
     newDetails,
     (oldFrag: Fragment, newFrag: Fragment) => {
-      ccOffset = oldFrag.cc - newFrag.cc;
+      if (oldFrag.relurl) {
+        // Do not compare CC if the old fragment has no url. This is a level.fragmentHint used by LL-HLS parts.
+        // It maybe be off by 1 if it was created before any parts or discontinuity tags were appended to the end
+        // of the playlist.
+        ccOffset = oldFrag.cc - newFrag.cc;
+      }
       if (
         Number.isFinite(oldFrag.startPTS) &&
         Number.isFinite(oldFrag.endPTS)
@@ -228,7 +233,7 @@ export function mergeDetails(
 
   const newFragments = newDetails.fragments;
   if (ccOffset) {
-    logger.log('discontinuity sliding from playlist, take drift into account');
+    logger.warn('discontinuity sliding from playlist, take drift into account');
     for (let i = 0; i < newFragments.length; i++) {
       newFragments[i].cc += ccOffset;
     }

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -488,9 +488,12 @@ export default class M3U8Parser {
     if (prevFrag && !prevFrag.relurl) {
       fragments.pop();
       totalduration -= prevFrag.duration;
-      level.fragmentHint = prevFrag;
-    } else {
+      if (level.partList) {
+        level.fragmentHint = prevFrag;
+      }
+    } else if (level.partList) {
       assignProgramDateTime(frag, prevFrag);
+      frag.cc = discontinuityCounter;
       level.fragmentHint = frag;
     }
     const fragmentLength = fragments.length;
@@ -528,7 +531,7 @@ export default class M3U8Parser {
       level.endSN = 0;
       level.startCC = 0;
     }
-    if (level.partList) {
+    if (level.fragmentHint) {
       totalduration += level.fragmentHint.duration;
     }
     level.totalduration = totalduration;

--- a/src/utils/discontinuities.ts
+++ b/src/utils/discontinuities.ts
@@ -134,7 +134,7 @@ function alignDiscontinuities(
       lastLevel.details,
       details
     );
-    if (referenceFrag?.start) {
+    if (referenceFrag && Number.isFinite(referenceFrag.start)) {
       logger.log(
         `Adjusting PTS using last level due to CC increase within current level ${details.url}`
       );


### PR DESCRIPTION
### This PR will...
Fix an issue that causes DISCONTINUITY values to be reassigned incorrectly.

### Why is this Pull Request needed?
`level.fragmentHint` should only be set on playlists with LL-HLS parts, and should not be used to detect "discontinuity sliding from playlist" in `mergeDetails` on live playlist update, as they could have a different discontinuity sequence number than the matching fragment in the next update. This results in a `ccOffset` that adjusts segments discontinuity sequence numbers incorrectly. We don't want that because then audio and video playlist alignment shifts things around, and it's a bad time for everyone.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
