### PR TITLE
Use track name over track index, fixes unordered track group switching

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -84,6 +84,8 @@ export interface AudioTrackSwitchingData {
     // (undocumented)
     id: number;
     // (undocumented)
+    name: string;
+    // (undocumented)
     type: MediaPlaylistType | 'main';
     // (undocumented)
     url: string;
@@ -2007,6 +2009,8 @@ export interface SubtitleTracksUpdatedData {
 export interface SubtitleTrackSwitchData {
     // (undocumented)
     id: number;
+    // (undocumented)
+    name?: string;
     // (undocumented)
     type?: MediaPlaylistType | 'main';
     // (undocumented)

--- a/demo/chart/timeline-chart.ts
+++ b/demo/chart/timeline-chart.ts
@@ -666,6 +666,9 @@ export class TimelineChart {
 }
 
 function stripDeliveryDirectives(url: string): string {
+  if (url === '') {
+    return url;
+  }
   try {
     const webUrl: URL = new self.URL(url);
     webUrl.searchParams.delete('_HLS_msn');

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -354,8 +354,8 @@ class SubtitleTrackController extends BasePlaylistController {
     this.log(`Switching to subtitle track ${newId}`);
     this.trackId = newId;
     if (track) {
-      const { url, type, id } = track;
-      this.hls.trigger(Events.SUBTITLE_TRACK_SWITCH, { id, type, url });
+      const { id, name, type, url } = track;
+      this.hls.trigger(Events.SUBTITLE_TRACK_SWITCH, { id, name, type, url });
       const hlsUrlParameters = this.switchParams(track.url, lastTrack?.details);
       this.loadPlaylist(hlsUrlParameters);
     } else {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -153,9 +153,10 @@ export interface LevelPTSUpdatedData {
 }
 
 export interface AudioTrackSwitchingData {
-  url: string;
-  type: MediaPlaylistType | 'main';
   id: number;
+  name: string;
+  type: MediaPlaylistType | 'main';
+  url: string;
 }
 
 export interface AudioTrackSwitchedData {
@@ -173,9 +174,10 @@ export interface SubtitleTracksUpdatedData {
 }
 
 export interface SubtitleTrackSwitchData {
-  url?: string;
-  type?: MediaPlaylistType | 'main';
   id: number;
+  name?: string;
+  type?: MediaPlaylistType | 'main';
+  url?: string;
 }
 
 export interface SubtitleTrackLoadedData extends TrackLoadedData {}

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -129,6 +129,7 @@ describe('SubtitleTrackController', function () {
         'hlsSubtitleTrackSwitch',
         {
           id: 1,
+          name: 'English',
           type: 'SUBTITLES',
           url: 'bar',
         }
@@ -163,6 +164,7 @@ describe('SubtitleTrackController', function () {
         'hlsSubtitleTrackSwitch',
         {
           id: 0,
+          name: 'English',
           type: 'SUBTITLES',
           url: 'baz',
         }


### PR DESCRIPTION
### This PR will...
- Use track name over track index, fixes unordered track group switching
- Adds 'name' property to audio and subtitle track switching events
- Sets `selectDefaultTrack` to `false` so that track name matching works when indexes are not aligned / there's a default track and no manual track selection to disable first

### Why is this Pull Request needed?
Fixes an exception when switching levels that use audio groups with inconsistent track order (and a default track) 

### Resolves issues:
Resolves #3729

### Checklist

- [x] changes have been done against master branch, and PR does not conflict

