### PR TITLE
Fix invalid target duration error on float values

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -40,7 +40,7 @@ const LEVEL_PLAYLIST_REGEX_SLOW = new RegExp(
     /#EXT-X-(PLAYLIST-TYPE):(.+)/.source,
     /#EXT-X-(MEDIA-SEQUENCE): *(\d+)/.source,
     /#EXT-X-(SKIP):(.+)/.source,
-    /#EXT-X-(TARGETDURATION): *(\d+)/.source,
+    /#EXT-X-(TARGETDURATION): *(\d+\.\d+)/.source,
     /#EXT-X-(KEY):(.+)/.source,
     /#EXT-X-(START):(.+)/.source,
     /#EXT-X-(ENDLIST)/.source,

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -40,7 +40,7 @@ const LEVEL_PLAYLIST_REGEX_SLOW = new RegExp(
     /#EXT-X-(PLAYLIST-TYPE):(.+)/.source,
     /#EXT-X-(MEDIA-SEQUENCE): *(\d+)/.source,
     /#EXT-X-(SKIP):(.+)/.source,
-    /#EXT-X-(TARGETDURATION): *(\d+\.\d+)/.source,
+    /#EXT-X-(TARGETDURATION): *(\d+(\.\d+)?)/.source,
     /#EXT-X-(KEY):(.+)/.source,
     /#EXT-X-(START):(.+)/.source,
     /#EXT-X-(ENDLIST)/.source,


### PR DESCRIPTION
### This PR will...

This fixes `Error while parsing manifest:invalid target duration` error when loaded playlist contains floating values. It turns out that current regexp treats TARGETDURATION numbers as integer and so doesn't work with values below 1.0 

Sample playlist:

```
#EXTM3U
#EXT-X-VERSION:7
#EXT-X-TARGETDURATION:0.500089
#EXT-X-MAP:URI="init.mp4"
#EXT-X-MEDIA-SEQUENCE:1639765123
#EXTINF:0.500089,
video1639765123.m4s
#EXTINF:0.500089,
video1639765124.m4s
#EXTINF:0.500089,
video1639765125.m4s
```

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
