### PR TITLE
Fix stream start with `bitrateTest` config option

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -237,6 +237,7 @@ class AbrController implements ComponentAPI {
           id: frag.type,
         };
         this.onFragBuffered(Events.FRAG_BUFFERED, fragBufferedData);
+        frag.bitrateTest = false;
       }
     }
   }
@@ -252,11 +253,7 @@ class AbrController implements ComponentAPI {
       return;
     }
     // Only count non-alt-audio frags which were actually buffered in our BW calculations
-    if (
-      frag.type !== PlaylistLevelType.MAIN ||
-      frag.sn === 'initSegment' ||
-      frag.bitrateTest
-    ) {
+    if (frag.type !== PlaylistLevelType.MAIN || frag.sn === 'initSegment') {
       return;
     }
     // Use the difference between parsing and request instead of buffering and request to compute fragLoadingProcessing;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -70,6 +70,7 @@ export default class BaseStreamController
   protected media?: any;
   protected mediaBuffer?: any;
   protected config: HlsConfig;
+  protected bitrateTest: boolean = false;
   protected lastCurrentTime: number = 0;
   protected nextLoadPosition: number = 0;
   protected startPosition: number = 0;
@@ -732,7 +733,11 @@ export default class BaseStreamController
     let frag;
 
     // If an initSegment is present, it must be buffered first
-    if (levelDetails.initSegment && !levelDetails.initSegment.data) {
+    if (
+      levelDetails.initSegment &&
+      !levelDetails.initSegment.data &&
+      !this.bitrateTest
+    ) {
       frag = levelDetails.initSegment;
     } else if (levelDetails.live) {
       const initialLiveManifestSize = config.initialLiveManifestSize;
@@ -858,7 +863,7 @@ export default class BaseStreamController
       if (liveStart !== null) {
         frag = this.getFragmentAtPosition(
           liveStart,
-          levelDetails.edge,
+          this.bitrateTest ? levelDetails.fragmentEnd : levelDetails.edge,
           levelDetails
         );
       }
@@ -885,7 +890,7 @@ export default class BaseStreamController
       levelDetails.partList &&
       fragmentHint
     );
-    if (loadingParts && fragmentHint) {
+    if (loadingParts && fragmentHint && !this.bitrateTest) {
       // Include incomplete fragment with parts at end
       fragments = fragments.concat(fragmentHint);
       endSN = fragmentHint.sn as number;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -43,7 +43,6 @@ export default class StreamController
   extends BaseStreamController
   implements NetworkComponentAPI {
   private audioCodecSwap: boolean = false;
-  private bitrateTest: boolean = false;
   private gapController: GapController | null = null;
   private level: number = -1;
   private _forceStartLoad: boolean = false;
@@ -250,7 +249,7 @@ export default class StreamController
 
     let frag = levelDetails.initSegment;
     let targetBufferTime = 0;
-    if (!frag || frag.data) {
+    if (!frag || frag.data || this.bitrateTest) {
       // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
       const levelBitrate = levelInfo.maxBitrate;
       let maxBufLen;
@@ -1026,17 +1025,10 @@ export default class StreamController
       this.state = State.IDLE;
       this.startFragRequested = false;
       this.bitrateTest = false;
-      frag.bitrateTest = false;
       const stats = frag.stats;
       // Bitrate tests fragments are neither parsed nor buffered
       stats.parsing.start = stats.parsing.end = stats.buffering.start = stats.buffering.end = self.performance.now();
-      hls.trigger(Events.FRAG_BUFFERED, {
-        stats,
-        frag,
-        part: null,
-        id: 'main',
-      });
-      this.tick();
+      hls.trigger(Events.FRAG_LOADED, data as FragLoadedData);
     });
   }
 


### PR DESCRIPTION
### This PR will...
Perform bitrate test when `bitrateTest` is set in the config.

### Why is this Pull Request needed?
Frag event changes led to a regression in performing the bitrate test in streams.

### Resolves issues:
Resolves #3582

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
