### PR TITLE
chore: migrate NetworkDetails from any -> null|XMLHttpRequest|Response;

### DIFF
--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -8,7 +8,7 @@ import {
 import type { HlsConfig } from '../config';
 import type { BaseSegment, Part } from './fragment';
 import type { FragLoadedData } from '../types/events';
-import { NetworkDetails } from '../types/network-details';
+import type { NetworkDetails } from '../types/network-details';
 
 const MIN_CHUNK_SIZE = Math.pow(2, 17); // 128kb
 

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -8,7 +8,7 @@ import {
 import type { HlsConfig } from '../config';
 import type { BaseSegment, Part } from './fragment';
 import type { FragLoadedData } from '../types/events';
-import { NetworkDetails } from "../types/network-details";
+import { NetworkDetails } from '../types/network-details';
 
 const MIN_CHUNK_SIZE = Math.pow(2, 17); // 128kb
 

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -8,6 +8,7 @@ import {
 import type { HlsConfig } from '../config';
 import type { BaseSegment, Part } from './fragment';
 import type { FragLoadedData } from '../types/events';
+import { NetworkDetails } from "../types/network-details";
 
 const MIN_CHUNK_SIZE = Math.pow(2, 17); // 128kb
 
@@ -305,7 +306,7 @@ export interface FragLoadFailResult {
     // error description
     text: string;
   };
-  networkDetails: any;
+  networkDetails: NetworkDetails;
 }
 
 export type FragmentLoadProgressCallback = (result: FragLoadedData) => void;

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -34,6 +34,7 @@ import type {
   ManifestLoadingData,
   TrackLoadingData,
 } from '../types/events';
+import { NetworkDetails } from "../types/network-details";
 
 function mapContextToLevelType(
   context: PlaylistLoaderContext
@@ -308,7 +309,7 @@ class PlaylistLoader {
     response: LoaderResponse,
     stats: LoaderStats,
     context: PlaylistLoaderContext,
-    networkDetails: any = null
+    networkDetails: NetworkDetails = null
   ): void {
     if (context.isSidxRequest) {
       this.handleSidxRequest(response, context);
@@ -346,7 +347,7 @@ class PlaylistLoader {
   private loaderror(
     response: LoaderResponse,
     context: PlaylistLoaderContext,
-    networkDetails: any = null
+    networkDetails: NetworkDetails = null
   ): void {
     this.handleNetworkError(context, networkDetails, false, response);
   }
@@ -354,7 +355,7 @@ class PlaylistLoader {
   private loadtimeout(
     stats: LoaderStats,
     context: PlaylistLoaderContext,
-    networkDetails: any = null
+    networkDetails: NetworkDetails = null
   ): void {
     this.handleNetworkError(context, networkDetails, true);
   }
@@ -363,7 +364,7 @@ class PlaylistLoader {
     response: LoaderResponse,
     stats: LoaderStats,
     context: PlaylistLoaderContext,
-    networkDetails: any
+    networkDetails: NetworkDetails
   ): void {
     const hls = this.hls;
     const string = response.data as string;
@@ -458,7 +459,7 @@ class PlaylistLoader {
     response: LoaderResponse,
     stats: LoaderStats,
     context: PlaylistLoaderContext,
-    networkDetails: any
+    networkDetails: NetworkDetails
   ): void {
     const hls = this.hls;
     const { id, level, type } = context;
@@ -574,7 +575,7 @@ class PlaylistLoader {
     response: LoaderResponse,
     context: PlaylistLoaderContext,
     reason: string,
-    networkDetails: any
+    networkDetails: NetworkDetails
   ): void {
     this.hls.trigger(Events.ERROR, {
       type: ErrorTypes.NETWORK_ERROR,
@@ -590,7 +591,7 @@ class PlaylistLoader {
 
   private handleNetworkError(
     context: PlaylistLoaderContext,
-    networkDetails: any,
+    networkDetails: NetworkDetails,
     timeout = false,
     response?: LoaderResponse
   ): void {
@@ -658,7 +659,7 @@ class PlaylistLoader {
     response: LoaderResponse,
     stats: LoaderStats,
     context: PlaylistLoaderContext,
-    networkDetails: any
+    networkDetails: NetworkDetails
   ): void {
     const {
       type,

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -34,7 +34,7 @@ import type {
   ManifestLoadingData,
   TrackLoadingData,
 } from '../types/events';
-import { NetworkDetails } from "../types/network-details";
+import { NetworkDetails } from '../types/network-details';
 
 function mapContextToLevelType(
   context: PlaylistLoaderContext

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -34,7 +34,7 @@ import type {
   ManifestLoadingData,
   TrackLoadingData,
 } from '../types/events';
-import { NetworkDetails } from '../types/network-details';
+import type { NetworkDetails } from '../types/network-details';
 
 function mapContextToLevelType(
   context: PlaylistLoaderContext

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -21,7 +21,7 @@ import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type { AttrList } from '../utils/attr-list';
 import type { HlsListeners } from '../events';
-import { NetworkDetails } from './network-details';
+import type { NetworkDetails } from './network-details';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -21,6 +21,7 @@ import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type { AttrList } from '../utils/attr-list';
 import type { HlsListeners } from '../events';
+import { NetworkDetails } from "./network-details";
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;
@@ -79,7 +80,7 @@ export interface ManifestLoadedData {
   audioTracks: MediaPlaylist[];
   captions?: MediaPlaylist[];
   levels: LevelParsed[];
-  networkDetails: any;
+  networkDetails: NetworkDetails;
   sessionData: Record<string, AttrList> | null;
   stats: LoaderStats;
   subtitles?: MediaPlaylist[];
@@ -123,7 +124,7 @@ export interface TrackLoadedData {
   details: LevelDetails;
   id: number;
   groupId: string;
-  networkDetails: any;
+  networkDetails: NetworkDetails;
   stats: LoaderStats;
   deliveryDirectives: HlsUrlParameters | null;
 }
@@ -132,7 +133,7 @@ export interface LevelLoadedData {
   details: LevelDetails;
   id: number;
   level: number;
-  networkDetails: any;
+  networkDetails: NetworkDetails;
   stats: LoaderStats;
   deliveryDirectives: HlsUrlParameters | null;
 }
@@ -221,7 +222,7 @@ export interface ErrorData {
   level?: number | undefined;
   levelRetry?: boolean;
   loader?: Loader<LoaderContext>;
-  networkDetails?: any;
+  networkDetails?: NetworkDetails;
   mimeType?: string;
   reason?: string;
   response?: LoaderResponse;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -21,7 +21,7 @@ import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type { AttrList } from '../utils/attr-list';
 import type { HlsListeners } from '../events';
-import { NetworkDetails } from "./network-details";
+import { NetworkDetails } from './network-details';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -2,7 +2,7 @@ import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 import type { HlsUrlParameters } from './level';
-import { NetworkDetails } from "./network-details";
+import { NetworkDetails } from './network-details';
 
 export interface LoaderContext {
   // target URL

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -2,6 +2,7 @@ import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 import type { HlsUrlParameters } from './level';
+import { NetworkDetails } from "./network-details";
 
 export interface LoaderContext {
   // target URL
@@ -71,14 +72,14 @@ export type LoaderOnSuccess<T extends LoaderContext> = (
   response: LoaderResponse,
   stats: LoaderStats,
   context: T,
-  networkDetails: any
+  networkDetails: NetworkDetails
 ) => void;
 
 export type LoaderOnProgress<T extends LoaderContext> = (
   stats: LoaderStats,
   context: T,
   data: string | ArrayBuffer,
-  networkDetails: any
+  networkDetails: NetworkDetails
 ) => void;
 
 export type LoaderOnError<T extends LoaderContext> = (
@@ -89,19 +90,19 @@ export type LoaderOnError<T extends LoaderContext> = (
     text: string;
   },
   context: T,
-  networkDetails: any
+  networkDetails: NetworkDetails
 ) => void;
 
 export type LoaderOnTimeout<T extends LoaderContext> = (
   stats: LoaderStats,
   context: T,
-  networkDetails: any
+  networkDetails: NetworkDetails
 ) => void;
 
 export type LoaderOnAbort<T extends LoaderContext> = (
   stats: LoaderStats,
   context: T,
-  networkDetails: any
+  networkDetails: NetworkDetails
 ) => void;
 
 export interface LoaderCallbacks<T extends LoaderContext> {

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -2,7 +2,7 @@ import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 import type { HlsUrlParameters } from './level';
-import { NetworkDetails } from './network-details';
+import type { NetworkDetails } from './network-details';
 
 export interface LoaderContext {
   // target URL

--- a/src/types/network-details.ts
+++ b/src/types/network-details.ts
@@ -1,0 +1,4 @@
+export type NetworkDetails =
+  | null // this is a nullable field
+  | Response
+  | XMLHttpRequest

--- a/src/types/network-details.ts
+++ b/src/types/network-details.ts
@@ -1,4 +1,4 @@
 export type NetworkDetails =
-  | null // this is a nullable field
-  | Response
-  | XMLHttpRequest
+  | null // this is a nullable field in several callback interfaces
+  | Response // from utils/fetch-loader.ts
+  | XMLHttpRequest; // from utils/xhr-loader.ts


### PR DESCRIPTION
### This PR will...

Properly declare the type for `NetworkDetails`

### Why is this Pull Request needed?

Removes reliance on `any` type in favor of properly declaring `NetworkDetails` for better developer ergonomics when matching against HTTP outcomes

### Are there any points in the code the reviewer needs to double check?
I traced the usage of `NetworkDetails` as best as possible to all existing usages in the codebase and found that in some cases it is declared as `networkDetails?` type and sometimes is is passed as a `null` object.  I did not clean this up because technically it could be a breaking change, but converging it so that `networkDetails?` is preferred would make sense for code clarity and overall maintainability in the future.

### Resolves issues:
resolves unnecessary dependence on `any` type

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
