### PR TITLE
Fix audio drift in DAI streams with overlapping AAC samples

### DIFF
--- a/demo/chart/timeline-chart.ts
+++ b/demo/chart/timeline-chart.ts
@@ -107,7 +107,7 @@ export class TimelineChart {
       if (pos.x > chartArea.left - 11) {
         const scale = this.chartScales[X_AXIS_SECONDS];
         if (event.deltaY) {
-          const direction = event.deltaY / Math.abs(event.deltaY);
+          const direction = -event.deltaY / Math.abs(event.deltaY);
           const normal = Math.min(333, Math.abs(event.deltaY)) / 1000;
           const ease = 1 - (1 - normal) * (1 - normal);
           this.zoom(scale, pos, ease * direction);

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -14,6 +14,7 @@ import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import type Hls from '../hls';
 import type { HlsEventEmitter } from '../events';
 import type { PlaylistLevelType } from '../types/loader';
+import type { TypeSupported } from './tsdemuxer';
 
 const MediaSource = getMediaSource() || { isTypeSupported: () => false };
 
@@ -54,7 +55,7 @@ export default class TransmuxerInterface {
     this.observer.on(Events.FRAG_DECRYPTED, forwardMessage);
     this.observer.on(Events.ERROR, forwardMessage);
 
-    const typeSupported = {
+    const typeSupported: TypeSupported = {
       mp4: MediaSource.isTypeSupported('video/mp4'),
       mpeg: MediaSource.isTypeSupported('audio/mpeg'),
       mp3: MediaSource.isTypeSupported('audio/mp4; codecs="mp3"'),
@@ -102,7 +103,8 @@ export default class TransmuxerInterface {
           this.observer,
           typeSupported,
           config,
-          vendor
+          vendor,
+          id
         );
         this.worker = null;
       }
@@ -111,7 +113,8 @@ export default class TransmuxerInterface {
         this.observer,
         typeSupported,
         config,
-        vendor
+        vendor,
+        id
       );
     }
   }

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -24,7 +24,8 @@ export default function TransmuxerWorker(self) {
           observer,
           data.typeSupported,
           config,
-          data.vendor
+          data.vendor,
+          data.id
         );
         enableLogs(config.debug);
         forwardMessage('init', null);

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -4,19 +4,19 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import Decrypter from '../crypt/decrypter';
 import AACDemuxer from '../demux/aacdemuxer';
 import MP4Demuxer from '../demux/mp4demuxer';
-import TSDemuxer from '../demux/tsdemuxer';
+import TSDemuxer, { TypeSupported } from '../demux/tsdemuxer';
 import MP3Demuxer from '../demux/mp3demuxer';
 import MP4Remuxer from '../remux/mp4-remuxer';
 import PassThroughRemuxer from '../remux/passthrough-remuxer';
+import ChunkCache from './chunk-cache';
+import { appendUint8Array } from '../utils/mp4-tools';
+import { logger } from '../utils/logger';
 import type { Demuxer, KeyData } from '../types/demuxer';
 import type { Remuxer } from '../types/remuxer';
 import type { TransmuxerResult, ChunkMetadata } from '../types/transmuxer';
-import ChunkCache from './chunk-cache';
-import { appendUint8Array } from '../utils/mp4-tools';
-
-import { logger } from '../utils/logger';
 import type { HlsConfig } from '../config';
-import { LevelKey } from '../loader/level-key';
+import type { LevelKey } from '../loader/level-key';
+import type { PlaylistLevelType } from '../types/loader';
 
 let now;
 // performance.now() not available on WebWorker, at least on Safari Desktop
@@ -47,9 +47,10 @@ muxConfig.forEach(({ demux }) => {
 
 export default class Transmuxer {
   private observer: HlsEventEmitter;
-  private typeSupported: any;
+  private typeSupported: TypeSupported;
   private config: HlsConfig;
-  private vendor: any;
+  private vendor: string;
+  private id: PlaylistLevelType;
   private demuxer?: Demuxer;
   private remuxer?: Remuxer;
   private decrypter?: Decrypter;
@@ -61,14 +62,16 @@ export default class Transmuxer {
 
   constructor(
     observer: HlsEventEmitter,
-    typeSupported,
+    typeSupported: TypeSupported,
     config: HlsConfig,
-    vendor
+    vendor: string,
+    id: PlaylistLevelType
   ) {
     this.observer = observer;
     this.typeSupported = typeSupported;
     this.config = config;
     this.vendor = vendor;
+    this.id = id;
   }
 
   configure(transmuxConfig: TransmuxConfig) {
@@ -258,7 +261,8 @@ export default class Transmuxer {
       textTrack,
       timeOffset,
       accurateTimeOffset,
-      true
+      true,
+      this.id
     );
     transmuxResults.push({
       remuxResult,
@@ -354,7 +358,8 @@ export default class Transmuxer {
       textTrack,
       timeOffset,
       accurateTimeOffset,
-      false
+      false,
+      this.id
     );
     return {
       remuxResult,
@@ -379,7 +384,8 @@ export default class Transmuxer {
           demuxResult.textTrack,
           timeOffset,
           accurateTimeOffset,
-          false
+          false,
+          this.id
         );
         return {
           remuxResult,

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -8,6 +8,7 @@ import {
   UserdataSample,
 } from './demuxer';
 import type { SourceBufferName } from './buffer';
+import type { PlaylistLevelType } from './loader';
 
 export interface Remuxer {
   remux(
@@ -17,7 +18,8 @@ export interface Remuxer {
     textTrack: DemuxedUserdataTrack,
     timeOffset: number,
     accurateTimeOffset: boolean,
-    flush: boolean
+    flush: boolean,
+    playlistType: PlaylistLevelType
   ): RemuxerResult;
   resetInitSegment(
     initSegment: Uint8Array | undefined,


### PR DESCRIPTION
### This PR will...

- Pass transmuxer-interface id (playlist type) into transmuxer so that when remuxing alt-audio, samples are aligned with video based on PTS.
- Remux overlapping AAC samples so that they are appended over earlier samples segment rather than dropping them. 
- Remove redundant audio drop/backfill code in remuxer.

### Why is this Pull Request needed?
[This mp4-remuxer workaround](https://github.com/video-dev/hls.js/commit/e478757a62e02681e87f34479593962a93601945#diff-fccedeec0ef12b083f3e18534af86e02cecca386bce4d9f328048b5423f2e9e3R756-R763) was disabled in transmuxers for audio-only streams to prioritize segment timing over PTS. This had the side-effect of appending overlapping samples in alt audio-tracks. This is something that happens a lot in certain DAI live streams leading to audio drift.

### Are there any points in the code the reviewer needs to double check?

To keep alt-audio in sync with the main stream, these changes pass the playlist type down to the remuxer so that overlapping audio frames are dropped again, preventing audio drift.

Rather than perform the same workaround as before that dropped samples, moving the remixed mp4 start to match the start PTS achieves virtually the same result with less code.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
