### PR TITLE
Only draft release on tag

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,15 +20,3 @@ tag-template: 'v$RESOLVED_VERSION'
 
 exclude-labels:
   - 'skip-change-log'
-
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,20 +1,20 @@
 template: |
   # Summary
-     HLS.js $RESOLVED_VERSION includes bug fixes and improvements over the last release.
+  HLS.js $RESOLVED_VERSION includes bug fixes and improvements over the last release.
 
-    ## Changes Since The Last Release
-    https://github.com/video-dev/hls.js/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+  ## Changes Since The Last Release
+  https://github.com/video-dev/hls.js/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
 
-    $CHANGES
+  $CHANGES
 
-     ## Demo Page
-     > Get demo url from https://github.com/video-dev/hls.js/tree/deployments
+  ## Demo Page
+  > Get demo url from https://github.com/video-dev/hls.js/tree/deployments
 
-    ## API and Breaking Changes
-    If you are upgrading from version v0.14.17 or lower, see the [MIGRATING](https://github.com/video-dev/hls.js/blob/v1.0.0/MIGRATING.md) guide for API changes between v0.14.x and v1.0.0.
+  ## API and Breaking Changes
+  If you are upgrading from version v0.14.17 or lower, see the [MIGRATING](https://github.com/video-dev/hls.js/blob/v1.0.0/MIGRATING.md) guide for API changes between v0.14.x and v1.0.0.
 
-    ## Feedback
-    Please provide feedback via [Issues in GitHub](https://github.com/video-dev/hls.js/issues/new/choose). For more details on how to contribute to HLS.js, see our [CONTRIBUTING guide](https://github.com/video-dev/hls.js/blob/master/CONTRIBUTING.md).
+  ## Feedback
+  Please provide feedback via [Issues in GitHub](https://github.com/video-dev/hls.js/issues/new/choose). For more details on how to contribute to HLS.js, see our [CONTRIBUTING guide](https://github.com/video-dev/hls.js/blob/master/CONTRIBUTING.md).
 
 tag-template: 'v$RESOLVED_VERSION'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
 
   update_draft_release:
     needs: [config, test_unit]
-    if: needs.config.outputs.tag || needs.config.outputs.isMainBranch == 'true'
+    if: needs.config.outputs.tag
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.draft_release.outputs.upload_url }}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,7 +6,7 @@ Releases are performed automatically with [GitHub actions](https://github.com/vi
 1. `git push`
 1. `git push --tag`
 1. Wait for the GitHub action to create a new draft GitHub release with the build attached. The publish to npm should happen around the same time from a different step.
-1. Add the release notes to the new draft GitHub release.
+1. Update the release notes to the new draft GitHub release if needed.
 1. Publish the GitHub release.
 
 ## Examples


### PR DESCRIPTION
### This PR will...
Only create the draft release when a tag is pushed instead of keeping one up to date all the time.

### Why is this Pull Request needed?
I'm not sure the 'live' one is useful, and having it might result in accidentally publishing a release without the build attached if the tag build hasn't completed yet.

If you think the live one is useful we can close this.