### PR TITLE
Don't assume media object exists when attempting buffer stall fix

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -523,7 +523,7 @@ media.currentTime += (nb nudge retry -1)\*nudgeOffset
 
 (default 3)
 
-Max nb of nudge retries before hls.js raise a fatal BUFFER_STALLED_ERROR
+Max nb - 1 (due to a bug) of nudge retries before hls.js raise a fatal BUFFER_STALLED_ERROR. I.e. a value of 3 means a max of 2 nudges will occur
 
 ### `maxFragLookUpTolerance`
 

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -164,6 +164,9 @@ export default class GapController {
     stalledDurationMs: number
   ) {
     const { config, fragmentTracker, media } = this;
+    if (!media) {
+      return;
+    }
     const currentTime = media.currentTime;
 
     const partial = fragmentTracker.getPartialFragment(currentTime);

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -145,6 +145,11 @@ export default class GapController {
       this._reportStall(bufferInfo.len);
     }
 
+    // Handle case where destroy() has been called & it set media to null
+    if (!media) {
+      return;
+    }
+
     const bufferedWithHoles = BufferHelper.bufferInfo(
       media,
       currentTime,
@@ -164,9 +169,6 @@ export default class GapController {
     stalledDurationMs: number
   ) {
     const { config, fragmentTracker, media } = this;
-    if (!media) {
-      return;
-    }
     const currentTime = media.currentTime;
 
     const partial = fragmentTracker.getPartialFragment(currentTime);

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -206,6 +206,8 @@ export default class StreamController
     this._errorEventsToTrigger = [];
 
     // these events must be triggered at the end of the call stack
+    // to make sure if a handler calls something like `detachMedia`
+    // we don't get in a weird state
     errorEventsToTrigger.forEach((errorEvent) =>
       this.hls.trigger(Events.ERROR, errorEvent)
     );

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -351,7 +351,7 @@ describe('StreamController', function () {
     beforeEach(function () {
       // @ts-ignore
       streamController.gapController = {
-        poll: function () {},
+        poll: () => [],
       };
       streamController['media'] = {
         buffered: {


### PR DESCRIPTION
### This PR will...

Fix an assumption that `media` exists

### Why is this Pull Request needed?

Sentry caught an error when a user was trying to play a video. I assume it stalled, and then this error got reported:

Cannot read properties of null (reading 'currentTime') (referring to [this line](https://github.com/video-dev/hls.js/blob/abb096e358ce0fcdd4903e599065fb04f96f7caf/src/controller/gap-controller.ts#L167))

### Are there any points in the code the reviewer needs to double check?

Probably not.

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
