### PR TITLE
Bugfix/hardware accelerated decoding apple silicon

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -892,6 +892,7 @@ class TSDemuxer implements Demuxer {
               tmp.set(lastUnit.data, 0);
               tmp.set(array.subarray(0, overflow), lastUnit.data.byteLength);
               lastUnit.data = tmp;
+              lastUnit.state = 0;
             }
           }
         }

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -261,4 +261,11 @@ module.exports = {
     abr: true,
     skipFunctionalTests: true,
   },
+  startDelimiterOverlappingBetweenPESPackets: {
+    url: 'https://hlsjs-test-streams-wistia.s3.amazonaws.com/start-delimiter.m3u8',
+    description: `A stream with the start delimiter overlapping between PES packets.
+       Related to https://github.com/video-dev/hls.js/issues/3834, where Apple Silicon chips throw decoding errors if
+       NAL units are not starting right at the beginning of the PES packet when using hardware accelerated decoding.`,
+    abr: false,
+  },
 };


### PR DESCRIPTION
### This PR will...
stop removing the start delimiter bytes from the PES packet during demuxing if they overlap. 

### Why is this Pull Request needed?
This PR is needed because hardware accelerated decoding on Apple Silicon cannot properly decode the MPEG-TS stream when it has been manipulated in this manner.

### Are there any points in the code the reviewer needs to double check?
1. I looked into the original issue for the addition of this conditional statement and all the test streams from that issue are no longer valid. https://github.com/video-dev/hls.js/issues/98. However, I did create several `mediafilesegmenter` streams to try and reproduce the original issue using an Intel Mac. I don't believe I was successful. 
2. I added the test stream from the original issue to be included here. However, because the issue was only impacting Apple Silicon, where the automated tests are executed from would impact if the tests fail _before_ this change is introduced. Reviewers with M1/pro/max Apple chips can add back in the changes from `tsdemuxer.ts` and will see the specs fail. I've also tried to document that fact in the test stream description. 

I spoke with @mangui about trying to see if this change would solve the issue which led to this conditional being added, but without access to those broken streams, I was unable to fully do so. There is a comment (https://github.com/video-dev/hls.js/issues/3834#issuecomment-953065814) from my bug report showing my inability to find this conditional being useful today.

### Resolves issues:
https://github.com/video-dev/hls.js/issues/3834

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
