### PR TITLE
Fix fetch loader stats marked as aborted after loaded

### DIFF
--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -51,8 +51,11 @@ class FetchLoader implements Loader<LoaderContext> {
   }
 
   abortInternal(): void {
-    this.stats.aborted = true;
-    this.controller.abort();
+    const response = this.response;
+    if (!response || !response.ok) {
+      this.stats.aborted = true;
+      this.controller.abort();
+    }
   }
 
   abort(): void {


### PR DESCRIPTION
### This PR will...
Fix fetch loader stats marked as aborted after loaded

### Why is this Pull Request needed?
Loader instances are destroyed after each use. The fetch loader was flipping on an `aborted` flag when destroyed even when complete.

### Resolves issues:
Fixes #3789

### Checklist

- [x] changes have been done against master branch, and PR does not conflict