### PR TITLE
bugfix: DEFAULT=YES on caption tracks was not being respected.

### DIFF
--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -191,13 +191,15 @@ class SubtitleTrackController extends BasePlaylistController {
       const lastTrack = this.tracksInGroup
         ? this.tracksInGroup[this.trackId]
         : undefined;
-      const initialTrackId =
-        this.findTrackId(lastTrack?.name) || this.findTrackId();
+
       const subtitleTracks = this.tracks.filter(
         (track): boolean => !textGroupId || track.groupId === textGroupId
       );
-      this.groupId = textGroupId;
       this.tracksInGroup = subtitleTracks;
+      const initialTrackId =
+        this.findTrackId(lastTrack?.name) || this.findTrackId();
+      this.groupId = textGroupId;
+
       const subtitleTracksUpdated: SubtitleTracksUpdatedData = {
         subtitleTracks,
       };
@@ -213,9 +215,9 @@ class SubtitleTrackController extends BasePlaylistController {
   }
 
   private findTrackId(name?: string): number {
-    const audioTracks = this.tracksInGroup;
-    for (let i = 0; i < audioTracks.length; i++) {
-      const track = audioTracks[i];
+    const textTracks = this.tracksInGroup;
+    for (let i = 0; i < textTracks.length; i++) {
+      const track = textTracks[i];
       if (!this.selectDefaultTrack || track.default) {
         if (!name || name === track.name) {
           return track.id;


### PR DESCRIPTION
### This PR will...

Ensure that the default track is selected after playback.

### Why is this Pull Request needed?

Subtitle groups were not respected prior to v1, and now that they are, there was just this tiny gap in the implementation.

By moving when the tracks in the group are populated, the functions work as intended, selecting the default track.

### Are there any points in the code the reviewer needs to double check?

Impact analysis on the change.

### Resolves issues:
Closes #3780

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
