### PR TITLE
Fix bandwidth sampling for small transfers and fast connections

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -8,10 +8,8 @@
 //
 // @public (undocumented)
 export type ABRControllerConfig = {
-    abrEwmaFastLive: number;
-    abrEwmaSlowLive: number;
-    abrEwmaFastVoD: number;
-    abrEwmaSlowVoD: number;
+    abrEwmaFast: number;
+    abrEwmaSlow: number;
     abrEwmaDefaultEstimate: number;
     abrBandWidthFactor: number;
     abrBandWidthUpFactor: number;
@@ -2110,16 +2108,16 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:156:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:157:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:159:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:160:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:161:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:163:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:165:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:166:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:167:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:168:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:154:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:155:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:157:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:158:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:159:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:161:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:163:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:164:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:165:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:166:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1058,11 +1058,11 @@ parameter should be a boolean
 
 ### `abrEwmaFastLive`
 
-(default: `3.0`)
+(default: `0.5`)
 
 Fast bitrate Exponential moving average half-life, used to compute average bitrate for Live streams.
 Half of the estimate is based on the last abrEwmaFastLive seconds of sample history.
-Each of the sample is weighted by the fragment loading duration.
+Each of the sample is weighted by the fragment duration.
 
 parameter should be a float greater than 0
 
@@ -1072,7 +1072,7 @@ parameter should be a float greater than 0
 
 Slow bitrate Exponential moving average half-life, used to compute average bitrate for Live streams.
 Half of the estimate is based on the last abrEwmaSlowLive seconds of sample history.
-Each of the sample is weighted by the fragment loading duration.
+Each of the sample is weighted by the fragment duration.
 
 parameter should be a float greater than [abrEwmaFastLive](#abrewmafastlive)
 
@@ -1082,7 +1082,7 @@ parameter should be a float greater than [abrEwmaFastLive](#abrewmafastlive)
 
 Fast bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams.
 Half of the estimate is based on the last abrEwmaFastVoD seconds of sample history.
-Each of the sample is weighted by the fragment loading duration.
+Each of the sample is weighted by the fragment duration.
 
 parameter should be a float greater than 0
 
@@ -1092,7 +1092,7 @@ parameter should be a float greater than 0
 
 Slow bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams.
 Half of the estimate is based on the last abrEwmaSlowVoD seconds of sample history.
-Each of the sample is weighted by the fragment loading duration.
+Each of the sample is weighted by the fragment duration.
 
 parameter should be a float greater than [abrEwmaFastVoD](#abrewmafastvod)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -79,10 +79,8 @@
   - [`stretchShortVideoTrack`](#stretchshortvideotrack)
   - [`maxAudioFramesDrift`](#maxaudioframesdrift)
   - [`forceKeyFrameOnDiscontinuity`](#forcekeyframeondiscontinuity)
-  - [`abrEwmaFastLive`](#abrewmafastlive)
-  - [`abrEwmaSlowLive`](#abrewmaslowlive)
-  - [`abrEwmaFastVoD`](#abrewmafastvod)
-  - [`abrEwmaSlowVoD`](#abrewmaslowvod)
+  - [`abrEwmaFast`](#abrewmafast)
+  - [`abrEwmaSlow`](#abrewmaslow)
   - [`abrEwmaDefaultEstimate`](#abrewmadefaultestimate)
   - [`abrBandWidthFactor`](#abrbandwidthfactor)
   - [`abrBandWidthUpFactor`](#abrbandwidthupfactor)
@@ -375,10 +373,8 @@ var config = {
   stretchShortVideoTrack: false,
   maxAudioFramesDrift: 1,
   forceKeyFrameOnDiscontinuity: true,
-  abrEwmaFastLive: 3.0,
-  abrEwmaSlowLive: 9.0,
-  abrEwmaFastVoD: 3.0,
-  abrEwmaSlowVoD: 9.0,
+  abrEwmaFastLive: 0.5,
+  abrEwmaSlowLive: 1.5,
   abrEwmaDefaultEstimate: 500000,
   abrBandWidthFactor: 0.95,
   abrBandWidthUpFactor: 0.7,
@@ -1056,45 +1052,23 @@ Setting this parameter to false can also generate decoding weirdness when switch
 
 parameter should be a boolean
 
-### `abrEwmaFastLive`
+### `abrEwmaFast`
 
 (default: `0.5`)
 
 Fast bitrate Exponential moving average half-life, used to compute average bitrate for Live streams.
-Half of the estimate is based on the last abrEwmaFastLive seconds of sample history.
-Each of the sample is weighted by the fragment duration.
+Half of the estimate is based on the last abrEwmaFast fragments or parts of sample history.
 
 parameter should be a float greater than 0
 
-### `abrEwmaSlowLive`
+### `abrEwmaSlow`
 
-(default: `9.0`)
+(default: `1.5`)
 
 Slow bitrate Exponential moving average half-life, used to compute average bitrate for Live streams.
-Half of the estimate is based on the last abrEwmaSlowLive seconds of sample history.
-Each of the sample is weighted by the fragment duration.
+Half of the estimate is based on the last abrEwmaSlow fragments or parts of sample history.
 
-parameter should be a float greater than [abrEwmaFastLive](#abrewmafastlive)
-
-### `abrEwmaFastVoD`
-
-(default: `3.0`)
-
-Fast bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams.
-Half of the estimate is based on the last abrEwmaFastVoD seconds of sample history.
-Each of the sample is weighted by the fragment duration.
-
-parameter should be a float greater than 0
-
-### `abrEwmaSlowVoD`
-
-(default: `9.0`)
-
-Slow bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams.
-Half of the estimate is based on the last abrEwmaSlowVoD seconds of sample history.
-Each of the sample is weighted by the fragment duration.
-
-parameter should be a float greater than [abrEwmaFastVoD](#abrewmafastvod)
+parameter should be a float greater than [abrEwmaFast](#abrewmafast)
 
 ### `abrEwmaDefaultEstimate`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,10 +24,8 @@ import type {
 } from './types/loader';
 
 export type ABRControllerConfig = {
-  abrEwmaFastLive: number;
-  abrEwmaSlowLive: number;
-  abrEwmaFastVoD: number;
-  abrEwmaSlowVoD: number;
+  abrEwmaFast: number;
+  abrEwmaSlow: number;
   abrEwmaDefaultEstimate: number;
   abrBandWidthFactor: number;
   abrBandWidthUpFactor: number;
@@ -242,10 +240,8 @@ export const hlsDefaultConfig: HlsConfig = {
   stretchShortVideoTrack: false, // used by mp4-remuxer
   maxAudioFramesDrift: 1, // used by mp4-remuxer
   forceKeyFrameOnDiscontinuity: true, // used by ts-demuxer
-  abrEwmaFastLive: 0.5, // used by abr-controller
-  abrEwmaSlowLive: 9, // used by abr-controller
-  abrEwmaFastVoD: 3, // used by abr-controller
-  abrEwmaSlowVoD: 9, // used by abr-controller
+  abrEwmaFast: 0.5, // used by abr-controller
+  abrEwmaSlow: 1.5, // used by abr-controller
   abrEwmaDefaultEstimate: 5e5, // 500 kbps  // used by abr-controller
   abrBandWidthFactor: 0.95, // used by abr-controller
   abrBandWidthUpFactor: 0.7, // used by abr-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -242,7 +242,7 @@ export const hlsDefaultConfig: HlsConfig = {
   stretchShortVideoTrack: false, // used by mp4-remuxer
   maxAudioFramesDrift: 1, // used by mp4-remuxer
   forceKeyFrameOnDiscontinuity: true, // used by ts-demuxer
-  abrEwmaFastLive: 3, // used by abr-controller
+  abrEwmaFastLive: 0.5, // used by abr-controller
   abrEwmaSlowLive: 9, // used by abr-controller
   abrEwmaFastVoD: 3, // used by abr-controller
   abrEwmaSlowVoD: 9, // used by abr-controller

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -196,7 +196,11 @@ class AbrController implements ComponentAPI {
       )} s
       Time to underbuffer: ${bufferStarvationDelay.toFixed(3)} s`);
     hls.nextLoadLevel = nextLoadLevel;
-    this.bwEstimator.sample(requestDelay, stats.loaded);
+    this.bwEstimator.sample(
+      part ? part.duration : frag.duration,
+      requestDelay,
+      stats.loaded
+    );
     this.clearTimer();
     if (frag.loader) {
       this.fragCurrent = this.partCurrent = null;
@@ -263,7 +267,11 @@ class AbrController implements ComponentAPI {
     // rationale is that buffer appending only happens once media is attached. This can happen when config.startFragPrefetch
     // is used. If we used buffering in that case, our BW estimate sample will be very large.
     const processingMs = stats.parsing.end - stats.loading.start;
-    this.bwEstimator.sample(processingMs, stats.loaded);
+    this.bwEstimator.sample(
+      part ? part.duration : frag.duration,
+      processingMs,
+      stats.loaded
+    );
     stats.bwEstimate = this.bwEstimator.getEstimate();
     if (frag.bitrateTest) {
       this.bitrateTestDelay = processingMs / 1000;

--- a/src/utils/ewma-bandwidth-estimator.ts
+++ b/src/utils/ewma-bandwidth-estimator.ts
@@ -27,14 +27,13 @@ class EwmaBandWidthEstimator {
       transferMs = Math.max(transferMs, 2);
       // value is bandwidth in bits/s
       const bandwidthInBps = (8000 * numBytes) / transferMs;
-      this.fast_.sample(1, bandwidthInBps);
-      this.slow_.sample(1, bandwidthInBps);
+      this.fast_.sample(bandwidthInBps);
+      this.slow_.sample(bandwidthInBps);
     }
   }
 
   canEstimate(): boolean {
-    const fast = this.fast_;
-    return fast && fast.getTotalWeight() >= this.minWeight_;
+    return this.fast_.getTotalWeight() >= this.minWeight_;
   }
 
   getEstimate(): number {

--- a/src/utils/ewma-bandwidth-estimator.ts
+++ b/src/utils/ewma-bandwidth-estimator.ts
@@ -16,28 +16,20 @@ class EwmaBandWidthEstimator {
 
   constructor(slow: number, fast: number, defaultEstimate: number) {
     this.defaultEstimate_ = defaultEstimate;
-    this.minWeight_ = 2.5;
+    this.minWeight_ = 1;
     this.slow_ = new EWMA(slow);
     this.fast_ = new EWMA(fast);
   }
 
-  update(slow: number, fast: number) {
-    const { slow_, fast_ } = this;
-    if (this.slow_.halfLife !== slow) {
-      this.slow_ = new EWMA(slow, slow_.getEstimate(), slow_.getTotalWeight());
-    }
-    if (this.fast_.halfLife !== fast) {
-      this.fast_ = new EWMA(fast, fast_.getEstimate(), fast_.getTotalWeight());
-    }
-  }
-
-  sample(durationS: number, transferMs: number, numBytes: number) {
+  sample(transferMs: number, numBytes: number) {
     // limit speed to mitigate uncertainty from very fast transfers
-    transferMs = Math.max(transferMs, 2);
-    // value is bandwidth in bits/s
-    const bandwidthInBps = (8000 * numBytes) / transferMs;
-    this.fast_.sample(durationS, bandwidthInBps);
-    this.slow_.sample(durationS, bandwidthInBps);
+    if (numBytes) {
+      transferMs = Math.max(transferMs, 2);
+      // value is bandwidth in bits/s
+      const bandwidthInBps = (8000 * numBytes) / transferMs;
+      this.fast_.sample(1, bandwidthInBps);
+      this.slow_.sample(1, bandwidthInBps);
+    }
   }
 
   canEstimate(): boolean {

--- a/src/utils/ewma.ts
+++ b/src/utils/ewma.ts
@@ -1,7 +1,6 @@
 /*
  * compute an Exponential Weighted moving average
  * - https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
- *  - heavily inspired from shaka-player
  */
 
 class EWMA {
@@ -19,10 +18,9 @@ class EWMA {
     this.totalWeight_ = weight;
   }
 
-  sample(weight: number, value: number) {
-    const adjAlpha = Math.pow(this.alpha_, weight);
-    this.estimate_ = value * (1 - adjAlpha) + adjAlpha * this.estimate_;
-    this.totalWeight_ += weight;
+  sample(value: number) {
+    this.estimate_ = value * (1 - this.alpha_) + this.alpha_ * this.estimate_;
+    this.totalWeight_++;
   }
 
   getTotalWeight(): number {

--- a/tests/unit/controller/ewma-bandwidth-estimator.ts
+++ b/tests/unit/controller/ewma-bandwidth-estimator.ts
@@ -15,25 +15,25 @@ describe('EwmaBandWidthEstimator', function () {
   it('returns last bitrate is fast=slow=0', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(0, 0, defaultEstimate);
-    bwEstimator.sample(8000, 1000000);
+    bwEstimator.sample(8, 8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4000, 1000000);
+    bwEstimator.sample(4, 4000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(2000000);
-    bwEstimator.sample(1000, 1000000);
+    bwEstimator.sample(1, 1000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(8000000);
   });
 
   it('returns correct value bitrate is slow=15,fast=4', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(15, 4, defaultEstimate);
-    bwEstimator.sample(8000, 1000000);
+    bwEstimator.sample(8, 8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4000, 1000000);
+    bwEstimator.sample(4, 4000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
       1396480.1544736226,
       0.000000001
     );
-    bwEstimator.sample(1000, 1000000);
+    bwEstimator.sample(1, 1000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
       2056826.9489827948,
       0.000000001
@@ -43,14 +43,14 @@ describe('EwmaBandWidthEstimator', function () {
   it('returns correct value bitrate is slow=9,fast=5', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(9, 5, defaultEstimate);
-    bwEstimator.sample(8000, 1000000);
+    bwEstimator.sample(8, 8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4000, 1000000);
+    bwEstimator.sample(4, 4000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
       1439580.319105247,
       0.000000001
     );
-    bwEstimator.sample(1000, 1000000);
+    bwEstimator.sample(1, 1000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
       2208342.324322311,
       0.000000001
@@ -61,9 +61,9 @@ describe('EwmaBandWidthEstimator', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(9, 3, defaultEstimate);
     expect(bwEstimator.getEstimate()).to.equal(defaultEstimate);
-    bwEstimator.sample(8000, 1000000);
+    bwEstimator.sample(8, 8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4000, 1000000);
+    bwEstimator.sample(4, 4000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
       1439580.319105247,
       0.000000001
@@ -73,7 +73,7 @@ describe('EwmaBandWidthEstimator', function () {
       1878125.393685882,
       0.000000001
     );
-    bwEstimator.sample(1000, 1000000);
+    bwEstimator.sample(1, 1000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
       2966543.443461984,
       0.000000001
@@ -85,7 +85,7 @@ describe('EwmaBandWidthEstimator', function () {
     const bwEstimator = new EwmaBandWidthEstimator(9, 3, defaultEstimate);
     bwEstimator.update(15, 4);
     expect(bwEstimator.getEstimate()).to.equal(defaultEstimate);
-    bwEstimator.sample(8000, 1000000);
+    bwEstimator.sample(8, 8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
   });
 });

--- a/tests/unit/controller/ewma-bandwidth-estimator.ts
+++ b/tests/unit/controller/ewma-bandwidth-estimator.ts
@@ -15,27 +15,27 @@ describe('EwmaBandWidthEstimator', function () {
   it('returns last bitrate is fast=slow=0', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(0, 0, defaultEstimate);
-    bwEstimator.sample(8, 8000, 1000000);
+    bwEstimator.sample(8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4, 4000, 1000000);
+    bwEstimator.sample(4000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(2000000);
-    bwEstimator.sample(1, 1000, 1000000);
+    bwEstimator.sample(1000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(8000000);
   });
 
   it('returns correct value bitrate is slow=15,fast=4', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(15, 4, defaultEstimate);
-    bwEstimator.sample(8, 8000, 1000000);
+    bwEstimator.sample(8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4, 4000, 1000000);
+    bwEstimator.sample(4000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
-      1396480.1544736226,
+      1511550.3977404737,
       0.000000001
     );
-    bwEstimator.sample(1, 1000, 1000000);
+    bwEstimator.sample(1000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
-      2056826.9489827948,
+      3775044.041335162,
       0.000000001
     );
   });
@@ -43,49 +43,17 @@ describe('EwmaBandWidthEstimator', function () {
   it('returns correct value bitrate is slow=9,fast=5', function () {
     const defaultEstimate = 5e5;
     const bwEstimator = new EwmaBandWidthEstimator(9, 5, defaultEstimate);
-    bwEstimator.sample(8, 8000, 1000000);
+    bwEstimator.sample(8000, 1000000);
     expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4, 4000, 1000000);
+    bwEstimator.sample(4000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
-      1439580.319105247,
+      1519244.5768252169,
       0.000000001
     );
-    bwEstimator.sample(1, 1000, 1000000);
+    bwEstimator.sample(1000, 1000000);
     expect(bwEstimator.getEstimate()).to.closeTo(
-      2208342.324322311,
+      3847839.2697109017,
       0.000000001
     );
-  });
-
-  it('returns correct value after updating slow and fast', function () {
-    const defaultEstimate = 5e5;
-    const bwEstimator = new EwmaBandWidthEstimator(9, 3, defaultEstimate);
-    expect(bwEstimator.getEstimate()).to.equal(defaultEstimate);
-    bwEstimator.sample(8, 8000, 1000000);
-    expect(bwEstimator.getEstimate()).to.equal(1000000);
-    bwEstimator.sample(4, 4000, 1000000);
-    expect(bwEstimator.getEstimate()).to.closeTo(
-      1439580.319105247,
-      0.000000001
-    );
-    bwEstimator.update(15, 4);
-    expect(bwEstimator.getEstimate()).to.closeTo(
-      1878125.393685882,
-      0.000000001
-    );
-    bwEstimator.sample(1, 1000, 1000000);
-    expect(bwEstimator.getEstimate()).to.closeTo(
-      2966543.443461984,
-      0.000000001
-    );
-  });
-
-  it('returns correct value when updating before a sample', function () {
-    const defaultEstimate = 5e5;
-    const bwEstimator = new EwmaBandWidthEstimator(9, 3, defaultEstimate);
-    bwEstimator.update(15, 4);
-    expect(bwEstimator.getEstimate()).to.equal(defaultEstimate);
-    bwEstimator.sample(8, 8000, 1000000);
-    expect(bwEstimator.getEstimate()).to.equal(1000000);
   });
 });


### PR DESCRIPTION
### This PR will...

Fix bandwidth sampling weight for small transfers and/or fast connections.

### Why is this Pull Request needed?

The current logic is broken for fast transfers (due to small transfer sizes, or from a fast connection). See #3563 for details.

### Are there any points in the code the reviewer needs to double check?

This changes the exact meaning of the `abrEwma<X>` options, which could be considered a breaking change.

I have also had to significantly lower the `abrEwmaFastLive` default to accommodate LL-HLS level downswitches. The old value meant that it takes too long to discover a new lowered bitrate, and could cause multiple successive emergency level switches and stalls. Note that the new value could make a temporary connection issue more likely to cause temporary downswitches. It might make sense to only use this low value for LL-HLS content, but that is outside the scope of this patch.

### Resolves issues:

Partly fixes #3563. With this PR, the ABR algorithm is more likely to switch up from a low level (still only when there is sufficient bandwidth). Low latency content on high latency links are still unable to measure a suitable bitrate.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
