### PR TITLE
Remove subtitle cues and data with the back-buffer

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -208,6 +208,15 @@ export class FragmentTracker implements ComponentAPI {
     }
   }
 
+  public fragBuffered(frag: Fragment) {
+    const fragKey = getFragmentKey(frag);
+    const fragmentEntity = this.fragments[fragKey];
+    if (fragmentEntity) {
+      fragmentEntity.backtrack = fragmentEntity.loaded = null;
+      fragmentEntity.buffered = true;
+    }
+  }
+
   private getBufferedTimes(
     fragment: Fragment,
     part: Part | null,
@@ -410,6 +419,29 @@ export class FragmentTracker implements ComponentAPI {
   private hasFragment(fragment: Fragment): boolean {
     const fragKey = getFragmentKey(fragment);
     return !!this.fragments[fragKey];
+  }
+
+  public removeFragmentsInRange(
+    start: number,
+    end: number,
+    playlistType: PlaylistLevelType
+  ) {
+    Object.keys(this.fragments).forEach((key) => {
+      const fragmentEntity = this.fragments[key];
+      if (!fragmentEntity) {
+        return;
+      }
+      if (fragmentEntity.buffered) {
+        const frag = fragmentEntity.body;
+        if (
+          frag.type === playlistType &&
+          frag.start < end &&
+          frag.end > start
+        ) {
+          this.removeFragment(frag);
+        }
+      }
+    });
   }
 
   public removeFragment(fragment: Fragment) {


### PR DESCRIPTION
### This PR will...
- Clear subtitle cues from the back-buffer
- Remove loaded subtitle data from the fragment-tracker

### Why is this Pull Request needed?
Longform VOD and live streams with VTT or IMSC1 subtitles should have data and cues cleared with the back-buffer to free up memory. The fragment-tracker was particularly leaky with memory as the loaded data was being added and never removed for each subtitle fragment loaded. 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
