### PR TITLE
Fix MEDIA_ATTACHED > `loadSource` recursive calls

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -67,6 +67,13 @@ export default class BufferController implements ComponentAPI {
     this.registerListeners();
   }
 
+  public hasSourceTypes(): boolean {
+    return (
+      this.getSourceBufferTypes().length > 0 ||
+      Object.keys(this.pendingTracks).length > 0
+    );
+  }
+
   public destroy() {
     this.unregisterListeners();
     this.details = null;


### PR DESCRIPTION
### This PR will...
Do not detach and reattach media in `loadSource` when in an hls.js event loop. 
When `loadSource` is called, only detach and reattach media if URL has changed, and source buffer types are set.

### Why is this Pull Request needed?
Prevents recursive calls when `loadSource` is called in an event handler such as `MEDIA_ATTACHED`, or any prior to `BUFFER_CODECS`. This is where the `BufferController`'s `SourceBuffer` configuration is set. Loading a new stream prior to that can be performed without reattaching. After that, reattaching is necessary to reset the source buffers.

### Resolves issues:
Resolves #3732

### Checklist

- [x] changes have been done against master branch, and PR does not conflict