### PR TITLE
Fix `hls.bandwidthEstimate()` with custom `abrController`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -893,6 +893,8 @@ Parameter should be a class providing 2 getters, 2 setters and a `destroy()` met
 - get/set `autoLevelCapping`: capping/max level value that could be used by ABR Controller
 - `destroy()`: should clean-up all used resources
 
+For `hls.bandwidthEstimate()` to return an estimate from your custom controller, it will also need to satisfy `abrController.bwEstimator.getEstimate()`.
+
 ### `bufferController`
 
 (default: internal buffer controller)

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -556,7 +556,11 @@ export default class Hls implements HlsEventEmitter {
    * @type {number}
    */
   get bandwidthEstimate(): number {
-    return this.abrController.bwEstimator.getEstimate();
+    const { bwEstimator } = this.abrController;
+    if (!bwEstimator) {
+      return NaN;
+    }
+    return bwEstimator.getEstimate();
   }
 
   /**


### PR DESCRIPTION
### This PR will...
- Return NaN with custom abrController that does not have bwEstimator property
- Add note to API docs on supplying a custom estimate

### Resolves issues:
Resolves #3562

### Checklist

- [x] changes have been done against master branch, and PR does not conflict