### PR TITLE
Fix repeated requests for initialization segments

### DIFF
--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -223,11 +223,6 @@ export function mergeDetails(
       if (oldFrag.initSegment) {
         newFrag.initSegment = oldFrag.initSegment;
         currentInitSegment = oldFrag.initSegment;
-      } else if (
-        !newFrag.initSegment ||
-        newFrag.initSegment.relurl == currentInitSegment?.relurl
-      ) {
-        newFrag.initSegment = currentInitSegment;
       }
     }
   );

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -232,6 +232,20 @@ export function mergeDetails(
     }
   );
 
+  if (currentInitSegment) {
+    const fragmentsToCheck = newDetails.fragmentHint
+      ? newDetails.fragments.concat(newDetails.fragmentHint)
+      : newDetails.fragments;
+    fragmentsToCheck.forEach((frag) => {
+      if (
+        !frag.initSegment ||
+        frag.initSegment.relurl === currentInitSegment?.relurl
+      ) {
+        frag.initSegment = currentInitSegment;
+      }
+    });
+  }
+
   if (newDetails.skippedSegments) {
     newDetails.deltaUpdateFailed = newDetails.fragments.some((frag) => !frag);
     if (newDetails.deltaUpdateFailed) {

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -225,6 +225,43 @@ expect: ${JSON.stringify(merged.fragments[i])}`
         ).to.deep.equal(merged.fragments[i]);
       });
     });
+
+    it('merges initSegments', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const oldInitSegment = new Fragment(PlaylistLevelType.MAIN, '');
+      oldInitSegment.sn = 'initSegment';
+      oldInitSegment.relurl = 'init.mp4';
+      oldPlaylist.fragments.forEach((frag) => {
+        frag.initSegment = oldInitSegment;
+      });
+      oldPlaylist.fragmentHint = new Fragment(PlaylistLevelType.MAIN, '');
+      oldPlaylist.fragmentHint.sn = 4;
+      oldPlaylist.fragmentHint.initSegment = oldInitSegment;
+
+      const newPlaylist = generatePlaylist([2, 3, 4]);
+      const newInitSegment = new Fragment(PlaylistLevelType.MAIN, '');
+      newInitSegment.sn = 'initSegment';
+      newInitSegment.relurl = 'init.mp4';
+      newPlaylist.fragments.forEach((frag) => {
+        frag.initSegment = newInitSegment;
+      });
+      newPlaylist.fragmentHint = new Fragment(PlaylistLevelType.MAIN, '');
+      newPlaylist.fragmentHint.sn = 5;
+      newPlaylist.fragmentHint.initSegment = newInitSegment;
+
+      mergeDetails(oldPlaylist, newPlaylist);
+
+      newPlaylist.fragments.forEach((frag, i) => {
+        expect(
+          frag.initSegment,
+          `Fragment sn: ${frag.sn} does not have correct initSegment`
+        ).to.equal(oldInitSegment);
+      });
+      expect(
+        newPlaylist.fragmentHint.initSegment,
+        'fragmentHint does not have correct initSegment'
+      ).to.equal(oldInitSegment);
+    });
   });
 
   describe('computeReloadInterval', function () {


### PR DESCRIPTION
### This PR will...

Prevent unnecessary requests for the same initialization segment. For live video, merging playlists did not updated non-overlapping fragments. Now, the level-helper will update any non-overlapping fragmentHint or fragments to reference existing initSegment fragments.

### Why is this Pull Request needed?

When multiple EXT-X-MAP support was included https://github.com/video-dev/hls.js/pull/3859, live playlists that include EXT-X-MAP may unnecessarily request the same initialization segment multiple times.

### Are there any points in the code the reviewer needs to double check?

I'm not super familiar with LL-HLS so it took me a while to figure out I needed to also include the `fragmentHint` in the update check. If there's something else missing with LL-HLS integration let me know and I can work through those issues. I've tested with the LL-HLS test stream

I've verified the behavior with some internal non-LL-HLS streams. Additionally the demo LL-HLS stream no longer shows repeated requests. Additionally `npm run test:func` and `npm run test:unit` pass on this branch. Otherwise I don't have a very diverse set of test cases available so if there are other areas that need testing any guidance on those tests would be appreciated.

### Resolves issues:

https://github.com/video-dev/hls.js/issues/4450

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md


Testing:
- 