### PR TITLE
Fix SAMPLE-AES when IV attribute is not explicit

### DIFF
--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -239,7 +239,11 @@ export class Fragment extends BaseSegment {
   ): LevelKey {
     let decryptdata = levelkey;
 
-    if (levelkey?.method === 'AES-128' && levelkey.uri && !levelkey.iv) {
+    if (
+      levelkey?.uri &&
+      !levelkey.iv &&
+      (levelkey.method === 'AES-128' || levelkey.method === 'SAMPLE-AES')
+    ) {
       decryptdata = LevelKey.fromURI(levelkey.uri);
       decryptdata.method = levelkey.method;
       decryptdata.iv = this.createInitializationVector(segmentNumber);


### PR DESCRIPTION
### This PR will...

Fix SAMPLE-AES if IV attribute is not set.

### Why is this Pull Request needed?

Current behavior is not conformant. Safari's player works in this case.

### Are there any points in the code the reviewer needs to double check?

I'm not familiar with hls.js source code. There might be other places where SAMPLE-AES case is not handled but should be.

### Resolves issues:

#4069 

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
