### PR TITLE
Bugfix: fix missing load stats for LL-HLS

### DIFF
--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -169,8 +169,8 @@ export default class FragmentLoader {
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
         highWaterMark: MIN_CHUNK_SIZE,
       };
-      // Assign part stats to the loader's stats reference
-      part.stats = loader.stats;
+      // Assign loader stats to the part's stats reference
+      loader.stats = part.stats;
       loader.load(loaderContext, loaderConfig, {
         onSuccess: (response, stats, context, networkDetails) => {
           this.resetLoader(frag, loader);


### PR DESCRIPTION
### This PR will...
Fix problem with missing load stats for LL-HLS.
### Why is this Pull Request needed?
With missing stats ABR for LL-HLS usually stuck on lowers channels. This PR will fix it.

Problem with existing code is following.
1. When new manifest parsed **oldPart** stats copied to **newPart**
https://github.com/video-dev/hls.js/blob/1ea75a236151c1ce4ee0cdf6829b571465a75c3f/src/controller/level-helper.ts#L260-L268
2. If part loading will start after that **loader** stats stats copied to **oldPart**
https://github.com/video-dev/hls.js/blob/1ea75a236151c1ce4ee0cdf6829b571465a75c3f/src/loader/fragment-loader.ts#L172-L173
As result ABR will use empty newPart stats.

Changing direction of assign fix this problem
### Are there any points in the code the reviewer needs to double check?
Maybe the same logic can be applied to fragment loading stats
### Resolves issues:
https://github.com/video-dev/hls.js/issues/3578
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
