### PR TITLE
parsePAT: scan PAT for PID instead of only reading the first entry

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -987,9 +987,19 @@ function createAVCSample(
 }
 
 function parsePAT(data, offset) {
-  // skip the PSI header and parse the first PMT entry
-  return ((data[offset + 10] & 0x1f) << 8) | data[offset + 11];
-  // logger.log('PMT PID:'  + this._pmtId);
+  const sectionLength = ((data[offset + 1] & 0x0f) << 8) | data[offset + 2];
+  const tableEnd = offset + 3 + sectionLength - 4;
+  let program, pid;
+  // advance the offset to the first entry in the table
+  offset += 8;
+  while (offset < tableEnd) {
+    program = (data[offset] << 8) | data[offset + 1];
+    pid = ((data[offset + 2] & 0x1f) << 8) | data[offset + 3];
+    if (program != 0)
+      return pid; /* do not select Network Information Table (program == 0) */
+    offset += 4;
+  }
+  return -1;
 }
 
 function parsePMT(data, offset, mpegSupported, isSampleAes) {


### PR DESCRIPTION
### This PR will...

Scan for PIDs and skip the Network Information Table when parsing the Program Association Table (PAT).

### Why is this Pull Request needed?

parsePAT() will fail to pick up a program if the first entry in the table is the Network Information Table. This change also provides a base for future select by program ID if wanted.

### Are there any points in the code the reviewer needs to double check?

parsePAT()

### Resolves issues:

https://github.com/video-dev/hls.js/issues/4574

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
