### PR TITLE
fix: stopLoad() after destroy() becomes no-op, startLoad() after destroy() throws nicer error message.

### DIFF
--- a/src/hls.ts
+++ b/src/hls.ts
@@ -40,7 +40,7 @@ export default class Hls implements HlsEventEmitter {
   public readonly userConfig: Partial<HlsConfig>;
 
   private coreComponents: ComponentAPI[];
-  private networkControllers: NetworkComponentAPI[] | undefined;
+  private networkControllers: NetworkComponentAPI[];
 
   private _emitter: HlsEventEmitter = new EventEmitter();
   private _autoLevelCapping: number;
@@ -282,15 +282,12 @@ export default class Hls implements HlsEventEmitter {
     this.removeAllListeners();
     this._autoLevelCapping = -1;
     this.url = null;
-    if (this.networkControllers) {
-      this.networkControllers.forEach((component) => component.destroy());
-      this.networkControllers = undefined;
-    }
-    if (this.coreComponents) {
-      this.coreComponents.forEach((component) => component.destroy());
-      // @ts-ignore
-      this.coreComponents = null;
-    }
+
+    this.networkControllers.forEach((component) => component.destroy());
+    this.networkControllers.length = 0;
+
+    this.coreComponents.forEach((component) => component.destroy());
+    this.coreComponents.length = 0;
   }
 
   /**
@@ -341,9 +338,6 @@ export default class Hls implements HlsEventEmitter {
    */
   startLoad(startPosition: number = -1) {
     logger.log(`startLoad(${startPosition})`);
-    if (!this.networkControllers) {
-      throw new Error('Cannot call `startLoad()` on destroyed instance of hls');
-    }
     this.networkControllers.forEach((controller) => {
       controller.startLoad(startPosition);
     });
@@ -354,11 +348,9 @@ export default class Hls implements HlsEventEmitter {
    */
   stopLoad() {
     logger.log('stopLoad');
-    if (this.networkControllers) {
-      this.networkControllers.forEach((controller) => {
-        controller.stopLoad();
-      });
-    }
+    this.networkControllers.forEach((controller) => {
+      controller.stopLoad();
+    });
   }
 
   /**

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -40,7 +40,7 @@ export default class Hls implements HlsEventEmitter {
   public readonly userConfig: Partial<HlsConfig>;
 
   private coreComponents: ComponentAPI[];
-  private networkControllers: NetworkComponentAPI[];
+  private networkControllers: NetworkComponentAPI[] | undefined;
 
   private _emitter: HlsEventEmitter = new EventEmitter();
   private _autoLevelCapping: number;
@@ -284,8 +284,7 @@ export default class Hls implements HlsEventEmitter {
     this.url = null;
     if (this.networkControllers) {
       this.networkControllers.forEach((component) => component.destroy());
-      // @ts-ignore
-      this.networkControllers = null;
+      this.networkControllers = undefined;
     }
     if (this.coreComponents) {
       this.coreComponents.forEach((component) => component.destroy());
@@ -342,6 +341,9 @@ export default class Hls implements HlsEventEmitter {
    */
   startLoad(startPosition: number = -1) {
     logger.log(`startLoad(${startPosition})`);
+    if (!this.networkControllers) {
+      throw new Error('Cannot call `startLoad()` on destroyed instance of hls');
+    }
     this.networkControllers.forEach((controller) => {
       controller.startLoad(startPosition);
     });
@@ -352,9 +354,11 @@ export default class Hls implements HlsEventEmitter {
    */
   stopLoad() {
     logger.log('stopLoad');
-    this.networkControllers.forEach((controller) => {
-      controller.stopLoad();
-    });
+    if (this.networkControllers) {
+      this.networkControllers.forEach((controller) => {
+        controller.stopLoad();
+      });
+    }
   }
 
   /**

--- a/tests/unit/hls.js
+++ b/tests/unit/hls.js
@@ -1,5 +1,6 @@
 import Hls from '../../src/hls';
 import { hlsDefaultConfig } from '../../src/config';
+import { expect } from 'chai';
 
 describe('Hls', function () {
   describe('bandwidthEstimate', function () {
@@ -18,6 +19,22 @@ describe('Hls', function () {
       const hls = new Hls();
       expect(hls.bandwidthEstimate).to.equal(
         hlsDefaultConfig.abrEwmaDefaultEstimate
+      );
+    });
+  });
+
+  describe('destroy', function () {
+    it('should allow stopLoad() after destroy()', function () {
+      const hls = new Hls();
+      hls.destroy();
+      expect(() => hls.stopLoad()).to.not.throw();
+    });
+
+    it('should not allow startLoad() after destroy()', function () {
+      const hls = new Hls();
+      hls.destroy();
+      expect(() => hls.startLoad()).to.throw(
+        'Cannot call `startLoad()` on destroyed instance of hls'
       );
     });
   });

--- a/tests/unit/hls.js
+++ b/tests/unit/hls.js
@@ -24,18 +24,16 @@ describe('Hls', function () {
   });
 
   describe('destroy', function () {
-    it('should allow stopLoad() after destroy()', function () {
+    it('should not crash on stopLoad() after destroy()', function () {
       const hls = new Hls();
       hls.destroy();
       expect(() => hls.stopLoad()).to.not.throw();
     });
 
-    it('should not allow startLoad() after destroy()', function () {
+    it('should not crash on startLoad() after destroy()', function () {
       const hls = new Hls();
       hls.destroy();
-      expect(() => hls.startLoad()).to.throw(
-        'Cannot call `startLoad()` on destroyed instance of hls'
-      );
+      expect(() => hls.startLoad()).to.not.throw();
     });
   });
 });


### PR DESCRIPTION
### This PR will make error messages nicer when you call stopLoad() or startLoad() after calling destroy.

### Why is this Pull Request needed?

This is a super minor fix.  I was getting the very unhelpful error: `TypeError: Cannot read property 'forEach' of null`.  It turns out I was calling `stopLoad()` after calling `destroy()`, and was running into:

```ts
this.networkControllers.forEach(...
```

but `this.networkControllers` had been set to `null` in the `destroy()` function.

So this change:

* Makes it so `networkControllers` is defined as an array or undefined.
* Handles the case where you call `stopLoad()` when `networkControllers` is undefined (this is a no-op now).
* Throws a slightly more user friendly "Cannot call `startLoad()` on destroyed instance of hls" when you call `startLoad()` after calling `destroy()`.

### Are there any points in the code the reviewer needs to double check?

No

### Resolves issues:

None.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
