### PR TITLE
Fix "age" header check in XHR loader

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -8,6 +8,8 @@ import type {
 } from '../types/loader';
 import { LoadStats } from '../loader/load-stats';
 
+const AGE_HEADER_LINE_REGEX = /^age:\s*[\d.]+\s*$/m;
+
 class XhrLoader implements Loader<LoaderContext> {
   private xhrSetup: Function | null;
   private requestTimeout?: number;
@@ -253,7 +255,7 @@ class XhrLoader implements Loader<LoaderContext> {
     let result: number | null = null;
     if (
       this.loader &&
-      this.loader.getAllResponseHeaders().indexOf('age') >= 0
+      AGE_HEADER_LINE_REGEX.test(this.loader.getAllResponseHeaders())
     ) {
       const ageHeader = this.loader.getResponseHeader('age');
       result = ageHeader ? parseFloat(ageHeader) : null;


### PR DESCRIPTION
### This PR will...
Use RegEx to match "age" header in `XMLHttpRequest.getAllResponseHeaders()`, skipping the CDN Tune-In "age" header check in live streams with no "age" in the playlist response header.

### Why is this Pull Request needed?
Fixes regression introduced in #3685 in response to #3680 that turns up the `Refused to get unsafe header "age"'` errors "to 11".

The solution that used `getAllResponseHeaders().indexOf('age')` matched the word "age" anywhere in the headers as in "max-age" as part of:
```
cache-control: max-age=2
content-length: 283
content-type: application/vnd.apple.mpegurl
date: Mon, 12 Apr 2021 20:39:28 GMT
expires: Mon, 12 Apr 2021 20:39:30 GMT
last-modified: Mon, 12 Apr 2021 20:39:28 GMT
```
 
### Resolves issues:
Resolves #3680

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
