### PR TITLE
Fix SAMPLE-DES decryption according to Apple doc

### DIFF
--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -93,12 +93,12 @@ class SampleAesDecrypter {
   // AVC - encrypt one 16 bytes block out of ten, starting from offset 32
   getAvcEncryptedData(decodedData: Uint8Array) {
     const encryptedDataLen =
-      Math.floor((decodedData.length - 48) / 160) * 16 + 16;
+      Math.floor((decodedData.length - 49) / 160) * 16 + 16;
     const encryptedData = new Int8Array(encryptedDataLen);
     let outputPos = 0;
     for (
       let inputPos = 32;
-      inputPos <= decodedData.length - 16;
+      inputPos < decodedData.length - 16;
       inputPos += 160, outputPos += 16
     ) {
       encryptedData.set(
@@ -118,7 +118,7 @@ class SampleAesDecrypter {
     let inputPos = 0;
     for (
       let outputPos = 32;
-      outputPos <= decodedData.length - 16;
+      outputPos < decodedData.length - 16;
       outputPos += 160, inputPos += 16
     ) {
       decodedData.set(


### PR DESCRIPTION
### This PR will...
make hls.js correctly decrypt SAMPLE-AES streams.

### Why is this Pull Request needed?
hls.js currently is not decrypting the video according to the [Apple documentation](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HLS_Sample_Encryption/Encryption/Encryption.html#//apple_ref/doc/uid/TP40012862-CH2-SW8) so there will be artifacts in video as the decoder is using incorrect data.

More specifically, for each NAL unit, the last 16 bytes should not be an encrypted block; there must be at least 1 trailing byte that's not encrypted.

### Are there any points in the code the reviewer needs to double check?
You can use [Apple's test content](https://developer.apple.com/services-account/download?path=/Developer_Tools/FairPlay_Streaming_Test_Streams/FairPlay_Streaming_Test_Content_v1.0.zip) to test it. You don't need a paid developer account to download it.

### Resolves issues:
N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
