### PR TITLE
Fix last segment in live removed "context changed" error

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -1,7 +1,7 @@
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
 import { getSkipValue, HlsSkip, HlsUrlParameters } from '../types/level';
-import { computeReloadInterval } from './level-helper';
+import { computeReloadInterval, mergeDetails } from './level-helper';
 import { logger } from '../utils/logger';
 import type { LevelDetails } from '../loader/level-details';
 import type { MediaPlaylist } from '../types/media-playlist';
@@ -11,7 +11,6 @@ import type {
   TrackLoadedData,
 } from '../types/events';
 import { ErrorData } from '../types/events';
-import * as LevelHelper from './level-helper';
 import { Events } from '../events';
 import { ErrorTypes } from '../errors';
 
@@ -128,7 +127,7 @@ export default class BasePlaylistController implements NetworkComponentAPI {
       }
       // Merge live playlists to adjust fragment starts and fill in delta playlist skipped segments
       if (previousDetails && details.fragments.length > 0) {
-        LevelHelper.mergeDetails(previousDetails, details);
+        mergeDetails(previousDetails, details);
       }
       if (!this.canLoad || !details.live) {
         return;

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -446,7 +446,11 @@ export function computeReloadInterval(
   return Math.round(estimatedTimeUntilUpdate);
 }
 
-export function getFragmentWithSN(level: Level, sn: number): Fragment | null {
+export function getFragmentWithSN(
+  level: Level,
+  sn: number,
+  fragCurrent: Fragment | null
+): Fragment | null {
   if (!level || !level.details) {
     return null;
   }
@@ -459,6 +463,9 @@ export function getFragmentWithSN(level: Level, sn: number): Fragment | null {
   fragment = levelDetails.fragmentHint;
   if (fragment && fragment.sn === sn) {
     return fragment;
+  }
+  if (sn < levelDetails.startSN && fragCurrent && fragCurrent.sn === sn) {
+    return fragCurrent;
   }
   return null;
 }


### PR DESCRIPTION
### This PR will...
Fix "The loading context changed while buffering fragment" in live streams loading removed fragment

### Why is this Pull Request needed?
When the transmuxer completes work on a segment, the stream controller looks for the fragment with a matching sn matching the transmuxer's context. If the fragment was removed from the live sliding window, the fragment was not found and the media would not be appended.

Instead, use the stream controller's `fragCurrent` in this case to complete buffering of the fragment.

### Relates to issues:
#3913

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
