### PR TITLE
Add Support for EXT-X-DATERANGE Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ HLS.js is written in [ECMAScript6] (`*.js`) and [TypeScript] (`*.ts`) (strongly 
   - Packetized metadata (ID3v2.3.0) Elementary Stream
 - AAC container (audio only streams)
 - MPEG Audio container (MPEG-1/2 Audio Layer III audio only streams)
-- Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS and FMP4 Emsg)
+- Timed Metadata for HTTP Live Streaming (ID3 format carried in MPEG-2 TS, Emsg in CMAF/Fragmented MP4, and DATERANGE playlist tags)
 - AES-128 decryption
 - SAMPLE-AES decryption (only supported if using MPEG-2 TS container)
 - Encrypted media extensions (EME) support for DRM (digital rights management)
@@ -102,10 +102,10 @@ The following properties are added to their respective variants' attribute list 
 - `#EXT-X-PRELOAD-HINT:<attribute-list>`
 - `#EXT-X-SKIP:<attribute-list>`
 - `#EXT-X-RENDITION-REPORT:<attribute-list>`
+- `#EXT-X-DATERANGE:<attribute-list>`
 
 The following tags are added to their respective fragment's attribute list but are not implemented in streaming and playback.
 
-- `#EXT-X-DATERANGE:<attribute-list>` (Not added to metadata TextTracks. See [#2218](https://github.com/video-dev/hls.js/issues/2218))
 - `#EXT-X-BITRATE` (Not used in ABR controller)
 - `#EXT-X-GAP` (Not implemented. See [#2940](https://github.com/video-dev/hls.js/issues/2940))
 
@@ -113,7 +113,6 @@ The following tags are added to their respective fragment's attribute list but a
 
 For a complete list of issues, see ["Top priorities" in the Release Planning and Backlog project tab](https://github.com/video-dev/hls.js/projects/6). Codec support is dependent on the runtime environment (for example, not all browsers on the same OS support HEVC).
 
-- `#EXT-X-DATERANGE` in "metadata" TextTracks [#2218](https://github.com/video-dev/hls.js/issues/2218)
 - `#EXT-X-GAP` filling [#2940](https://github.com/video-dev/hls.js/issues/2940)
 - `#EXT-X-I-FRAME-STREAM-INF` I-frame Media Playlist files
 - `SAMPLE-AES` with fmp4, aac, mp3, vtt... segments (MPEG-2 TS only)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -282,6 +282,31 @@ export interface CuesParsedData {
     type: 'captions' | 'subtitles';
 }
 
+// Warning: (ae-missing-release-tag) "DateRange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class DateRange {
+    constructor(dateRangeAttr: AttrList, dateRangeWithSameId?: DateRange);
+    // (undocumented)
+    attr: AttrList;
+    // (undocumented)
+    get class(): string;
+    // (undocumented)
+    get duration(): number | null;
+    // (undocumented)
+    get endDate(): Date | null;
+    // (undocumented)
+    get endOnNext(): boolean;
+    // (undocumented)
+    get id(): string;
+    // (undocumented)
+    get isValid(): boolean;
+    // (undocumented)
+    get plannedDuration(): number | null;
+    // (undocumented)
+    get startDate(): Date;
+}
+
 // Warning: (ae-missing-release-tag) "DRMSystemOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -918,6 +943,7 @@ class Hls implements HlsEventEmitter {
     on<E extends keyof HlsListeners, Context = undefined>(event: E, listener: HlsListeners[E], context?: Context): void;
     // (undocumented)
     once<E extends keyof HlsListeners, Context = undefined>(event: E, listener: HlsListeners[E], context?: Context): void;
+    get playingDate(): Date | null;
     recoverMediaError(): void;
     // (undocumented)
     removeAllListeners<E extends keyof HlsListeners>(event?: E | undefined): void;
@@ -1341,6 +1367,8 @@ export class LevelDetails {
     canSkipDateRanges: boolean;
     // (undocumented)
     canSkipUntil: number;
+    // (undocumented)
+    dateRanges: Record<string, DateRange>;
     // (undocumented)
     deltaUpdateFailed?: boolean;
     // (undocumented)
@@ -1845,6 +1873,20 @@ export interface MetadataSample {
     len?: number;
     // (undocumented)
     pts: number;
+    // (undocumented)
+    type: MetadataSchema;
+}
+
+// Warning: (ae-missing-release-tag) "MetadataSchema" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export enum MetadataSchema {
+    // (undocumented)
+    audioId3 = "org.id3",
+    // (undocumented)
+    dateRange = "com.apple.quicktime.HLS",
+    // (undocumented)
+    emsg = "https://aomedia.org/emsg/ID3"
 }
 
 // Warning: (ae-missing-release-tag) "MP4RemuxerConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/docs/API.md
+++ b/docs/API.md
@@ -130,6 +130,8 @@
   - [`hls.latency`](#hlslatency)
   - [`hls.maxLatency`](#hlsmaxlatency)
   - [`hls.targetLatency`](#hlstargetlatency)
+  - [`hls.drift`](#hlsdrift)
+  - [`hls.playingDate`](#hlsplayingdate)
 - [Runtime Events](#runtime-events)
 - [Loader Composition](#loader-composition)
 - [Errors](#errors)
@@ -1385,6 +1387,10 @@ get : target distance from the edge as calculated by the latency controller
 ### `hls.drift`
 
 get : the rate at which the edge of the current live playlist is advancing or 1 if there is none
+
+### `hls.playingDate`
+
+get: the datetime value relative to media.currentTime for the active level Program Date Time if present
 
 ## Runtime Events
 

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -5,9 +5,12 @@ import {
   removeCuesInRange,
 } from '../utils/texttrack-utils';
 import * as ID3 from '../demux/id3';
+import { DateRange, DateRangeAttribute } from '../loader/date-range';
+import { MetadataSchema } from '../types/demuxer';
 import type {
   BufferFlushingData,
   FragParsingMetadataData,
+  LevelUpdatedData,
   MediaAttachedData,
 } from '../types/events';
 import type { ComponentAPI } from '../types/component-api';
@@ -19,12 +22,38 @@ declare global {
   }
 }
 
+type Cue = VTTCue | TextTrackCue;
+
 const MIN_CUE_DURATION = 0.25;
 
+function getCueClass() {
+  // Attempt to recreate Safari functionality by creating
+  // WebKitDataCue objects when available and store the decoded
+  // ID3 data in the value property of the cue
+  return (self.WebKitDataCue || self.VTTCue || self.TextTrackCue) as any;
+}
+
+function dateRangeDateToTimelineSeconds(date: Date, offset: number): number {
+  return date.getTime() / 1000 - offset;
+}
+
+function hexToArrayBuffer(str): ArrayBuffer {
+  return Uint8Array.from(
+    str
+      .replace(/^0x/, '')
+      .replace(/([\da-fA-F]{2}) ?/g, '0x$1 ')
+      .replace(/ +$/, '')
+      .split(' ')
+  ).buffer;
+}
 class ID3TrackController implements ComponentAPI {
   private hls: Hls;
   private id3Track: TextTrack | null = null;
   private media: HTMLMediaElement | null = null;
+  private dateRangeCuesAppended: Record<
+    string,
+    { cues: Record<string, Cue>; dateRange: DateRange; durationKnown: boolean }
+  > = {};
 
   constructor(hls) {
     this.hls = hls;
@@ -39,16 +68,20 @@ class ID3TrackController implements ComponentAPI {
     const { hls } = this;
     hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+    hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.FRAG_PARSING_METADATA, this.onFragParsingMetadata, this);
     hls.on(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
+    hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
   }
 
   private _unregisterListeners() {
     const { hls } = this;
     hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+    hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.FRAG_PARSING_METADATA, this.onFragParsingMetadata, this);
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
+    hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
   }
 
   // Add ID3 metatadata text track.
@@ -66,6 +99,17 @@ class ID3TrackController implements ComponentAPI {
     clearCurrentCues(this.id3Track);
     this.id3Track = null;
     this.media = null;
+    this.dateRangeCuesAppended = {};
+  }
+
+  private onManifestLoading() {
+    this.dateRangeCuesAppended = {};
+  }
+
+  createTrack(media: HTMLMediaElement): TextTrack {
+    const track = this.getID3Track(media.textTracks) as TextTrack;
+    track.mode = 'hidden';
+    return track;
   }
 
   getID3Track(textTracks: TextTrackList): TextTrack | void {
@@ -96,17 +140,12 @@ class ID3TrackController implements ComponentAPI {
 
     // create track dynamically
     if (!this.id3Track) {
-      this.id3Track = this.getID3Track(this.media.textTracks) as TextTrack;
-      this.id3Track.mode = 'hidden';
+      this.id3Track = this.createTrack(this.media);
     }
 
     // VTTCue end time must be finite, so use playlist edge or fragment end until next fragment with same frame type is found
     const maxCueTime = details.edge || fragment.end;
-
-    // Attempt to recreate Safari functionality by creating
-    // WebKitDataCue objects when available and store the decoded
-    // ID3 data in the value property of the cue
-    const Cue = (self.WebKitDataCue || self.VTTCue || self.TextTrackCue) as any;
+    const Cue = getCueClass();
     let updateCueRanges = false;
     const frameTypesAdded: Record<string, number | null> = {};
 
@@ -127,6 +166,10 @@ class ID3TrackController implements ComponentAPI {
           if (!ID3.isTimeStampFrame(frame)) {
             const cue = new Cue(startTime, endTime, '');
             cue.value = frame;
+            const type = samples[i].type;
+            if (type) {
+              cue.type = type;
+            }
             this.id3Track.addCue(cue);
             frameTypesAdded[frame.key] = null;
             updateCueRanges = true;
@@ -161,12 +204,133 @@ class ID3TrackController implements ComponentAPI {
     event: Events.BUFFER_FLUSHING,
     { startOffset, endOffset, type }: BufferFlushingData
   ) {
-    if (!type || type === 'audio') {
-      // id3 cues come from parsed audio only remove cues when audio buffer is cleared
-      const { id3Track } = this;
-      if (id3Track) {
-        removeCuesInRange(id3Track, startOffset, endOffset);
+    const { id3Track } = this;
+    if (id3Track) {
+      let predicate;
+      if (type === 'audio') {
+        predicate = (cue) => (cue as any).type === MetadataSchema.audioId3;
+      } else if (type === 'video') {
+        predicate = (cue) => (cue as any).type === MetadataSchema.emsg;
+      } else {
+        predicate = (cue) =>
+          (cue as any).type === MetadataSchema.audioId3 ||
+          (cue as any).type === MetadataSchema.emsg;
       }
+      removeCuesInRange(id3Track, startOffset, endOffset, predicate);
+    }
+  }
+
+  onLevelUpdated(event: Events.LEVEL_UPDATED, { details }: LevelUpdatedData) {
+    if (!this.media || !details.hasProgramDateTime) {
+      return;
+    }
+    const { dateRangeCuesAppended, id3Track } = this;
+    const { dateRanges } = details;
+    const ids = Object.keys(dateRanges);
+    // Remove cues from track not found in details.dateRanges
+    if (id3Track) {
+      const idsToRemove = Object.keys(dateRangeCuesAppended).filter(
+        (id) => !ids.includes(id)
+      );
+      for (let i = idsToRemove.length; i--; ) {
+        const id = idsToRemove[i];
+        Object.keys(dateRangeCuesAppended[id].cues).forEach((key) => {
+          id3Track.removeCue(dateRangeCuesAppended[id].cues[key]);
+        });
+        delete dateRangeCuesAppended[id];
+      }
+    }
+    // Exit if the playlist does not have Date Ranges or does not have Program Date Time
+    const lastFragment = details.fragments[details.fragments.length - 1];
+    if (ids.length === 0 || !Number.isFinite(lastFragment?.programDateTime)) {
+      return;
+    }
+
+    if (!this.id3Track) {
+      this.id3Track = this.createTrack(this.media);
+    }
+
+    const dateTimeOffset =
+      (lastFragment.programDateTime as number) / 1000 - lastFragment.start;
+    const maxCueTime = details.edge || lastFragment.end;
+    const Cue = getCueClass();
+
+    for (let i = 0; i < ids.length; i++) {
+      const id = ids[i];
+      const dateRange = dateRanges[id];
+      const appendedDateRangeCues = dateRangeCuesAppended[id];
+      const cues = appendedDateRangeCues?.cues || {};
+      let durationKnown = appendedDateRangeCues?.durationKnown || false;
+      const startTime = dateRangeDateToTimelineSeconds(
+        dateRange.startDate,
+        dateTimeOffset
+      );
+      let endTime = maxCueTime;
+      const endDate = dateRange.endDate;
+      if (endDate) {
+        endTime = dateRangeDateToTimelineSeconds(endDate, dateTimeOffset);
+        durationKnown = true;
+      } else if (dateRange.endOnNext && !durationKnown) {
+        const nextDateRangeWithSameClass = ids
+          .reduce((filterMapArray, id) => {
+            const candidate = dateRanges[id];
+            if (
+              candidate.class === dateRange.class &&
+              candidate.id !== id &&
+              candidate.startDate > dateRange.startDate
+            ) {
+              filterMapArray.push(candidate);
+            }
+            return filterMapArray;
+          }, [] as DateRange[])
+          .sort((a, b) => a.startDate.getTime() - b.startDate.getTime())[0];
+        if (nextDateRangeWithSameClass) {
+          endTime = dateRangeDateToTimelineSeconds(
+            nextDateRangeWithSameClass.startDate,
+            dateTimeOffset
+          );
+          durationKnown = true;
+        }
+      }
+
+      const attributes = Object.keys(dateRange.attr);
+      for (let j = 0; j < attributes.length; j++) {
+        const key = attributes[j];
+        if (
+          key === DateRangeAttribute.ID ||
+          key === DateRangeAttribute.CLASS ||
+          key === DateRangeAttribute.START_DATE ||
+          key === DateRangeAttribute.DURATION ||
+          key === DateRangeAttribute.END_DATE ||
+          key === DateRangeAttribute.END_ON_NEXT
+        ) {
+          continue;
+        }
+        let cue = cues[key] as any;
+        if (cue) {
+          if (durationKnown && !appendedDateRangeCues.durationKnown) {
+            cue.endTime = endTime;
+          }
+        } else {
+          let data = dateRange.attr[key];
+          cue = new Cue(startTime, endTime, '');
+          if (
+            key === DateRangeAttribute.SCTE35_OUT ||
+            key === DateRangeAttribute.SCTE35_IN
+          ) {
+            data = hexToArrayBuffer(data);
+          }
+          cue.value = { key, data };
+          cue.type = MetadataSchema.dateRange;
+          this.id3Track.addCue(cue);
+          cues[key] = cue;
+        }
+      }
+      dateRangeCuesAppended[id] = {
+        cues,
+        dateRange,
+        durationKnown,
+      };
     }
   }
 }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1329,35 +1329,54 @@ export default class StreamController
     }
   }
 
-  get nextLevel() {
+  get nextLevel(): number {
     const frag = this.nextBufferedFrag;
     if (frag) {
       return frag.level;
-    } else {
-      return -1;
     }
+    return -1;
   }
 
-  get currentLevel() {
+  get currentFrag(): Fragment | null {
     const media = this.media;
     if (media) {
-      const fragPlayingCurrent = this.getAppendedFrag(media.currentTime);
-      if (fragPlayingCurrent) {
-        return fragPlayingCurrent.level;
+      return this.fragPlaying || this.getAppendedFrag(media.currentTime);
+    }
+    return null;
+  }
+
+  get currentProgramDateTime(): Date | null {
+    const media = this.media;
+    if (media) {
+      const currentTime = media.currentTime;
+      const frag = this.currentFrag;
+      if (
+        frag &&
+        Number.isFinite(currentTime) &&
+        Number.isFinite(frag.programDateTime)
+      ) {
+        const epocMs =
+          (frag.programDateTime as number) + (currentTime - frag.start) * 1000;
+        return new Date(epocMs);
       }
+    }
+    return null;
+  }
+
+  get currentLevel(): number {
+    const frag = this.currentFrag;
+    if (frag) {
+      return frag.level;
     }
     return -1;
   }
 
   get nextBufferedFrag() {
-    const media = this.media;
-    if (media) {
-      // first get end range of current fragment
-      const fragPlayingCurrent = this.getAppendedFrag(media.currentTime);
-      return this.followingBufferedFrag(fragPlayingCurrent);
-    } else {
-      return null;
+    const frag = this.currentFrag;
+    if (frag) {
+      return this.followingBufferedFrag(frag);
     }
+    return null;
   }
 
   get forceStartLoad() {

--- a/src/demux/base-audio-demuxer.ts
+++ b/src/demux/base-audio-demuxer.ts
@@ -1,5 +1,5 @@
 import * as ID3 from '../demux/id3';
-import type {
+import {
   DemuxerResult,
   Demuxer,
   DemuxedAudioTrack,
@@ -8,6 +8,7 @@ import type {
   DemuxedVideoTrack,
   DemuxedUserdataTrack,
   KeyData,
+  MetadataSchema,
 } from '../types/demuxer';
 import { dummyTrack } from './dummy-demuxed-track';
 import { appendUint8Array } from '../utils/mp4-tools';
@@ -77,6 +78,7 @@ class BaseAudioDemuxer implements Demuxer {
         pts: this.initPTS,
         dts: this.initPTS,
         data: id3Data,
+        type: MetadataSchema.audioId3,
       });
     }
 
@@ -96,7 +98,12 @@ class BaseAudioDemuxer implements Demuxer {
       } else if (ID3.canParse(data, offset)) {
         // after a ID3.canParse, a call to ID3.getID3Data *should* always returns some data
         id3Data = ID3.getID3Data(data, offset)!;
-        id3Track.samples.push({ pts: pts, dts: pts, data: id3Data });
+        id3Track.samples.push({
+          pts: pts,
+          dts: pts,
+          data: id3Data,
+          type: MetadataSchema.audioId3,
+        });
         offset += id3Data.length;
         lastDataIndex = offset;
       } else {

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -9,6 +9,7 @@ import {
   DemuxedUserdataTrack,
   DemuxedMetadataTrack,
   KeyData,
+  MetadataSchema,
 } from '../types/demuxer';
 import {
   findBox,
@@ -161,6 +162,7 @@ class MP4Demuxer implements Demuxer {
               len: payload.byteLength,
               dts: pts,
               pts: pts,
+              type: MetadataSchema.emsg,
             });
           }
         });

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -23,7 +23,7 @@ import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import type { HlsConfig } from '../config';
 import type { HlsEventEmitter } from '../events';
-import type {
+import {
   DemuxedAvcTrack,
   DemuxedAudioTrack,
   DemuxedTrack,
@@ -34,6 +34,7 @@ import type {
   DemuxedUserdataTrack,
   ElementaryStreamData,
   KeyData,
+  MetadataSchema,
 } from '../types/demuxer';
 import { AudioFrame } from '../types/demuxer';
 
@@ -969,7 +970,10 @@ class TSDemuxer implements Demuxer {
       logger.warn('[tsdemuxer]: ID3 PES unknown PTS');
       return;
     }
-    id3Track.samples.push(pes as Required<PES>);
+    const id3Sample = Object.assign({}, pes as Required<PES>, {
+      type: this._avcTrack ? MetadataSchema.emsg : MetadataSchema.audioId3,
+    });
+    id3Track.samples.push(id3Sample);
   }
 }
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -672,6 +672,14 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
+   * get the datetime value relative to media.currentTime for the active level Program Date Time if present
+   * @type {Date}
+   */
+  public get playingDate(): Date | null {
+    return this.streamController.currentProgramDateTime;
+  }
+
+  /**
    * @type {AudioTrack[]}
    */
   get audioTracks(): Array<MediaPlaylist> {
@@ -856,11 +864,16 @@ export type {
 } from './config';
 export type { CuesInterface } from './utils/cues';
 export type { MediaKeyFunc, KeySystems } from './utils/mediakeys-helper';
+export type { DateRange } from './loader/date-range';
 export type { LoadStats } from './loader/load-stats';
 export type { LevelKey } from './loader/level-key';
 export type { LevelDetails } from './loader/level-details';
 export type { SourceBufferName } from './types/buffer';
-export type { MetadataSample, UserdataSample } from './types/demuxer';
+export type {
+  MetadataSample,
+  MetadataSchema,
+  UserdataSample,
+} from './types/demuxer';
 export type {
   LevelParsed,
   LevelAttributes,

--- a/src/loader/date-range.ts
+++ b/src/loader/date-range.ts
@@ -1,0 +1,113 @@
+import { AttrList } from '../utils/attr-list';
+import { logger } from '../utils/logger';
+
+export enum DateRangeAttribute {
+  ID = 'ID',
+  CLASS = 'CLASS',
+  START_DATE = 'START-DATE',
+  DURATION = 'DURATION',
+  END_DATE = 'END-DATE',
+  END_ON_NEXT = 'END-ON-NEXT',
+  PLANNED_DURATION = 'PLANNED-DURATION',
+  SCTE35_OUT = 'SCTE35-OUT',
+  SCTE35_IN = 'SCTE35-IN',
+}
+
+export class DateRange {
+  public attr: AttrList;
+  private _startDate: Date;
+  private _endDate?: Date;
+  private _badValueForSameId?: string;
+
+  constructor(dateRangeAttr: AttrList, dateRangeWithSameId?: DateRange) {
+    if (dateRangeWithSameId) {
+      const previousAttr = dateRangeWithSameId.attr;
+      for (const key in previousAttr) {
+        if (
+          Object.prototype.hasOwnProperty.call(dateRangeAttr, key) &&
+          dateRangeAttr[key] !== previousAttr[key]
+        ) {
+          logger.warn(
+            `DATERANGE tag attribute: "${key}" does not match for tags with ID: "${dateRangeAttr.ID}"`
+          );
+          this._badValueForSameId = key;
+          break;
+        }
+      }
+      // Merge DateRange tags with the same ID
+      dateRangeAttr = Object.assign(
+        new AttrList({}),
+        previousAttr,
+        dateRangeAttr
+      );
+    }
+    this.attr = dateRangeAttr;
+    this._startDate = new Date(dateRangeAttr[DateRangeAttribute.START_DATE]);
+    if (DateRangeAttribute.END_DATE in this.attr) {
+      const endDate = new Date(this.attr[DateRangeAttribute.END_DATE]);
+      if (Number.isFinite(endDate.getTime())) {
+        this._endDate = endDate;
+      }
+    }
+  }
+
+  get id(): string {
+    return this.attr.ID;
+  }
+
+  get class(): string {
+    return this.attr.CLASS;
+  }
+
+  get startDate(): Date {
+    return this._startDate;
+  }
+
+  get endDate(): Date | null {
+    if (this._endDate) {
+      return this._endDate;
+    }
+    const duration = this.duration;
+    if (duration !== null) {
+      return new Date(this._startDate.getTime() + duration * 1000);
+    }
+    return null;
+  }
+
+  get duration(): number | null {
+    if (DateRangeAttribute.DURATION in this.attr) {
+      const duration = this.attr.decimalFloatingPoint(
+        DateRangeAttribute.DURATION
+      );
+      if (Number.isFinite(duration)) {
+        return duration;
+      }
+    } else if (this._endDate) {
+      return (this._endDate.getTime() - this._startDate.getTime()) / 1000;
+    }
+    return null;
+  }
+
+  get plannedDuration(): number | null {
+    if (DateRangeAttribute.PLANNED_DURATION in this.attr) {
+      return this.attr.decimalFloatingPoint(
+        DateRangeAttribute.PLANNED_DURATION
+      );
+    }
+    return null;
+  }
+
+  get endOnNext(): boolean {
+    return this.attr.bool(DateRangeAttribute.END_ON_NEXT);
+  }
+
+  get isValid(): boolean {
+    return (
+      !!this.id &&
+      !this._badValueForSameId &&
+      Number.isFinite(this.startDate.getTime()) &&
+      (this.duration === null || this.duration >= 0) &&
+      (!this.endOnNext || !!this.class)
+    );
+  }
+}

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -1,6 +1,7 @@
 import { Part } from './fragment';
 import type { Fragment } from './fragment';
 import type { AttrList } from '../utils/attr-list';
+import type { DateRange } from './date-range';
 
 const DEFAULT_TARGET_DURATION = 10;
 
@@ -13,6 +14,7 @@ export class LevelDetails {
   public fragments: Fragment[];
   public fragmentHint?: Fragment;
   public partList: Part[] | null = null;
+  public dateRanges: Record<string, DateRange>;
   public live: boolean = true;
   public ageHeader: number = 0;
   public advancedDateTime?: number;
@@ -49,6 +51,7 @@ export class LevelDetails {
 
   constructor(baseUrl) {
     this.fragments = [];
+    this.dateRanges = {};
     this.url = baseUrl;
   }
 

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -1,5 +1,6 @@
 import * as URLToolkit from 'url-toolkit';
 
+import { DateRange } from './date-range';
 import { Fragment, Part } from './fragment';
 import { LevelDetails } from './level-details';
 import { LevelKey } from './level-key';
@@ -37,24 +38,11 @@ const LEVEL_PLAYLIST_REGEX_FAST = new RegExp(
 const LEVEL_PLAYLIST_REGEX_SLOW = new RegExp(
   [
     /#(EXTM3U)/.source,
-    /#EXT-X-(PLAYLIST-TYPE):(.+)/.source,
-    /#EXT-X-(MEDIA-SEQUENCE): *(\d+)/.source,
-    /#EXT-X-(SKIP):(.+)/.source,
-    /#EXT-X-(TARGETDURATION): *(\d+)/.source,
-    /#EXT-X-(KEY):(.+)/.source,
-    /#EXT-X-(START):(.+)/.source,
-    /#EXT-X-(ENDLIST)/.source,
-    /#EXT-X-(DISCONTINUITY-SEQ)UENCE: *(\d+)/.source,
-    /#EXT-X-(DIS)CONTINUITY/.source,
-    /#EXT-X-(VERSION):(\d+)/.source,
-    /#EXT-X-(MAP):(.+)/.source,
-    /#EXT-X-(SERVER-CONTROL):(.+)/.source,
-    /#EXT-X-(PART-INF):(.+)/.source,
-    /#EXT-X-(GAP)/.source,
-    /#EXT-X-(BITRATE):\s*(\d+)/.source,
-    /#EXT-X-(PART):(.+)/.source,
-    /#EXT-X-(PRELOAD-HINT):(.+)/.source,
-    /#EXT-X-(RENDITION-REPORT):(.+)/.source,
+    /#EXT-X-(DATERANGE|KEY|MAP|PART|PART-INF|PLAYLIST-TYPE|PRELOAD-HINT|RENDITION-REPORT|SERVER-CONTROL|SKIP|START):(.+)/
+      .source,
+    /#EXT-X-(BITRATE|DISCONTINUITY-SEQUENCE|MEDIA-SEQUENCE|TARGETDURATION|VERSION): *(\d+)/
+      .source,
+    /#EXT-X-(DISCONTINUITY|ENDLIST|GAP)/.source,
     /(#)([^:]*):(.*)/.source,
     /(#)(.*)(?:.*)\r?\n?/.source,
   ].join('|')
@@ -338,16 +326,32 @@ export default class M3U8Parser {
               frag.tagList.push(value2 ? [value1, value2] : [value1]);
             }
             break;
-          case 'DIS':
+          case 'DISCONTINUITY':
             discontinuityCounter++;
-          /* falls through */
+            frag.tagList.push(['DIS']);
+            break;
           case 'GAP':
             frag.tagList.push([tag]);
             break;
           case 'BITRATE':
             frag.tagList.push([tag, value1]);
             break;
-          case 'DISCONTINUITY-SEQ':
+          case 'DATERANGE': {
+            const dateRangeAttr = new AttrList(value1);
+            const dateRange = new DateRange(
+              dateRangeAttr,
+              level.dateRanges[dateRangeAttr.ID]
+            );
+            if (dateRange.isValid || level.skippedSegments) {
+              level.dateRanges[dateRange.id] = dateRange;
+            } else {
+              logger.warn(`Ignoring invalid DATERANGE tag: "${value1}"`);
+            }
+            // Add to fragment tag list for backwards compatibility (< v1.2.0)
+            frag.tagList.push(['EXT-X-DATERANGE', value1]);
+            break;
+          }
+          case 'DISCONTINUITY-SEQUENCE':
             discontinuityCounter = parseInt(value1);
             break;
           case 'KEY': {

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -88,11 +88,17 @@ export interface DemuxedUserdataTrack extends DemuxedTrack {
   samples: UserdataSample[];
 }
 
+export enum MetadataSchema {
+  audioId3 = 'org.id3',
+  dateRange = 'com.apple.quicktime.HLS',
+  emsg = 'https://aomedia.org/emsg/ID3',
+}
 export interface MetadataSample {
   pts: number;
   dts: number;
   len?: number;
   data: Uint8Array;
+  type: MetadataSchema;
 }
 
 export interface UserdataSample {

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -64,7 +64,8 @@ export function clearCurrentCues(track: TextTrack) {
 export function removeCuesInRange(
   track: TextTrack,
   start: number,
-  end: number
+  end: number,
+  predicate?: (cue: TextTrackCue) => boolean
 ) {
   const mode = track.mode;
   if (mode === 'disabled') {
@@ -74,7 +75,9 @@ export function removeCuesInRange(
   if (track.cues && track.cues.length > 0) {
     const cues = getCuesInRange(track.cues, start, end);
     for (let i = 0; i < cues.length; i++) {
-      track.removeCue(cues[i]);
+      if (!predicate || predicate(cues[i])) {
+        track.removeCue(cues[i]);
+      }
     }
   }
   if (mode === 'disabled') {

--- a/tests/unit/loader/date-range.ts
+++ b/tests/unit/loader/date-range.ts
@@ -1,0 +1,154 @@
+import { DateRange } from '../../../src/loader/date-range';
+import { AttrList } from '../../../src/utils/attr-list';
+
+import * as chai from 'chai';
+
+const expect = chai.expect;
+
+describe('DateRange class', function () {
+  const startDateAndDuration = new AttrList(
+    'ID="ad1",CLASS="com.apple.hls.interstitial",START-DATE="2020-01-02T21:55:44.000Z",DURATION=15.0'
+  );
+  const startDateAndEndDate = new AttrList(
+    'ID="ad2",CLASS="com.apple.hls.interstitial",START-DATE="2020-01-02T21:55:44.000Z",END-DATE="2020-01-02T21:56:44.001Z"'
+  );
+  const startDateAndEndOnNext = new AttrList(
+    'ID="ad3",CLASS="com.apple.hls.interstitial",START-DATE="2022-01-01T00:00:00.100Z",END-ON-NEXT=YES'
+  );
+
+  const sctePlanned = new AttrList(
+    'ID="s1",START-DATE="2014-03-05T11:15:00Z",PLANNED-DURATION=59.993,SCTE35-OUT=0xFC'
+  );
+  const scteDurationUpdate = new AttrList(
+    'ID="s1",DURATION=59.994,SCTE35-IN=0xFC01'
+  );
+
+  const scteInvalidChange = new AttrList(
+    'ID="s1",PLANNED-DURATION=60.0,SCTE35-OUT=0xFCCC,DURATION=59.993,SCTE35-IN=0xFC'
+  );
+
+  const missingId = new AttrList(
+    'START-DATE="2020-01-02T21:55:44.000Z",DURATION=15.0'
+  );
+  const missingStartDate = new AttrList('ID="ad1",DURATION=15.0');
+
+  const invalidStartDate = new AttrList(
+    'ID="ad1",START-DATE="20-01-02-21:55",DURATION=15.0'
+  );
+  const negativeDuration = new AttrList(
+    'ID="ad1",START-DATE="2020-01-02T21:55:44.000Z",DURATION=-1.0'
+  );
+  const endDateEarlierThanStartDate = new AttrList(
+    'ID="ad2",START-DATE="2020-01-02T21:55:44.000Z",END-DATE="2019-01-02T21:56:44.001Z"'
+  );
+  const endOnNextWithNoClass = new AttrList(
+    'ID="ad3",START-DATE="2022-01-01T00:00:00.100Z",END-ON-NEXT=YES'
+  );
+
+  it('parses id, class, date, duration, and end-on-next attributes', function () {
+    const dateRangeDuration = new DateRange(startDateAndDuration);
+    expect(dateRangeDuration.id).to.equal('ad1');
+    expect(dateRangeDuration.class).to.equal('com.apple.hls.interstitial');
+    expect(dateRangeDuration.startDate.toISOString()).to.equal(
+      '2020-01-02T21:55:44.000Z'
+    );
+    expect(dateRangeDuration.duration).to.equal(15);
+
+    const dateRangeEndDate = new DateRange(startDateAndEndDate);
+    expect(dateRangeEndDate.id).to.equal('ad2');
+    expect(dateRangeEndDate.class).to.equal('com.apple.hls.interstitial');
+    expect(dateRangeEndDate.startDate.toISOString()).to.equal(
+      '2020-01-02T21:55:44.000Z'
+    );
+    expect(dateRangeEndDate.endDate?.toISOString()).to.equal(
+      '2020-01-02T21:56:44.001Z'
+    );
+
+    const dateRangeEndOnNext = new DateRange(startDateAndEndOnNext);
+    expect(dateRangeEndOnNext.id).to.equal('ad3');
+    expect(dateRangeEndOnNext.class).to.equal('com.apple.hls.interstitial');
+    expect(dateRangeEndOnNext.startDate.toISOString()).to.equal(
+      '2022-01-01T00:00:00.100Z'
+    );
+    expect(dateRangeEndOnNext.endOnNext).to.equal(true);
+
+    const dateRangePlannedDuration = new DateRange(sctePlanned);
+    expect(dateRangePlannedDuration.id).to.equal('s1');
+    expect(dateRangePlannedDuration.startDate.toISOString()).to.equal(
+      '2014-03-05T11:15:00.000Z'
+    );
+    expect(dateRangePlannedDuration.plannedDuration).to.equal(59.993);
+  });
+
+  it('calculates end-date based on duration', function () {
+    const dateRangeDuration = new DateRange(startDateAndDuration);
+    expect(dateRangeDuration.endDate?.toISOString()).to.equal(
+      '2020-01-02T21:55:59.000Z'
+    );
+  });
+
+  it('calculates duration based on end-date', function () {
+    const dateRangeEndDate = new DateRange(startDateAndEndDate);
+    expect(dateRangeEndDate.duration).to.equal(60.001);
+  });
+
+  describe('merges tags with matching ID attributes', function () {
+    const scteOut = new DateRange(sctePlanned);
+    const scteIn = new DateRange(scteDurationUpdate, scteOut);
+    expect(scteIn.startDate.toISOString()).to.equal('2014-03-05T11:15:00.000Z');
+    expect(scteIn.plannedDuration).to.equal(59.993);
+    expect(scteIn.duration).to.equal(59.994);
+    expect(scteIn.attr['SCTE35-OUT']).to.equal('0xFC');
+    expect(scteIn.attr['SCTE35-IN']).to.equal('0xFC01');
+    expect(scteIn.isValid).to.equal(true);
+  });
+
+  describe('isValid indicates that DATERANGE tag:', function () {
+    function validateDateRange(attributeList: AttrList, expected: boolean) {
+      expect(new DateRange(attributeList).isValid).to.equal(
+        expected,
+        `Expected attributes to be ${
+          expected ? 'valid' : 'invalid'
+        } ${JSON.stringify(attributeList)}`
+      );
+    }
+
+    it('has required attributes', function () {
+      validateDateRange(startDateAndDuration, true);
+      validateDateRange(startDateAndEndDate, true);
+      validateDateRange(startDateAndEndOnNext, true);
+      validateDateRange(sctePlanned, true);
+
+      validateDateRange(missingId, false);
+      validateDateRange(missingStartDate, false);
+      validateDateRange(scteDurationUpdate, false);
+    });
+
+    it('has a valid START-DATE date/time value', function () {
+      validateDateRange(invalidStartDate, false);
+    });
+
+    it('has an optional DURATION is not negative', function () {
+      validateDateRange(negativeDuration, false);
+    });
+
+    it('has an optional END-DATE that is equal to or later than the value of START-DATE', function () {
+      validateDateRange(endDateEarlierThanStartDate, false);
+    });
+
+    it('has a CLASS attribute when END-ON-NEXT=YES', function () {
+      validateDateRange(endOnNextWithNoClass, false);
+    });
+
+    it('has another DateRange tag with the same ID attribute value, and attributes that appear in both tags have the same value', function () {
+      const scteOut = new DateRange(sctePlanned);
+      const scteIn = new DateRange(scteInvalidChange, scteOut);
+      expect(scteIn.isValid).to.equal(
+        false,
+        `Expected DateRange with same ID to be invalid because of conflicting attribute values\n${JSON.stringify(
+          scteOut
+        )}\n${JSON.stringify(scteIn)}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
### This PR will...

Parse and validate Date Range tags in HLS playlists on playlist load. Date Range tags are converted to cues on the HTMLMediaElement's metadata text track on level update. In addition, the presence and duration of Date Range cues (as well as inband ID3 and emsg metadata cues already supported by HLS.js) are updated to reflect the Date Range content of the active playlist and inband metadata found in buffered audio/video tracks.

### Why is this Pull Request needed?

These updates should more closely match the metadata text track cues produced by Safari when playing the same HLS stream natively in Safari. 

### Additional changes

- Add `hls.playingDate` to API: gets program date time at media playhead (`video.currentTime`) 
- Fixed build regression by formatting code with prettier

### Resolves issues:

Resolves #2218

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
