### PR TITLE
bugfix audio-track-controller selectInitialTrack() now reset trackId if video has no audio tracks

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -205,10 +205,13 @@ class AudioTrackController extends BasePlaylistController {
 
   private selectInitialTrack(): void {
     const audioTracks = this.tracksInGroup;
-    console.assert(
-      audioTracks.length,
-      'Initial audio track should be selected when tracks are known'
-    );
+
+    if (!audioTracks.length) {
+      // video without audio tracks
+      this.trackId = -1;
+      return;
+    }
+
     const currentAudioTrackName = this.trackName;
     const trackId =
       this.findTrackId(currentAudioTrackName) || this.findTrackId();


### PR DESCRIPTION
AudioTrackController will no longer throw assertion error if no audio track is present. Instead, it reset trackId to default value (-1).

Without this fix, video doesn't fire at first play. Users have to click twice to get video playing.