### PR TITLE
Fix subtitle segment loading with current time less than target-duration

### DIFF
--- a/src/utils/buffer-helper.ts
+++ b/src/utils/buffer-helper.ts
@@ -91,6 +91,7 @@ export class BufferHelper {
     end: number;
     nextStart?: number;
   } {
+    pos = Math.max(0, pos);
     // sort on buffer.start/smaller end (IE does not always return sorted buffered range)
     buffered.sort(function (a, b) {
       const diff = a.start - b.start;


### PR DESCRIPTION
### This PR will...
Fix regression introduced in v1.0.6 with #3993 where subtitle track segment loading at a position less than target duration only loads the first segment.

(only appears in streams with irregularly large target durations compared to segment duration)

### Why is this Pull Request needed?
The position argument passed to `bufferedInfo` should never be less than 0 as that is almost certain to not intersect with any buffered time range. subtitle-stream-controller passes in the current time - target duration so that it loads all subtitles at and adjacent to the current time. That resulted in negative values being passes to our buffer util which resulted in misses getting the end of the subtitle stream buffer.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
