### PR TITLE
fix readyState no change after xhrSetup

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -84,6 +84,8 @@ class XhrLoader implements Loader<LoaderContext> {
     stats.loaded = 0;
     const xhrSetup = this.xhrSetup;
 
+    xhr.onreadystatechange = this.readystatechange.bind(this);
+
     try {
       if (xhrSetup) {
         try {
@@ -115,7 +117,6 @@ class XhrLoader implements Loader<LoaderContext> {
       );
     }
 
-    xhr.onreadystatechange = this.readystatechange.bind(this);
     xhr.onprogress = this.loadprogress.bind(this);
     xhr.responseType = context.responseType as XMLHttpRequestResponseType;
     // setup timeout before we perform request


### PR DESCRIPTION
### This PR will...
https://github.com/video-dev/hls.js/blob/8c41dff11b165cd8b58cc1f5aa9667e15d593dfe/src/utils/xhr-loader.ts#L98-L100
In the first call this`xhr.readyState` always is 0, because `onreadystatechange` is after xhrSetup.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?
no.
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
