### PR TITLE
fix play without BANDWIDTH in master playlist

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -24,6 +24,7 @@ export default class LevelController extends EventHandler {
     this.currentLevelIndex = null;
     this.manualLevelIndex = -1;
     this.timer = null;
+    this._firstLevel = -1;
 
     chromeOrFirefox = /chrome|firefox/.test(navigator.userAgent.toLowerCase());
   }


### PR DESCRIPTION
### This PR will...
Fix used `firstLevel` if `hls.startLevel` & `config.startLevel` are not defined

### Why is this Pull Request needed?
If master playlist not have BANDWIDTH then used `firstLevel`.  At the moment `firstLevel` not defined in constructor so have this error:

`Error while trying to switch to level NaN` 

This problem only in 0.x.x versions in 1.0.0 [already fixed ](https://github.com/video-dev/hls.js/blob/03226bc1c9dcf8f8385b9960afed69f8469b2efe/src/controller/level-controller.ts#L31)

Examples (the playlist opens in the CIS, ues VPN if need): 
0.14.17: https://hls-js-76506a25-92a4-462c-aa38-cc2cd20ce706.netlify.app/demo/?src=https%3A%2F%2Fcdn-volta.wasd.tv%2Flive%2F5774%2Findex-1616129555-5132.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOnRydWUsImR1bXBmTVA0IjpmYWxzZSwibGV2ZWxDYXBwaW5nIjotMSwibGltaXRNZXRyaWNzIjotMX0=

1.0.0-rc-5: https://hls-js-79fb5bf4-02e6-4474-8d1f-ec2bfc3527ff.netlify.app/demo/?src=https%3A%2F%2Fcdn-volta.wasd.tv%2Flive%2F5774%2Findex-1616129555-5132.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOnRydWUsInN0b3BPblN0YWxsIjpmYWxzZSwiZHVtcGZNUDQiOmZhbHNlLCJsZXZlbENhcHBpbmciOi0xLCJsaW1pdE1ldHJpY3MiOi0xfQ==


### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
