### PR TITLE
Bugfix: Failed to execute 'update' on 'MediaKeySession

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -316,7 +316,9 @@ class EMEController implements ComponentAPI {
           data ? data.byteLength : data
         }), updating key-session`
       );
-      keySession.update(data);
+      keySession.update(data).catch((err) => {
+        logger.warn(`Updating key-session failed: ${err}`);
+      });
     });
   }
 


### PR DESCRIPTION
### This PR will...
Fix several uncaught drm exceptions when call load/unload frequently.

### Why is this Pull Request needed? 
`keySession.update` is called in a callback. And it will raise exception when trying to update keys which belong to closed key session:
```
Uncaught (in promise) DOMException: Failed to execute 'update' on 'MediaKeySession': The session is already closed.
    at https://hls-js.netlify.app/dist/hls.js:6259:18
    at EMEController._onLicenseRequestReadyStageChange (https://hls-js.netlify.app/dist/hls.js:6457:11)
```

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
https://github.com/video-dev/hls.js/issues/4576

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md