### PR TITLE
Bugfix: forwardBufferLength calculation

### DIFF
--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -114,9 +114,11 @@ export default class LatencyController implements ComponentAPI {
       return 0;
     }
     const bufferedRanges = media.buffered.length;
-    return bufferedRanges
-      ? media.buffered.end(bufferedRanges - 1)
-      : levelDetails.edge - this.currentTime;
+    return (
+      (bufferedRanges
+        ? media.buffered.end(bufferedRanges - 1)
+        : levelDetails.edge) - this.currentTime
+    );
   }
 
   public destroy(): void {


### PR DESCRIPTION
### This PR will...
Fix bug of forwardBufferLength calculation.

### Why is this Pull Request needed?
I think forwardBufferLength should be buffered.end - this.currentTime or levelDetails.edge - this.currentTime, so the statement should be:
```
(bufferedRanges ? media.buffered.end(bufferedRanges - 1) : levelDetails.edge) - this.currentTime
```
While current statement will return media.buffered.end(bufferedRanges - 1) instead.

### Are there any points in the code the reviewer needs to double check?
No.

### Resolves issues:
N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
