### PR TITLE
Report only 1 FRAG_PARSING_ERROR per parsed TS file

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -272,6 +272,7 @@ class TSDemuxer implements Demuxer {
     }
 
     // loop through TS packets
+    let tsPacketErrors = 0;
     for (let start = syncOffset; start < len; start += 188) {
       if (data[start] === 0x47) {
         const stt = !!(data[start + 1] & 0x40);
@@ -391,13 +392,17 @@ class TSDemuxer implements Demuxer {
             break;
         }
       } else {
-        this.observer.emit(Events.ERROR, Events.ERROR, {
-          type: ErrorTypes.MEDIA_ERROR,
-          details: ErrorDetails.FRAG_PARSING_ERROR,
-          fatal: false,
-          reason: 'TS packet did not start with 0x47',
-        });
+        tsPacketErrors++;
       }
+    }
+
+    if (tsPacketErrors > 0) {
+      this.observer.emit(Events.ERROR, Events.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.FRAG_PARSING_ERROR,
+        fatal: false,
+        reason: `Found ${tsPacketErrors} TS packet/s that do not start with 0x47`,
+      });
     }
 
     avcTrack.pesData = avcData;


### PR DESCRIPTION
### This PR will...

Improve error reporting

### Why is this Pull Request needed?

In order to improve error reporting we want to report only one `FRAG_PARSING_ERROR` per parsed `TS`.

### Are there any points in the code the reviewer needs to double check?

&nbsp;-&nbsp;

### Resolves issues:

https://github.com/video-dev/hls.js/issues/4469

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
