### PR TITLE
Improve handling of fmp4 streams when probing fails or codecs are unknown

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -53,6 +53,10 @@ Event order and content have changed in some places. See **Breaking Changes** be
   - `SUBTITLE_LOAD_ERROR`
   - `SUBTITLE_TRACK_LOAD_TIMEOUT`
   - `UNKNOWN`
+- Added additional error detail for streams that cannot start because source buffer(s) could not be created after parsing media codecs
+  - `BUFFER_INCOMPATIBLE_CODECS_ERROR` will fire instead of `BUFFER_CREATED` with an empty `tracks` list. This media error
+    is fatal and not recoverable. If you encounter this error make sure you include the correct CODECS string in
+    your manifest, as this is most likely to occur when attempting to play a fragmented mp4 playlist with unknown codecs.
 
 ### Fragment Stats
 

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -383,6 +383,8 @@ export enum ErrorDetails {
     // (undocumented)
     BUFFER_FULL_ERROR = "bufferFullError",
     // (undocumented)
+    BUFFER_INCOMPATIBLE_CODECS_ERROR = "bufferIncompatibleCodecsError",
+    // (undocumented)
     BUFFER_NUDGE_ON_STALL = "bufferNudgeOnStall",
     // (undocumented)
     BUFFER_SEEK_OVER_HOLE = "bufferSeekOverHole",

--- a/demo/main.js
+++ b/demo/main.js
@@ -807,7 +807,10 @@ function loadSelectedStream() {
         break;
       case Hls.ErrorDetails.BUFFER_ADD_CODEC_ERROR:
         logError(
-          'Buffer add codec error for ' + data.mimeType + ':' + data.err.message
+          'Buffer add codec error for ' +
+            data.mimeType +
+            ':' +
+            data.error.message
         );
         break;
       case Hls.ErrorDetails.BUFFER_APPENDING_ERROR:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1540,7 +1540,9 @@ Full list of errors is described below:
 - `Hls.ErrorDetails.FRAG_PARSING_ERROR` - raised when fragment parsing fails
   - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.FRAG_PARSING_ERROR`, fatal : `true` or `false`, reason : failure reason }
 - `Hls.ErrorDetails.BUFFER_ADD_CODEC_ERROR` - raised when MediaSource fails to add new sourceBuffer
-  - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.BUFFER_ADD_CODEC_ERROR`, fatal : `false`, err : error raised by MediaSource, mimeType: mimeType on which the failure happened }
+  - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.BUFFER_ADD_CODEC_ERROR`, fatal : `false`, error : error raised by MediaSource, mimeType: mimeType on which the failure happened }
+- `Hls.ErrorDetails.BUFFER_INCOMPATIBLE_CODECS_ERROR` - raised when no MediaSource(s) could be created based on track codec(s)
+  - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.BUFFER_INCOMPATIBLE_CODECS_ERROR`, fatal : `true`, reason : failure reason }
 - `Hls.ErrorDetails.BUFFER_APPEND_ERROR` - raised when exception is raised while calling buffer append
   - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.BUFFER_APPEND_ERROR`, fatal : `true` or `false`, parent : parent stream controller }
 - `Hls.ErrorDetails.BUFFER_APPENDING_ERROR` - raised when exception is raised during buffer appending

--- a/docs/design.md
+++ b/docs/design.md
@@ -287,6 +287,7 @@ design idea is pretty simple :
   - if auto level switch is enabled and loaded frag level is greater than 0, this error is not fatal: in that case [src/controller/level-controller.ts][] will trigger an emergency switch down to level 0.
   - if frag level is 0 or auto level switch is disabled, this error is marked as fatal and a call to `hls.startLoad()` could help recover it.
 - `BUFFER_ADD_CODEC_ERROR` is raised by [src/controller/buffer-controller.ts][] when an exception is raised when calling mediaSource.addSourceBuffer(). this error is non fatal.
+- `BUFFER_INCOMPATIBLE_CODECS_ERROR` is raised by [src/controller/buffer-controller.ts][] when an exception is raised when all attempts to add SourceBuffer(s) failed. this error is fatal.
 - `BUFFER_APPEND_ERROR` is raised by [src/controller/buffer-controller.ts][] when an exception is raised when calling sourceBuffer.appendBuffer(). this error is non fatal and become fatal after config.appendErrorMaxRetry retries. when fatal, a call to `hls.recoverMediaError()` could help recover it.
 - `BUFFER_APPENDING_ERROR` is raised by [src/controller/buffer-controller.ts][] after SourceBuffer appending error. this error is fatal and a call to `hls.recoverMediaError()` could help recover it.
 - `BUFFER_FULL_ERROR` is raised by [src/controller/buffer-controller.ts][] if sourcebuffer is full

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -77,15 +77,9 @@ export default class TransmuxerInterface {
             details: ErrorDetails.INTERNAL_EXCEPTION,
             fatal: true,
             event: 'demuxerWorker',
-            err: {
-              message:
-                event.message +
-                ' (' +
-                event.filename +
-                ':' +
-                event.lineno +
-                ')',
-            },
+            error: new Error(
+              `${event.message}  (${event.filename}:${event.lineno})`
+            ),
           });
         };
         worker.postMessage({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -60,8 +60,10 @@ export enum ErrorDetails {
   KEY_LOAD_ERROR = 'keyLoadError',
   // Identifier for decrypt key load timeout error - data: { frag : fragment object}
   KEY_LOAD_TIMEOUT = 'keyLoadTimeOut',
-  // Triggered when an exception occurs while adding a sourceBuffer to MediaSource - data : {  err : exception , mimeType : mimeType }
+  // Triggered when an exception occurs while adding a sourceBuffer to MediaSource - data : { error : exception , mimeType : mimeType }
   BUFFER_ADD_CODEC_ERROR = 'bufferAddCodecError',
+  // Triggered when source buffer(s) could not be created using level (manifest CODECS attribute), parsed media, or best guess codec(s) - data: { reason : error reason }
+  BUFFER_INCOMPATIBLE_CODECS_ERROR = 'bufferIncompatibleCodecsError',
   // Identifier for a buffer append error - data: append error description
   BUFFER_APPEND_ERROR = 'bufferAppendError',
   // Identifier for a buffer appending error event - data: appending error description

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -1,10 +1,11 @@
-import type { InitData } from '../utils/mp4-tools';
+import type { InitData, InitDataTrack } from '../utils/mp4-tools';
 import {
   getDuration,
   getStartDTS,
   offsetStartDTS,
   parseInitSegment,
 } from '../utils/mp4-tools';
+import { ElementaryStreamTypes } from '../loader/fragment';
 import { logger } from '../utils/logger';
 import type { TrackSet } from '../types/track';
 import type {
@@ -60,14 +61,19 @@ class PassThroughRemuxer implements Remuxer {
     }
     const initData = (this.initData = parseInitSegment(initSegment));
 
-    // default audio codec if nothing specified
-    // TODO : extract that from initSegment
+    // Get codec from initSegment or fallback to default
     if (!audioCodec) {
-      audioCodec = 'mp4a.40.5';
+      audioCodec = getParsedTrackCodec(
+        initData.audio,
+        ElementaryStreamTypes.AUDIO
+      );
     }
 
     if (!videoCodec) {
-      videoCodec = 'avc1.42e01e';
+      videoCodec = getParsedTrackCodec(
+        initData.video,
+        ElementaryStreamTypes.VIDEO
+      );
     }
 
     const tracks: TrackSet = {};
@@ -207,4 +213,26 @@ class PassThroughRemuxer implements Remuxer {
 const computeInitPTS = (initData, data, timeOffset) =>
   getStartDTS(initData, data) - timeOffset;
 
+function getParsedTrackCodec(
+  track: InitDataTrack | undefined,
+  type: ElementaryStreamTypes.AUDIO | ElementaryStreamTypes.VIDEO
+): string {
+  const parsedCodec = track?.codec;
+  if (parsedCodec && parsedCodec.length > 4) {
+    return parsedCodec;
+  }
+  // Since mp4-tools cannot parse full codec string (see 'TODO: Parse codec details'... in mp4-tools)
+  // Provide defaults based on codec type
+  // This allows for some playback of some fmp4 playlists without CODECS defined in manifest
+  if (parsedCodec === 'hvc1') {
+    return 'hvc1.1.c.L120.90';
+  }
+  if (parsedCodec === 'av01') {
+    return 'av01.0.04M.08';
+  }
+  if (parsedCodec === 'avc1' || type === ElementaryStreamTypes.VIDEO) {
+    return 'avc1.42e01e';
+  }
+  return 'mp4a.40.5';
+}
 export default PassThroughRemuxer;

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -40,6 +40,7 @@ const sampleEntryCodesISO = {
     avc3: true,
     avc4: true,
     avcp: true,
+    av01: true,
     drac: true,
     dvav: true,
     dvhe: true,

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -10,8 +10,8 @@ type Mp4BoxData = {
 const UINT32_MAX = Math.pow(2, 32) - 1;
 const push = [].push;
 
-export function bin2str(buffer: Uint8Array): string {
-  return String.fromCharCode.apply(null, buffer);
+export function bin2str(data: Uint8Array): string {
+  return String.fromCharCode.apply(null, data);
 }
 
 export function readUint16(
@@ -230,7 +230,7 @@ export function parseSegmentIndex(initSegment: Uint8Array): SidxInfo | null {
  * the init segment is malformed.
  */
 
-interface InitDataTrack {
+export interface InitDataTrack {
   timescale: number;
   id: number;
   codec: string;
@@ -278,14 +278,19 @@ export function parseInitSegment(initSegment: Uint8Array): InitData {
             vide: ElementaryStreamTypes.VIDEO,
           }[hdlrType];
           if (type) {
-            // TODO: Parse codec details to be able to build MIME type.
-            const codexBoxes = findBox(trak, ['mdia', 'minf', 'stbl', 'stsd']);
+            // Parse codec details
+            const stsd = findBox(trak, ['mdia', 'minf', 'stbl', 'stsd'])[0];
             let codec;
-            if (codexBoxes.length) {
-              const codecBox = codexBoxes[0];
+            if (stsd) {
               codec = bin2str(
-                codecBox.data.subarray(codecBox.start + 12, codecBox.start + 16)
+                stsd.data.subarray(stsd.start + 12, stsd.start + 16)
               );
+              // TODO: Parse codec details to be able to build MIME type.
+              // stsd.start += 8;
+              // const codecBox = findBox(stsd, [codec])[0];
+              // if (codecBox) {
+              //   TODO: Codec parsing support for avc1, mp4a, hevc, av01...
+              // }
             }
             result[trackId] = { timescale, type };
             result[type] = { timescale, id: trackId, codec };

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -170,17 +170,22 @@ class XhrLoader implements Loader<LoaderContext> {
           }
           stats.loaded = stats.total = len;
 
-          const onProgress = this.callbacks!.onProgress;
+          if (!this.callbacks) {
+            return;
+          }
+          const onProgress = this.callbacks.onProgress;
           if (onProgress) {
             onProgress(stats, context, data, xhr);
           }
-
+          if (!this.callbacks) {
+            return;
+          }
           const response = {
             url: xhr.responseURL,
             data: data,
           };
 
-          this.callbacks!.onSuccess(response, stats, context, xhr);
+          this.callbacks.onSuccess(response, stats, context, xhr);
         } else {
           // if max nb of retries reached or if http status between 400 and 499 (such error cannot be recovered, retrying is useless), return error
           if (

--- a/tests/functional/auto/testbench.js
+++ b/tests/functional/auto/testbench.js
@@ -135,7 +135,9 @@ function startStream(streamUrl, config, callback, autoplay) {
         if (data.details === Hls.ErrorDetails.INTERNAL_EXCEPTION) {
           console.log('[test] > exception in :' + data.event);
           console.log(
-            data.err.stack ? JSON.stringify(data.err.stack) : data.err.message
+            data.error.stack
+              ? JSON.stringify(data.error.stack)
+              : data.error.message
           );
         }
         callback({ code: data.details, logs: logString });

--- a/tests/unit/controller/buffer-controller.js
+++ b/tests/unit/controller/buffer-controller.js
@@ -169,6 +169,7 @@ describe('BufferController tests', function () {
       bufferController.onMediaAttaching(Events.MEDIA_ATTACHING, {
         media: video,
       });
+      sandbox.stub(bufferController.mediaSource, 'addSourceBuffer');
 
       hls.on(Hls.Events.BUFFER_CREATED, (event, data) => {
         const tracks = data.tracks;
@@ -177,7 +178,20 @@ describe('BufferController tests', function () {
         done();
       });
 
-      bufferController.pendingTracks = { video: { codec: 'testing' } };
+      hls.once(Hls.Events.ERROR, (event, data) => {
+        // Async timeout prevents assertion from throwing in event handler
+        self.setTimeout(() => {
+          expect(data.error.message).to.equal(null);
+          done();
+        });
+      });
+
+      bufferController.pendingTracks = {
+        video: {
+          container: 'video/mp4',
+          codec: 'avc1.42e01e',
+        },
+      };
       bufferController.checkPendingTracks();
 
       video = null;


### PR DESCRIPTION
### This PR will...
1. - Fallback to mp4 passthough when probing fails (not mp3 transmux)
2. - Add 'av01' to video codecs lookup table
3. - Parse codec box with TODO
4. - Added fatal `BUFFER_INCOMPATIBLE_CODECS_ERROR` media error when all attempts to add SourceBuffers fail.
And `BUFFER_CREATED` no longer fires right after `BUFFER_ADD_CODEC_ERROR`.

### Why is this Pull Request needed?

1. Prevents hls.js from treating mp4 segments as audio/mpeg when probing fails.
2. Recognizes AV1 "av01" codec strings as video in manifest CODEC attributes.
3. Took the next step in parsing codecs from fmp4 data. Added better codec defaults for when hls.js only parses"hvc1" or "av01" from an init segment and manifest CODECS are missing.
4. A fatal error should be expected when all attempts to add SourceBuffers fail, and these failures should not trigger `BUFFER_CREATED`.

### Resolves issues:
Resolves #3669

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
