### PR TITLE
Filter out audio-only codec signaled stream when others have a resolution but no codecs attribute

### DIFF
--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -85,6 +85,7 @@ export default class LevelController extends BasePlaylistController {
     let bitrateStart: number | undefined;
     const levelSet: { [bitrate: number]: Level } = {};
     let levelFromSet: Level;
+    let resolutionFound = false;
     let videoCodecFound = false;
     let audioCodecFound = false;
 
@@ -92,6 +93,8 @@ export default class LevelController extends BasePlaylistController {
     data.levels.forEach((levelParsed: LevelParsed) => {
       const attributes = levelParsed.attrs;
 
+      resolutionFound =
+        resolutionFound || !!(levelParsed.width && levelParsed.height);
       videoCodecFound = videoCodecFound || !!levelParsed.videoCodec;
       audioCodecFound = audioCodecFound || !!levelParsed.audioCodec;
 
@@ -125,9 +128,11 @@ export default class LevelController extends BasePlaylistController {
       }
     });
 
-    // remove audio-only level if we also have levels with audio+video codecs signalled
-    if (videoCodecFound && audioCodecFound) {
-      levels = levels.filter(({ videoCodec }) => !!videoCodec);
+    // remove audio-only level if we also have levels with video codecs or RESOLUTION signalled
+    if ((resolutionFound || videoCodecFound) && audioCodecFound) {
+      levels = levels.filter(
+        ({ videoCodec, width, height }) => !!videoCodec || !!(width && height)
+      );
     }
 
     // only keep levels with supported audio/video codecs


### PR DESCRIPTION
### This PR will...
Filter out audio-only codec signaled stream when others have a resolution but no codecs attribute

### Why is this Pull Request needed?
hls.js does not support switching between variants with and without audio and video, so it filters out audio-only variants when variants with video and audio are detected. I've encountered streams with CODECS on the audio-only variants, but only RESOLUTION on the ones with video and audio.

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",FORCED=NO,AUTOSELECT=YES,URI="subtitlelist_leng_b174000.m3u8",LANGUAGE="eng"
#EXT-X-STREAM-INF:BANDWIDTH=174000,RESOLUTION=320x180,SUBTITLES="subs"
chunklist_b174000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=64000,CODECS="mp4a.40.2",SUBTITLES="subs"
chunklist_b64000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=332000,RESOLUTION=320x180,SUBTITLES="subs"
chunklist_b332000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=732000,RESOLUTION=640x360,SUBTITLES="subs"
chunklist_b732000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1128000,RESOLUTION=848x480,SUBTITLES="subs"
chunklist_b1128000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1928000,RESOLUTION=1024x576,SUBTITLES="subs"
chunklist_b1928000.m3u8
```

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
