### PR TITLE
clear cue start time on reset

### DIFF
--- a/src/utils/output-filter.ts
+++ b/src/utils/output-filter.ts
@@ -41,5 +41,6 @@ export default class OutputFilter {
 
   reset() {
     this.cueRanges = [];
+    this.startTime = null;
   }
 }


### PR DESCRIPTION
### This PR will...
Fix cues for 608 live captions having a wrong start time after seek.

### Why is this Pull Request needed?
608 cues can have a wrong start time after seek back>forward>back, which causes captions to be shown at the wrong time position.

### Are there any points in the code the reviewer needs to double check?
Whether this can have any side effects on 608 captions behavior.

### Resolves issues:
https://github.com/video-dev/hls.js/issues/4466

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
