### PR TITLE
Add support for emsg ID3 metadata in fmp4 segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ HLS.js is written in [ECMAScript6] (`*.js`) and [TypeScript] (`*.ts`) (strongly 
   - Packetized metadata (ID3v2.3.0) Elementary Stream
 - AAC container (audio only streams)
 - MPEG Audio container (MPEG-1/2 Audio Layer III audio only streams)
-- Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS)
+- Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS and FMP4 Emsg)
 - AES-128 decryption
 - SAMPLE-AES decryption (only supported if using MPEG-2 TS container)
 - Encrypted media extensions (EME) support for DRM (digital rights management)
@@ -114,7 +114,6 @@ The following tags are added to their respective fragment's attribute list but a
 For a complete list of issues, see ["Top priorities" in the Release Planning and Backlog project tab](https://github.com/video-dev/hls.js/projects/6). Codec support is dependent on the runtime environment (for example, not all browsers on the same OS support HEVC).
 
 - CMAF CC support [#2623](https://github.com/video-dev/hls.js/issues/2623)
-- `Emsg` Inband Timed Metadata for FMP4 (ID3 within Emsgv1) in "metadata" TextTracks [#2360](https://github.com/video-dev/hls.js/issues/2360)
 - `#EXT-X-DATERANGE` in "metadata" TextTracks [#2218](https://github.com/video-dev/hls.js/issues/2218)
 - `#EXT-X-GAP` filling [#2940](https://github.com/video-dev/hls.js/issues/2940)
 - `#EXT-X-I-FRAME-STREAM-INF` I-frame Media Playlist files

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -1,3 +1,4 @@
+import { flushTextTrackMetadataCueSamples } from './mp4-remuxer';
 import type { InitData, InitDataTrack } from '../utils/mp4-tools';
 import {
   getDuration,
@@ -201,9 +202,14 @@ class PassThroughRemuxer implements Remuxer {
 
     result.audio = track.type === 'audio' ? track : undefined;
     result.video = track.type !== 'audio' ? track : undefined;
-    result.text = textTrack;
-    result.id3 = id3Track;
     result.initSegment = initSegment;
+    const id3InitPts = this.initPTS ?? 0;
+    result.id3 = flushTextTrackMetadataCueSamples(
+      id3Track,
+      timeOffset,
+      id3InitPts,
+      id3InitPts
+    );
 
     return result;
   }


### PR DESCRIPTION
### This PR will...

Add support for emsg timed metadata within fragmented MP4. 

These changes allow for timed metadata delivery (ID3 via emsg) for use cases such as content labeling and advertising in CMAF streams in the same way HLS.js currently supports ID3 in other container formats. 

`HTMLMediaElement` text track and cues generated by HLS.js are similar in timing and content to those added with native HLS playback in Safari. 

Supported schemas include any url containing "/emsg/ID3" or "/emsg-id3" (case insensitive).

Sample test streams from #2360: 
- https://d24rwxnt7vw9qb.cloudfront.net/out/v1/62a7ec8a0f3b4f19ad76eac54f2f2dce/cmaf-clear/index.m3u8
- http://db2.indexcom.com/bucket/ram/00/01x/256k/program.m3u8 
- https://storage.googleapis.com/dlevin/tmp/fmp4-emsg-id3/1567191409/master.m3u8

### Resolves issues:
Closes #2360

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
