### PR TITLE
Add a config flag for exponential backoff

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -773,7 +773,7 @@ export type FragmentLoaderConfig = {
     fragLoadingMaxRetry: number;
     fragLoadingRetryDelay: number;
     fragLoadingMaxRetryTimeout: number;
-    fragExponantialBackoff: boolean;
+    fragExponentialBackoff: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "FragmentLoaderConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -773,6 +773,7 @@ export type FragmentLoaderConfig = {
     fragLoadingMaxRetry: number;
     fragLoadingRetryDelay: number;
     fragLoadingMaxRetryTimeout: number;
+    fragExponantialBackoff: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "FragmentLoaderConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1607,6 +1608,8 @@ export interface LoaderCallbacks<T extends LoaderContext> {
 // @public (undocumented)
 export interface LoaderConfiguration {
     // (undocumented)
+    exponentialBackoff: boolean;
+    // (undocumented)
     highWaterMark: number;
     // (undocumented)
     maxRetry: number;
@@ -2161,18 +2164,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:163:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:173:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:176:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:178:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:180:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:183:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:185:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:188:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:164:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:175:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:178:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:179:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:181:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:186:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:188:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:189:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -675,6 +675,12 @@ Any I/O error will trigger retries every 500ms,1s,2s,4s,8s, ... capped to `fragL
 
 Prefetch start fragment although media not attached.
 
+### `fragExponentialBackoff`
+
+(default: `true`)
+
+Disable exponential backoff for fragment loading. Delay between retries will stay the same (`fragLoadingRetryDelay`)
+
 ### `startFragPrefetch`
 
 (default: `false`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,7 @@ export type FragmentLoaderConfig = {
   fragLoadingMaxRetry: number;
   fragLoadingRetryDelay: number;
   fragLoadingMaxRetryTimeout: number;
-  fragExponantialBackoff: boolean;
+  fragExponentialBackoff: boolean;
 };
 
 export type FPSControllerConfig = {
@@ -246,7 +246,7 @@ export const hlsDefaultConfig: HlsConfig = {
   fragLoadingMaxRetry: 6, // used by fragment-loader
   fragLoadingRetryDelay: 1000, // used by fragment-loader
   fragLoadingMaxRetryTimeout: 64000, // used by fragment-loader
-  fragExponantialBackoff: true, // used by fragment-loader
+  fragExponentialBackoff: true, // used by fragment-loader
   startFragPrefetch: false, // used by stream-controller
   fpsDroppedMonitoringPeriod: 5000, // used by fps-controller
   fpsDroppedMonitoringThreshold: 0.2, // used by fps-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,7 @@ export type FragmentLoaderConfig = {
   fragLoadingMaxRetry: number;
   fragLoadingRetryDelay: number;
   fragLoadingMaxRetryTimeout: number;
+  fragExponantialBackoff: boolean;
 };
 
 export type FPSControllerConfig = {
@@ -245,6 +246,7 @@ export const hlsDefaultConfig: HlsConfig = {
   fragLoadingMaxRetry: 6, // used by fragment-loader
   fragLoadingRetryDelay: 1000, // used by fragment-loader
   fragLoadingMaxRetryTimeout: 64000, // used by fragment-loader
+  fragExponantialBackoff: true, // used by fragment-loader
   startFragPrefetch: false, // used by stream-controller
   fpsDroppedMonitoringPeriod: 5000, // used by fps-controller
   fpsDroppedMonitoringThreshold: 0.2, // used by fps-controller

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1238,11 +1238,15 @@ export default class BaseStreamController
       if (this.resetLiveStartWhenNotLoaded(frag.level)) {
         return;
       }
-      // exponential backoff capped to config.fragLoadingMaxRetryTimeout
-      const delay = Math.min(
-        Math.pow(2, this.fragLoadError) * config.fragLoadingRetryDelay,
-        config.fragLoadingMaxRetryTimeout
-      );
+      let delay = config.fragLoadingRetryDelay;
+
+      if (config.fragExponantialBackoff) {
+        // exponential backoff capped to config.fragLoadingMaxRetryTimeout
+        delay = Math.min(
+          Math.pow(2, this.fragLoadError) * config.fragLoadingRetryDelay,
+          config.fragLoadingMaxRetryTimeout
+        );
+      }
       this.warn(
         `Fragment ${frag.sn} of ${filterType} ${frag.level} failed to load, retrying in ${delay}ms`
       );

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1240,7 +1240,7 @@ export default class BaseStreamController
       }
       let delay = config.fragLoadingRetryDelay;
 
-      if (config.fragExponantialBackoff) {
+      if (config.fragExponentialBackoff) {
         // exponential backoff capped to config.fragLoadingMaxRetryTimeout
         delay = Math.min(
           Math.pow(2, this.fragLoadError) * config.fragLoadingRetryDelay,

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -75,7 +75,7 @@ export default class FragmentLoader {
         maxRetry: 0,
         retryDelay: 0,
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-        exponentialBackoff: config.fragExponantialBackoff,
+        exponentialBackoff: config.fragExponentialBackoff,
         highWaterMark: frag.sn === 'initSegment' ? Infinity : MIN_CHUNK_SIZE,
       };
       // Assign frag stats to the loader's stats reference
@@ -168,7 +168,7 @@ export default class FragmentLoader {
         maxRetry: 0,
         retryDelay: 0,
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-        exponentialBackoff: config.fragExponantialBackoff,
+        exponentialBackoff: config.fragExponentialBackoff,
         highWaterMark: MIN_CHUNK_SIZE,
       };
       // Assign part stats to the loader's stats reference

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -75,6 +75,7 @@ export default class FragmentLoader {
         maxRetry: 0,
         retryDelay: 0,
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
+        exponentialBackoff: config.fragExponantialBackoff,
         highWaterMark: frag.sn === 'initSegment' ? Infinity : MIN_CHUNK_SIZE,
       };
       // Assign frag stats to the loader's stats reference
@@ -167,6 +168,7 @@ export default class FragmentLoader {
         maxRetry: 0,
         retryDelay: 0,
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
+        exponentialBackoff: config.fragExponantialBackoff,
         highWaterMark: MIN_CHUNK_SIZE,
       };
       // Assign part stats to the loader's stats reference

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -97,6 +97,7 @@ export default class KeyLoader implements ComponentAPI {
         retryDelay: config.fragLoadingRetryDelay,
         maxRetryDelay: config.fragLoadingMaxRetryTimeout,
         highWaterMark: 0,
+        exponentialBackoff: true,
       };
 
       const loaderCallbacks: LoaderCallbacks<KeyLoaderContext> = {

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -289,6 +289,7 @@ class PlaylistLoader {
       maxRetry,
       retryDelay,
       maxRetryDelay,
+      exponentialBackoff: true,
       highWaterMark: 0,
     };
 

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -36,6 +36,8 @@ export interface LoaderConfiguration {
   maxRetryDelay: number;
   // When streaming progressively, this is the minimum chunk size required to emit a PROGRESS event
   highWaterMark: number;
+  // When retrying, multiply the retry by a factor of 2 each time
+  exponentialBackoff: boolean;
 }
 
 export interface LoaderResponse {


### PR DESCRIPTION
### This PR will...
add a config flag to disable exponential backoff on fragment loading (true by default, current behavior)

### Why is this Pull Request needed?

The retries are great but the exponential backoff for the retry delays means we cannot control easily when the player will retry to load the fragments.

Using a config flag for exponential backoff could be really useful, retryDelay would not increase with time and we could retry every 4/5 seconds.

### Are there any points in the code the reviewer needs to double check?

There is also a exponential backoff in xhr-loader, but I could not find the correct config for it

### Resolves issues:

https://github.com/video-dev/hls.js/issues/4575

### Checklist

- [ x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ x] API or design changes are documented in API.md
