### PR TITLE
Fix exception in fetch-loader error handler

### DIFF
--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -155,7 +155,11 @@ class FetchLoader implements Loader<LoaderContext> {
         // when destroying, 'error' itself can be undefined
         const code: number = !error ? 0 : error.code || 0;
         const text: string = !error ? null : error.message;
-        callbacks.onError({ code, text }, context, error.details);
+        callbacks.onError(
+          { code, text },
+          context,
+          error ? error.details : null
+        );
       });
   }
 

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -152,12 +152,10 @@ class FetchLoader implements Loader<LoaderContext> {
           return;
         }
         // CORS errors result in an undefined code. Set it to 0 here to align with XHR's behavior
-        const code = error.code || 0;
-        callbacks.onError(
-          { code, text: error.message },
-          context,
-          error.details
-        );
+        // when destroying, 'error' itself can be undefined
+        const code: number = !error ? 0 : error.code || 0;
+        const text: string = !error ? null : error.message;
+        callbacks.onError({ code, text }, context, error.details);
       });
   }
 


### PR DESCRIPTION
when destroying, 'error' itself can be undefined