### PR TITLE
switch auto merge to pull_request_target

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,25 +1,10 @@
 name: Auto Merge Dependency Updates
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      hasSecret: ${{ steps.check_secret_access.outputs.result == 'true' }}
-    steps:
-      - name: check secret access
-        id: check_secret_access
-        run: |
-          if ! [[ -z "$SECRET" ]]; then
-            echo "::set-output name=result::true"
-          fi
-        env:
-          SECRET: ${{ secrets.CI_GITHUB_TOKEN }}
   run:
-    needs: config
-    if: needs.config.outputs.hasSecret == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: tjenkinson/gh-action-auto-merge-dependency-updates@791110cb91cf883fb4894ffd080ddbe36607cd31


### PR DESCRIPTION
### This PR will...
Switch the auto merge action to `pull_request_target` instead of `pull_request`, which is still a trigger when a PR is changed, but the context is set to the base branch and secrets are always provided. The context change doesn't make a difference in our case given we're not checking out or running any code from the PR head commit.

### Why is this Pull Request needed?
[Triggers from dependabot no longer get the secrets](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) meaning the current updates aren't being merged.
