### PR TITLE
fix(types): Remove unused Loader.loader property.

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1560,8 +1560,6 @@ export interface Loader<T extends LoaderContext> {
     // (undocumented)
     load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<T>): void;
     // (undocumented)
-    loader: any;
-    // (undocumented)
     stats: LoaderStats;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6007,6 +6007,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -10966,6 +10976,13 @@
       "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -15800,6 +15817,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -21861,7 +21885,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -22511,7 +22539,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -122,7 +122,6 @@ export interface Loader<T extends LoaderContext> {
   ): void;
   getResponseHeader(name: string): string | null;
   context: T;
-  loader: any;
   stats: LoaderStats;
 }
 

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -37,7 +37,7 @@ class FetchLoader implements Loader<LoaderContext> {
   private config: LoaderConfiguration | null = null;
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public stats: LoaderStats;
-  public loader: Response | null = null;
+  private loader: Response | null = null;
 
   constructor(config /* HlsConfig */) {
     this.fetchSetup = config.fetchSetup || getRequest;

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -17,7 +17,7 @@ class XhrLoader implements Loader<LoaderContext> {
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public context!: LoaderContext;
 
-  public loader: XMLHttpRequest | null = null;
+  private loader: XMLHttpRequest | null = null;
   public stats: LoaderStats;
 
   constructor(config /* HlsConfig */) {

--- a/tests/unit/loader/fragment-loader.ts
+++ b/tests/unit/loader/fragment-loader.ts
@@ -22,7 +22,6 @@ const expect = chai.expect;
 
 class MockXhr implements Loader<LoaderContext> {
   context!: LoaderContext;
-  loader: any;
   stats: LoadStats;
   callbacks?: LoaderCallbacks<FragmentLoaderContext>;
 


### PR DESCRIPTION
### This PR removes `Loader.loader`

### Why is this Pull Request needed?

(This is the non-breaking part of https://github.com/video-dev/hls.js/pull/3707).

The `Loader` interface has a property named `loader` of type `any`.  This property is not read by any hls.js code.  The two implementations of loader (xhr-loader and fetch-loader) set this to an XMLHttpRequest and a fetch Response, respectively.

I'm writing a loader that loads data from a local cache - I don't even have an HTTP request involved in my loader, so I have nothing to put here.  But, since no one reads from it anyways, easiest just to remove it, and then I don't have to set it to `undefined`.  The existing `MockXhr` loader is an example of a loader, used in fragment loading tests, is another example of a loader that never defines this.

I'm not sure why this property was here in the first place - was it maybe intended to make it so third parties could read from the response when they instantiate a loader?  We could leave it `public` in fetch-loader and xhr-loader I suppose, but again I'm not sure what it's for.

This is a non-breaking change, because we're just removing a property - if implementations of `Loader` still have this property that's fine - hls.js will continue to ignore them.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

None.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
