### PR TITLE
Direct set SearchParams on URL and remove sort.

### DIFF
--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -68,18 +68,15 @@ export class HlsUrlParameters {
 
   addDirectives(uri: string): string | never {
     const url: URL = new self.URL(uri);
-    const searchParams: URLSearchParams = url.searchParams;
     if (this.msn !== undefined) {
-      searchParams.set('_HLS_msn', this.msn.toString());
+      url.searchParams.set('_HLS_msn', this.msn.toString());
     }
     if (this.part !== undefined) {
-      searchParams.set('_HLS_part', this.part.toString());
+      url.searchParams.set('_HLS_part', this.part.toString());
     }
     if (this.skip) {
-      searchParams.set('_HLS_skip', this.skip);
+      url.searchParams.set('_HLS_skip', this.skip);
     }
-    searchParams.sort();
-    url.search = searchParams.toString();
     return url.toString();
   }
 }


### PR DESCRIPTION
### This PR will...

- Set the ```SearchParams``` directly on ```URL``` instead of  set to ```url.search```.
- Remove sort ```SearChParams```.

### Why is this Pull Request needed?

Through set ```url.search``` to add SearchParams that will cause the url isn't equal origin url even if doesn't have any parameter set to. I think the ```url.toString()``` will do encode and server side check the url by string type not equal origin url, so response 403 forbidden. 

### Are there any points in the code the reviewer needs to double check?

Please help to check my thoughts correctly.

### Resolves issues:

https://github.com/video-dev/hls.js/issues/3786