### PR TITLE
Preemptive backtracking

### DIFF
--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -40,6 +40,7 @@ export interface RemuxedTrack {
   hasAudio: boolean;
   hasVideo: boolean;
   independent?: boolean;
+  firstKeyFrame?: number;
   nb: number;
   transferredData1?: ArrayBuffer;
   transferredData2?: ArrayBuffer;


### PR DESCRIPTION
### This PR will...
Perform preemptive backtracking in streams with segments that do not start with a video keyframe.

### Why is this Pull Request needed?
If a seek or level switch moves buffering to a non-contiguous point in the stream, and the segment meant to fill the buffer at that position cannot, because it does not start with a keyframe, the player needs to backtrack. This happens when video samples are dropped due to keyframes being located after the start of a segment, and media can only be appended ahead of the play-head.

Backtracking is inefficient in the current player architecture. Side-effects include:
- Reloading of segments that require backtracking to an earlier segment (since data is neutered once sent to the worker, and backtracking resets the transmuxer-worker)
- Removal of content from the buffer for backtrack loading
- Frequent stalls and oscillation of ABR switching since at least 1-2 unanticipated segment fetches are required to fill the buffer on level switch
- Intermittent segment loading loops related to abort/append/backtrack timing (this PR also attempt to minimize this effect when backtracking)

These changes identify when loaded segments do not start with a keyframe, and mark the stream as one that could backtrack. When selecting which fragment to load in a situation where we know video frames could be dropped and backtracking could occur, select the previous segment. This will help avoid backtracking and its side-effects.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Relates to #3847 and #3811

Should fix ["should seek 3s from end and receive video ended event for Duplicate sequential PDT values with 2 or less buffered ranges" test failure](https://github.com/video-dev/hls.js/pull/3866/checks?check_run_id=2524025419) as long as the second segment (which has 30 video samples before the first keyframe) buffers before seek. Seeking near the end of the stream at the start of the last segment reproduces the issue:

https://deploy-preview-3866--hls-js-dev.netlify.app/demo/?src=https%3A%2F%2Fplayertest.longtailvideo.com%2Fadaptive%2Fartbeats%2Fmanifest.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOnRydWUsInN0b3BPblN0YWxsIjpmYWxzZSwiZHVtcGZNUDQiOmZhbHNlLCJsZXZlbENhcHBpbmciOi0xLCJsaW1pdE1ldHJpY3MiOi0xfQ==

### Checklist

- [x] changes have been done against master branch, and PR does not conflict