### PR TITLE
Fix audio-buffer stall with frequent audio group switching

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -659,7 +659,7 @@ class AudioStreamController
   ) {
     if (type === ElementaryStreamTypes.AUDIO) {
       const media = this.mediaBuffer ? this.mediaBuffer : this.media;
-      this.afterBufferFlushed(media, type);
+      this.afterBufferFlushed(media, type, PlaylistLevelType.AUDIO);
     }
   }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1184,14 +1184,22 @@ export default class BaseStreamController
     }
   }
 
-  protected afterBufferFlushed(media: Bufferable, type: SourceBufferName) {
+  protected afterBufferFlushed(
+    media: Bufferable,
+    bufferType: SourceBufferName,
+    playlistType: PlaylistLevelType
+  ) {
     if (!media) {
       return;
     }
     // After successful buffer flushing, filter flushed fragments from bufferedFrags use mediaBuffered instead of media
     // (so that we will check against video.buffered ranges in case of alt audio track)
     const bufferedTimeRanges = BufferHelper.getBuffered(media);
-    this.fragmentTracker.detectEvictedFragments(type, bufferedTimeRanges);
+    this.fragmentTracker.detectEvictedFragments(
+      bufferType,
+      bufferedTimeRanges,
+      playlistType
+    );
     if (this.state === State.ENDED) {
       this.resetLoadingState();
     }

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -136,12 +136,19 @@ export class FragmentTracker implements ComponentAPI {
    */
   public detectEvictedFragments(
     elementaryStream: SourceBufferName,
-    timeRange: TimeRanges
+    timeRange: TimeRanges,
+    playlistType?: PlaylistLevelType
   ) {
     // Check if any flagged fragments have been unloaded
     Object.keys(this.fragments).forEach((key) => {
       const fragmentEntity = this.fragments[key];
-      if (!fragmentEntity || !fragmentEntity.buffered) {
+      if (!fragmentEntity) {
+        return;
+      }
+      if (!fragmentEntity.buffered) {
+        if (fragmentEntity.body.type === playlistType) {
+          this.removeFragment(fragmentEntity.body);
+        }
         return;
       }
       const esData = fragmentEntity.range[elementaryStream];

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -938,7 +938,7 @@ export default class StreamController
         (type === ElementaryStreamTypes.VIDEO
           ? this.videoBuffer
           : this.mediaBuffer) || this.media;
-      this.afterBufferFlushed(media, type);
+      this.afterBufferFlushed(media, type, PlaylistLevelType.MAIN);
     }
   }
 


### PR DESCRIPTION
### This PR will...
Evict unbuffered audio and main fragments from the tracker on `BUFFER_FLUSHED`.

### Why is this Pull Request needed?
Fixes intermittent (mostly Firefox) audio-buffer stall with frequent audio group switching.

### Resolves issues:
Resolves #3770

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
