### PR TITLE
Calculate Live Drift

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1313,6 +1313,16 @@ export class LevelDetails {
     // (undocumented)
     deltaUpdateFailed?: boolean;
     // (undocumented)
+    get drift(): number;
+    // (undocumented)
+    driftEnd: number;
+    // (undocumented)
+    driftEndTime: number;
+    // (undocumented)
+    driftStart: number;
+    // (undocumented)
+    driftStartTime: number;
+    // (undocumented)
     get edge(): number;
     // (undocumented)
     endCC: number;

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -129,9 +129,6 @@ export default class BasePlaylistController implements NetworkComponentAPI {
       // Merge live playlists to adjust fragment starts and fill in delta playlist skipped segments
       if (previousDetails && details.fragments.length > 0) {
         LevelHelper.mergeDetails(previousDetails, details);
-        if (!details.advanced) {
-          details.advancedDateTime = previousDetails.advancedDateTime;
-        }
       }
       if (!this.canLoad || !details.live) {
         return;

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -92,6 +92,14 @@ export default class LatencyController implements ComponentAPI {
     return Math.min(Math.max(min, syncPosition), max);
   }
 
+  get drift(): number {
+    const { levelDetails } = this;
+    if (levelDetails === null) {
+      return 1;
+    }
+    return levelDetails.drift;
+  }
+
   get edgeStalled(): number {
     const { levelDetails } = this;
     if (levelDetails === null) {

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -275,6 +275,23 @@ export function mergeDetails(
   if (newFragments.length) {
     newDetails.totalduration = newDetails.edge - newFragments[0].start;
   }
+
+  newDetails.driftStartTime = oldDetails.driftStartTime;
+  newDetails.driftStart = oldDetails.driftStart;
+  const advancedDateTime = newDetails.advancedDateTime;
+  if (newDetails.advanced && advancedDateTime) {
+    const edge = newDetails.edge;
+    if (!newDetails.driftStart) {
+      newDetails.driftStartTime = advancedDateTime;
+      newDetails.driftStart = edge;
+    }
+    newDetails.driftEndTime = advancedDateTime;
+    newDetails.driftEnd = edge;
+  } else {
+    newDetails.driftEndTime = oldDetails.driftEndTime;
+    newDetails.driftEnd = oldDetails.driftEnd;
+    newDetails.advancedDateTime = oldDetails.advancedDateTime;
+  }
 }
 
 export function mapPartIntersection(

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -43,6 +43,10 @@ export class LevelDetails {
   public renditionReports?: AttrList[];
   public tuneInGoal: number = 0;
   public deltaUpdateFailed?: boolean;
+  public driftStartTime: number = 0;
+  public driftEndTime: number = 0;
+  public driftStart: number = 0;
+  public driftEnd: number = 0;
 
   constructor(baseUrl) {
     this.fragments = [];
@@ -86,6 +90,15 @@ export class LevelDetails {
       this.targetduration ||
       DEFAULT_TARGET_DURATION
     );
+  }
+
+  get drift(): number {
+    const runTime = this.driftEndTime - this.driftStartTime;
+    if (runTime > 0) {
+      const runDuration = this.driftEnd - this.driftStart;
+      return (runDuration * 1000) / runTime;
+    }
+    return 1;
   }
 
   get edge(): number {


### PR DESCRIPTION
### This PR will...
- Calculate drift (live edge advance rate) 
- Display live program date time in demo stats

### Why is this Pull Request needed?
Live streams do not always update at a steady rate. Drift reveals when a live stream's edge has not advanced as much as time has passed since it first advanced.

Displaying program date time in the demo and its distance from local date-time provides a second latency estimate, as well as get a rough idea of how accurate the stream PDT is.

Viewing drift for a live stream helps to explain why the latency metric may be artificially low or high, do to the rate at which the edge is advancing. At the same time the "seconds ago" PDT value can provide a sense of what time the encoder is assigning to the start of each segment, and how well it aligns with the edge update-based latency estimate.

![drift](https://user-images.githubusercontent.com/333258/112707885-07f19700-8e85-11eb-93ea-fd0ae490c48f.png)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
