### PR TITLE
Cleanup hls.destroy()

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -854,6 +854,7 @@ class Hls implements HlsEventEmitter {
     get firstLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "firstLevel" must appear on the getter, not the setter.
     set firstLevel(newLevel: number);
+    get forceStartLoad(): boolean;
     // (undocumented)
     static isSupported(): boolean;
     get latency(): number;

--- a/demo/main.js
+++ b/demo/main.js
@@ -1630,16 +1630,6 @@ function addChartEventListeners(hls) {
     chart
   );
   hls.on(
-    Hls.Events.FRAG_LOADING,
-    () => {
-      // TODO: mutate level datasets
-      // Update loadLevel
-      chart.removeType('level');
-      chart.updateLevels(hls.levels);
-    },
-    chart
-  );
-  hls.on(
     Hls.Events.LEVEL_UPDATED,
     (eventName, { details }) => {
       chart.updateLevelOrTrack(details);

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -64,6 +64,9 @@ class AbrController implements ComponentAPI {
   public destroy() {
     this.unregisterListeners();
     this.clearTimer();
+    // @ts-ignore
+    this.hls = this.onCheck = null;
+    this.fragCurrent = this.partCurrent = null;
   }
 
   protected onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -58,13 +58,12 @@ class AudioStreamController
 
   constructor(hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls, fragmentTracker, '[audio-stream-controller]');
-    this.fragmentLoader = new FragmentLoader(hls.config);
-
     this._registerListeners();
   }
 
   protected onHandlerDestroying() {
     this._unregisterListeners();
+    this.mainDetails = null;
   }
 
   private _registerListeners() {

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -48,6 +48,8 @@ class AudioTrackController extends BasePlaylistController {
 
   public destroy() {
     this.unregisterListeners();
+    this.tracks.length = 0;
+    this.tracksInGroup.length = 0;
     super.destroy();
   }
 

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -20,8 +20,8 @@ export default class BasePlaylistController implements NetworkComponentAPI {
   protected timer: number = -1;
   protected canLoad: boolean = false;
   protected retryCount: number = 0;
-  protected readonly log: (msg: any) => void;
-  protected readonly warn: (msg: any) => void;
+  protected log: (msg: any) => void;
+  protected warn: (msg: any) => void;
 
   constructor(hls: Hls, logPrefix: string) {
     this.log = logger.log.bind(logger, `${logPrefix}:`);
@@ -31,6 +31,8 @@ export default class BasePlaylistController implements NetworkComponentAPI {
 
   public destroy(): void {
     this.clearTimer();
+    // @ts-ignore
+    this.hls = this.log = this.warn = null;
   }
 
   protected onError(event: Events.ERROR, data: ErrorData): void {

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -150,9 +150,9 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onMediaDetaching() {
-    logger.log('[buffer-controller]: media source detaching');
     const { media, mediaSource, _objectUrl } = this;
     if (mediaSource) {
+      logger.log('[buffer-controller]: media source detaching');
       if (mediaSource.readyState === 'open') {
         try {
           // endOfStream could trigger exception if any sourcebuffer is in updating state

--- a/src/controller/cap-level-controller.ts
+++ b/src/controller/cap-level-controller.ts
@@ -18,7 +18,6 @@ import type Hls from '../hls';
 class CapLevelController implements ComponentAPI {
   public autoLevelCapping: number;
   public firstLevel: number;
-  public levels: Array<Level>;
   public media: HTMLVideoElement | null;
   public restrictedLevels: Array<number>;
   public timer: number | undefined;
@@ -30,7 +29,6 @@ class CapLevelController implements ComponentAPI {
   constructor(hls: Hls) {
     this.hls = hls;
     this.autoLevelCapping = Number.POSITIVE_INFINITY;
-    this.levels = [];
     this.firstLevel = -1;
     this.media = null;
     this.restrictedLevels = [];
@@ -47,10 +45,12 @@ class CapLevelController implements ComponentAPI {
   public destroy() {
     this.unregisterListener();
     if (this.hls.config.capLevelToPlayerSize) {
-      this.media = null;
-      this.clientRect = null;
       this.stopCapping();
     }
+    this.media = null;
+    this.clientRect = null;
+    // @ts-ignore
+    this.hls = this.streamController = null;
   }
 
   protected registerListeners() {
@@ -58,7 +58,6 @@ class CapLevelController implements ComponentAPI {
     hls.on(Events.FPS_DROP_LEVEL_CAPPING, this.onFpsDropLevelCapping, this);
     hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.on(Events.MANIFEST_PARSED, this.onManifestParsed, this);
-    hls.on(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.on(Events.BUFFER_CODECS, this.onBufferCodecs, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
   }
@@ -68,7 +67,6 @@ class CapLevelController implements ComponentAPI {
     hls.off(Events.FPS_DROP_LEVEL_CAPPING, this.onFpsDropLevelCapping, this);
     hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.off(Events.MANIFEST_PARSED, this.onManifestParsed, this);
-    hls.off(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.off(Events.BUFFER_CODECS, this.onBufferCodecs, this);
     hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
   }
@@ -101,7 +99,6 @@ class CapLevelController implements ComponentAPI {
   ) {
     const hls = this.hls;
     this.restrictedLevels = [];
-    this.levels = data.levels;
     this.firstLevel = data.firstLevel;
     if (hls.config.capLevelToPlayerSize && data.video) {
       // Start capping immediately if the manifest has signaled video codecs
@@ -122,23 +119,16 @@ class CapLevelController implements ComponentAPI {
     }
   }
 
-  protected onLevelsUpdated(
-    event: Events.LEVELS_UPDATED,
-    data: LevelsUpdatedData
-  ) {
-    this.levels = data.levels;
-  }
-
   protected onMediaDetaching() {
     this.stopCapping();
   }
 
   detectPlayerSize() {
     if (this.media && this.mediaHeight > 0 && this.mediaWidth > 0) {
-      const levelsLength = this.levels ? this.levels.length : 0;
-      if (levelsLength) {
+      const levels = this.hls.levels;
+      if (levels.length) {
         const hls = this.hls;
-        hls.autoLevelCapping = this.getMaxLevel(levelsLength - 1);
+        hls.autoLevelCapping = this.getMaxLevel(levels.length - 1);
         if (
           hls.autoLevelCapping > this.autoLevelCapping &&
           this.streamController
@@ -156,11 +146,12 @@ class CapLevelController implements ComponentAPI {
    * returns level should be the one with the dimensions equal or greater than the media (player) dimensions (so the video will be downscaled)
    */
   getMaxLevel(capLevelIndex: number): number {
-    if (!this.levels) {
+    const levels = this.hls.levels;
+    if (!levels.length) {
       return -1;
     }
 
-    const validLevels = this.levels.filter(
+    const validLevels = levels.filter(
       (level, index) =>
         CapLevelController.isLevelAllowed(index, this.restrictedLevels) &&
         index <= capLevelIndex

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -120,6 +120,7 @@ class EMEController implements ComponentAPI {
   private _requestLicenseFailureCount: number = 0;
 
   private mediaKeysPromise: Promise<MediaKeys> | null = null;
+  private _onMediaEncrypted = this.onMediaEncrypted.bind(this);
 
   /**
    * @constructs
@@ -141,6 +142,9 @@ class EMEController implements ComponentAPI {
 
   public destroy() {
     this._unregisterListeners();
+    // @ts-ignore
+    this.hls = this._onMediaEncrypted = null;
+    this._requestMediaKeySystemAccess = null;
   }
 
   private _registerListeners() {
@@ -318,7 +322,7 @@ class EMEController implements ComponentAPI {
    * @private
    * @param e {MediaEncryptedEvent}
    */
-  private _onMediaEncrypted = (e: MediaEncryptedEvent) => {
+  private onMediaEncrypted(e: MediaEncryptedEvent) {
     logger.log(`Media is encrypted using "${e.initDataType}" init data type`);
 
     if (!this.mediaKeysPromise) {
@@ -345,7 +349,7 @@ class EMEController implements ComponentAPI {
     this.mediaKeysPromise
       .then(finallySetKeyAndStartSession)
       .catch(finallySetKeyAndStartSession);
-  };
+  }
 
   /**
    * @private

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -59,9 +59,9 @@ export class FragmentTracker implements ComponentAPI {
   }
 
   public destroy() {
-    this.fragments = Object.create(null);
-    this.timeRanges = Object.create(null);
     this._unregisterListeners();
+    // @ts-ignore
+    this.fragments = this.timeRanges = null;
   }
 
   /**

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -31,6 +31,11 @@ export default class GapController {
     this.hls = hls;
   }
 
+  public destroy() {
+    // @ts-ignore
+    this.hls = this.fragmentTracker = this.media = null;
+  }
+
   /**
    * Checks if the playhead is stuck within a gap, and if so, attempts to free it.
    * A gap is an unbuffered range between two buffered ranges (or the start and the first buffered range).

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -12,7 +12,7 @@ import type Hls from '../hls';
 import type { HlsConfig } from '../config';
 
 export default class LatencyController implements ComponentAPI {
-  private readonly hls: Hls;
+  private hls: Hls;
   private readonly config: HlsConfig;
   private media: HTMLMediaElement | null = null;
   private levelDetails: LevelDetails | null = null;
@@ -117,6 +117,9 @@ export default class LatencyController implements ComponentAPI {
   public destroy(): void {
     this.unregisterListeners();
     this.onMediaDetaching();
+    this.levelDetails = null;
+    // @ts-ignore
+    this.hls = this.timeupdateHandler = null;
   }
 
   private registerListeners() {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -59,9 +59,10 @@ export default class LevelController extends BasePlaylistController {
   }
 
   public destroy() {
-    super.destroy();
     this._unregisterListeners();
     this.manualLevelIndex = -1;
+    this._levels.length = 0;
+    super.destroy();
   }
 
   public startLoad(): void {
@@ -189,7 +190,10 @@ export default class LevelController extends BasePlaylistController {
       };
       this.hls.trigger(Events.MANIFEST_PARSED, edata);
 
-      this.onParsedComplete();
+      // Initiate loading after all controllers have received MANIFEST_PARSED
+      if (this.hls.config.autoStartLoad || this.hls.forceStartLoad) {
+        this.hls.startLoad(this.hls.config.startPosition);
+      }
     } else {
       this.hls.trigger(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -58,9 +58,6 @@ export default class StreamController
 
   constructor(hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls, fragmentTracker, '[stream-controller]');
-    this.fragmentLoader = new FragmentLoader(hls.config);
-    this.state = State.STOPPED;
-
     this._registerListeners();
   }
 
@@ -109,6 +106,7 @@ export default class StreamController
 
   protected onHandlerDestroying() {
     this._unregisterListeners();
+    this.onMediaDetaching();
   }
 
   public startLoad(startPosition: number): void {
@@ -516,8 +514,13 @@ export default class StreamController
       media.removeEventListener('playing', this.onvplaying);
       media.removeEventListener('seeked', this.onvseeked);
       this.onvplaying = this.onvseeked = null;
+      this.videoBuffer = null;
     }
-
+    this.fragPlaying = null;
+    if (this.gapController) {
+      this.gapController.destroy();
+      this.gapController = null;
+    }
     super.onMediaDetaching();
   }
 

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -46,7 +46,6 @@ export class SubtitleStreamController
     this.mediaBuffer = null;
     this.state = State.STOPPED;
     this.tracksBuffered = [];
-    this.fragmentLoader = new FragmentLoader(hls.config);
 
     this._registerListeners();
   }

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -35,6 +35,10 @@ class SubtitleTrackController extends BasePlaylistController {
 
   public destroy() {
     this.unregisterListeners();
+    this.tracks.length = 0;
+    this.tracksInGroup.length = 0;
+    // @ts-ignore
+    this.trackChangeListener = null;
     super.destroy();
   }
 

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -58,8 +58,8 @@ export class TimelineController implements ComponentAPI {
   private unparsedVttFrags: Array<FragLoadedData | FragDecryptedData> = [];
   private captionsTracks: Record<string, TextTrack> = {};
   private nonNativeCaptionsTracks: Record<string, NonNativeCaptionsTrack> = {};
-  private readonly cea608Parser1!: Cea608Parser;
-  private readonly cea608Parser2!: Cea608Parser;
+  private cea608Parser1!: Cea608Parser;
+  private cea608Parser2!: Cea608Parser;
   private lastSn: number = -1;
   private prevCC: number = -1;
   private vttCCs: VTTCCs = newVTTCCs();
@@ -103,11 +103,6 @@ export class TimelineController implements ComponentAPI {
       this.cea608Parser2 = new Cea608Parser(3, channel3, channel4);
     }
 
-    this._registerListeners();
-  }
-
-  private _registerListeners(): void {
-    const { hls } = this;
     hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
@@ -122,7 +117,7 @@ export class TimelineController implements ComponentAPI {
     hls.on(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
   }
 
-  private _unregisterListeners(): void {
+  public destroy(): void {
     const { hls } = this;
     hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
@@ -136,6 +131,8 @@ export class TimelineController implements ComponentAPI {
     hls.off(Events.INIT_PTS_FOUND, this.onInitPtsFound, this);
     hls.off(Events.SUBTITLE_TRACKS_CLEARED, this.onSubtitleTracksCleared, this);
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
+    // @ts-ignore
+    this.hls = this.config = this.cea608Parser1 = this.cea608Parser2 = null;
   }
 
   public addCues(
@@ -276,10 +273,6 @@ export class TimelineController implements ComponentAPI {
       return;
     }
     return media.addTextTrack(kind, label, lang);
-  }
-
-  public destroy() {
-    this._unregisterListeners();
   }
 
   private onMediaAttaching(

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -48,6 +48,11 @@ export default class Decrypter {
     }
   }
 
+  destroy() {
+    // @ts-ignore
+    this.observer = null;
+  }
+
   public isSync() {
     return this.config.enableSoftwareAES;
   }

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -20,6 +20,13 @@ export default class FragmentLoader {
     this.config = config;
   }
 
+  destroy() {
+    if (this.loader) {
+      this.loader.destroy();
+      this.loader = null;
+    }
+  }
+
   abort() {
     if (this.loader) {
       // Abort the loader for current fragment. Only one may load at any given time
@@ -53,6 +60,9 @@ export default class FragmentLoader {
     const DefaultILoader = config.loader;
 
     return new Promise((resolve, reject) => {
+      if (this.loader) {
+        this.loader.destroy();
+      }
       const loader = (this.loader = frag.loader = FragmentILoader
         ? new FragmentILoader(config)
         : (new DefaultILoader(config) as Loader<FragmentLoaderContext>));
@@ -139,6 +149,9 @@ export default class FragmentLoader {
     const DefaultILoader = config.loader;
 
     return new Promise((resolve, reject) => {
+      if (this.loader) {
+        this.loader.destroy();
+      }
       const loader = (this.loader = frag.loader = FragmentILoader
         ? new FragmentILoader(config)
         : (new DefaultILoader(config) as Loader<FragmentLoaderContext>));
@@ -246,6 +259,7 @@ export default class FragmentLoader {
       self.clearTimeout(this.partLoadTimeout);
       this.loader = null;
     }
+    loader.destroy();
   }
 }
 

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -35,12 +35,16 @@ class XhrLoader implements Loader<LoaderContext> {
 
   abortInternal(): void {
     const loader = this.loader;
-    if (loader && loader.readyState !== 4) {
-      this.stats.aborted = true;
-      loader.abort();
-    }
     self.clearTimeout(this.requestTimeout);
     self.clearTimeout(this.retryTimeout);
+    if (loader) {
+      loader.onreadystatechange = null;
+      loader.onprogress = null;
+      if (loader.readyState !== 4) {
+        this.stats.aborted = true;
+        loader.abort();
+      }
+    }
   }
 
   abort(): void {
@@ -146,6 +150,8 @@ class XhrLoader implements Loader<LoaderContext> {
       }
 
       if (readyState === 4) {
+        xhr.onreadystatechange = null;
+        xhr.onprogress = null;
         const status = xhr.status;
         // http status between 200 to 299 are all successful
         if (status >= 200 && status < 300) {

--- a/tests/unit/controller/cap-level-controller.js
+++ b/tests/unit/controller/cap-level-controller.js
@@ -176,7 +176,6 @@ describe('CapLevelController', function () {
     });
 
     it('constructs with no restrictions', function () {
-      expect(capLevelController.levels).to.be.empty;
       expect(capLevelController.restrictedLevels).to.be.empty;
       expect(capLevelController.timer).to.not.exist;
       expect(capLevelController.autoLevelCapping).to.equal(
@@ -212,7 +211,6 @@ describe('CapLevelController', function () {
       };
 
       capLevelController.onManifestParsed(Events.MANIFEST_PARSED, data);
-      expect(capLevelController.levels).to.equal(data.levels);
       expect(capLevelController.firstLevel).to.equal(data.firstLevel);
       expect(capLevelController.restrictedLevels).to.be.empty;
     });


### PR DESCRIPTION
### This PR will...
Free up references when destroying player to prevent memory leaks and improve GC.

Also made a couple of small optimizations to the Timeline chart on the demo page after observing that it can impact player performance with very active streams (LL-HLS CMAF 0.5s parts). Panning the chart or keeping it running for long periods impacts page performance that hls.js needs to handle requests and MSE appends.

### Why is this Pull Request needed?
A new player should be created and the previous destroyed for each HLS stream played. The previous player should be completely destroyed and not retain (cyclical) references that the browser cannot garbage collect.

### Resolves issues:
Resolves #2104
Relates to #3605 and possibly #3606

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
