### PR TITLE
Fix uninitialized variable in basic usage example

### DIFF
--- a/demo/basic-usage.html
+++ b/demo/basic-usage.html
@@ -12,8 +12,8 @@
     </center>
 
     <script>
+      var video = document.getElementById('video');
       if (Hls.isSupported()) {
-        var video = document.getElementById('video');
         var hls = new Hls({
           debug: true,
         });


### PR DESCRIPTION
The basic usage example contains a bug in which, if HLS is not supported, the `video` variable will never be initialized. Yet the `else if` branch assumes that `video` contains a reference to the `<video>` element.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
