### PR TITLE
Bugfix: freeze after buffer full error occur

### DIFF
--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -161,7 +161,7 @@ export default class TransmuxerInterface {
     const discontinuity = !(lastFrag && frag.cc === lastFrag.cc);
     const trackSwitch = !(lastFrag && chunkMeta.level === lastFrag.level);
     const snDiff = lastFrag ? chunkMeta.sn - (lastFrag.sn as number) : -1;
-    const partDiff = this.part ? chunkMeta.part - this.part.index : 1;
+    const partDiff = this.part ? chunkMeta.part - this.part.index : -1;
     const contiguous =
       !trackSwitch && (snDiff === 1 || (snDiff === 0 && partDiff === 1));
     const now = self.performance.now();


### PR DESCRIPTION
### This PR will...
Fixes bug of playback stuck after BUFFER_FULL_ERROR when maxBufferSize set to a very big value.

###Why is this Pull Request needed?
Per design, contiguous will be true when:
- track not switched
- sn in sequence
  - or same sn but part sn in sequence (low latency mode)

But partDiff is always 1 in current implementation for non-low-latency streams, so contiguous will be true even sn is same, which is not correct.

### Are there any points in the code the reviewer needs to double check?
No.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
