### PR TITLE
Fix incorrect audio track segments loaded before video segment with > 0 startPosition

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -180,6 +180,7 @@ class AudioStreamController
           const { frag, part, cache, complete } = waitingData;
           if (this.initPTS[frag.cc] !== undefined) {
             this.waitingData = null;
+            this.waitingVideoCC = -1;
             this.state = State.FRAG_LOADING;
             const payload = cache.flush();
             const data: FragLoadedData = {
@@ -200,9 +201,10 @@ class AudioStreamController
             this.clearWaitingFragment();
           } else {
             // Drop waiting fragment if an earlier fragment is needed
+            const pos = this.getLoadPosition();
             const bufferInfo = BufferHelper.bufferInfo(
               this.mediaBuffer,
-              this.media.currentTime,
+              pos,
               this.config.maxBufferHole
             );
             const waitingFragmentAtPosition = fragmentWithinToleranceTest(


### PR DESCRIPTION
### This PR will...
Use `startPosition` to determine if audio-stream-controller waiting fragment should be cleared.

### Why is this Pull Request needed?
While waiting for init PTS from the stream-controller's first video segment, the audio-stream-controller will prefetch a segment, and then on tick, check if that `waitingFragment` is correct for the current loading context. If not it is cleared so that it can prefetch a better match.

The logic for this used the initial `video.currentTime` of `0` which doesn't match `startPosition`. The player only seeks after media has been buffered to avoid multiple seeks or stalls so it's important that this check use `this.getLoadPosition()` instead. That way  `startPosition` is honored until media is buffered and `video.currentTime` has been adjusted to start playback at the start position.

### Resolves issues:
Fixes #3950

### Checklist

- [x] changes have been done against master branch, and PR does not conflict