### PR TITLE
Bugfix: Network hangs on streaming level switch using fetch loader

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -470,8 +470,15 @@ export default class StreamController
     if (fragCurrent?.loader) {
       fragCurrent.loader.abort();
     }
-    if (this.state === State.KEY_LOADING) {
-      this.state = State.IDLE;
+    switch (this.state) {
+      case State.KEY_LOADING:
+      case State.FRAG_LOADING:
+      case State.FRAG_LOADING_WAITING_RETRY:
+      case State.PARSING:
+      case State.PARSED:
+      case State.BACKTRACKING:
+        this.state = State.IDLE;
+        break;
     }
     this.nextLoadPosition = this.getLoadPosition();
   }


### PR DESCRIPTION
**Summary:**

Bug fix:
Segment loading may stop when level switching while using the fetch loader.

**Steps To Reproduce:**
1. Add `"progressive": true` to the config to use the fetch loader to stream segments
2. Switch current/next/loadingLevel while playing

**Results:**
If the streaming fragment is aborted while the stream controller’s state is loading or parsing, the state is not reset to IDLE and no more segments are loaded.

### Why is this Pull Request needed?

This Pull Request fixes the issue described above.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
