### PR TITLE
Fix forward buffer length estimation and error handling

### DIFF
--- a/src/controller/buffer-operation-queue.ts
+++ b/src/controller/buffer-operation-queue.ts
@@ -67,6 +67,7 @@ export default class BufferOperationQueue {
         // Only shift the current operation off, otherwise the updateend handler will do this for us
         if (!sb || !sb.updating) {
           queue.shift();
+          this.executeNext(type);
         }
       }
     }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -255,19 +255,16 @@ export class SubtitleStreamController
         return;
       }
 
-      const { maxBufferHole, maxFragLookUpTolerance } = config;
-      const maxConfigBuffer = Math.min(
-        config.maxBufferLength,
-        config.maxMaxBufferLength
-      );
       const bufferedInfo = BufferHelper.bufferedInfo(
         this.mediaBufferTimeRanges,
         media.currentTime,
-        maxBufferHole
+        config.maxBufferHole
       );
       const { end: targetBufferTime, len: bufferLen } = bufferedInfo;
 
-      if (bufferLen > maxConfigBuffer) {
+      const maxBufLen = this.getMaxBufferLength();
+
+      if (bufferLen > maxBufLen) {
         return;
       }
 
@@ -284,6 +281,7 @@ export class SubtitleStreamController
       let foundFrag;
       const fragPrevious = this.fragPrevious;
       if (targetBufferTime < end) {
+        const { maxFragLookUpTolerance } = config;
         if (fragPrevious && trackDetails.hasProgramDateTime) {
           foundFrag = findFragmentByPDT(
             fragments,

--- a/src/utils/buffer-helper.ts
+++ b/src/utils/buffer-helper.ts
@@ -8,7 +8,7 @@
  * Also @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered
  */
 
-import { logger } from '../utils/logger';
+import { logger } from './logger';
 
 type BufferTimeRange = {
   start: number;


### PR DESCRIPTION
### This PR will...
- Fix forward buffer length estimation when in a gap not spanned by `maxBufferHole` (#3914)
- Fix buffer controller blocked after "SourceBuffer is full" append error
- Cleanup fragment-tracker with `afterBufferFlushed` on tick with audio-stream-controller to prevent the player from clearing audio segments not yet shown in the buffer after `onBufferFlushed` 

### Why is this Pull Request needed?
Prevents hls.js from over-buffering because of incorrect estimation at a gap. Recovers correctly when buffering does fail because of a SourceBuffer full error.

### Resolves issues:
Resolves #3914

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
