### PR TITLE
Improve end-of-stream handling

### DIFF
--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -267,17 +267,7 @@ async function testSeekOnVOD(url, config) {
                   logs: self.logString,
                 });
               }
-            }, 3000);
-            self.setTimeout(function () {
-              const { currentTime, paused } = video;
-              callback({
-                code: 'timeout-waiting-for-ended-event',
-                currentTime,
-                duration,
-                paused,
-                logs: self.logString,
-              });
-            }, 10000);
+            }, 5000);
           };
           const seekToTime = video.seekable.end(0) - 3;
           console.log(
@@ -287,6 +277,16 @@ async function testSeekOnVOD(url, config) {
               seekToTime
           );
           video.currentTime = seekToTime;
+          self.setTimeout(function () {
+            const { currentTime, paused } = video;
+            callback({
+              code: 'timeout-waiting-for-ended-event',
+              currentTime,
+              duration,
+              paused,
+              logs: self.logString,
+            });
+          }, 12000);
         }, 3000);
       };
       // Fail test early if more than 2 buffered ranges are found (with configured exceptions)

--- a/tests/functional/auto/testbench.js
+++ b/tests/functional/auto/testbench.js
@@ -72,7 +72,7 @@ function objectAssign(target) {
     ) {
       var nextKey = keysArray[nextIndex];
       var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
-      if (desc?.enumerable) {
+      if (desc !== undefined && desc.enumerable) {
         to[nextKey] = nextSource[nextKey];
       }
     }


### PR DESCRIPTION
### This PR will...
Improve end-of-stream handling in Firefox and Safari with multi-track streams

### Why is this Pull Request needed?
Playback can stall when seeking to the end of streams. This is often why our functional tests fail in Safari and Firefox. These changes help the case where these tests would timeout completely because both 'seeked' and 'ended' events never fire.

HLS.js now calls `mediaSource.endOfStream()` **only once** after both audio and video tracks have appended their final segment, and both SourceBuffers are marked `ended` prevents playback from stalling while seeking to the end. The 'ended' event still may not fire in cases where audio and video are not aligned near the end.

Before, each call to `mediaSource.endOfStream()` triggered a "durationchange" on the video element. This was happening twice, once for each track, with some streams. Now, since the duration already set should match the end of the stream after both SourceBuffers are marked `ended`, we shouldn't see any additional "durationchange" events unless a level or track switch produces a new track end time.

Steps to repro:
1. Goto https://hls-js-dev.netlify.app/demo/?src=https%3A%2F%2Fplayertest.longtailvideo.com%2Fadaptive%2Felephants_dream_v4%2Findex.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOnRydWUsInN0b3BPblN0YWxsIjpmYWxzZSwiZHVtcGZNUDQiOmZhbHNlLCJsZXZlbENhcHBpbmciOi0xLCJsaW1pdE1ldHJpY3MiOi0xfQ==
2. Play
3. Seek to duration-3

Expected behavior:
Seeks and plays last 3 seconds then ends

Actual behavior:
Stalls in the "seeking" state at (duration-3) 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
