### PR TITLE
issue/4483-CMCD-tb

### DIFF
--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -218,7 +218,7 @@ export default class CMCDController implements ComponentAPI {
         ot == CMCDObjectType.MUXED
       ) {
         data.br = level.bitrate / 1000;
-        data.tb = this.getTopBandwidth(ot);
+        data.tb = this.getTopBandwidth(ot) / 1000;
         data.bl = this.getBufferLength(ot);
       }
 
@@ -261,12 +261,15 @@ export default class CMCDController implements ComponentAPI {
    * Get the highest bitrate.
    */
   private getTopBandwidth(type: CMCDObjectType) {
+    const hls = this.hls;
+    const levels = type === CMCDObjectType.AUDIO ? hls.audioTracks : hls.levels;
+    const max = hls.maxAutoLevel;
+    const len = max > -1 ? max + 1 : hls.levels.length;
+
     let bitrate: number = 0;
 
-    const levels =
-      type === CMCDObjectType.AUDIO ? this.hls.audioTracks : this.hls.levels;
-
-    for (const level of levels) {
+    for (let i = 0; i < len; i++) {
+      const level = levels[i];
       if (level.bitrate > bitrate) {
         bitrate = level.bitrate;
       }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -663,7 +663,7 @@ export default class Hls implements HlsEventEmitter {
    * this setter is used to force next auto level.
    * this is useful to force a switch down in auto mode:
    * in case of load error on level N, hls.js can set nextAutoLevel to N-1 for example)
-   * forced value is valid for one fragment. upon succesful frag loading at forced level,
+   * forced value is valid for one fragment. upon successful frag loading at forced level,
    * this value will be resetted to -1 by ABR controller.
    * @type {number}
    */


### PR DESCRIPTION
### This PR will...
Fix CMCD top bitrate reporting
- The `tb` (top bitrate) property should honor bitrate/size ABR constraints and only report the top playable bitrate.
- The `tb` property should be in kbps

### Why is this Pull Request needed?
The `tb` property is not working as intended.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #4483 

### Checklist
- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
