### PR TITLE
Fix part INDEPENDENT parsing to match spec

### DIFF
--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -302,9 +302,7 @@ export class Part extends BaseSegment {
     super(baseurl);
     this.duration = partAttrs.decimalFloatingPoint('DURATION');
     this.gap = partAttrs.bool('GAP');
-    this.independent = partAttrs.INDEPENDENT
-      ? partAttrs.bool('INDEPENDENT')
-      : true;
+    this.independent = partAttrs.INDEPENDENT === 'YES';
     this.relurl = partAttrs.enumeratedString('URI') as string;
     this.fragment = frag;
     this.index = index;

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -1140,7 +1140,7 @@ fileSequence1151231.ts
 fileSequence1151232.ts
 #EXT-X-PART:DURATION=1.00000,INDEPENDENT=YES,URI="lowLatencyHLS.php?segment=filePart1151233.1.ts"
 #EXT-X-PART:DURATION=0.99999,INDEPENDENT=YES,URI="lowLatencyHLS.php?segment=filePart1151233.2.ts"
-#EXT-X-PART:DURATION=1.00000,INDEPENDENT=NO,URI="lowLatencyHLS.php?segment=filePart1151233.3.ts"
+#EXT-X-PART:DURATION=1.00000,URI="lowLatencyHLS.php?segment=filePart1151233.3.ts"
 #EXT-X-PART:DURATION=1.00000,GAP=YES,INDEPENDENT=YES,URI="lowLatencyHLS.php?segment=filePart1151233.4.ts"
 #EXTINF:4.00000,
 fileSequence1151233.ts


### PR DESCRIPTION
### This PR will...

Fix the parsing of the `INDEPENDENT` attribute to match the spec: https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-08#section-4.4.4.9

### Why is this Pull Request needed?

A missing `INDEPENDENT` attribute is incorrectly assigned the value `true`.

### Are there any points in the code the reviewer needs to double check?

No

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
