### PR TITLE
fix: Replace Loader.getResponseHeader() with Loader.getCacheAge().

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1555,8 +1555,9 @@ export interface Loader<T extends LoaderContext> {
     context: T;
     // (undocumented)
     destroy(): void;
-    // (undocumented)
-    getResponseHeader(name: string): string | null;
+    getCacheAge?: () => number;
+    // @deprecated
+    getResponseHeader?: (name: 'age') => string | null;
     // (undocumented)
     load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<T>): void;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1555,9 +1555,7 @@ export interface Loader<T extends LoaderContext> {
     context: T;
     // (undocumented)
     destroy(): void;
-    getCacheAge?: () => number;
-    // @deprecated
-    getResponseHeader?: (name: 'age') => string | null;
+    getCacheAge?: () => number | null;
     // (undocumented)
     load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<T>): void;
     // (undocumented)

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -684,8 +684,14 @@ class PlaylistLoader {
     }
 
     if (levelDetails.live) {
-      const ageHeader = loader.getResponseHeader('age');
-      levelDetails.ageHeader = ageHeader ? parseFloat(ageHeader) : 0;
+      if (loader.getCacheAge) {
+        levelDetails.ageHeader = loader.getCacheAge();
+      } else if (loader.getResponseHeader) {
+        const ageHeaderStr = loader.getResponseHeader('age');
+        levelDetails.ageHeader = ageHeaderStr ? parseFloat(ageHeaderStr) : 0;
+      } else {
+        levelDetails.ageHeader = 0;
+      }
     }
 
     switch (type) {

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -685,11 +685,9 @@ class PlaylistLoader {
 
     if (levelDetails.live) {
       if (loader.getCacheAge) {
-        levelDetails.ageHeader = loader.getCacheAge();
-      } else if (loader.getResponseHeader) {
-        const ageHeaderStr = loader.getResponseHeader('age');
-        levelDetails.ageHeader = ageHeaderStr ? parseFloat(ageHeaderStr) : 0;
-      } else {
+        levelDetails.ageHeader = loader.getCacheAge() || 0;
+      }
+      if (!loader.getCacheAge || isNaN(levelDetails.ageHeader)) {
         levelDetails.ageHeader = 0;
       }
     }

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -120,7 +120,30 @@ export interface Loader<T extends LoaderContext> {
     config: LoaderConfiguration,
     callbacks: LoaderCallbacks<T>
   ): void;
-  getResponseHeader(name: string): string | null;
+  /**
+   * `getCacheAge()` is called by hls.js to get the duration that a given object
+   * has been sitting in a cache proxy when playing live.  If implemented,
+   * this should return a value in seconds.
+   *
+   * For HTTP based loaders, this should return the contents of the "age" header.
+   *
+   * @returns time object being lodaded
+   */
+  getCacheAge?: () => number;
+  /**
+   * `getResponseHeader()` is called by hls.js to get the duration that a given
+   * object has been sitting in a proxy cache when playing live.
+   *
+   * For HTTP based loaders, this should just return the "age" header.  For
+   * non-HTTP based loaders, if the retrieved object has been cached, this
+   * should return the time the object has been in a cache, as a string, possibly
+   * with a decimal point.  Otherwise implementers should return "0" or null.
+   *
+   * Note that HLS.js will never call this for a header other than "age".
+   *
+   * @deprecated - Implement `getCacheAge()` instead.
+   */
+  getResponseHeader?: (name: 'age') => string | null;
   context: T;
   loader: any;
   stats: LoaderStats;

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -129,21 +129,7 @@ export interface Loader<T extends LoaderContext> {
    *
    * @returns time object being lodaded
    */
-  getCacheAge?: () => number;
-  /**
-   * `getResponseHeader()` is called by hls.js to get the duration that a given
-   * object has been sitting in a proxy cache when playing live.
-   *
-   * For HTTP based loaders, this should just return the "age" header.  For
-   * non-HTTP based loaders, if the retrieved object has been cached, this
-   * should return the time the object has been in a cache, as a string, possibly
-   * with a decimal point.  Otherwise implementers should return "0" or null.
-   *
-   * Note that HLS.js will never call this for a header other than "age".
-   *
-   * @deprecated - Implement `getCacheAge()` instead.
-   */
-  getResponseHeader?: (name: 'age') => string | null;
+  getCacheAge?: () => number | null;
   context: T;
   loader: any;
   stats: LoaderStats;

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -160,11 +160,11 @@ class FetchLoader implements Loader<LoaderContext> {
       });
   }
 
-  getCacheAge(): number {
-    let result: number = 0;
+  getCacheAge(): number | null {
+    let result: number | null = null;
     if (this.response) {
       const ageHeader = this.response.headers.get('age');
-      result = ageHeader ? parseFloat(ageHeader) : 0;
+      result = ageHeader ? parseFloat(ageHeader) : null;
     }
     return result;
   }

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -160,15 +160,13 @@ class FetchLoader implements Loader<LoaderContext> {
       });
   }
 
-  getResponseHeader(name: string): string | null {
+  getCacheAge(): number {
+    let result: number = 0;
     if (this.response) {
-      try {
-        return this.response.headers.get(name);
-      } catch (error) {
-        /* Could not get header */
-      }
+      const ageHeader = this.response.headers.get('age');
+      result = ageHeader ? parseFloat(ageHeader) : 0;
     }
-    return null;
+    return result;
   }
 
   private loadProgressively(

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -249,14 +249,14 @@ class XhrLoader implements Loader<LoaderContext> {
     }
   }
 
-  getCacheAge(): number {
-    let result: number = 0;
+  getCacheAge(): number | null {
+    let result: number | null = null;
     if (
       this.loader &&
       this.loader.getAllResponseHeaders().indexOf('age') >= 0
     ) {
       const ageHeader = this.loader.getResponseHeader('age');
-      result = ageHeader ? parseFloat(ageHeader) : 0;
+      result = ageHeader ? parseFloat(ageHeader) : null;
     }
     return result;
   }

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -249,11 +249,16 @@ class XhrLoader implements Loader<LoaderContext> {
     }
   }
 
-  getResponseHeader(name: string): string | null {
-    if (this.loader && this.loader.getAllResponseHeaders().indexOf(name) >= 0) {
-      return this.loader.getResponseHeader(name);
+  getCacheAge(): number {
+    let result: number = 0;
+    if (
+      this.loader &&
+      this.loader.getAllResponseHeaders().indexOf('age') >= 0
+    ) {
+      const ageHeader = this.loader.getResponseHeader('age');
+      result = ageHeader ? parseFloat(ageHeader) : 0;
     }
-    return null;
+    return result;
   }
 }
 

--- a/tests/unit/loader/fragment-loader.ts
+++ b/tests/unit/loader/fragment-loader.ts
@@ -36,9 +36,6 @@ class MockXhr implements Loader<LoaderContext> {
 
   abort() {}
   destroy(): void {}
-  getResponseHeader(name: string): string | null {
-    return null;
-  }
 }
 
 describe('FragmentLoader tests', function () {


### PR DESCRIPTION
### This PR will replace `Loader.getResponseHeader()` with `Loader.getCacheAge()`, in a backward-compatibly fashion.

### Why is this Pull Request needed?

Loader has a function called getResponseHeader() (added in 1.0.0), which returns the value of a response header. It's used to find the "age" header to see if a request has been in a proxy for a while, when playing live.

But, this API is way too broad - first it assumes the underlying transport is HTTP based. If the underlying transport is something else, like WebRTC or websocket, what should getResponseHeader() return? Or, in my case, I have a caching loader which caches playlists locally, and my HTTP headers are long gone (and if I wanted to save them explicitly for the loader, it wouldn't even be useful, because the "age" header would be out of date by the time my loader fetches them).

You could argue it should just return undefined for WebRTC and websocket, and maybe in my local cache case I should construct an "age" based on how long I've cached it, but making such an argument implies that getResponseHeader() will only ever be used to fetch the "age" header. But there's nothing about this API which restricts hls.js from calling it and asking for other headers.  As an implementer, you're left trying to work out what possible HTTP headers hls.js might want in this or future versions, and trying to reconstruct them from whatever data you have available to you from your transport. 

This PR replaces `getResponseHeader()` with `getCacheAge()`, which is a much nicer API to try to implement as someone writing a non-HTTP loader.  This PR leaves `getResponseHeader()` in place as a `@deprecated` API, so that existing implmentations won't break with this change, and further specifies it as `getResponseHeader(name: 'age')`, which guarantees that hls.js will never call it with something other than "age", but still allows existing implementations with `(name: string)` to continue to work.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

None.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
