### PR TITLE
Fix setInterval/Timer regression in fps-controller

### DIFF
--- a/src/controller/fps-controller.ts
+++ b/src/controller/fps-controller.ts
@@ -58,7 +58,7 @@ class FPSController implements ComponentAPI {
       }
 
       self.clearInterval(this.timer);
-      this.timer = self.setTimeout(
+      this.timer = self.setInterval(
         this.checkFPSInterval.bind(this),
         config.fpsDroppedMonitoringPeriod
       );


### PR DESCRIPTION
### This PR will...
Fix a regression introduced in #3072 that changed the fps-controller 's repeating interval to a timer that only fires once.

### Why is this Pull Request needed?
So that fps-controller's `checkFPS` is called continuously when `config.capLevelOnFPSDrop` is set to `true`.

### Resolves issues:
Fixes #3790

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
