### PR TITLE
Allow exact bitrate matches for minAutoLevel getter

### DIFF
--- a/src/hls.ts
+++ b/src/hls.ts
@@ -622,7 +622,7 @@ export default class Hls implements HlsEventEmitter {
 
     const len = levels.length;
     for (let i = 0; i < len; i++) {
-      if (levels[i].maxBitrate > minAutoBitrate) {
+      if (levels[i].maxBitrate >= minAutoBitrate) {
         return i;
       }
     }


### PR DESCRIPTION
### This PR will...
Resolves #4628 

### Why is this Pull Request needed?
`minAutoLevel` API returns the wrong value when an exact bitrate is used for `player.config.minAutoBitrate`.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#4628 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
