### PR TITLE
Fix handling encrypted AAC frames when there's no encrypted data in a frame

### DIFF
--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -45,6 +45,11 @@ class SampleAesDecrypter {
     sync: boolean
   ) {
     const curUnit = samples[sampleIndex].unit;
+    if (curUnit.length <= 16) {
+      // No encrypted portion in this sample (first 16 bytes is not
+      // encrypted, see https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HLS_Sample_Encryption/Encryption/Encryption.html),
+      return;
+    }
     const encryptedData = curUnit.subarray(
       16,
       curUnit.length - (curUnit.length % 16)


### PR DESCRIPTION
The `decryptAacSample()` was failing when the content size of the frame was
less than 16 bytes (which is the size of unencrypted portion). Specifically,
`curUnit.set(decryptedData, 16);` code was failing because `curUnit`
was smaller than 16, so there was attempt to write outside of the buffer.

According to the documentation [1], each AAC frame consists of
* ADTS Header (7-9 bytes)
* unencrypted leader (16 bytes)
* a sequence of 16 bytes encrypted blocks (n x 16 bytes)
* unencrypted trailer (0-15 bytes)

In the failing case, the frame contained ADTS header (7 bytes), but the
unencrypted leader was only 13 bytes long.

[1] Section `2.3.1.1 AAC` https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HLS_Sample_Encryption/Encryption/Encryption.html

### This PR will fix...
 handling AAC files with frames where unencrypted ladder is less than 16 bytes long

### Why is this Pull Request needed?
To correctly handle edge cases 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
