### PR TITLE
fix: level playlist parse error of ProgramDateTime

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -228,6 +228,7 @@ export default class M3U8Parser {
         if (currentInitSegment) {
           frag.initSegment = currentInitSegment;
           frag.rawProgramDateTime = currentInitSegment.rawProgramDateTime;
+          currentInitSegment.rawProgramDateTime = null;
         }
       }
 

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -1569,6 +1569,81 @@ http://dummy.url.com/hls/live/segment/segment_022916_164500865_719928.ts
       'http://dummy.url.com/180724_Allison VLOG v3_00002.ts'
     );
   });
+
+  it('parse fmp4 level with discontinuities and program date time', function () {
+    const level = `#EXTM3U
+#EXT-X-VERSION:6
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:1638262
+#EXT-X-DISCONTINUITY-SEQUENCE:28141
+
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:5.005,
+#EXT-X-MAP:URI="init.mp4"
+#EXT-X-PROGRAM-DATE-TIME:2021-11-10T03:25:49.015Z
+3.mp4
+#EXTINF:5.005,
+4.mp4
+#EXTINF:1.961,
+5.mp4
+#EXT-X-DISCONTINUITY
+#EXTINF:5.005,
+0.mp4
+#EXTINF:5.005,
+1.mp4
+#EXTINF:5.005,
+2.mp4
+#EXTINF:5.005,
+3.mp4
+#EXTINF:5.005,
+4.mp4
+#EXTINF:1.961,
+5.mp4
+#EXT-X-DISCONTINUITY
+#EXTINF:5.005,
+0.mp4
+#EXTINF:5.005,
+1.mp4
+#EXTINF:5.005,
+2.mp4
+#EXTINF:5.005,
+3.mp4
+#EXTINF:5.005,
+4.mp4
+#EXTINF:1.961,
+5.mp4
+#EXT-X-DISCONTINUITY
+#EXTINF:5.005,
+0.mp4
+#EXTINF:4.037,
+1.mp4
+#EXT-X-PROGRAM-DATE-TIME:2021-11-10T03:27:04Z
+#EXT-X-CUE-IN
+#EXT-X-MAP:URI="init_960719739.mp4"
+#EXT-X-DISCONTINUITY
+#EXTINF:6.0,
+media_1638274.m4s
+#EXTINF:6.0,
+media_1638275.m4s
+#EXTINF:6.0,
+media_1638276.m4s
+#EXTINF:6.0,
+media_1638277.m4s
+#EXTINF:6.0,
+media_1638278.m4s`;
+    const result = M3U8Parser.parseLevelPlaylist(
+      level,
+      'http://foo.com/adaptive/test.m3u8',
+      0
+    );
+    expect(result.fragments.length).to.equal(22);
+    let pdt = 1636514824000;
+    for (let i = 17; i < result.fragments.length; i++) {
+      const frag = result.fragments[i];
+      expect(frag.programDateTime).to.equal(pdt);
+      pdt += frag.duration * 1000;
+    }
+  });
 });
 
 function expectWithJSONMessage(value, msg) {


### PR DESCRIPTION
### This PR will...
Fix level playlist parse error when `#EXT-X-PROGRAM-DATE-TIME` appear before `#EXT-X-MAP`

### Why is this Pull Request needed?
When `#EXT-X-PROGRAM-DATE-TIME` appear before `#EXT-X-MAP`, `rawProgramDateTime` of currentInitSegment will be set:
https://github.com/video-dev/hls.js/blob/116e7cd4b93b4adf45159e3684c9ec3d2cfd8f80/src/loader/m3u8-parser.ts#L274

Then `rawProgramDateTime` of the following fragments will be set to same `rawProgramDateTime`:
https://github.com/video-dev/hls.js/blob/116e7cd4b93b4adf45159e3684c9ec3d2cfd8f80/src/loader/m3u8-parser.ts#L228-L231

Thus, `programDateTime` will be set to wrong value in function `assignProgramDateTime`:
https://github.com/video-dev/hls.js/blob/116e7cd4b93b4adf45159e3684c9ec3d2cfd8f80/src/loader/m3u8-parser.ts#L613-L615

So `currentInitSegment.rawProgramDateTime` need to be cleared after set once.

### Are there any points in the code the reviewer needs to double check?
No.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
