### PR TITLE
Reset stream controller ENDED state pt.2

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -935,7 +935,10 @@ export default class StreamController
     event: Events.BUFFER_FLUSHED,
     { type }: BufferFlushedData
   ) {
-    if (type !== ElementaryStreamTypes.AUDIO) {
+    if (
+      type !== ElementaryStreamTypes.AUDIO ||
+      (this.audioOnly && !this.altAudio)
+    ) {
       const media =
         (type === ElementaryStreamTypes.VIDEO
           ? this.videoBuffer


### PR DESCRIPTION
### This PR will...
Reset stream controller ENDED state after flushing the buffer for main audio-only streams

### Why is this Pull Request needed?
The fix in #3774 did not cover audio-only streams handled by the stream-controller. That change only reset the loading state in stream-controller after removing media from the video source buffer.

### Resolves issues:
Completes #3774

### Checklist

- [x] changes have been done against master branch, and PR does not conflict