### PR TITLE
Bugfix/ll hls endofstream

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -151,7 +151,7 @@ export default class BaseStreamController
     ) {
       const partList = (levelDetails as LevelDetails).partList;
       // Since the last part isn't guaranteed to correspond to fragCurrent for ll-hls, check instead if the last part is buffered.
-      if (partList && partList.length) {
+      if (partList?.length) {
         const lastPart = partList[partList.length - 1];
 
         // Checking the midpoint of the part for potential margin of error and related issues.

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -134,7 +134,7 @@ export default class BaseStreamController
     this.state = State.STOPPED;
   }
 
-  protected _streamEnded(bufferInfo, levelDetails) {
+  protected _streamEnded(bufferInfo, levelDetails: LevelDetails) {
     const { fragCurrent, fragmentTracker } = this;
     // we just got done loading the final fragment and there is no other buffered range after ...
     // rationale is that in case there are any buffered ranges after, it means that there are unbuffered portion in between
@@ -149,7 +149,7 @@ export default class BaseStreamController
       fragCurrent.sn >= levelDetails.endSN &&
       !bufferInfo.nextStart
     ) {
-      const partList = (levelDetails as LevelDetails).partList;
+      const partList = levelDetails.partList;
       // Since the last part isn't guaranteed to correspond to fragCurrent for ll-hls, check instead if the last part is buffered.
       if (partList?.length) {
         const lastPart = partList[partList.length - 1];

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -151,7 +151,7 @@ export default class BaseStreamController
     ) {
       const partList = (levelDetails as LevelDetails).partList;
       // Since the last part isn't guaranteed to correspond to fragCurrent for ll-hls, check instead if the last part is buffered.
-      if (partList) {
+      if (partList && partList.length) {
         const lastPart = partList[partList.length - 1];
 
         // Checking the midpoint of the part for potential margin of error and related issues.

--- a/tests/mocks/time-ranges.mock.js
+++ b/tests/mocks/time-ranges.mock.js
@@ -1,0 +1,36 @@
+const assertValidRange = (name, length, index) => {
+  if (index >= length || index < 0) {
+    throw new DOMException(
+      `Failed to execute '${name}' on 'TimeRanges': The index provided (${index}) is greater than the maximum bound (${length}).`
+    );
+  }
+  return true;
+};
+
+export class TimeRangesMock {
+  _ranges = [];
+
+  // Accepts an argument list of [start, end] tuples or { start: number, end: number } objects
+  constructor(...ranges) {
+    this._ranges = ranges.map((range) =>
+      Array.isArray(range) ? range : [range.start, range.end]
+    );
+  }
+
+  get length() {
+    const { _ranges: ranges } = this;
+    return ranges.length;
+  }
+
+  start(i) {
+    const { _ranges: ranges, length } = this;
+    assertValidRange('start', length, i);
+    return ranges[i] && ranges[i][0];
+  }
+
+  end(i) {
+    const { _ranges: ranges, length } = this;
+    assertValidRange('end', length, i);
+    return ranges[i] && ranges[i][1];
+  }
+}

--- a/tests/unit/controller/base-stream-controller.js
+++ b/tests/unit/controller/base-stream-controller.js
@@ -1,6 +1,7 @@
 import BaseStreamController from '../../../src/controller/stream-controller';
 import Hls from '../../../src/hls';
 import { FragmentState } from '../../../src/controller/fragment-tracker';
+import { TimeRangesMock } from '../../mocks/time-ranges.mock';
 
 describe('BaseStreamController', function () {
   let baseStreamController;
@@ -74,6 +75,26 @@ describe('BaseStreamController', function () {
         baseStreamController._streamEnded(bufferInfo, levelDetails),
         `fragState is ${fragmentTracker.getState()}, expecting OK`
       ).to.be.true;
+    });
+
+    it('returns true if parts are buffered for low latency content', function () {
+      media.buffered = new TimeRangesMock([0, 1]);
+      baseStreamController.fragCurrent = { sn: 10 };
+      levelDetails.endSN = 10;
+      levelDetails.partList = [{ start: 0, duration: 1 }];
+
+      expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
+        .true;
+    });
+
+    it('returns true even if fragCurrent is after the last fragment due to low latency content modeling', function () {
+      media.buffered = new TimeRangesMock([0, 1]);
+      baseStreamController.fragCurrent = { sn: 11 };
+      levelDetails.endSN = 10;
+      levelDetails.partList = [{ start: 0, duration: 1 }];
+
+      expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
+        .true;
     });
   });
 });


### PR DESCRIPTION
### This PR will...

Fix a couple of end of stream issues with ll-hls content to ensure ended will still occur.

I've also created a simple TimeRangesMock for the testing side.

Since this is an ENDLIST/end of stream issue, I can't provide a test stream, but I can assist with starting/ending ll-hls streams for reviewers if needed (I'm in Chicago/US Central Time for a rough sense of availability)

### Why is this Pull Request needed?

The conditions for detecting end of stream for are insufficient ll-hls content, which results in a stall instead of ended. Part of this is related to the fact that fragCurrent for playlists with parts may in fact be "ahead" of the current endSN. Part of this is because FragmentTracker/its usage to determine endOfStream does not account for parts.

### Are there any points in the code the reviewer needs to double check?

I'm currently relying on the levelDetails.partList to detect end of stream conditions.
1. I'm only checking the last part, but I believe it's possible that there could be a gap in the current implementation where hypothetically e.g. lastPart - 1 should also be checked and is missing from the buffer but lastPart is not.
2. Aside from some of the basic conditional checks, this feels like it belongs in FragmentTracker. Unfortunately, there isn't equivalent modeling for `activeParts` when they're buffered, evicted, etc, so this would be a much larger effort. I've confirmed that we could check the last activePart against the relevant timeRanges in `getState()`, but this feels too operationally intensive for that method, something like

```js
// ...
  else if (this.activeParts && this.activeParts.length) {
      const { activeParts } = this;
      const lastActivePart = activeParts[activeParts.length - 1];
      const partFragKey = getFragmentKey(lastActivePart.fragment); // or filter for all activeParts w/same key as fragment
      if (partFragKey === fragKey) {
        const timeRange = getTimeRangeForType(fragment.type);
        if (this.isBuffered(lastActivePart.start, lastActivePart.start + lastActivePart.duration) {
          return APPROPRIATE_STATE/STATES;
        }
      }
  }
```

### Resolves issues:

Fixes #4463 

### Checklist

- [x ] changes have been done against master branch, and PR does not conflict
- [ x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
