### PR TITLE
Retry aligning audio playlist with main playlist if levelloaded came too early

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -55,6 +55,8 @@ class AudioStreamController
   private waitingData: WaitingForPTSData | null = null;
   private mainDetails: LevelDetails | null = null;
   private bufferFlushed: boolean = false;
+  private retryCount: number = 0;
+  private timer: number = 0;
 
   constructor(hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls, fragmentTracker, '[audio-stream-controller]');
@@ -416,6 +418,7 @@ class AudioStreamController
   }
 
   onAudioTrackLoaded(event: Events.AUDIO_TRACK_LOADED, data: TrackLoadedData) {
+    const { config } = this.hls;
     const { levels } = this;
     const { details: newDetails, id: trackId } = data;
     if (!levels) {
@@ -430,12 +433,32 @@ class AudioStreamController
     let sliding = 0;
     if (newDetails.live || track.details?.live) {
       const mainDetails = this.mainDetails;
+      const retry = this.retryCount < config.levelLoadingMaxRetry;
       if (!newDetails.fragments[0]) {
         newDetails.deltaUpdateFailed = true;
       }
-      if (newDetails.deltaUpdateFailed || !mainDetails) {
+      if (newDetails.deltaUpdateFailed || (!mainDetails && !retry)) {
         return;
       }
+      if (!mainDetails) {
+        // If this event occurred just before onLevelLoaded, don't wait around for
+        // the full segment length.
+        const delay = Math.min(
+          Math.pow(2, this.retryCount) * config.levelLoadingRetryDelay,
+          config.levelLoadingMaxRetryTimeout
+        );
+        // Schedule level/track reload
+        this.timer = self.setTimeout(
+          () => this.hls.trigger(Events.AUDIO_TRACK_LOADED, data),
+          delay
+        );
+        this.warn(
+          `retry audiotrack loading #${this.retryCount} in ${delay} ms`
+        );
+        this.retryCount++;
+        return;
+      }
+      this.retryCount = 0;
       if (
         !track.details &&
         newDetails.hasProgramDateTime &&

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -55,6 +55,7 @@ class AudioStreamController
   private waitingData: WaitingForPTSData | null = null;
   private mainDetails: LevelDetails | null = null;
   private bufferFlushed: boolean = false;
+  private cachedTrackLoadedData: TrackLoadedData | null = null;
 
   constructor(hls: Hls, fragmentTracker: FragmentTracker) {
     super(hls, fragmentTracker, '[audio-stream-controller]');
@@ -413,9 +414,17 @@ class AudioStreamController
 
   onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
     this.mainDetails = data.details;
+    if (this.cachedTrackLoadedData !== null) {
+      this.hls.trigger(Events.AUDIO_TRACK_LOADED, this.cachedTrackLoadedData);
+      this.cachedTrackLoadedData = null;
+    }
   }
 
   onAudioTrackLoaded(event: Events.AUDIO_TRACK_LOADED, data: TrackLoadedData) {
+    if (this.mainDetails == null) {
+      this.cachedTrackLoadedData = data;
+      return;
+    }
     const { levels } = this;
     const { details: newDetails, id: trackId } = data;
     if (!levels) {

--- a/tests/unit/controller/audio-stream-controller.js
+++ b/tests/unit/controller/audio-stream-controller.js
@@ -61,6 +61,7 @@ describe('AudioStreamController', function () {
       };
 
       audioStreamController.levels = tracks;
+      audioStreamController.mainDetails = details;
       audioStreamController.tick = () => {};
 
       audioStreamController.onAudioTrackLoaded(Events.AUDIO_TRACK_LOADED, {


### PR DESCRIPTION
### This will retry aligning the audio playlist with the main playlist if levelloaded came too early

### Why is this Pull Request needed?

The problem is that sometimes the onLevelLoaded event comes just after onAudioTrackLoaded, and then everything has to wait around for the entire segment time before it finally gets going.

A very simple workaround looks like this, but that has some rather obvious downsides:

```diff
diff --git a/src/controller/audio-stream-controller.ts b/src/controller/audio-stream-controller.ts
index e9fa2d1c..91e16dc9 100644
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -433,7 +436,14 @@ class AudioStreamController
	   if (!newDetails.fragments[0]) {
		 newDetails.deltaUpdateFailed = true;
	   }
	   if (newDetails.deltaUpdateFailed || !mainDetails) {
+        setTimeout(() => {
+          this.hls.trigger(Events.AUDIO_TRACK_LOADED, data)
+        }, 100)
		 return;
	   }
	   if 
```

Instead I modeled it on the `levelLoadingRetryDelay` code as in base-playlist-controller which deals with a similar scenario.
https://github.com/video-dev/hls.js/blob/5039b2364de95893e3952855886d73ef5e2733bd/src/controller/base-playlist-controller.ts#L239-L264

### Are there any points in the code the reviewer needs to double check?

There may be a much better way to do this. In my testing the mistiming only seems to be very slight, so even the default `levelLoadingRetryDelay` of 1000 ms is rather long. 100 ms does the trick without being noticeable.

```
# audiotrack loaded, too early
12:02:00.316 [log] > [audio-stream-controller]: Track 0 loaded [1673,1677],duration:30 [hls.js:5914:10](http://213.219.154.49:8000/dist/hls.js)

# new addition to retry in a bit rather than in 10 seconds or whatever the segment length is
12:02:00.317 [warn] > [audio-stream-controller]: retry audiotrack loading #0 in 1000 ms [hls.js:5938:14](http://213.219.154.49:8000/dist/hls.js)

# level loaded, only 10 ms later
12:02:00.327 [log] > [level-controller]: reload live playlist 2 in 5957 ms [hls.js:6781:12](http://213.219.154.49:8000/dist/hls.js)
12:02:00.327 [log] > [stream-controller]: Level 2 loaded [1673,1677], cc [0, 0] duration:30 [hls.js:13827:10](http://213.219.154.49:8000/dist/hls.js)
```

Additionally, whatever the best solution may be, it should presumably be copied more or less verbatim to subtitle-stream-controller. I haven't done testing with that yet, plus as I said I'm not sure if this PR as currently written is necessarily the way to go.

https://github.com/video-dev/hls.js/blob/5039b2364de95893e3952855886d73ef5e2733bd/src/controller/subtitle-stream-controller.ts#L249-L252

### Resolves issues:

Fixes #4288.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
