### PR TITLE
Fix `currentLevel` and `getAppendedFrag` with alt-audio streams

### DIFF
--- a/src/types/fragment-tracker.ts
+++ b/src/types/fragment-tracker.ts
@@ -1,13 +1,9 @@
-// eslint-disable-next-line import/no-duplicates
 import type { Fragment } from '../loader/fragment';
-// eslint-disable-next-line import/no-duplicates
-import type { Part } from '../loader/fragment';
 import type { SourceBufferName } from './buffer';
 import type { FragLoadedData } from './events';
 
 export interface FragmentEntity {
   body: Fragment;
-  part: Part | null;
   loaded: FragLoadedData | null;
   backtrack: FragLoadedData | null;
   buffered: boolean;


### PR DESCRIPTION
### This PR will...
Only track `activeFragment` and `activeParts` in fragment-tracker for "main" playlist segments. And, only use these in calls to `getAppendedFrag` for the "main" `levelType`.

### Why is this Pull Request needed?
`getAppendedFrag` is used to determine `hls.currentLevel`. Matching "audio" type fragments or parts resulted in `currentLevel` being returned as `0`.

### Resolves issues:
> 1. Ignores `levelType`

#3602

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
