### PR TITLE
Live stream sync fixes and imrovements

### DIFF
--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -64,7 +64,7 @@ export default class LatencyController implements ComponentAPI {
           ? liveSyncDuration
           : liveSyncDurationCount * targetduration;
     }
-    const maxLiveSyncOnStallIncrease = levelDetails.targetduration;
+    const maxLiveSyncOnStallIncrease = targetduration;
     const liveSyncOnStallIncrease = 1.0;
     return (
       targetLatency +


### PR DESCRIPTION
### This PR will...
Only resync playback with live streams if the buffer is starved or playback is behind `liveMaxLatencyDuration` or `liveMaxLatencyDurationCount`.

### Why is this Pull Request needed?
A regression is causing hls.js to seek forwards to the start of the live sliding window on level update whenever playback is behind the sliding start (by more than `maxFragLookUpTolerance`, which is very small). This ignores the `liveMaxLatencyDuration` or `liveMaxLatencyDurationCount` options that should allow playback to fall behind up to that amount, as long as media is buffered.

These changes ensure that whenever playback is outside the sliding window, and the buffer is starved, _or_ playback is behind the configured max latency, the player will resync with the stream.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
