### PR TITLE
Bugfix/webvtt-parse: cue offset (subtitle stream without X-TIMESTAMP-MAP)

### DIFF
--- a/src/utils/webvtt-parser.ts
+++ b/src/utils/webvtt-parser.ts
@@ -109,7 +109,6 @@ export function parseWebVTT(
   let timestampMapLOCAL = 0;
   let parsingError: Error;
   let inHeader = true;
-  let timestampMap = false;
 
   parser.oncue = function (cue: VTTCue) {
     // Adjust cue timing; clamp cues to start no earlier than - and drop cues that don't end after - 0 on timeline.
@@ -134,16 +133,14 @@ export function parseWebVTT(
       cueOffset = webVttMpegTsMapOffset - vttCCs.presentationOffset;
     }
 
-    if (timestampMap) {
-      const duration = cue.endTime - cue.startTime;
-      const startTime =
-        normalizePts(
-          (cue.startTime + cueOffset - timestampMapLOCAL) * 90000,
-          timeOffset * 90000
-        ) / 90000;
-      cue.startTime = startTime;
-      cue.endTime = startTime + duration;
-    }
+    const duration = cue.endTime - cue.startTime;
+    const startTime =
+      normalizePts(
+        (cue.startTime + cueOffset - timestampMapLOCAL) * 90000,
+        timeOffset * 90000
+      ) / 90000;
+    cue.startTime = startTime;
+    cue.endTime = startTime + duration;
 
     //trim trailing webvtt block whitespaces
     const text = cue.text.trim();
@@ -180,7 +177,6 @@ export function parseWebVTT(
       if (startsWith(line, 'X-TIMESTAMP-MAP=')) {
         // Once found, no more are allowed anyway, so stop searching.
         inHeader = false;
-        timestampMap = true;
         // Extract LOCAL and MPEGTS.
         line
           .substr(16)
@@ -196,7 +192,6 @@ export function parseWebVTT(
           // Convert cue time to seconds
           timestampMapLOCAL = cueString2millis(cueTime) / 1000;
         } catch (error) {
-          timestampMap = false;
           parsingError = error;
         }
         // Return without parsing X-TIMESTAMP-MAP line.


### PR DESCRIPTION
### This PR will...
Removes unnecessary code, 1.x.x versions do not need this code, they already have the cueOffset calculation fixed
### Why is this Pull Request needed?
subtitle stream without X-TIMESTAMP-MAP, has incorrect cue start/end time 
### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#4500

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
