### PR TITLE
Fix AES-128 in streams with alt-audio tracks

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -344,11 +344,7 @@ class AudioStreamController
     }
 
     if (frag.decryptdata?.keyFormat === 'identity' && !frag.decryptdata?.key) {
-      this.log(
-        `Loading key for ${frag.sn} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}`
-      );
-      this.state = State.KEY_LOADING;
-      hls.trigger(Events.KEY_LOADING, { frag });
+      this.loadKey(frag, trackDetails);
     } else {
       this.loadFragment(frag, trackDetails, targetBufferTime);
     }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -306,18 +306,10 @@ export default class StreamController
     // We want to load the key if we're dealing with an identity key, because we will decrypt
     // this content using the key we fetch. Other keys will be handled by the DRM CDM via EME.
     if (frag.decryptdata?.keyFormat === 'identity' && !frag.decryptdata?.key) {
-      this.log(
-        `Loading key for ${frag.sn} of [${levelDetails.startSN}-${levelDetails.endSN}], level ${level}`
-      );
-      this.loadKey(frag);
+      this.loadKey(frag, levelDetails);
     } else {
       this.loadFragment(frag, levelDetails, targetBufferTime);
     }
-  }
-
-  private loadKey(frag: Fragment) {
-    this.state = State.KEY_LOADING;
-    this.hls.trigger(Events.KEY_LOADING, { frag });
   }
 
   protected loadFragment(
@@ -472,6 +464,9 @@ export default class StreamController
     this.fragCurrent = null;
     if (fragCurrent?.loader) {
       fragCurrent.loader.abort();
+    }
+    if (this.state === State.KEY_LOADING) {
+      this.state = State.IDLE;
     }
     this.nextLoadPosition = this.getLoadPosition();
   }

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -98,8 +98,14 @@ module.exports = {
   oceansAES: {
     url:
       'https://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8',
-    description: 'AES encrypted,ABR',
+    description: 'AES-128 encrypted, ABR',
     abr: true,
+  },
+  tracksWithAES: {
+    url:
+      'https://playertest.longtailvideo.com/adaptive/aes-with-tracks/master.m3u8',
+    description: 'AES-128 encrypted, TS main with AAC audio track',
+    abr: false,
   },
   mp3Audio: {
     url:


### PR DESCRIPTION
### This PR will...
Fix a regression in AES key loading that causes the main and audio stream controllers to load each others' fragments on KEY_LOADED.

### Why is this Pull Request needed?
Prior to v1.0, `onKeyLoaded` would set the stream controllers' state to IDLE (even if it was the other controller/level/track fragment's key that was loaded), but this wasn't a show stopper (at worst I guess it would result in keys being requested more than once).

In v1.0 the fragment is requested as soon as the key is loaded and parsed, rather than waiting for the next tick. This was done in an effort to improve the performance of AES streams. Our test samples do not include an encrypted stream with separate tracks like the one found in #3772 so this one slipped through.

### Resolves issues:
Fixes #3772

### Checklist

- [x] changes have been done against master branch, and PR does not conflict