### PR TITLE
Make Opus sample entry lowercase

### DIFF
--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -24,7 +24,7 @@ const sampleEntryCodesISO = {
     mlpa: true,
     mp4a: true,
     'raw ': true,
-    Opus: true,
+    opus: true, // browsers expect this to be lowercase despite MP4RA says 'Opus'
     samr: true,
     sawb: true,
     sawp: true,


### PR DESCRIPTION
This commit violates RFC6381 + MP4RA ISO code list for compatibility with browsers and other players.

### This PR will make hls.js accept `opus` codec
Chrome and Firefox accept `opus` codec only as lowercase despite ISO code has a capital O:

No player plays an M3U8 with `CODECS="Opus"`, but some players do play an M3U8 with `CODECS="opus"`.
`codecs="opus"` is also playable in DASH.

### Why is this Pull Request needed?
Opus is modern open audio codec already used in Internet communications and it has a potential use in video streaming.
Browsers (I checked Firefox and Chrome) violate some specs and accept only lowercase codec for Opus:
```
> MediaSource.isTypeSupported('audio/mp4; codecs="opus"')
true
> MediaSource.isTypeSupported('audio/mp4; codecs="Opus"')
false
```

### Are there any points in the code the reviewer needs to double check?
no

### Resolves issues:
#4527

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
