### PR TITLE
Fix mid-stream insertion of missing AAC audio frames

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -683,7 +683,6 @@ export default class MP4Remuxer implements Remuxer {
 
     let inputSamples: Array<AudioSample> = track.samples;
     let offset: number = rawMPEG ? 0 : 8;
-    let fillFrame: any;
     let nextAudioPts: number = this.nextAudioPts || -1;
 
     // window.audioSamples ? window.audioSamples.push(inputSamples.map(s => s.pts)) : (window.audioSamples = [inputSamples.map(s => s.pts)]);
@@ -766,9 +765,8 @@ export default class MP4Remuxer implements Remuxer {
                 (1000 * delta) / inputTimeScale
               )} ms.`
             );
-            this.nextAudioPts = nextAudioPts = pts;
+            this.nextAudioPts = nextAudioPts = nextPts = pts;
           }
-          nextPts = pts;
         } // eslint-disable-line brace-style
 
         // Insert missing frames if:
@@ -801,7 +799,7 @@ export default class MP4Remuxer implements Remuxer {
           );
           for (let j = 0; j < missing; j++) {
             const newStamp = Math.max(nextPts as number, 0);
-            fillFrame = AAC.getSilentFrame(
+            let fillFrame = AAC.getSilentFrame(
               track.manifestCodec || track.codec,
               track.channelCount
             );


### PR DESCRIPTION
### This PR will...
Fix mid-stream insertion of missing AAC audio frames

### Why is this Pull Request needed?
TS streams with missing AAC samples ended up with bad sample times after frames were inserted after 74ac1002ef60ffd81f515899f63debca961e3369. This happened when earlier samples were pushed forward more than a sample duration, and the remaining samples were not retimed properly.

### Resolves issues:
Resolves #3976

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
