### PR TITLE
Ignore out-of-range level indexes as in previous major version

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@ const { merge } = require('webpack-merge');
 const webpackConfig = require('./webpack.config')({ debug: true })[0];
 delete webpackConfig.entry;
 delete webpackConfig.output;
-const mergeConfig = merge(webpackConfig, {
+const karmaWebpack = {
   devtool: 'inline-source-map',
   module: {
     rules: [
@@ -24,7 +24,14 @@ const mergeConfig = merge(webpackConfig, {
   node: {
     global: true,
   },
-});
+};
+
+// Remove coverage post-processor for JavaScript debugging when running `test:unit:debug`
+if (process.env.DEBUG_UNIT_TESTS) {
+  karmaWebpack.module.rules = [];
+}
+
+const mergeConfig = merge(webpackConfig, karmaWebpack);
 
 module.exports = function (config) {
   config.set({

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "start": "npm run dev",
     "test": "npm run test:unit && npm run test:func",
     "test:unit": "karma start karma.conf.js",
+    "test:unit:debug": "DEBUG_UNIT_TESTS=1 karma start karma.conf.js --auto-watch --no-single-run --browsers Chrome",
     "test:unit:watch": "karma start karma.conf.js --auto-watch --no-single-run",
     "test:func": "BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "test:func:light": "BABEL_ENV=development HLSJS_LIGHT=1 mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -218,21 +218,29 @@ export default class LevelController extends BasePlaylistController {
 
   set level(newLevel: number) {
     const levels = this._levels;
+    if (levels.length === 0) {
+      return;
+    }
     if (this.currentLevelIndex === newLevel && levels[newLevel]?.details) {
       return;
     }
     // check if level idx is valid
     if (newLevel < 0 || newLevel >= levels.length) {
       // invalid level id given, trigger error
+      const fatal = newLevel < 0;
       this.hls.trigger(Events.ERROR, {
         type: ErrorTypes.OTHER_ERROR,
         details: ErrorDetails.LEVEL_SWITCH_ERROR,
         level: newLevel,
-        fatal: false,
+        fatal,
         reason: 'invalid level idx',
       });
-      return;
+      if (fatal) {
+        return;
+      }
+      newLevel = Math.min(newLevel, levels.length - 1);
     }
+
     // stopping live reloading timer if any
     this.clearTimer();
 

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -29,8 +29,8 @@ describe('StreamController', function () {
 
   beforeEach(function () {
     hls = new Hls({});
-    fragmentTracker = new FragmentTracker(hls);
-    streamController = new StreamController(hls, fragmentTracker);
+    streamController = hls['streamController'];
+    fragmentTracker = streamController['fragmentTracker'];
     streamController['startFragRequested'] = true;
   });
 


### PR DESCRIPTION
### This PR will...
Ignore out-of-range level indexes as in previous major version.

Also adds a script for running unit tests in debug mode without coverage instrumentation in Chrome.

### Why is this Pull Request needed?
So that playback starts even with an invalid `startLevel`.

### Resolves issues:
Fixes #3618

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
