### PR TITLE
Prevent async abort handler from causing current fragment to be reloaded

### DIFF
--- a/src/task-loop.ts
+++ b/src/task-loop.ts
@@ -112,11 +112,15 @@ export default class TaskLoop {
       // -> schedule a call on the next main loop iteration to process this task processing request
       if (this._tickCallCount > 1) {
         // make sure only one timer exists at any time at max
-        this.clearNextTick();
-        this._tickTimer = self.setTimeout(this._boundTick, 0);
+        this.tickImmediate();
       }
       this._tickCallCount = 0;
     }
+  }
+
+  public tickImmediate(): void {
+    this.clearNextTick();
+    this._tickTimer = self.setTimeout(this._boundTick, 0);
   }
 
   /**

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -20,6 +20,7 @@ describe('SubtitleStreamController', function () {
 
   beforeEach(function () {
     hls = new Hls({});
+    mediaMock.currentTime = 0;
     fragmentTracker = new FragmentTracker(hls);
     subtitleStreamController = new SubtitleStreamController(
       hls,
@@ -126,7 +127,18 @@ describe('SubtitleStreamController', function () {
 
   describe('onMediaSeeking', function () {
     it('nulls fragPrevious when seeking away from fragCurrent', function () {
-      subtitleStreamController.fragCurrent = { start: 1000, duration: 10 };
+      subtitleStreamController.fragCurrent = {
+        start: 1000,
+        duration: 10,
+        loader: {
+          abort: () => {
+            this.state.aborted = true;
+          },
+          stats: {
+            aborted: false,
+          },
+        },
+      };
       subtitleStreamController.fragPrevious = {};
       subtitleStreamController.onMediaSeeking();
       expect(subtitleStreamController.fragPrevious).to.not.exist;


### PR DESCRIPTION
### This PR will...
- Yield before calling `tick` on seek so that async abort behavior can complete before loading the next fragment
- Don't abort forward buffer fragment requests on seek since this can abort the next fragment at buffer end
- Exit from `flushMainBuffer` when the range is invalid (length of `0`)

### Why is this Pull Request needed?
Prevents HLS.js from looping on fragment load and abort when seeking to or starting on a segment with a gap. This occurs mostly in streams that drop frames from segments that do not start with a keyframe.

### Resolves issues:
Fixes #3811 #3847

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
