### PR TITLE
Bugfix: not download initial segment repeatedly for LLHLS streams

### DIFF
--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -256,6 +256,16 @@ export function mergeDetails(
   if (newDetails.skippedSegments) {
     newDetails.startCC = newDetails.fragments[0].cc;
   }
+  // Use existing init segment data for fragments not handled by mapFragmentIntersection (no corresponding oldFrag)
+  for (let i = 0; i < newFragments.length; i++) {
+    const newFrag = newFragments[i];
+    if (
+      newFrag.initSegment &&
+      newFrag.initSegment.relurl == currentInitSegment?.relurl
+    ) {
+      newFrag.initSegment = currentInitSegment;
+    }
+  }
 
   // Merge parts
   mapPartIntersection(

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -379,6 +379,14 @@ export function mapFragmentIntersection(
       }
     }
   }
+
+  const lastNewFrag = newFrags[end];
+  for (let i = end + 1; i < newFrags.length; i++) {
+    const newFrag = newFrags[i];
+    if (newFrag.initSegment?.relurl == lastNewFrag?.initSegment?.relurl) {
+      newFrag.initSegment = lastNewFrag.initSegment;
+    }
+  }
 }
 
 export function adjustSliding(

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -352,6 +352,7 @@ export function mapFragmentIntersection(
     ? oldDetails.fragments.concat(oldDetails.fragmentHint)
     : oldDetails.fragments;
 
+  let lastSameSegment: Fragment | null = null;
   for (let i = start; i <= end; i++) {
     const oldFrag = oldFrags[delta + i];
     let newFrag = newFrags[i];
@@ -360,7 +361,12 @@ export function mapFragmentIntersection(
       newFrag = newDetails.fragments[i] = oldFrag;
     }
     if (oldFrag && newFrag) {
+      lastSameSegment = oldFrag;
       intersectionFn(oldFrag, newFrag);
+    } else if (newFrag && lastSameSegment) {
+      if (newFrag.initSegment?.relurl == lastSameSegment?.initSegment?.relurl) {
+        newFrag.initSegment = lastSameSegment.initSegment;
+      }
     }
   }
 }

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -379,14 +379,6 @@ export function mapFragmentIntersection(
       }
     }
   }
-
-  const lastNewFrag = newFrags[end];
-  for (let i = end + 1; i < newFrags.length; i++) {
-    const newFrag = newFrags[i];
-    if (newFrag.initSegment?.relurl == lastNewFrag?.initSegment?.relurl) {
-      newFrag.initSegment = lastNewFrag.initSegment;
-    }
-  }
 }
 
 export function adjustSliding(


### PR DESCRIPTION
### This PR will...
Based on #4034, Use existing fMP4 init segment data if it was already downloaded before for LLHLS streams.

### Why is this Pull Request needed?
As new emerged preload-hint will generate a new fragment, but this fragment will not run FragmentIntersection as this is not appeared in oldDetails, so init segment data will not be copied as expected.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
https://github.com/video-dev/hls.js/issues/4310

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
