### PR TITLE
Update ID3 cues to span until playlist end, or next cue with same tag type (value.key) on cue append

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -814,6 +814,8 @@ export interface FragParsingInitSegmentData {
 // @public (undocumented)
 export interface FragParsingMetadataData {
     // (undocumented)
+    details: LevelDetails;
+    // (undocumented)
     frag: Fragment;
     // (undocumented)
     id: string;
@@ -825,6 +827,8 @@ export interface FragParsingMetadataData {
 //
 // @public (undocumented)
 export interface FragParsingUserdataData {
+    // (undocumented)
+    details: LevelDetails;
     // (undocumented)
     frag: Fragment;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1483,9 +1483,9 @@ Full list of Events is available below:
 - `Hls.Events.FRAG_PARSING_INIT_SEGMENT` - fired when Init Segment has been extracted from fragment
   - data: { id: demuxer id, frag : fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment }
 - `Hls.Events.FRAG_PARSING_USERDATA` - fired when parsing sei text is completed
-  - data: { id : demuxer id, frag: fragment object, samples : [ sei samples pes ] }
+  - data: { id : demuxer id, frag: fragment object, samples : [ sei samples pes ], details: `levelDetails` object (please see [below](#leveldetails) for more information) }
 - `Hls.Events.FRAG_PARSING_METADATA` - fired when parsing id3 is completed
-  - data: { id: demuxer id, frag : fragment object, samples : [ id3 pes - pts and dts timestamp are relative, values are in seconds] }
+  - data: { id: demuxer id, frag : fragment object, samples : [ id3 pes - pts and dts timestamp are relative, values are in seconds], details: `levelDetails` object (please see [below](#leveldetails) for more information) }
 - `Hls.Events.FRAG_PARSING_DATA` - [deprecated]
 - `Hls.Events.FRAG_PARSED` - fired when fragment parsing is completed
   - data: { frag : fragment object, partIndex }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -680,12 +680,16 @@ class AudioStreamController
       this.resetLiveStartWhenNotLoaded(chunkMeta.level);
       return;
     }
-    const { frag, part } = context;
+    const {
+      frag,
+      part,
+      level: { details },
+    } = context;
     const { audio, text, id3, initSegment } = remuxResult;
 
     // Check if the current fragment has been aborted. We check this by first seeing if we're still playing the current level.
     // If we are, subsequently check if the currently loading fragment (fragCurrent) has changed.
-    if (this.fragContextChanged(frag)) {
+    if (this.fragContextChanged(frag) || !details) {
       return;
     }
 
@@ -726,8 +730,9 @@ class AudioStreamController
     if (id3?.samples?.length) {
       const emittedID3: FragParsingMetadataData = Object.assign(
         {
-          frag,
           id,
+          frag,
+          details,
         },
         id3
       );
@@ -736,8 +741,9 @@ class AudioStreamController
     if (text) {
       const emittedText: FragParsingUserdataData = Object.assign(
         {
-          frag,
           id,
+          frag,
+          details,
         },
         text
       );

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1048,6 +1048,7 @@ export default class StreamController
     }
     const { frag, part, level } = context;
     const { video, text, id3, initSegment } = remuxResult;
+    const { details } = level;
     // The audio-stream-controller handles audio buffering if Hls.js is playing an alternate audio track
     const audio = this.altAudio ? undefined : remuxResult.audio;
 
@@ -1080,7 +1081,7 @@ export default class StreamController
 
     // Avoid buffering if backtracking this fragment
     if (video && remuxResult.independent !== false) {
-      if (level.details) {
+      if (details) {
         const { startPTS, endPTS, startDTS, endDTS } = video;
         if (part) {
           part.elementaryStreams[video.type] = {
@@ -1145,18 +1146,20 @@ export default class StreamController
       this.bufferFragmentData(audio, frag, part, chunkMeta);
     }
 
-    if (id3?.samples?.length) {
+    if (details && id3?.samples?.length) {
       const emittedID3: FragParsingMetadataData = {
-        frag,
         id,
+        frag,
+        details,
         samples: id3.samples,
       };
       hls.trigger(Events.FRAG_PARSING_METADATA, emittedID3);
     }
-    if (text) {
+    if (details && text) {
       const emittedText: FragParsingUserdataData = {
-        frag,
         id,
+        frag,
+        details,
         samples: text.samples,
       };
       hls.trigger(Events.FRAG_PARSING_USERDATA, emittedText);

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -305,12 +305,14 @@ export interface FragParsingInitSegmentData {}
 export interface FragParsingUserdataData {
   id: string;
   frag: Fragment;
+  details: LevelDetails;
   samples: UserdataSample[];
 }
 
 export interface FragParsingMetadataData {
   id: string;
   frag: Fragment;
+  details: LevelDetails;
   samples: MetadataSample[];
 }
 


### PR DESCRIPTION
### This PR will...

Update ID3 cues in timed metadata text tracks to span until the playlist end or until the start of the next cue with the same frame type. 

### Why is this Pull Request needed?

This change improves the handling of ID3 metadata for applications using metadata TextTrack active cues. Since ID3v2 frames have no duration or end time, cues should remain active until the HLS playlist's end or until another cue with the same ID3 frame type begins. 

### Are there any points in the code the reviewer needs to double check?

In Safari, DataCues are assigned an endTime of Infinity, but since HLS.js may use VTTCues, which must have finite start and end times, the current playlist end time was chosen to keep the number of active cues manageable. Applications wishing to modify the default endTime of new cues may do so on "cuechange". 

### Resolves issues:

Resolves #3879

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
