### PR TITLE
Remove Loader.loader and replace Loader.getResponseHeader() with Laoder.getCacheAge()

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1555,8 +1555,7 @@ export interface Loader<T extends LoaderContext> {
     context: T;
     // (undocumented)
     destroy(): void;
-    // (undocumented)
-    getResponseHeader(name: string): string | null;
+    getCacheAge(): number;
     // (undocumented)
     load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<T>): void;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1560,8 +1560,6 @@ export interface Loader<T extends LoaderContext> {
     // (undocumented)
     load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<T>): void;
     // (undocumented)
-    loader: any;
-    // (undocumented)
     stats: LoaderStats;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6007,6 +6007,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -10966,6 +10976,13 @@
       "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -15800,6 +15817,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -21861,7 +21885,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -22511,7 +22539,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -684,8 +684,7 @@ class PlaylistLoader {
     }
 
     if (levelDetails.live) {
-      const ageHeader = loader.getResponseHeader('age');
-      levelDetails.ageHeader = ageHeader ? parseFloat(ageHeader) : 0;
+      levelDetails.ageHeader = loader.getCacheAge();
     }
 
     switch (type) {

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -122,7 +122,6 @@ export interface Loader<T extends LoaderContext> {
   ): void;
   getResponseHeader(name: string): string | null;
   context: T;
-  loader: any;
   stats: LoaderStats;
 }
 

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -120,7 +120,11 @@ export interface Loader<T extends LoaderContext> {
     config: LoaderConfiguration,
     callbacks: LoaderCallbacks<T>
   ): void;
-  getResponseHeader(name: string): string | null;
+  /**
+   * Returns the time, in seconds, that this object has been in a proxy cache.
+   * For HTTP based loaders, this returns the value of the "age" HTTP header.
+   */
+  getCacheAge(): number;
   context: T;
   stats: LoaderStats;
 }

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -37,7 +37,7 @@ class FetchLoader implements Loader<LoaderContext> {
   private config: LoaderConfiguration | null = null;
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public stats: LoaderStats;
-  public loader: Response | null = null;
+  private loader: Response | null = null;
 
   constructor(config /* HlsConfig */) {
     this.fetchSetup = config.fetchSetup || getRequest;

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -160,15 +160,13 @@ class FetchLoader implements Loader<LoaderContext> {
       });
   }
 
-  getResponseHeader(name: string): string | null {
+  getCacheAge(): number {
+    let result: number = 0;
     if (this.response) {
-      try {
-        return this.response.headers.get(name);
-      } catch (error) {
-        /* Could not get header */
-      }
+      const ageHeader = this.response.headers.get('age');
+      result = ageHeader ? parseFloat(ageHeader) : 0;
     }
-    return null;
+    return result;
   }
 
   private loadProgressively(

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -17,7 +17,7 @@ class XhrLoader implements Loader<LoaderContext> {
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public context!: LoaderContext;
 
-  public loader: XMLHttpRequest | null = null;
+  private loader: XMLHttpRequest | null = null;
   public stats: LoaderStats;
 
   constructor(config /* HlsConfig */) {

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -249,11 +249,16 @@ class XhrLoader implements Loader<LoaderContext> {
     }
   }
 
-  getResponseHeader(name: string): string | null {
-    if (this.loader && this.loader.getAllResponseHeaders().indexOf(name) >= 0) {
-      return this.loader.getResponseHeader(name);
+  getCacheAge(): number {
+    let result: number = 0;
+    if (
+      this.loader &&
+      this.loader.getAllResponseHeaders().indexOf('age') >= 0
+    ) {
+      const ageHeader = this.loader.getResponseHeader('age');
+      result = ageHeader ? parseFloat(ageHeader) : 0;
     }
-    return null;
+    return result;
   }
 }
 

--- a/tests/unit/loader/fragment-loader.ts
+++ b/tests/unit/loader/fragment-loader.ts
@@ -35,8 +35,8 @@ class MockXhr implements Loader<LoaderContext> {
 
   abort() {}
   destroy(): void {}
-  getResponseHeader(name: string): string | null {
-    return null;
+  getCacheAge(): number {
+    return 0;
   }
 }
 

--- a/tests/unit/loader/fragment-loader.ts
+++ b/tests/unit/loader/fragment-loader.ts
@@ -22,7 +22,6 @@ const expect = chai.expect;
 
 class MockXhr implements Loader<LoaderContext> {
   context!: LoaderContext;
-  loader: any;
   stats: LoadStats;
   callbacks?: LoaderCallbacks<FragmentLoaderContext>;
 


### PR DESCRIPTION
### This PR removes `Loader.loader` replaces `Loader.getResponseHeader()` with `Loader.getCacheAge()`.

### Why is this Pull Request needed?

This is two small changes in one PR, but they're both related to the Loader API.

#### Loader.loader

First: The `Loader` interface has a property named `loader` of type `any`.  This property is not read by any hls.js code.  The two implementations of loader (xhr-loader and fetch-loader) set this to an XMLHttpRequest and a fetch Response, respectively.

I'm writing a loader that loads data from a local cache - I don't even have an HTTP request involved in my loader, so I have nothing to put here.  But, since no one reads from it anyways, easiest just to remove it, and then I don't have to set it to `undefined`.  The existing `MockXhr` loader is an example of a loader, used in fragment loading tests, is another example of a loader that never defines this.

I'm not sure why this property was here in the first place - was it maybe intended to make it so third parties could read from the response when they instantiate a loader?  We could leave it `public` in fetch-loader and xhr-loader I suppose, but again I'm not sure what it's for.

#### Loader.getResponseHeader()

The second change: Loader has a function called `getResponseHeader()` (again, added in 1.0.0), which returns the value of a response header.  It's used to find the "age" header to see if a request has been in a proxy for a while, when playing live.

But, this API is way too broad - first it assumes the underlying transport is HTTP based.  If the underlying transport is something else, like WebRTC or websocket, what should `getResponseHeader()` return?  Or what if (as in my above case) you're caching playlists locally?  You could argue it should just return undefined for WebRTC and websocket, and maybe in my local cache case I should construct an "age" based on how long I've cached it, but making such an argument implies that `getResponseHeader()` will only ever be used to fetch the "age" header.  But there's nothing about this API which restricts hls.js from calling it and asking for other headers.

So, as an implementer, you're left trying to work out what possible HTTP headers hls.js might want in this or future versions, and trying to reconstruct them from whatever data you have available to you from your transport.  I replaced this with `getCacheAge()`, which is a much nicer API to try to implement as someone writing a non-HTTP loader.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

None.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
