### PR TITLE
Prevent base stream from logging after stop

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -377,6 +377,9 @@ export default class BaseStreamController
         this._handleFragmentLoadComplete(data);
       })
       .catch((reason) => {
+        if (this.state === State.STOPPED) {
+          return;
+        }
         this.warn(reason);
         this.resetFragmentLoading(frag);
       });


### PR DESCRIPTION
Prevent base stream from logging after stop

### This PR will...

This PR will prevent the base stream controller from attempting to log after the state has changed to STOPPED.

### Why is this Pull Request needed?

The logger is set to null when the state is STOPPED; this pull request prevents an unhandled type error.

### Are there any points in the code the reviewer needs to double check?

Should the code check if `this.warn` is a function instead of checking the state?

### Resolves issues:

[#4092](https://github.com/video-dev/hls.js/issues/4092)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
