### PR TITLE
Add Opus audio codec support to fMP4 segments

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -232,6 +232,9 @@ function getParsedTrackCodec(
   if (parsedCodec === 'avc1' || type === ElementaryStreamTypes.VIDEO) {
     return 'avc1.42e01e';
   }
+  if (parsedCodec === 'Opus') {
+    return 'opus';
+  }
   return 'mp4a.40.5';
 }
 export default PassThroughRemuxer;


### PR DESCRIPTION
### This PR will...

add support for Opus audio codec for fragmented MP4 video streams, tested on my mp4 collection HLS video streams both on Chrome and Firefox

### Why is this Pull Request needed?

Without this patch, HLS.js treats MP4 videos with Opus codec as AAC audio and doesn't play them at all

### Are there any points in the code the reviewer needs to double check?

I guess it will break nothing

### Resolves issues:

Fixes 1713 issue but only for fragmented MP4 streams

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
