### PR TITLE
bugfix: Reset fragPrevious when there is a subtitle track switch

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -212,6 +212,7 @@ export class SubtitleStreamController
     data: TrackSwitchedData
   ) {
     this.currentTrackId = data.id;
+    this.fragPrevious = null;
 
     if (!this.levels.length || this.currentTrackId === -1) {
       this.clearInterval();

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -1,7 +1,7 @@
 import { Events } from '../events';
 import { logger } from '../utils/logger';
 import { BufferHelper } from '../utils/buffer-helper';
-import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
+import { findFragmentByPTS } from './fragment-finders';
 import { alignMediaPlaylistByPDT } from '../utils/discontinuities';
 import { addSliding } from './level-helper';
 import { FragmentState } from './fragment-tracker';
@@ -212,7 +212,6 @@ export class SubtitleStreamController
     data: TrackSwitchedData
   ) {
     this.currentTrackId = data.id;
-    this.fragPrevious = null;
 
     if (!this.levels.length || this.currentTrackId === -1) {
       this.clearInterval();
@@ -377,27 +376,18 @@ export class SubtitleStreamController
       const fragPrevious = this.fragPrevious;
       if (targetBufferTime < end) {
         const { maxFragLookUpTolerance } = config;
-        if (fragPrevious && trackDetails.hasProgramDateTime) {
-          foundFrag = findFragmentByPDT(
-            fragments,
-            fragPrevious.endProgramDateTime,
-            maxFragLookUpTolerance
-          );
-        }
-        if (!foundFrag) {
-          foundFrag = findFragmentByPTS(
-            fragPrevious,
-            fragments,
-            targetBufferTime,
-            maxFragLookUpTolerance
-          );
-          if (
-            !foundFrag &&
-            fragPrevious &&
-            fragPrevious.start < fragments[0].start
-          ) {
-            foundFrag = fragments[0];
-          }
+        foundFrag = findFragmentByPTS(
+          fragPrevious,
+          fragments,
+          targetBufferTime,
+          maxFragLookUpTolerance
+        );
+        if (
+          !foundFrag &&
+          fragPrevious &&
+          fragPrevious.start < fragments[0].start
+        ) {
+          foundFrag = fragments[0];
         }
       } else {
         foundFrag = fragments[fragLen - 1];


### PR DESCRIPTION
### This PR will...

This PR resets the `fragPrevious` on the subtitle stream controller.

### Why is this Pull Request needed?

After switching subtitle tracks, it doesn't load new subtitle frags (`webvtt` files).

In my particular case, the subtitle playlist is very long. When a subtitle track is switched, instead of loading current time's frags, it loads the one that continue from previous subtitle track. In my specific case, I had to wait like a minute in order to reach the loaded frags of the new track.

### Are there any points in the code the reviewer needs to double check?

Please some help in order to introduce functional tests :).

### Resolves issues:

- #4403 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
