### PR TITLE
Fix fmp4 segmented audio group switching

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -82,6 +82,8 @@ export interface AudioTrackSwitchedData {
 // @public (undocumented)
 export interface AudioTrackSwitchingData {
     // (undocumented)
+    groupId: string;
+    // (undocumented)
     id: number;
     // (undocumented)
     name: string;
@@ -2007,6 +2009,8 @@ export interface SubtitleTracksUpdatedData {
 //
 // @public (undocumented)
 export interface SubtitleTrackSwitchData {
+    // (undocumented)
+    groupId?: string;
     // (undocumented)
     id: number;
     // (undocumented)

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -188,11 +188,17 @@ class AudioTrackController extends BasePlaylistController {
 
     const lastTrack = tracks[this.trackId];
     this.log(`Now switching to audio-track index ${newId}`);
-    const { id, name, type, url } = track;
+    const { id, groupId = '', name, type, url } = track;
     this.trackId = newId;
     this.trackName = name;
     this.selectDefaultTrack = false;
-    this.hls.trigger(Events.AUDIO_TRACK_SWITCHING, { id, name, type, url });
+    this.hls.trigger(Events.AUDIO_TRACK_SWITCHING, {
+      id,
+      groupId,
+      name,
+      type,
+      url,
+    });
     const hlsUrlParameters = this.switchParams(track.url, lastTrack?.details);
     this.loadPlaylist(hlsUrlParameters);
   }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -121,10 +121,7 @@ export default class BaseStreamController
     if (frag) {
       this.fragmentTracker.removeFragment(frag);
     }
-    if (this.transmuxer) {
-      this.transmuxer.destroy();
-      this.transmuxer = null;
-    }
+    this.resetTransmuxer();
     this.fragCurrent = null;
     this.fragPrevious = null;
     this.clearInterval();
@@ -1228,10 +1225,7 @@ export default class BaseStreamController
             this.warn(
               `Could not parse fragment ${frag.sn} ${type} duration reliably (${parsedDuration}) resetting transmuxer to fallback to playlist timing`
             );
-            if (this.transmuxer) {
-              this.transmuxer.destroy();
-              this.transmuxer = null;
-            }
+            this.resetTransmuxer();
             return result || false;
           }
           const drift = partial
@@ -1266,6 +1260,13 @@ export default class BaseStreamController
       this.fragCurrent = null;
       this.fragPrevious = null;
       this.state = State.IDLE;
+    }
+  }
+
+  protected resetTransmuxer() {
+    if (this.transmuxer) {
+      this.transmuxer.destroy();
+      this.transmuxer = null;
     }
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -715,13 +715,6 @@ export default class StreamController
     );
   }
 
-  private resetTransmuxer() {
-    if (this.transmuxer) {
-      this.transmuxer.destroy();
-      this.transmuxer = null;
-    }
-  }
-
   private onAudioTrackSwitching(
     event: Events.AUDIO_TRACK_SWITCHING,
     data: AudioTrackSwitchingData

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -5,7 +5,6 @@ import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import type { FragmentTracker } from './fragment-tracker';
 import { FragmentState } from './fragment-tracker';
 import BaseStreamController, { State } from './base-stream-controller';
-import FragmentLoader from '../loader/fragment-loader';
 import { PlaylistLevelType } from '../types/loader';
 import { Level } from '../types/level';
 import type { NetworkComponentAPI } from '../types/component-api';

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -354,8 +354,14 @@ class SubtitleTrackController extends BasePlaylistController {
     this.log(`Switching to subtitle track ${newId}`);
     this.trackId = newId;
     if (track) {
-      const { id, name, type, url } = track;
-      this.hls.trigger(Events.SUBTITLE_TRACK_SWITCH, { id, name, type, url });
+      const { id, groupId = '', name, type, url } = track;
+      this.hls.trigger(Events.SUBTITLE_TRACK_SWITCH, {
+        id,
+        groupId,
+        name,
+        type,
+        url,
+      });
       const hlsUrlParameters = this.switchParams(track.url, lastTrack?.details);
       this.loadPlaylist(hlsUrlParameters);
     } else {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -155,6 +155,7 @@ export interface LevelPTSUpdatedData {
 export interface AudioTrackSwitchingData {
   id: number;
   name: string;
+  groupId: string;
   type: MediaPlaylistType | 'main';
   url: string;
 }
@@ -176,6 +177,7 @@ export interface SubtitleTracksUpdatedData {
 export interface SubtitleTrackSwitchData {
   id: number;
   name?: string;
+  groupId?: string;
   type?: MediaPlaylistType | 'main';
   url?: string;
 }

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -129,6 +129,7 @@ describe('SubtitleTrackController', function () {
         'hlsSubtitleTrackSwitch',
         {
           id: 1,
+          groupId: 'default-text-group',
           name: 'English',
           type: 'SUBTITLES',
           url: 'bar',
@@ -164,6 +165,7 @@ describe('SubtitleTrackController', function () {
         'hlsSubtitleTrackSwitch',
         {
           id: 0,
+          groupId: 'default-text-group',
           name: 'English',
           type: 'SUBTITLES',
           url: 'baz',


### PR DESCRIPTION
### This PR will...
- Reset transmuxer on audio-tracks-updated to handle audio group track switching
- Added `groupId` to `AudioTrackSwitchingData` and `SubtitleTrackSwitchData` (just added `name` recently and in light of this issue, `groupId` is also something you'd want to know about an upcoming track change)

### Why is this Pull Request needed?
The transmuxer doesn't see audio groups so tracks in different groups with the same index appear as contiguous segments. Resetting the transmuxer on audio track update deals with this type of discontinuity resetting where audio is appended when the active group is changed.

https://github.com/video-dev/hls.js/blob/072ef4b15e011d5194dbc7e7ad8782dd88ffd0b5/src/demux/transmuxer-interface.ts#L159-L163

### Are there any points in the code the reviewer needs to double check?
I considered adding groupId or original track id indexes (across groups) to the transmux pipeline but that would involve adding them to Fragment objects, ChunkMeta, multiple playlist/track types, as well multiple event types. This change has a much smaller footprint, making it a safer patch. 

### Resolves issues:
Resolves #3741

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] API or design changes are documented in API.md
