### PR TITLE
hold dependency updates back for 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,5 @@
       "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "widen"
     }
-  ],
-  "lockFileMaintenance": { "enabled": true }
+  ]
 }


### PR DESCRIPTION
### This PR will...

Hold dependency updates back for 7 days to reduce the risk of a hacked package version being merged in, because hopefully someone would notice in 7 days and have the hacked version removed.

Also enable `vulnerabilityAlerts` meaning if GitHub mark a version as venerable and have a fix, that is automatically created immediately.

Luckily we missed https://github.com/advisories/GHSA-pjwm-rvh2-c87w this time, but this should help make things like this less likely to effect us.

### Why is this Pull Request needed?
Helps reduce the risk of a hacked package getting merged in, whilst still keeping dependencies up to date and notifying us of any build problems with new versions.