### PR TITLE
Paused-but-seeking video buffer hole gap jump support

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -77,7 +77,7 @@ export default class GapController {
 
     // The playhead should not be moving
     if (
-      media.paused ||
+      (media.paused && !seeking) ||
       media.ended ||
       media.playbackRate === 0 ||
       !BufferHelper.getBuffered(media).length


### PR DESCRIPTION

### This PR will...
This PR will enabled the "seeked" event to complete on paused videos that are seeking to a new timepoint, by supporting buffer hold gap jumps videos that have occasional gaps.
Both the UPV Paella Player and the Jellyfin Web players `pause` the video prior to doing a seek.  Both players are experiencing frozen seek events with HLS.js 1.1.3-1.1.5

### Why is this Pull Request needed?
Videos are freezing up when seeking and in paused state (when they hit a bad buffer that needs a gap jump).

### Are there any points in the code the reviewer needs to double check?
Please verify that it makes sense that the playhead is indeed moving, or needs to move, when the video is actively seeking to a new time point, although the video is in paused state, the playhead still needs to jump for the seek to succeed.

### Resolves issues:
It resolves  Issue #4367

Here is an example log
```
[log] > [stream-controller]: Loaded fragment 240 of level 7
[log] > [stream-controller]: FRAG_LOADING->PARSING 
[log] > [transmuxer.ts]: Flushed fragment 240 of level 7 
[log] > [stream-controller]: PARSING->PARSED 
[log] > [stream-controller]: Buffered main sn: 240 of level 7 [1434.067,1446.067][1452.067,1458.067][4176.067,4218.067][4224.067,4248.067][4254.067,4260.067][4266.067,4272.067]
[log] > [stream-controller]: PARSED->IDLE  <---- AAAH, this is where the log normally stop cold and stays stuck
#DCE Buffer hole gap jump attempt for media 'video_1' paused:true seeking:true startJump: 0.005666000000019267 currentTime:1434.061 nextStart:1434.066666   <---- Custom log while local testing to verify the paused: true
[warn] > skipping hole, adjusting currentTime from 1434.061 to 1434.1609999999998 
[log] > [stream-controller]: media seeking to 1434.161, state: IDLE
[log] > [audio-stream-controller]: media seeking to 1434.161, state: IDLE 
[log] > [subtitle-stream-controller]: media seeking to 1434.161, state: IDLE 
[log] > [stream-controller]: Media seeked to 1434.161   <--- YAAAAYYY!!! whop whop, we got the 'seeked' event!
```
