### PR TITLE
IE11, README v1, and Functional Test Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,18 @@ Find the commit on [https://github.com/video-dev/hls.js/blob/deployments/README.
 
 hls.js is only compatible with browsers supporting MediaSource extensions (MSE) API with 'video/MP4' mime-type inputs.
 
-Hls.js is supported on:
+hls.js is supported on:
 
-- Chrome for Android 39+
-- Chrome for Desktop 39+
-- Firefox for Android 41+
-- Firefox for Desktop 42+
-- IE11+ for Windows 8.1+
+- Chrome 39+ for Android
+- Chrome 39+ for Desktop
+- Firefox 41+ for Android
+- Firefox 42+ for Desktop
+- IE11 for Windows 8.1+
 - Edge for Windows 10+
-- Opera for Desktop
-- Vivaldi for Desktop
-- Safari for Mac 8+ (beta)
+- Safari 8+ for MacOS 10.10+
 - Safari for ipadOS 13+
+
+A [Promise polyfill](https://github.com/taylorhakes/promise-polyfill) is required in browsers missing native promise support.
 
 **Please note:** iOS Safari on iPhone does not support the MediaSource API. This includes all browsers on iOS as well as apps using UIWebView and WKWebView.
 
@@ -193,7 +193,7 @@ made by [gramk](https://github.com/gramk/chrome-hls), plays hls from address bar
 No external JS libs are needed.
 Prepackaged builds are included [with each release](https://github.com/video-dev/hls.js/releases).
 
-Hls.js can be installed as a dependency using npm:
+hls.js can be installed as a dependency using npm:
 
 ```
 npm install hls.js

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -841,6 +841,7 @@ class Hls implements HlsEventEmitter {
     static set DefaultConfig(defaultConfig: HlsConfig);
     destroy(): void;
     detachMedia(): void;
+    get drift(): number | null;
     // (undocumented)
     emit<E extends keyof HlsListeners>(event: E, name: E, eventObject: Parameters<HlsListeners[E]>[1]): boolean;
     // (undocumented)

--- a/demo/chart/timeline-chart.ts
+++ b/demo/chart/timeline-chart.ts
@@ -435,7 +435,7 @@ export class TimelineChart {
           sourceBuffer,
         })
       );
-      sourceBuffer.onupdate = () => {
+      sourceBuffer.addEventListener('update', () => {
         try {
           replaceTimeRangeTuples(sourceBuffer.buffered, data);
         } catch (error) {
@@ -445,7 +445,7 @@ export class TimelineChart {
         }
         replaceTimeRangeTuples(media.buffered, mediaBufferData);
         this.update();
-      };
+      });
     });
 
     if (trackTypes.length === 0) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -1215,9 +1215,7 @@ function checkBuffer() {
           `  Max Latency: ${hls.maxLatency}\n` +
           `  Target Latency: ${hls.targetLatency.toFixed(3)}\n` +
           `  Latency: ${hls.latency.toFixed(3)}\n` +
-          `  Drift: ${hls.latencyController.drift.toFixed(
-            3
-          )} (edge advance rate)\n` +
+          `  Drift: ${hls.drift.toFixed(3)} (edge advance rate)\n` +
           `  Edge Stall: ${hls.latencyController.edgeStalled.toFixed(
             3
           )} (playlist refresh over target duration/part)\n` +

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# API
+# HLS.js v1 API
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -1346,6 +1346,10 @@ returns 0 before first playlist is loaded
 ### `hls.targetLatency`
 
 get : target distance from the edge as calculated by the latency controller
+
+### `hls.drift`
+
+get : the rate at which the edge of the current live playlist is advancing or 1 if there is none
 
 ## Runtime Events
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:func": "BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "test:func:light": "BABEL_ENV=development HLSJS_LIGHT=1 mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "test:func:sauce": "SAUCE=1 UA=safari OS='OS X 10.15' BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
+    "test:func:sauce-ie": "SAUCE=1 UA='internet explorer' OS='Windows 10' BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch"
   },

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -312,10 +312,12 @@ export default class BaseStreamController
           return;
         }
         this.fragLoadError = 0;
+        const state = this.state;
         if (this.fragContextChanged(frag)) {
           if (
-            this.state === State.FRAG_LOADING ||
-            this.state === State.BACKTRACKING
+            state === State.FRAG_LOADING ||
+            state === State.BACKTRACKING ||
+            (!this.fragCurrent && state === State.PARSING)
           ) {
             this.fragmentTracker.removeFragment(frag);
             this.state = State.IDLE;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -398,7 +398,7 @@ export default class BufferController implements ComponentAPI {
             browser is able to evict some data from sourcebuffer. Retrying can help recover.
           */
           if (this.appendError > hls.config.appendErrorMaxRetry) {
-            logger.log(
+            logger.error(
               `[buffer-controller]: Failed ${hls.config.appendErrorMaxRetry} times to append segment in sourceBuffer`
             );
             event.fatal = true;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -470,11 +470,11 @@ export default class StreamController
 
   private abortCurrentFrag() {
     const fragCurrent = this.fragCurrent;
+    this.fragCurrent = null;
     if (fragCurrent?.loader) {
       fragCurrent.loader.abort();
     }
     this.nextLoadPosition = this.getLoadPosition();
-    this.fragCurrent = null;
   }
 
   protected flushMainBuffer(startOffset: number, endOffset: number) {

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -790,6 +790,14 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
+   * the rate at which the edge of the current live playlist is advancing or 1 if there is none
+   * @type {number}
+   */
+  get drift(): number | null {
+    return this.latencyController.drift;
+  }
+
+  /**
    * set to true when startLoad is called before MANIFEST_PARSED event
    * @type {boolean}
    */

--- a/tests/functional/auto/.eslintrc.js
+++ b/tests/functional/auto/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+  env: {
+    node: true,
+    commonjs: true,
+    es6: false,
+    mocha: true,
+  },
+  plugins: ['mocha', 'node'],
+  globals: {
+    // Test globals
+    after: false,
+    afterEach: false,
+    assert: false,
+    before: false,
+    beforeEach: false,
+    describe: false,
+    expect: true,
+    sinon: false,
+    xit: false,
+  },
+  rules: {
+    'object-shorthand': ['error', 'never'], // Object-shorthand not supported in IE11
+    // destructuring is not supported in IE11. This does not prevent it.
+    // ES6 env settings in parent files cannot be overwritten.
+    'prefer-destructuring': ['error', { object: false, array: false }],
+    'one-var': 0,
+    'no-undefined': 0,
+    'no-unused-expressions': 0,
+    'no-restricted-properties': [
+      2,
+      { property: 'findIndex' }, // Intended to block usage of Array.prototype.findIndex
+      { property: 'find' }, // Intended to block usage of Array.prototype.find
+      { property: 'only' }, // Intended to block usage of it.only in commits
+    ],
+    'node/no-restricted-require': ['error', ['assert']],
+    'mocha/no-mocha-arrows': 2,
+  },
+};

--- a/tests/functional/auto/index-light.html
+++ b/tests/functional/auto/index-light.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="style.css" />
+    <script src="../../../node_modules/promise-polyfill/dist/polyfill.min.js"></script>
     <script src="../../../dist/hls.light.min.js"></script>
     <script src="testbench.js"></script>
   </head>

--- a/tests/functional/auto/index.html
+++ b/tests/functional/auto/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="style.css" />
+    <script src="../../../node_modules/promise-polyfill/dist/polyfill.min.js"></script>
     <script src="../../../dist/hls.min.js"></script>
     <script src="testbench.js"></script>
   </head>

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -4,29 +4,29 @@
  * @param {string} description
  * @param {boolean} [live]
  * @param {boolean} [abr]
- * @param {string[]} [blacklist_ua]
- * @returns {{url: string, description: string, live: boolean, abr: boolean, blacklist_ua: string[]}}
+ * @param {string[]} [skip_ua]
+ * @returns {{url: string, description: string, live: boolean, abr: boolean, skip_ua: string[]}}
  */
 function createTestStream(
   url,
   description,
   live = false,
   abr = true,
-  blacklist_ua = []
+  skip_ua = []
 ) {
   return {
-    url,
-    description,
-    live,
-    abr,
-    blacklist_ua,
+    url: url,
+    description: description,
+    live: live,
+    abr: abr,
+    skip_ua: skip_ua,
   };
 }
 
 /**
  * @param {Object} target
  * @param {Object} [config]
- * @returns {{url: string, description: string, live: boolean, abr: boolean, blacklist_ua: string[]}}
+ * @returns {{url: string, description: string, live: boolean, abr: boolean, skip_ua: string[]}}
  */
 function createTestStreamWithConfig(target, config) {
   if (typeof target !== 'object') {
@@ -38,7 +38,7 @@ function createTestStreamWithConfig(target, config) {
     target.description,
     target.live,
     target.abr,
-    target.blacklist_ua
+    target.skip_ua
   );
 
   testStream.config = config;
@@ -62,7 +62,7 @@ module.exports = {
       'https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8',
     description: 'Big Buck Bunny - 480p only',
     abr: false,
-    blacklist_ua: ['internet explorer'],
+    skip_ua: ['internet explorer'],
   },
   arte: {
     url: 'https://test-streams.mux.dev/test_001/stream.m3u8',
@@ -74,7 +74,7 @@ module.exports = {
       'https://test-streams.mux.dev/dai-discontinuity-deltatre/manifest.m3u8',
     description: 'Ad-insertion in event stream',
     abr: false,
-    blacklist_ua: ['internet explorer'],
+    skip_ua: ['internet explorer'],
   },
   issue666: {
     url:
@@ -82,7 +82,7 @@ module.exports = {
     description:
       'Surveillance footage - https://github.com/video-dev/hls.js/issues/666',
     abr: false,
-    blacklist_ua: ['internet explorer'],
+    skip_ua: ['internet explorer'],
   },
   closedCaptions: {
     url: 'https://playertest.longtailvideo.com/adaptive/captions/playlist.m3u8',
@@ -111,21 +111,21 @@ module.exports = {
     url: 'https://pl.streamingvideoprovider.com/mp3-playlist/playlist.m3u8',
     description: 'MPEG Audio Only demo',
     abr: false,
-    blacklist_ua: ['internet explorer', 'MicrosoftEdge', 'firefox'],
+    skip_ua: ['internet explorer', 'MicrosoftEdge', 'firefox'],
   },
   fmp4: {
     url:
       'https://storage.googleapis.com/shaka-demo-assets/angel-one-hls/hls.m3u8',
     description: 'HLS fMP4 Angel-One multiple audio-tracks',
     abr: true,
-    blacklist_ua: ['internet explorer'],
+    skip_ua: ['internet explorer'],
   },
   fmp4Bitmovin: {
     url:
       'https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
     description: 'HLS fMP4 by Bitmovin',
     abr: true,
-    blacklist_ua: ['internet explorer'],
+    skip_ua: ['internet explorer'],
   },
   fmp4BitmovinHevc: {
     url:
@@ -133,7 +133,7 @@ module.exports = {
     description:
       'HLS HEVC fMP4 by Bitmovin (Safari and Edge? only as of 2020-08)',
     abr: true,
-    blacklist_ua: ['internet explorer'],
+    skip_ua: ['internet explorer'],
     skipFunctionalTests: true,
   },
   offset_pts: {
@@ -148,7 +148,7 @@ module.exports = {
       description:
         'Shaka-packager Widevine DRM (EME) HLS-fMP4 - Angel One Demo',
       abr: true,
-      blacklist_ua: [
+      skip_ua: [
         'firefox',
         'safari',
         'internet explorer',


### PR DESCRIPTION
### This PR will...
- Update README for v1
- Add [`drift`](https://github.com/video-dev/hls.js/pull/3690) to public API
- Include Promise polyfill in functional tests for IE11 and legacy Edge browsers
- Fix IE11 smooth switch stuck in PARSING state
- Fix demo Timeline media buffers in IE11
- Do not allow object-shorthand and remove destructuring in functional test scripts (not supported by IE11)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] API or design changes are documented in API.md
