### PR TITLE
disable apple ll-hls streams that are unavailable

### DIFF
--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -233,16 +233,16 @@ module.exports = {
     description:
       'Advanced stream (HEVC/H.264, AC-3/AAC,  WebVTT, fMP4 segments)',
   },
-//   AppleLowLatencyHls: {
-//     url: 'https://ll-hls-test.apple.com/master.m3u8',
-//     description: 'Apple Low-Latency HLS sample (TS segments)',
-//     live: true,
-//   },
-//   AppleLowLatencyCmafHls: {
-//     url: 'https://ll-hls-test.apple.com/cmaf/master.m3u8',
-//     description: 'Apple Low-Latency HLS sample (fMP4 segments)',
-//     live: true,
-//   },
+  //   AppleLowLatencyHls: {
+  //     url: 'https://ll-hls-test.apple.com/master.m3u8',
+  //     description: 'Apple Low-Latency HLS sample (TS segments)',
+  //     live: true,
+  //   },
+  //   AppleLowLatencyCmafHls: {
+  //     url: 'https://ll-hls-test.apple.com/cmaf/master.m3u8',
+  //     description: 'Apple Low-Latency HLS sample (fMP4 segments)',
+  //     live: true,
+  //   },
   groupIds: {
     url: 'https://mtoczko.github.io/hls-test-streams/test-group/playlist.m3u8',
     description: 'Group-id: subtitle and audio',


### PR DESCRIPTION
### This PR will...
disable apple ll-hls streams that are unavailable.

They currently fail with
>Not Found on Accelerator
Description: Your request on the host was not found. Check the location and try again.

### Why is this Pull Request needed?
Because it's causing all PR's to fail, including the dependency updates.