### PR TITLE
Clear muxed "audiovideo" SourceBuffer on BUFFER_FLUSHING 

### DIFF
--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -322,19 +322,31 @@ describe('BufferController', function () {
       });
     });
 
-    it('dequeues the remove operation if the SourceBuffer does not exist during the operation', function () {
+    it('Does not queue remove operations when there are no SourceBuffers', function () {
       bufferController.sourceBuffer = {};
       bufferController.onBufferFlushing(Events.BUFFER_FLUSHING, {
         startOffset: 0,
         endOffset: Infinity,
       });
 
-      expect(queueAppendSpy, 'Two remove operations should have been appended')
-        .to.have.been.calledTwice;
       expect(
-        shiftAndExecuteNextSpy,
-        'The queues should have been cycled'
-      ).to.have.callCount(2);
+        queueAppendSpy,
+        'No remove operations should have been appended'
+      ).to.have.callCount(0);
+    });
+
+    it('Only queues remove operations for existing SourceBuffers', function () {
+      bufferController.sourceBuffer = {
+        audiovideo: {},
+      };
+      bufferController.onBufferFlushing(Events.BUFFER_FLUSHING, {
+        startOffset: 0,
+        endOffset: Infinity,
+      });
+      expect(
+        queueAppendSpy,
+        'Queue one remove for muxed "audiovideo" SourceBuffer'
+      ).to.have.been.calledOnce;
     });
 
     it('dequeues the remove operation if the requested remove range is not valid', function () {
@@ -346,7 +358,7 @@ describe('BufferController', function () {
 
       expect(
         queueAppendSpy,
-        'Four remove operations should have been appended'
+        'Two remove operations should have been appended'
       ).to.have.callCount(2);
       expect(
         shiftAndExecuteNextSpy,


### PR DESCRIPTION
### This PR will...
Clear muxed "audiovideo" SourceBuffer on BUFFER_FLUSHING without SourceBufferName type

### Why is this Pull Request needed?
Operations are now queued based on which SourceBuffers have been created. This allows HLS.js to remove content from the forward buffer when switching qualities, as well as clear the back buffer.

Prior to these changes, "audio" and "video" remove operations were queued regardless of which buffers were present. This meant media with only one "audiovideo" SourceBuffer would not have its buffer ejected by the browser, preventing immediate or next segment quality switching and back-buffer removal from working as expected. 

### Resolves issues:
Resolves #3850

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
