### PR TITLE
Add support for CMAF SEI Captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ The following tags are added to their respective fragment's attribute list but a
 
 For a complete list of issues, see ["Top priorities" in the Release Planning and Backlog project tab](https://github.com/video-dev/hls.js/projects/6). Codec support is dependent on the runtime environment (for example, not all browsers on the same OS support HEVC).
 
-- CMAF CC support [#2623](https://github.com/video-dev/hls.js/issues/2623)
 - `#EXT-X-DATERANGE` in "metadata" TextTracks [#2218](https://github.com/video-dev/hls.js/issues/2218)
 - `#EXT-X-GAP` filling [#2940](https://github.com/video-dev/hls.js/issues/2940)
 - `#EXT-X-I-FRAME-STREAM-INF` I-frame Media Playlist files

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2143,9 +2143,19 @@ export type TSDemuxerConfig = {
 // @public (undocumented)
 export interface UserdataSample {
     // (undocumented)
-    bytes: Uint8Array;
+    bytes?: Uint8Array;
+    // (undocumented)
+    payloadType?: number;
     // (undocumented)
     pts: number;
+    // (undocumented)
+    type?: number;
+    // (undocumented)
+    userData?: string;
+    // (undocumented)
+    userDataBytes?: Uint8Array;
+    // (undocumented)
+    uuid?: string;
 }
 
 // Warnings were encountered during analysis:

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -664,23 +664,25 @@ export class TimelineController implements ComponentAPI {
   }
 
   private extractCea608Data(byteArray: Uint8Array): number[][] {
-    const count = byteArray[0] & 31;
-    let position = 2;
     const actualCCBytes: number[][] = [[], []];
+    const count = byteArray[0] & 0x1f;
+    let position = 2;
 
     for (let j = 0; j < count; j++) {
       const tmpByte = byteArray[position++];
       const ccbyte1 = 0x7f & byteArray[position++];
       const ccbyte2 = 0x7f & byteArray[position++];
-      const ccValid = (4 & tmpByte) !== 0;
-      const ccType = 3 & tmpByte;
-
       if (ccbyte1 === 0 && ccbyte2 === 0) {
         continue;
       }
-
+      const ccValid = (0x04 & tmpByte) !== 0; // Support all four channels
       if (ccValid) {
-        if (ccType === 0 || ccType === 1) {
+        const ccType = 0x03 & tmpByte;
+        if (
+          0x00 /* CEA608 field1*/ === ccType ||
+          0x01 /* CEA608 field2*/ === ccType
+        ) {
+          // Exclude CEA708 CC data.
           actualCCBytes[ccType].push(ccbyte1);
           actualCCBytes[ccType].push(ccbyte2);
         }

--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -19,8 +19,13 @@ class AACDemuxer extends BaseAudioDemuxer {
     this.config = config;
   }
 
-  resetInitSegment(audioCodec, videoCodec, duration) {
-    super.resetInitSegment(audioCodec, videoCodec, duration);
+  resetInitSegment(
+    initSegment: Uint8Array | undefined,
+    audioCodec: string | undefined,
+    videoCodec: string | undefined,
+    trackDuration: number
+  ) {
+    super.resetInitSegment(initSegment, audioCodec, videoCodec, trackDuration);
     this._audioTrack = {
       container: 'audio/adts',
       type: 'audio',
@@ -30,7 +35,7 @@ class AACDemuxer extends BaseAudioDemuxer {
       isAAC: true,
       samples: [],
       manifestCodec: audioCodec,
-      duration: duration,
+      duration: trackDuration,
       inputTimeScale: 90000,
       dropped: 0,
     };

--- a/src/demux/base-audio-demuxer.ts
+++ b/src/demux/base-audio-demuxer.ts
@@ -5,7 +5,7 @@ import type {
   DemuxedAudioTrack,
   AudioFrame,
   DemuxedMetadataTrack,
-  DemuxedAvcTrack,
+  DemuxedVideoTrack,
   DemuxedUserdataTrack,
   KeyData,
 } from '../types/demuxer';
@@ -20,7 +20,12 @@ class BaseAudioDemuxer implements Demuxer {
   protected cachedData: Uint8Array | null = null;
   protected initPTS: number | null = null;
 
-  resetInitSegment(audioCodec: string, videoCodec: string, duration: number) {
+  resetInitSegment(
+    initSegment: Uint8Array | undefined,
+    audioCodec: string | undefined,
+    videoCodec: string | undefined,
+    trackDuration: number
+  ) {
     this._id3Track = {
       type: 'id3',
       id: 3,
@@ -109,7 +114,7 @@ class BaseAudioDemuxer implements Demuxer {
 
     return {
       audioTrack: track,
-      avcTrack: dummyTrack() as DemuxedAvcTrack,
+      videoTrack: dummyTrack() as DemuxedVideoTrack,
       id3Track,
       textTrack: dummyTrack() as DemuxedUserdataTrack,
     };
@@ -137,7 +142,7 @@ class BaseAudioDemuxer implements Demuxer {
 
     return {
       audioTrack: this._audioTrack,
-      avcTrack: dummyTrack() as DemuxedAvcTrack,
+      videoTrack: dummyTrack() as DemuxedVideoTrack,
       id3Track: this._id3Track,
       textTrack: dummyTrack() as DemuxedUserdataTrack,
     };

--- a/src/demux/dummy-demuxed-track.ts
+++ b/src/demux/dummy-demuxed-track.ts
@@ -1,11 +1,11 @@
 import type { DemuxedTrack } from '../types/demuxer';
 
-export function dummyTrack(): DemuxedTrack {
+export function dummyTrack(type = '', inputTimeScale = 90000): DemuxedTrack {
   return {
-    type: '',
+    type,
     id: -1,
     pid: -1,
-    inputTimeScale: 90000,
+    inputTimeScale,
     sequenceNumber: -1,
     samples: [],
     dropped: 0,

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -9,8 +9,13 @@ import * as MpegAudio from './mpegaudio';
 class MP3Demuxer extends BaseAudioDemuxer {
   static readonly minProbeByteLength: number = 4;
 
-  resetInitSegment(audioCodec, videoCodec, duration) {
-    super.resetInitSegment(audioCodec, videoCodec, duration);
+  resetInitSegment(
+    initSegment: Uint8Array | undefined,
+    audioCodec: string | undefined,
+    videoCodec: string | undefined,
+    trackDuration: number
+  ) {
+    super.resetInitSegment(initSegment, audioCodec, videoCodec, trackDuration);
     this._audioTrack = {
       container: 'audio/mpeg',
       type: 'audio',
@@ -20,7 +25,7 @@ class MP3Demuxer extends BaseAudioDemuxer {
       isAAC: false,
       samples: [],
       manifestCodec: audioCodec,
-      duration: duration,
+      duration: trackDuration,
       inputTimeScale: 90000,
       dropped: 0,
     };

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -4,7 +4,7 @@
 import {
   Demuxer,
   DemuxerResult,
-  PassthroughVideoTrack,
+  PassthroughTrack,
   DemuxedAudioTrack,
   DemuxedUserdataTrack,
   DemuxedMetadataTrack,
@@ -15,6 +15,9 @@ import {
   segmentValidRange,
   appendUint8Array,
   parseEmsg,
+  parseSamples,
+  parseInitSegment,
+  RemuxerTrackIdConfig,
 } from '../utils/mp4-tools';
 import { dummyTrack } from './dummy-demuxed-track';
 import type { HlsEventEmitter } from '../events';
@@ -25,85 +28,145 @@ const emsgSchemePattern = /\/emsg[-/]ID3/i;
 class MP4Demuxer implements Demuxer {
   static readonly minProbeByteLength = 1024;
   private remainderData: Uint8Array | null = null;
+  private timeOffset: number = 0;
   private config: HlsConfig;
+  private videoTrack?: PassthroughTrack;
+  private audioTrack?: DemuxedAudioTrack;
+  private id3Track?: DemuxedMetadataTrack;
+  private txtTrack?: DemuxedUserdataTrack;
 
   constructor(observer: HlsEventEmitter, config: HlsConfig) {
     this.config = config;
   }
 
-  resetTimeStamp() {}
+  public resetTimeStamp() {}
 
-  resetInitSegment() {}
+  public resetInitSegment(
+    initSegment: Uint8Array,
+    audioCodec: string | undefined,
+    videoCodec: string | undefined,
+    trackDuration: number
+  ) {
+    const initData = parseInitSegment(initSegment);
+    const videoTrack = (this.videoTrack = dummyTrack(
+      'video',
+      1
+    ) as PassthroughTrack);
+    const audioTrack = (this.audioTrack = dummyTrack(
+      'audio',
+      1
+    ) as DemuxedAudioTrack);
+    const captionTrack = (this.txtTrack = dummyTrack(
+      'text',
+      1
+    ) as DemuxedUserdataTrack);
 
-  resetContiguity(): void {}
+    this.id3Track = dummyTrack('id3', 1) as DemuxedMetadataTrack;
+    this.timeOffset = 0;
 
-  static probe(data) {
-    // ensure we find a moof box in the first 16 kB
-    return (
-      findBox({ data: data, start: 0, end: Math.min(data.length, 16384) }, [
-        'moof',
-      ]).length > 0
-    );
+    if (initData.video) {
+      const { id, timescale, codec } = initData.video;
+      videoTrack.id = id;
+      videoTrack.timescale = captionTrack.timescale = timescale;
+      videoTrack.codec = codec;
+    }
+
+    if (initData.audio) {
+      const { id, timescale, codec } = initData.audio;
+      audioTrack.id = id;
+      audioTrack.timescale = timescale;
+      audioTrack.codec = codec;
+    }
+
+    captionTrack.id = RemuxerTrackIdConfig.text;
+    videoTrack.sampleDuration = 0;
+    videoTrack.duration = audioTrack.duration = trackDuration;
   }
 
-  demux(data: Uint8Array, timeOffset: number): DemuxerResult {
+  public resetContiguity(): void {}
+
+  static probe(data: Uint8Array) {
+    // ensure we find a moof box in the first 16 kB
+    data = data.length > 16384 ? data.subarray(0, 16384) : data;
+    return findBox(data, ['moof']).length > 0;
+  }
+
+  public demux(data: Uint8Array, timeOffset: number): DemuxerResult {
+    this.timeOffset = timeOffset;
     // Load all data into the avc track. The CMAF remuxer will look for the data in the samples object; the rest of the fields do not matter
-    let avcSamples = data;
-    const avcTrack = dummyTrack() as PassthroughVideoTrack;
+    let videoSamples = data;
+    const videoTrack = this.videoTrack as PassthroughTrack;
+    const textTrack = this.txtTrack as DemuxedUserdataTrack;
     if (this.config.progressive) {
       // Split the bytestream into two ranges: one encompassing all data up until the start of the last moof, and everything else.
       // This is done to guarantee that we're sending valid data to MSE - when demuxing progressively, we have no guarantee
       // that the fetch loader gives us flush moof+mdat pairs. If we push jagged data to MSE, it will throw an exception.
       if (this.remainderData) {
-        avcSamples = appendUint8Array(this.remainderData, data);
+        videoSamples = appendUint8Array(this.remainderData, data);
       }
-      const segmentedData = segmentValidRange(avcSamples);
+      const segmentedData = segmentValidRange(videoSamples);
       this.remainderData = segmentedData.remainder;
-      avcTrack.samples = segmentedData.valid || new Uint8Array();
+      videoTrack.samples = segmentedData.valid || new Uint8Array();
     } else {
-      avcTrack.samples = avcSamples;
+      videoTrack.samples = videoSamples;
     }
 
-    const id3Track = dummyTrack() as DemuxedMetadataTrack;
-    const emsgs = findBox(avcTrack.samples, ['emsg']);
-    if (emsgs) {
-      id3Track.inputTimeScale = 1;
-      emsgs.forEach(({ data, start, end }) => {
-        const emsgInfo = parseEmsg(data.subarray(start, end));
-        if (emsgSchemePattern.test(emsgInfo.schemeIdUri)) {
-          const pts = Number.isFinite(emsgInfo.presentationTime)
-            ? emsgInfo.presentationTime! / emsgInfo.timeScale
-            : timeOffset + emsgInfo.presentationTimeDelta! / emsgInfo.timeScale;
-          const payload = emsgInfo.payload;
-          id3Track.samples.push({
-            data: payload,
-            len: payload.byteLength,
-            dts: pts,
-            pts: pts,
-          });
-        }
-      });
-    }
+    const id3Track = this.extractID3Track(videoTrack, timeOffset);
+    textTrack.samples = parseSamples(timeOffset, videoTrack);
 
     return {
+      videoTrack,
+      audioTrack: this.audioTrack as DemuxedAudioTrack,
+      id3Track,
+      textTrack: this.txtTrack as DemuxedUserdataTrack,
+    };
+  }
+
+  public flush() {
+    const timeOffset = this.timeOffset;
+    const videoTrack = this.videoTrack as PassthroughTrack;
+    const textTrack = this.txtTrack as DemuxedUserdataTrack;
+    videoTrack.samples = this.remainderData || new Uint8Array();
+    this.remainderData = null;
+
+    const id3Track = this.extractID3Track(videoTrack, this.timeOffset);
+    textTrack.samples = parseSamples(timeOffset, videoTrack);
+
+    return {
+      videoTrack,
       audioTrack: dummyTrack() as DemuxedAudioTrack,
-      avcTrack,
       id3Track,
       textTrack: dummyTrack() as DemuxedUserdataTrack,
     };
   }
 
-  flush() {
-    const avcTrack = dummyTrack() as PassthroughVideoTrack;
-    avcTrack.samples = this.remainderData || new Uint8Array();
-    this.remainderData = null;
-
-    return {
-      audioTrack: dummyTrack() as DemuxedAudioTrack,
-      avcTrack,
-      id3Track: dummyTrack() as DemuxedMetadataTrack,
-      textTrack: dummyTrack() as DemuxedUserdataTrack,
-    };
+  private extractID3Track(
+    videoTrack: PassthroughTrack,
+    timeOffset: number
+  ): DemuxedMetadataTrack {
+    const id3Track = this.id3Track as DemuxedMetadataTrack;
+    if (videoTrack.samples.length) {
+      const emsgs = findBox(videoTrack.samples, ['emsg']);
+      if (emsgs) {
+        emsgs.forEach((data: Uint8Array) => {
+          const emsgInfo = parseEmsg(data);
+          if (emsgSchemePattern.test(emsgInfo.schemeIdUri)) {
+            const pts = Number.isFinite(emsgInfo.presentationTime)
+              ? emsgInfo.presentationTime! / emsgInfo.timeScale
+              : timeOffset +
+                emsgInfo.presentationTimeDelta! / emsgInfo.timeScale;
+            const payload = emsgInfo.payload;
+            id3Track.samples.push({
+              data: payload,
+              len: payload.byteLength,
+              dts: pts,
+              pts: pts,
+            });
+          }
+        });
+      }
+    }
+    return id3Track;
   }
 
   demuxSampleAes(

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -11,7 +11,7 @@ import PassThroughRemuxer from '../remux/passthrough-remuxer';
 import ChunkCache from './chunk-cache';
 import { appendUint8Array } from '../utils/mp4-tools';
 import { logger } from '../utils/logger';
-import type { Demuxer, KeyData } from '../types/demuxer';
+import type { Demuxer, DemuxerResult, KeyData } from '../types/demuxer';
 import type { Remuxer } from '../types/remuxer';
 import type { TransmuxerResult, ChunkMetadata } from '../types/transmuxer';
 import type { HlsConfig } from '../config';
@@ -202,7 +202,7 @@ export default class Transmuxer {
       });
     }
 
-    const transmuxResults: Array<TransmuxerResult> = [];
+    const transmuxResults: TransmuxerResult[] = [];
     const { timeOffset } = currentTransmuxState;
     if (decrypter) {
       // The decrypter may have data cached, which needs to be demuxed. In this case we'll have two TransmuxResults
@@ -247,8 +247,12 @@ export default class Transmuxer {
     return transmuxResults;
   }
 
-  private flushRemux(transmuxResults, demuxResult, chunkMeta) {
-    const { audioTrack, avcTrack, id3Track, textTrack } = demuxResult;
+  private flushRemux(
+    transmuxResults: TransmuxerResult[],
+    demuxResult: DemuxerResult,
+    chunkMeta: ChunkMetadata
+  ) {
+    const { audioTrack, videoTrack, id3Track, textTrack } = demuxResult;
     const { accurateTimeOffset, timeOffset } = this.currentTransmuxState;
     logger.log(
       `[transmuxer.ts]: Flushed fragment ${chunkMeta.sn}${
@@ -257,7 +261,7 @@ export default class Transmuxer {
     );
     const remuxResult = this.remuxer!.remux(
       audioTrack,
-      avcTrack,
+      videoTrack,
       id3Track,
       textTrack,
       timeOffset,
@@ -295,13 +299,18 @@ export default class Transmuxer {
     initSegmentData: Uint8Array | undefined,
     audioCodec: string | undefined,
     videoCodec: string | undefined,
-    duration: number
+    trackDuration: number
   ) {
     const { demuxer, remuxer } = this;
     if (!demuxer || !remuxer) {
       return;
     }
-    demuxer.resetInitSegment(audioCodec, videoCodec, duration);
+    demuxer.resetInitSegment(
+      initSegmentData,
+      audioCodec,
+      videoCodec,
+      trackDuration
+    );
     remuxer.resetInitSegment(initSegmentData, audioCodec, videoCodec);
   }
 
@@ -349,12 +358,12 @@ export default class Transmuxer {
     accurateTimeOffset: boolean,
     chunkMeta: ChunkMetadata
   ): TransmuxerResult {
-    const { audioTrack, avcTrack, id3Track, textTrack } = (
+    const { audioTrack, videoTrack, id3Track, textTrack } = (
       this.demuxer as Demuxer
     ).demux(data, timeOffset, false, !this.config.progressive);
     const remuxResult = this.remuxer!.remux(
       audioTrack,
-      avcTrack,
+      videoTrack,
       id3Track,
       textTrack,
       timeOffset,
@@ -380,7 +389,7 @@ export default class Transmuxer {
       .then((demuxResult) => {
         const remuxResult = this.remuxer!.remux(
           demuxResult.audioTrack,
-          demuxResult.avcTrack,
+          demuxResult.videoTrack,
           demuxResult.id3Track,
           demuxResult.textTrack,
           timeOffset,

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -12,10 +12,13 @@
 import * as ADTS from './adts';
 import * as MpegAudio from './mpegaudio';
 import ExpGolomb from './exp-golomb';
-import { utf8ArrayToStr } from './id3';
 import SampleAesDecrypter from './sample-aes';
 import { Events } from '../events';
-import { appendUint8Array } from '../utils/mp4-tools';
+import {
+  appendUint8Array,
+  parseSEIMessageFromNALu,
+  RemuxerTrackIdConfig,
+} from '../utils/mp4-tools';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import type { HlsConfig } from '../config';
@@ -33,21 +36,6 @@ import type {
   KeyData,
 } from '../types/demuxer';
 import { AudioFrame } from '../types/demuxer';
-
-// We are using fixed track IDs for driving the MP4 remuxer
-// instead of following the TS PIDs.
-// There is no reason not to do this and some browsers/SourceBuffer-demuxers
-// may not like if there are TrackID "switches"
-// See https://github.com/video-dev/hls.js/issues/1331
-// Here we are mapping our internal track types to constant MP4 track IDs
-// With MSE currently one can only have one track of each, and we are muxing
-// whatever video/audio rendition in them.
-const RemuxerTrackIdConfig = {
-  video: 1,
-  audio: 2,
-  id3: 3,
-  text: 4,
-};
 
 type ParsedTimestamp = {
   pts?: number;
@@ -76,18 +64,15 @@ class TSDemuxer implements Demuxer {
 
   private sampleAes: SampleAesDecrypter | null = null;
   private pmtParsed: boolean = false;
-  private audioCodec!: string;
-  private videoCodec!: string;
+  private audioCodec?: string;
+  private videoCodec?: string;
   private _duration: number = 0;
-  private aacLastPTS: number | null = null;
-  private _initPTS: number | null = null;
-  private _initDTS?: number | null = null;
   private _pmtId: number = -1;
 
-  private _avcTrack!: DemuxedAvcTrack;
-  private _audioTrack!: DemuxedAudioTrack;
-  private _id3Track!: DemuxedMetadataTrack;
-  private _txtTrack!: DemuxedUserdataTrack;
+  private _avcTrack?: DemuxedAvcTrack;
+  private _audioTrack?: DemuxedAudioTrack;
+  private _id3Track?: DemuxedMetadataTrack;
+  private _txtTrack?: DemuxedUserdataTrack;
   private aacOverFlow: AudioFrame | null = null;
   private avcSample: ParsedAvcSample | null = null;
   private remainderData: Uint8Array | null = null;
@@ -145,7 +130,7 @@ class TSDemuxer implements Demuxer {
    */
   static createTrack(
     type: 'audio' | 'video' | 'id3' | 'text',
-    duration: number
+    duration?: number
   ): DemuxedTrack {
     return {
       container:
@@ -166,38 +151,29 @@ class TSDemuxer implements Demuxer {
    * Resets all internal track instances of the demuxer.
    */
   public resetInitSegment(
+    initSegment: Uint8Array | undefined,
     audioCodec: string,
     videoCodec: string,
-    duration: number
+    trackDuration: number
   ) {
     this.pmtParsed = false;
     this._pmtId = -1;
 
-    this._avcTrack = TSDemuxer.createTrack(
-      'video',
-      duration
-    ) as DemuxedAvcTrack;
+    this._avcTrack = TSDemuxer.createTrack('video') as DemuxedAvcTrack;
     this._audioTrack = TSDemuxer.createTrack(
       'audio',
-      duration
+      trackDuration
     ) as DemuxedAudioTrack;
-    this._id3Track = TSDemuxer.createTrack(
-      'id3',
-      duration
-    ) as DemuxedMetadataTrack;
-    this._txtTrack = TSDemuxer.createTrack(
-      'text',
-      duration
-    ) as DemuxedUserdataTrack;
+    this._id3Track = TSDemuxer.createTrack('id3') as DemuxedMetadataTrack;
+    this._txtTrack = TSDemuxer.createTrack('text') as DemuxedUserdataTrack;
     this._audioTrack.isAAC = true;
 
     // flush any partial content
     this.aacOverFlow = null;
-    this.aacLastPTS = null;
     this.avcSample = null;
     this.audioCodec = audioCodec;
     this.videoCodec = videoCodec;
-    this._duration = duration;
+    this._duration = trackDuration;
   }
 
   public resetTimeStamp() {}
@@ -214,7 +190,6 @@ class TSDemuxer implements Demuxer {
       _id3Track.pesData = null;
     }
     this.aacOverFlow = null;
-    this.aacLastPTS = null;
   }
 
   public demux(
@@ -229,12 +204,13 @@ class TSDemuxer implements Demuxer {
 
     let pes: PES | null;
 
-    const avcTrack = this._avcTrack;
-    const audioTrack = this._audioTrack;
-    const id3Track = this._id3Track;
+    const videoTrack = this._avcTrack as DemuxedAvcTrack;
+    const audioTrack = this._audioTrack as DemuxedAudioTrack;
+    const id3Track = this._id3Track as DemuxedMetadataTrack;
+    const textTrack = this._txtTrack as DemuxedUserdataTrack;
 
-    let avcId = avcTrack.pid;
-    let avcData = avcTrack.pesData;
+    let avcId = videoTrack.pid;
+    let avcData = videoTrack.pesData;
     let audioId = audioTrack.pid;
     let id3Id = id3Track.pid;
     let audioData = audioTrack.pesData;
@@ -254,9 +230,9 @@ class TSDemuxer implements Demuxer {
       this.remainderData = data;
       return {
         audioTrack,
-        avcTrack,
+        videoTrack,
         id3Track,
-        textTrack: this._txtTrack,
+        textTrack,
       };
     }
 
@@ -295,7 +271,7 @@ class TSDemuxer implements Demuxer {
           case avcId:
             if (stt) {
               if (avcData && (pes = parsePES(avcData))) {
-                this.parseAVCPES(pes, false);
+                this.parseAVCPES(videoTrack, textTrack, pes, false);
               }
 
               avcData = { data: [], size: 0 };
@@ -309,9 +285,9 @@ class TSDemuxer implements Demuxer {
             if (stt) {
               if (audioData && (pes = parsePES(audioData))) {
                 if (audioTrack.isAAC) {
-                  this.parseAACPES(pes);
+                  this.parseAACPES(audioTrack, pes);
                 } else {
-                  this.parseMPEGPES(pes);
+                  this.parseMPEGPES(audioTrack, pes);
                 }
               }
               audioData = { data: [], size: 0 };
@@ -324,7 +300,7 @@ class TSDemuxer implements Demuxer {
           case id3Id:
             if (stt) {
               if (id3Data && (pes = parsePES(id3Data))) {
-                this.parseID3PES(pes);
+                this.parseID3PES(id3Track, pes);
               }
 
               id3Data = { data: [], size: 0 };
@@ -362,7 +338,7 @@ class TSDemuxer implements Demuxer {
             // but we are not using this for MP4 track IDs.
             avcId = parsedPIDs.avc;
             if (avcId > 0) {
-              avcTrack.pid = avcId;
+              videoTrack.pid = avcId;
             }
 
             audioId = parsedPIDs.audio;
@@ -405,15 +381,15 @@ class TSDemuxer implements Demuxer {
       });
     }
 
-    avcTrack.pesData = avcData;
+    videoTrack.pesData = avcData;
     audioTrack.pesData = audioData;
     id3Track.pesData = id3Data;
 
     const demuxResult: DemuxerResult = {
       audioTrack,
-      avcTrack,
+      videoTrack,
       id3Track,
-      textTrack: this._txtTrack,
+      textTrack,
     };
 
     if (flush) {
@@ -431,10 +407,10 @@ class TSDemuxer implements Demuxer {
       result = this.demux(remainderData, -1, false, true);
     } else {
       result = {
-        audioTrack: this._audioTrack,
-        avcTrack: this._avcTrack,
-        textTrack: this._txtTrack,
-        id3Track: this._id3Track,
+        videoTrack: this._avcTrack as DemuxedAvcTrack,
+        audioTrack: this._audioTrack as DemuxedAudioTrack,
+        id3Track: this._id3Track as DemuxedMetadataTrack,
+        textTrack: this._txtTrack as DemuxedUserdataTrack,
       };
     }
     this.extractRemainingSamples(result);
@@ -445,25 +421,30 @@ class TSDemuxer implements Demuxer {
   }
 
   private extractRemainingSamples(demuxResult: DemuxerResult) {
-    const { audioTrack, avcTrack, id3Track } = demuxResult;
-    const avcData = avcTrack.pesData;
+    const { audioTrack, videoTrack, id3Track, textTrack } = demuxResult;
+    const avcData = videoTrack.pesData;
     const audioData = audioTrack.pesData;
     const id3Data = id3Track.pesData;
     // try to parse last PES packets
     let pes: PES | null;
     if (avcData && (pes = parsePES(avcData))) {
-      this.parseAVCPES(pes, true);
-      avcTrack.pesData = null;
+      this.parseAVCPES(
+        videoTrack as DemuxedAvcTrack,
+        textTrack as DemuxedUserdataTrack,
+        pes,
+        true
+      );
+      videoTrack.pesData = null;
     } else {
       // either avcData null or PES truncated, keep it for next frag parsing
-      avcTrack.pesData = avcData;
+      videoTrack.pesData = avcData;
     }
 
     if (audioData && (pes = parsePES(audioData))) {
       if (audioTrack.isAAC) {
-        this.parseAACPES(pes);
+        this.parseAACPES(audioTrack, pes);
       } else {
-        this.parseMPEGPES(pes);
+        this.parseMPEGPES(audioTrack, pes);
       }
 
       audioTrack.pesData = null;
@@ -479,7 +460,7 @@ class TSDemuxer implements Demuxer {
     }
 
     if (id3Data && (pes = parsePES(id3Data))) {
-      this.parseID3PES(pes);
+      this.parseID3PES(id3Track, pes);
       id3Track.pesData = null;
     } else {
       // either id3Data null or PES truncated, keep it for next frag parsing
@@ -511,19 +492,19 @@ class TSDemuxer implements Demuxer {
     sampleAes: SampleAesDecrypter
   ): Promise<DemuxerResult> {
     return new Promise((resolve) => {
-      const { audioTrack, avcTrack } = demuxResult;
+      const { audioTrack, videoTrack } = demuxResult;
       if (audioTrack.samples && audioTrack.isAAC) {
         sampleAes.decryptAacSamples(audioTrack.samples, 0, () => {
-          if (avcTrack.samples) {
-            sampleAes.decryptAvcSamples(avcTrack.samples, 0, 0, () => {
+          if (videoTrack.samples) {
+            sampleAes.decryptAvcSamples(videoTrack.samples, 0, 0, () => {
               resolve(demuxResult);
             });
           } else {
             resolve(demuxResult);
           }
         });
-      } else if (avcTrack.samples) {
-        sampleAes.decryptAvcSamples(avcTrack.samples, 0, 0, () => {
+      } else if (videoTrack.samples) {
+        sampleAes.decryptAvcSamples(videoTrack.samples, 0, 0, () => {
           resolve(demuxResult);
         });
       }
@@ -531,13 +512,16 @@ class TSDemuxer implements Demuxer {
   }
 
   public destroy() {
-    this._initPTS = this._initDTS = null;
     this._duration = 0;
   }
 
-  private parseAVCPES(pes: PES, last: boolean) {
-    const track = this._avcTrack;
-    const units = this.parseAVCNALu(pes.data);
+  private parseAVCPES(
+    track: DemuxedAvcTrack,
+    textTrack: DemuxedUserdataTrack,
+    pes: PES,
+    last: boolean
+  ) {
+    const units = this.parseAVCNALu(track, pes.data);
     const debug = false;
     let avcSample = this.avcSample;
     let push: boolean;
@@ -618,106 +602,11 @@ class TSDemuxer implements Demuxer {
           if (debug && avcSample) {
             avcSample.debug += 'SEI ';
           }
-
-          const expGolombDecoder = new ExpGolomb(discardEPB(unit.data));
-
-          // skip frameType
-          expGolombDecoder.readUByte();
-
-          let payloadType = 0;
-          let payloadSize = 0;
-          let endOfCaptions = false;
-          let b = 0;
-
-          while (!endOfCaptions && expGolombDecoder.bytesAvailable > 1) {
-            payloadType = 0;
-            do {
-              b = expGolombDecoder.readUByte();
-              payloadType += b;
-            } while (b === 0xff);
-
-            // Parse payload size.
-            payloadSize = 0;
-            do {
-              b = expGolombDecoder.readUByte();
-              payloadSize += b;
-            } while (b === 0xff);
-
-            // TODO: there can be more than one payload in an SEI packet...
-            // TODO: need to read type and size in a while loop to get them all
-            if (payloadType === 4 && expGolombDecoder.bytesAvailable !== 0) {
-              endOfCaptions = true;
-
-              const countryCode = expGolombDecoder.readUByte();
-
-              if (countryCode === 181) {
-                const providerCode = expGolombDecoder.readUShort();
-
-                if (providerCode === 49) {
-                  const userStructure = expGolombDecoder.readUInt();
-
-                  if (userStructure === 0x47413934) {
-                    const userDataType = expGolombDecoder.readUByte();
-
-                    // Raw CEA-608 bytes wrapped in CEA-708 packet
-                    if (userDataType === 3) {
-                      const firstByte = expGolombDecoder.readUByte();
-                      const secondByte = expGolombDecoder.readUByte();
-
-                      const totalCCs = 31 & firstByte;
-                      const byteArray = [firstByte, secondByte];
-
-                      for (let i = 0; i < totalCCs; i++) {
-                        // 3 bytes per CC
-                        byteArray.push(expGolombDecoder.readUByte());
-                        byteArray.push(expGolombDecoder.readUByte());
-                        byteArray.push(expGolombDecoder.readUByte());
-                      }
-
-                      insertSampleInOrder(this._txtTrack.samples, {
-                        type: 3,
-                        pts: pes.pts,
-                        bytes: byteArray,
-                      });
-                    }
-                  }
-                }
-              }
-            } else if (
-              payloadType === 5 &&
-              expGolombDecoder.bytesAvailable !== 0
-            ) {
-              endOfCaptions = true;
-
-              if (payloadSize > 16) {
-                const uuidStrArray: Array<string> = [];
-                for (let i = 0; i < 16; i++) {
-                  uuidStrArray.push(expGolombDecoder.readUByte().toString(16));
-
-                  if (i === 3 || i === 5 || i === 7 || i === 9) {
-                    uuidStrArray.push('-');
-                  }
-                }
-                const length = payloadSize - 16;
-                const userDataPayloadBytes = new Uint8Array(length);
-                for (let i = 0; i < length; i++) {
-                  userDataPayloadBytes[i] = expGolombDecoder.readUByte();
-                }
-
-                insertSampleInOrder(this._txtTrack.samples, {
-                  pts: pes.pts,
-                  payloadType: payloadType,
-                  uuid: uuidStrArray.join(''),
-                  userData: utf8ArrayToStr(userDataPayloadBytes),
-                  userDataBytes: userDataPayloadBytes,
-                });
-              }
-            } else if (payloadSize < expGolombDecoder.bytesAvailable) {
-              for (let i = 0; i < payloadSize; i++) {
-                expGolombDecoder.readUByte();
-              }
-            }
-          }
+          parseSEIMessageFromNALu(
+            discardEPB(unit.data),
+            pes.pts as number,
+            textTrack.samples
+          );
           break;
           // SPS
         }
@@ -802,12 +691,11 @@ class TSDemuxer implements Demuxer {
     }
   }
 
-  private getLastNalUnit() {
+  private getLastNalUnit(samples: AvcSample[]) {
     let avcSample = this.avcSample;
     let lastUnit;
     // try to fallback to previous sample if current one is empty
     if (!avcSample || avcSample.units.length === 0) {
-      const samples = this._avcTrack.samples;
       avcSample = samples[samples.length - 1];
     }
     if (avcSample?.units) {
@@ -817,13 +705,15 @@ class TSDemuxer implements Demuxer {
     return lastUnit;
   }
 
-  private parseAVCNALu(array: Uint8Array): Array<{
+  private parseAVCNALu(
+    track: DemuxedAvcTrack,
+    array: Uint8Array
+  ): Array<{
     data: Uint8Array;
     type: number;
     state?: number;
   }> {
     const len = array.byteLength;
-    const track = this._avcTrack;
     let state = track.naluState || 0;
     const lastState = state;
     const units = [] as Array<{
@@ -875,7 +765,7 @@ class TSDemuxer implements Demuxer {
           // first check if start code delimiter is overlapping between 2 PES packets,
           // ie it started in last packet (lastState not zero)
           // and ended at the beginning of this PES packet (i <= 4 - lastState)
-          const lastUnit = this.getLastNalUnit();
+          const lastUnit = this.getLastNalUnit(track.samples);
           if (lastUnit) {
             if (lastState && i <= 4 - lastState) {
               // start delimiter overlapping between PES packets
@@ -928,7 +818,7 @@ class TSDemuxer implements Demuxer {
     // no NALu found
     if (units.length === 0) {
       // append pes.data to previous NAL unit
-      const lastUnit = this.getLastNalUnit();
+      const lastUnit = this.getLastNalUnit(track.samples);
       if (lastUnit) {
         const tmp = new Uint8Array(lastUnit.data.byteLength + array.byteLength);
         tmp.set(lastUnit.data, 0);
@@ -940,9 +830,8 @@ class TSDemuxer implements Demuxer {
     return units;
   }
 
-  private parseAACPES(pes: PES) {
+  private parseAACPES(track: DemuxedAudioTrack, pes: PES) {
     let startOffset = 0;
-    const track = this._audioTrack;
     const aacOverFlow = this.aacOverFlow;
     const data = pes.data;
     if (aacOverFlow) {
@@ -990,7 +879,13 @@ class TSDemuxer implements Demuxer {
       }
     }
 
-    ADTS.initTrackConfig(track, this.observer, data, offset, this.audioCodec);
+    ADTS.initTrackConfig(
+      track,
+      this.observer,
+      data,
+      offset,
+      this.audioCodec as string
+    );
 
     let pts: number;
     if (pes.pts !== undefined) {
@@ -1031,7 +926,7 @@ class TSDemuxer implements Demuxer {
     }
   }
 
-  private parseMPEGPES(pes: PES) {
+  private parseMPEGPES(track: DemuxedAudioTrack, pes: PES) {
     const data = pes.data;
     const length = data.length;
     let frameIndex = 0;
@@ -1045,7 +940,7 @@ class TSDemuxer implements Demuxer {
     while (offset < length) {
       if (MpegAudio.isHeader(data, offset)) {
         const frame = MpegAudio.appendFrame(
-          this._audioTrack,
+          track,
           data,
           offset,
           pts,
@@ -1065,12 +960,12 @@ class TSDemuxer implements Demuxer {
     }
   }
 
-  private parseID3PES(pes: PES) {
+  private parseID3PES(id3Track: DemuxedMetadataTrack, pes: PES) {
     if (pes.pts === undefined) {
       logger.warn('[tsdemuxer]: ID3 PES unknown PTS');
       return;
     }
-    this._id3Track.samples.push(pes as Required<PES>);
+    id3Track.samples.push(pes as Required<PES>);
   }
 }
 
@@ -1301,24 +1196,6 @@ function pushAccessUnit(avcSample: ParsedAvcSample, avcTrack: DemuxedAvcTrack) {
   }
   if (avcSample.debug.length) {
     logger.log(avcSample.pts + '/' + avcSample.dts + ':' + avcSample.debug);
-  }
-}
-
-function insertSampleInOrder(arr, data) {
-  const len = arr.length;
-  if (len > 0) {
-    if (data.pts >= arr[len - 1].pts) {
-      arr.push(data);
-    } else {
-      for (let pos = len - 1; pos >= 0; pos--) {
-        if (data.pts < arr[pos].pts) {
-          arr.splice(pos, 0, data);
-          break;
-        }
-      }
-    }
-  } else {
-    arr.push(data);
   }
 }
 

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -75,7 +75,7 @@ export default class FragmentLoader {
         maxRetry: 0,
         retryDelay: 0,
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-        highWaterMark: MIN_CHUNK_SIZE,
+        highWaterMark: frag.sn === 'initSegment' ? Infinity : MIN_CHUNK_SIZE,
       };
       // Assign frag stats to the loader's stats reference
       frag.stats = loader.stats;

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -13,9 +13,10 @@ export interface Demuxer {
   flush(timeOffset?: number): DemuxerResult | Promise<DemuxerResult>;
   destroy(): void;
   resetInitSegment(
+    initSegment: Uint8Array | undefined,
     audioCodec: string | undefined,
     videoCodec: string | undefined,
-    duration: number
+    trackDuration: number
   );
   resetTimeStamp(defaultInitPTS?: number | null): void;
   resetContiguity(): void;
@@ -23,7 +24,7 @@ export interface Demuxer {
 
 export interface DemuxerResult {
   audioTrack: DemuxedAudioTrack;
-  avcTrack: DemuxedVideoTrack;
+  videoTrack: DemuxedVideoTrack;
   id3Track: DemuxedMetadataTrack;
   textTrack: DemuxedUserdataTrack;
 }
@@ -48,6 +49,13 @@ export interface DemuxedTrack {
   codec?: string;
 }
 
+export interface PassthroughTrack extends DemuxedTrack {
+  sampleDuration: number;
+  samples: Uint8Array;
+  timescale: number;
+  duration: number;
+  codec: string;
+}
 export interface DemuxedAudioTrack extends DemuxedTrack {
   config?: number[];
   samplerate?: number;
@@ -72,10 +80,6 @@ export interface DemuxedAvcTrack extends DemuxedVideoTrack {
   samples: AvcSample[];
 }
 
-export interface PassthroughVideoTrack extends DemuxedVideoTrack {
-  samples: Uint8Array;
-}
-
 export interface DemuxedMetadataTrack extends DemuxedTrack {
   samples: MetadataSample[];
 }
@@ -93,7 +97,12 @@ export interface MetadataSample {
 
 export interface UserdataSample {
   pts: number;
-  bytes: Uint8Array;
+  bytes?: Uint8Array;
+  type?: number;
+  payloadType?: number;
+  uuid?: string;
+  userData?: string;
+  userDataBytes?: Uint8Array;
 }
 
 export interface AvcSample {

--- a/src/utils/imsc1-ttml-parser.ts
+++ b/src/utils/imsc1-ttml-parser.ts
@@ -34,9 +34,7 @@ export function parseIMSC1(
     return;
   }
   const mdat = results[0];
-  const ttml = utf8ArrayToStr(
-    new Uint8Array(payload, mdat.start, mdat.end - mdat.start)
-  );
+  const ttml = utf8ArrayToStr(mdat);
   const syncTime = toTimescaleFromScale(initPTS, 1, timescale);
 
   try {


### PR DESCRIPTION
### This PR will...

Add extraction of 608 captions from fragmented MP4 segments. HLS.js will handle captions found in MP4 segments, as it does for MPEG-2 TS segments.

- Add support for CMAF SEI 608 captions in AVC and HEVC video tracks - Resolves #2623
- Optimize SEI and CEA608 caption extraction
  - Remove `Mp4BoxData` from mp4-tools and replace it with `Uint8Array[]` views for all results from `findBox`
  - Replace use of `ExpGolomb` decoder with mp4-tools data methods for reading bytes from SEI NALu packets
  - Parse all unregistered SEI messages so that they are present in `FRAG_PARSING_USERDATA` API events - Resolves #4242
- Rename the DemuxerResult field `avcTrack` to `videoTrack` since this track carries video of any codec (not just AVC) and rename its interface from `PassthroughVideoTrack` to `PassthroughTrack`
- Update UserdataSample interface to reflect the fields present in SEI data samples in `FRAG_PARSING_USERDATA` API events
- Cleanup TSDexumer
  - Remove unused fields `acLastPTS`, `_initPTS` and `_initDTS` from TSDexumer
  - Pass tracks and samples by reference
  - Remove `insertSampleInOrder` since SEI samples are sorted again by the mp4-remuxer in `flushTextTrackUserdataCueSamples`
- Fix progressive MP4 streaming by disabling it for init segments in the fragment-loader - Fixes #4317

### Resolves issues:
Closes #4421 (Does hls.js support extracting SEI frame from videos?)
Resolves #2623 (Add CMAF CC support)
Resolves #4242 (Fix parsing multiple user data unregistered SEI)
Fixes #4317 (Progressive mode is broken with fmp4 playback)

- [x] changes have been done against master branch, and PR does not conflict
