### PR TITLE
Checks if Promise is supported in isSupported fixes #3791

### DIFF
--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -10,6 +10,9 @@ export function isSupported(): boolean {
   if (!mediaSource) {
     return false;
   }
+  if (!('Promise' in self)) {
+    return false;
+  }
   const sourceBuffer = getSourceBuffer();
   const isTypeSupported =
     mediaSource &&


### PR DESCRIPTION
### This PR will...
Add a check for `Promise` support in `Hls.isSupported()`

### Why is this Pull Request needed?
Hls.js 1.0 now requires `Promise` support, so `Hls.isSupported()` should make sure `Promise` is actually present before returning `true`.

### Are there any points in the code the reviewer needs to double check?
I don't think so, it is basically one line.

### Resolves issues:
#3791 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict