### PR TITLE
Fix nudge retries happening one time fewer than `nudgeRetry` config

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -265,13 +265,12 @@ export default class GapController {
    * @private
    */
   private _tryNudgeBuffer() {
-    const { config, hls, media } = this;
+    const { config, hls, media, nudgeRetry } = this;
     const currentTime = media.currentTime;
-    const nudgeRetry = (this.nudgeRetry || 0) + 1;
-    this.nudgeRetry = nudgeRetry;
+    this.nudgeRetry++;
 
     if (nudgeRetry < config.nudgeMaxRetry) {
-      const targetTime = currentTime + nudgeRetry * config.nudgeOffset;
+      const targetTime = currentTime + (nudgeRetry + 1) * config.nudgeOffset;
       // playback stalled in buffered area ... let's nudge currentTime to try to overcome this
       logger.warn(`Nudging 'currentTime' from ${currentTime} to ${targetTime}`);
       media.currentTime = targetTime;

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -34,13 +34,24 @@ describe('GapController', function () {
 
   describe('_tryNudgeBuffer', function () {
     it('should increment the currentTime by a multiple of nudgeRetry and the configured nudge amount', function () {
-      for (let i = 1; i < config.nudgeMaxRetry; i++) {
-        const expected = media.currentTime + i * config.nudgeOffset;
+      for (let i = 0; i < config.nudgeMaxRetry; i++) {
+        triggerSpy.resetHistory();
+
+        const expected = media.currentTime + (i + 1) * config.nudgeOffset;
         gapController._tryNudgeBuffer();
         expect(media.currentTime).to.equal(expected);
+
+        expect(triggerSpy).to.have.been.calledWith(Events.ERROR, {
+          type: ErrorTypes.MEDIA_ERROR,
+          details: ErrorDetails.BUFFER_NUDGE_ON_STALL,
+          fatal: false,
+        });
       }
 
-      expect(triggerSpy).to.have.been.calledWith(Events.ERROR, {
+      triggerSpy.resetHistory();
+      gapController._tryNudgeBuffer();
+
+      expect(triggerSpy).not.to.have.been.calledWith(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_NUDGE_ON_STALL,
         fatal: false,


### PR DESCRIPTION
### This PR will...
Fix nudge retries happening one time fewer than `nudgeRetry` config

### Why is this Pull Request needed?
It's one off.

I'm wondering if we should treat this as a breaking change and maybe just update the docs instead?

Or we could change the default from value from 3 to 2 so there's no behaviour change for people who haven't set the config option.

Or maybe it's fine. My concern is if people are expecting there to be X events and now there will be X + 1.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
