### PR TITLE
Update nextLoadPosition right before loading a fragment or part

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -818,7 +818,6 @@ class AudioStreamController
         this.state = State.WAITING_INIT_PTS;
       } else {
         this.startFragRequested = true;
-        this.nextLoadPosition = frag.start + frag.duration;
         super.loadFragment(frag, trackDetails, targetBufferTime);
       }
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -234,7 +234,7 @@ export default class BaseStreamController
     }
 
     // in case seeking occurs although no media buffered, adjust startPosition and nextLoadPosition to seek target
-    if (!this.loadedmetadata) {
+    if (!this.loadedmetadata && !bufferInfo.len) {
       this.nextLoadPosition = this.startPosition = currentTime;
     }
 
@@ -527,6 +527,7 @@ export default class BaseStreamController
               targetBufferTime.toFixed(3)
             )}`
           );
+          this.nextLoadPosition = part.start + part.duration;
           this.state = State.FRAG_LOADING;
           this.hls.trigger(Events.FRAG_LOADING, {
             frag,
@@ -556,7 +557,10 @@ export default class BaseStreamController
         frag.level
       }, target: ${parseFloat(targetBufferTime.toFixed(3))}`
     );
-
+    // Don't update nextLoadPosition for fragments which are not buffered
+    if (Number.isFinite(frag.sn as number) && !this.bitrateTest) {
+      this.nextLoadPosition = frag.start + frag.duration;
+    }
     this.state = State.FRAG_LOADING;
     this.hls.trigger(Events.FRAG_LOADING, { frag, targetBufferTime });
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -329,11 +329,6 @@ export default class StreamController
     // Check if fragment is not loaded
     let fragState = this.fragmentTracker.getState(frag);
     this.fragCurrent = frag;
-    // Don't update nextLoadPosition for fragments which are not buffered
-    if (Number.isFinite(frag.sn as number) && !this.bitrateTest) {
-      this.nextLoadPosition = frag.start + frag.duration;
-    }
-
     // Use data from loaded backtracked fragment if available
     if (fragState === FragmentState.BACKTRACKED) {
       const data = this.fragmentTracker.getBacktrackData(frag);


### PR DESCRIPTION
### This PR will...
Update nextLoadPosition right before loading a fragment or part.

### Why is this Pull Request needed?
`nextLoadPosition` is set too far ahead when LL-HLS part loading. In most cases, this doesn't matter, but it could potentially lead to skipped parts or gaps in some cases when starting a CMAF stream.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
