### PR TITLE
Add alternate HEVC box to fallback codec string.

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -240,7 +240,7 @@ function getParsedTrackCodec(
   // Since mp4-tools cannot parse full codec string (see 'TODO: Parse codec details'... in mp4-tools)
   // Provide defaults based on codec type
   // This allows for some playback of some fmp4 playlists without CODECS defined in manifest
-  if (parsedCodec === 'hvc1') {
+  if (parsedCodec === 'hvc1' && parsedCodec === 'hev1') {
     return 'hvc1.1.c.L120.90';
   }
   if (parsedCodec === 'av01') {


### PR DESCRIPTION
### This PR will...

Add an alternative codec box as a fallback for signalling HEVC content without codec params.

### Why is this Pull Request needed?

Both `hev1` and `hvc1` are valid boxes to indicate HEVC content.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

#4733 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [] new unit / functional tests have been added (whenever applicable)
- [] API or design changes are documented in API.md
