### PR TITLE
set headers after XMLHttpRequest OPEN

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -85,13 +85,6 @@ class XhrLoader implements Loader<LoaderContext> {
     const xhrSetup = this.xhrSetup;
 
     try {
-      const headers = this.context.headers;
-      if (headers) {
-        for (const header in headers) {
-          xhr.setRequestHeader(header, headers[header]);
-        }
-      }
-
       if (xhrSetup) {
         try {
           xhrSetup(xhr, context.url);
@@ -104,6 +97,13 @@ class XhrLoader implements Loader<LoaderContext> {
       }
       if (!xhr.readyState) {
         xhr.open('GET', context.url, true);
+      }
+
+      const headers = this.context.headers;
+      if (headers) {
+        for (const header in headers) {
+          xhr.setRequestHeader(header, headers[header]);
+        }
       }
     } catch (e) {
       // IE11 throws an exception on xhr.open if attempting to access an HTTP resource over HTTPS


### PR DESCRIPTION
### This PR will...

Move the call to set the headers (added in https://github.com/video-dev/hls.js/pull/4346) to after the `XMLHttpRequest` is opened.

Without this you get an error when enabling CMCD with `useHeaders: true`.

### Why is this Pull Request needed?

Otherwise if the `XMLHttpRequest` is not open it throws an exception.

### Resolves issues:
fixes #4422

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
