### PR TITLE
Align live WebVTT subtitle playlists with main playlist

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -212,6 +212,8 @@ export interface BufferFlushingData {
     // (undocumented)
     endOffset: number;
     // (undocumented)
+    endOffsetSubtitles?: number;
+    // (undocumented)
     startOffset: number;
     // (undocumented)
     type: SourceBufferName | null;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -1,20 +1,20 @@
 import BaseStreamController, { State } from './base-stream-controller';
-import type { NetworkComponentAPI } from '../types/component-api';
 import { Events } from '../events';
 import { BufferHelper } from '../utils/buffer-helper';
-import type { FragmentTracker } from './fragment-tracker';
 import { FragmentState } from './fragment-tracker';
 import { Level } from '../types/level';
 import { PlaylistLevelType } from '../types/loader';
 import { Fragment, ElementaryStreamTypes, Part } from '../loader/fragment';
 import ChunkCache from '../demux/chunk-cache';
 import TransmuxerInterface from '../demux/transmuxer-interface';
-import type { TransmuxerResult } from '../types/transmuxer';
 import { ChunkMetadata } from '../types/transmuxer';
 import { fragmentWithinToleranceTest } from './fragment-finders';
 import { alignPDT } from '../utils/discontinuities';
 import { ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
+import type { NetworkComponentAPI } from '../types/component-api';
+import type { FragmentTracker } from './fragment-tracker';
+import type { TransmuxerResult } from '../types/transmuxer';
 import type Hls from '../hls';
 import type { LevelDetails } from '../loader/level-details';
 import type { TrackSet } from '../types/track';
@@ -31,8 +31,8 @@ import type {
   FragParsingMetadataData,
   FragParsingUserdataData,
   FragBufferedData,
+  ErrorData,
 } from '../types/events';
-import type { ErrorData } from '../types/events';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
 
@@ -453,8 +453,8 @@ class AudioStreamController
       }
       if (
         !track.details &&
-        this.mainDetails?.hasProgramDateTime &&
-        newDetails.hasProgramDateTime
+        newDetails.hasProgramDateTime &&
+        this.mainDetails?.hasProgramDateTime
       ) {
         alignPDT(newDetails, this.mainDetails);
         sliding = newDetails.fragments[0].start;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -411,24 +411,7 @@ class AudioStreamController
   }
 
   onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
-    if (this.mainDetails === null) {
-      const mainDetails = (this.mainDetails = data.details);
-      // compute start position if we haven't already
-      const trackId = this.levelLastLoaded;
-      if (
-        trackId !== null &&
-        this.levels &&
-        this.startPosition === -1 &&
-        mainDetails.live
-      ) {
-        const track = this.levels[trackId];
-        if (!track.details || !track.details.fragments[0]) {
-          return;
-        }
-        alignPDT(track.details, mainDetails);
-        this.setStartPosition(track.details, track.details.fragments[0].start);
-      }
-    }
+    this.mainDetails = data.details;
   }
 
   onAudioTrackLoaded(event: Events.AUDIO_TRACK_LOADED, data: TrackLoadedData) {
@@ -445,18 +428,19 @@ class AudioStreamController
     const track = levels[trackId];
     let sliding = 0;
     if (newDetails.live || track.details?.live) {
+      const mainDetails = this.mainDetails;
       if (!newDetails.fragments[0]) {
         newDetails.deltaUpdateFailed = true;
       }
-      if (newDetails.deltaUpdateFailed) {
+      if (newDetails.deltaUpdateFailed || !mainDetails) {
         return;
       }
       if (
         !track.details &&
         newDetails.hasProgramDateTime &&
-        this.mainDetails?.hasProgramDateTime
+        mainDetails.hasProgramDateTime
       ) {
-        alignPDT(newDetails, this.mainDetails);
+        alignPDT(newDetails, mainDetails);
         sliding = newDetails.fragments[0].start;
       } else {
         sliding = this.alignPlaylists(newDetails, track.details);

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -372,17 +372,20 @@ export function adjustSliding(
   const delta =
     newDetails.startSN + newDetails.skippedSegments - oldDetails.startSN;
   const oldFragments = oldDetails.fragments;
-  const newFragments = newDetails.fragments;
   if (delta < 0 || delta >= oldFragments.length) {
     return;
   }
-  const playlistStartOffset = oldFragments[delta].start;
-  if (playlistStartOffset) {
-    for (let i = newDetails.skippedSegments; i < newFragments.length; i++) {
-      newFragments[i].start += playlistStartOffset;
+  addSliding(newDetails, oldFragments[delta].start);
+}
+
+export function addSliding(details: LevelDetails, start: number) {
+  if (start) {
+    const fragments = details.fragments;
+    for (let i = details.skippedSegments; i < fragments.length; i++) {
+      fragments[i].start += start;
     }
-    if (newDetails.fragmentHint) {
-      newDetails.fragmentHint.start += playlistStartOffset;
+    if (details.fragmentHint) {
+      details.fragmentHint.start += start;
     }
   }
 }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -245,18 +245,25 @@ export class SubtitleStreamController
       if (newDetails.deltaUpdateFailed) {
         return;
       }
+      const mainDetails = this.mainDetails;
+      const mainSlidingStartFragment = mainDetails
+        ? mainDetails.fragments[0]
+        : null;
       if (!track.details) {
-        const mainDetails = this.mainDetails;
         if (mainDetails) {
           if (newDetails.hasProgramDateTime && mainDetails.hasProgramDateTime) {
             alignPDT(newDetails, mainDetails);
-          } else if (mainDetails.fragments[0]) {
+          } else if (mainSlidingStartFragment) {
             // line up live playlist with main so that fragments in range are loaded
-            addSliding(newDetails, mainDetails.fragments[0].start);
+            addSliding(newDetails, mainSlidingStartFragment.start);
           }
         }
       } else {
-        this.alignPlaylists(newDetails, track.details);
+        const sliding = this.alignPlaylists(newDetails, track.details);
+        if (sliding === 0 && mainSlidingStartFragment) {
+          // realign with main when there is no overlap with last refresh
+          addSliding(newDetails, mainSlidingStartFragment.start);
+        }
       }
     }
     track.details = newDetails;

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -625,7 +625,7 @@ export class TimelineController implements ComponentAPI {
 
   onBufferFlushing(
     event: Events.BUFFER_FLUSHING,
-    { startOffset, endOffset, type }: BufferFlushingData
+    { startOffset, endOffset, endOffsetSubtitles, type }: BufferFlushingData
   ) {
     const { media } = this;
     if (!media || media.currentTime < endOffset) {
@@ -641,10 +641,14 @@ export class TimelineController implements ComponentAPI {
     }
     if (this.config.renderTextTracksNatively) {
       // Clear VTT/IMSC1 subtitle cues from the subtitle TextTracks when the back buffer is flushed
-      if (startOffset === 0 && endOffset !== Number.POSITIVE_INFINITY) {
+      if (startOffset === 0 && endOffsetSubtitles !== undefined) {
         const { textTracks } = this;
         Object.keys(textTracks).forEach((trackName) =>
-          removeCuesInRange(textTracks[trackName], startOffset, endOffset)
+          removeCuesInRange(
+            textTracks[trackName],
+            startOffset,
+            endOffsetSubtitles
+          )
         );
       }
     }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -64,6 +64,7 @@ export interface BufferEOSData {
 export interface BufferFlushingData {
   startOffset: number;
   endOffset: number;
+  endOffsetSubtitles?: number;
   type: SourceBufferName | null;
 }
 

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -51,11 +51,10 @@ export function clearCurrentCues(track: TextTrack) {
   if (mode === 'disabled') {
     track.mode = 'hidden';
   }
-  if (!track.cues) {
-    return;
-  }
-  for (let i = track.cues.length; i--; ) {
-    track.removeCue(track.cues[i]);
+  if (track.cues) {
+    for (let i = track.cues.length; i--; ) {
+      track.removeCue(track.cues[i]);
+    }
   }
   if (mode === 'disabled') {
     track.mode = mode;
@@ -71,12 +70,12 @@ export function removeCuesInRange(
   if (mode === 'disabled') {
     track.mode = 'hidden';
   }
-  if (!track.cues || !track.cues.length) {
-    return;
-  }
-  const cues = getCuesInRange(track.cues, start, end);
-  for (let i = 0; i < cues.length; i++) {
-    track.removeCue(cues[i]);
+
+  if (track.cues && track.cues.length > 0) {
+    const cues = getCuesInRange(track.cues, start, end);
+    for (let i = 0; i < cues.length; i++) {
+      track.removeCue(cues[i]);
+    }
   }
   if (mode === 'disabled') {
     track.mode = mode;

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -98,7 +98,6 @@ describe('SubtitleStreamController', function () {
         details: details,
       });
       expect(subtitleStreamController.levels[1].details).to.equal(details);
-      expect(subtitleStreamController.setInterval).to.have.been.calledOnce;
     });
 
     it('should ignore the event if the data does not match the current track', function () {


### PR DESCRIPTION
### This PR will...
- Align live WebVTT subtitle playlists with main variant using media-sequence when program-date-time is unavailable/
- Fix a regression in v1.0.5 where a subtitle track is enabled after back-buffer removal sets a track's mode to "hidden"
- Update audio-stream alignment with main to be simpler. Both subtitle and audio live playlists will wait for main before being aligned and loading fragments
- Subtitle playlists will be realigned with main if they get into a state where a loading fragment candidate cannot be found

### Why is this Pull Request needed?
Subtitle tracks should be aligned when enabled with the main playlist based on Program-Date-Time when available. Otherwise, aligning on SN may work as is the case with the test stream in #3987

### Resolves issues:
Resolves #3987

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
