### PR TITLE
Add FLAC support

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -31,7 +31,6 @@ import type { LevelDetails } from '../loader/level-details';
 
 const MediaSource = getMediaSource();
 const VIDEO_CODEC_PROFILE_REPACE = /([ha]vc.)(?:\.[^.,]+)+/;
-const AUDIO_CODEC_REGEXP = /flac|opus/gi;
 
 export default class BufferController implements ComponentAPI {
   // The level details used to determine duration, target-duration and live
@@ -265,11 +264,8 @@ export default class BufferController implements ComponentAPI {
           );
           if (currentCodec !== nextCodec) {
             let trackCodec = levelCodec || codec;
-            if (trackName.indexOf('audio') !== -1) {
-              trackCodec = trackCodec.replace(
-                AUDIO_CODEC_REGEXP,
-                getCodecCompatibleName
-              );
+            if (trackName.slice(0, 5) === 'audio') {
+              trackCodec = getCodecCompatibleName(trackCodec);
             }
             const mimeType = `${container};codecs=${trackCodec}`;
             this.appendChangeType(trackName, mimeType);
@@ -758,8 +754,8 @@ export default class BufferController implements ComponentAPI {
         // use levelCodec as first priority
         let codec = track.levelCodec || track.codec;
         if (codec) {
-          if (trackName.indexOf('audio') !== -1) {
-            codec = codec.replace(AUDIO_CODEC_REGEXP, getCodecCompatibleName);
+          if (trackName.slice(0, 5) === 'audio') {
+            codec = getCodecCompatibleName(codec);
           }
         }
         const mimeType = `${track.container};codecs=${codec}`;

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -16,7 +16,7 @@ import {
 import { HdcpLevel, HdcpLevels, Level } from '../types/level';
 import { Events } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
-import { isCodecSupportedInMp4 } from '../utils/codecs';
+import { isCodecSupportedInMp4, getCodecCompatibleName } from '../utils/codecs';
 import BasePlaylistController from './base-playlist-controller';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import type Hls from '../hls';
@@ -25,6 +25,8 @@ import type { MediaPlaylist } from '../types/media-playlist';
 import ContentSteeringController from './content-steering-controller';
 
 let chromeOrFirefox: boolean;
+
+const AUDIO_CODEC_REGEXP = /flac|opus/gi;
 
 export default class LevelController extends BasePlaylistController {
   private _levels: Level[] = [];
@@ -120,6 +122,13 @@ export default class LevelController extends BasePlaylistController {
         if (chromeOrFirefox) {
           levelParsed.audioCodec = undefined;
         }
+      }
+
+      if (levelParsed.audioCodec) {
+        levelParsed.audioCodec = levelParsed.audioCodec.replace(
+          AUDIO_CODEC_REGEXP,
+          getCodecCompatibleName
+        );
       }
 
       const {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -26,8 +26,6 @@ import ContentSteeringController from './content-steering-controller';
 
 let chromeOrFirefox: boolean;
 
-const AUDIO_CODEC_REGEXP = /flac|opus/gi;
-
 export default class LevelController extends BasePlaylistController {
   private _levels: Level[] = [];
   private _firstLevel: number = -1;
@@ -125,10 +123,7 @@ export default class LevelController extends BasePlaylistController {
       }
 
       if (levelParsed.audioCodec) {
-        levelParsed.audioCodec = levelParsed.audioCodec.replace(
-          AUDIO_CODEC_REGEXP,
-          getCodecCompatibleName
-        );
+        levelParsed.audioCodec = getCodecCompatibleName(levelParsed.audioCodec);
       }
 
       const {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1227,7 +1227,12 @@ export default class StreamController
         }
       }
       // HE-AAC is broken on Android, always signal audio codec as AAC even if variant manifest states otherwise
-      if (ua.indexOf('android') !== -1 && audio.container !== 'audio/mpeg') {
+      if (
+        audioCodec &&
+        audioCodec.indexOf('mp4a.40.5') !== -1 &&
+        ua.indexOf('android') !== -1 &&
+        audio.container !== 'audio/mpeg'
+      ) {
         // Exclude mpeg audio
         audioCodec = 'mp4a.40.2';
         this.log(`Android: force audio codec to ${audioCodec}`);

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/mp4-tools';
 import { ElementaryStreamTypes } from '../loader/fragment';
 import { logger } from '../utils/logger';
+import { getCodecCompatibleName } from '../utils/codecs';
 import type { TrackSet } from '../types/track';
 import type {
   InitSegmentData,
@@ -257,7 +258,7 @@ function getParsedTrackCodec(
     return 'avc1.42e01e';
   }
   if (parsedCodec === 'fLaC' || parsedCodec === 'Opus') {
-    return parsedCodec;
+    return getCodecCompatibleName(parsedCodec);
   }
   return 'mp4a.40.5';
 }

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -256,6 +256,12 @@ function getParsedTrackCodec(
   if (parsedCodec === 'avc1' || type === ElementaryStreamTypes.VIDEO) {
     return 'avc1.42e01e';
   }
+  if (parsedCodec === 'fLaC') {
+    return 'fLaC';
+  }
+  if (parsedCodec === 'Opus') {
+    return 'Opus';
+  }
   return 'mp4a.40.5';
 }
 export default PassThroughRemuxer;

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -256,11 +256,8 @@ function getParsedTrackCodec(
   if (parsedCodec === 'avc1' || type === ElementaryStreamTypes.VIDEO) {
     return 'avc1.42e01e';
   }
-  if (parsedCodec === 'fLaC') {
-    return 'fLaC';
-  }
-  if (parsedCodec === 'Opus') {
-    return 'Opus';
+  if (parsedCodec === 'fLaC' || parsedCodec === 'Opus') {
+    return parsedCodec;
   }
   return 'mp4a.40.5';
 }

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -118,6 +118,9 @@ function getCodecCompatibleNameLower(
   return lowerCaseCodec;
 }
 
+const AUDIO_CODEC_REGEXP = /flac|opus/i;
 export function getCodecCompatibleName(codec: string): string {
-  return getCodecCompatibleNameLower(codec.toLowerCase() as LowerCaseCodecType);
+  return codec.replace(AUDIO_CODEC_REGEXP, (m) =>
+    getCodecCompatibleNameLower(m.toLowerCase() as LowerCaseCodecType)
+  );
 }

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -14,6 +14,9 @@ const sampleEntryCodesISO = {
     dtsh: true,
     'ec-3': true,
     enca: true,
+    fLaC: true, // MP4-RA listed codec entry for FLAC
+    flac: true, // legacy browser codec name for FLAC
+    FLAC: true, // some manifests may list "FLAC" with Apple's tools
     g719: true,
     g726: true,
     m4ae: true,
@@ -82,4 +85,39 @@ export function isCodecSupportedInMp4(codec: string, type: CodecType): boolean {
   return MediaSource.isTypeSupported(
     `${type || 'video'}/mp4;codecs="${codec}"`
   );
+}
+
+interface CodecNameCache {
+  flac?: string;
+  opus?: string;
+}
+
+const CODEC_COMPATIBLE_NAMES: CodecNameCache = {};
+
+type LowerCaseCodecType = 'flac' | 'opus';
+
+function getCodecCompatibleNameLower(
+  lowerCaseCodec: LowerCaseCodecType
+): string {
+  if (CODEC_COMPATIBLE_NAMES[lowerCaseCodec]) {
+    return CODEC_COMPATIBLE_NAMES[lowerCaseCodec]!;
+  }
+
+  const codecsToCheck = {
+    flac: ['fLaC', 'flac', 'FLAC'],
+    opus: ['Opus', 'opus'],
+  }[lowerCaseCodec];
+
+  for (let i = 0; i < codecsToCheck.length; i++) {
+    if (isCodecSupportedInMp4(codecsToCheck[i], 'audio')) {
+      CODEC_COMPATIBLE_NAMES[lowerCaseCodec] = codecsToCheck[i];
+      return codecsToCheck[i];
+    }
+  }
+
+  return lowerCaseCodec;
+}
+
+export function getCodecCompatibleName(codec: string): string {
+  return getCodecCompatibleNameLower(codec.toLowerCase() as LowerCaseCodecType);
 }

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -103,9 +103,12 @@ function getCodecCompatibleNameLower(
     return CODEC_COMPATIBLE_NAMES[lowerCaseCodec]!;
   }
 
+  // Idealy fLaC and Opus would be first (spec-compliant) but
+  // some browsers will report that fLaC is supported then fail.
+  // see: https://bugs.chromium.org/p/chromium/issues/detail?id=1422728
   const codecsToCheck = {
-    flac: ['fLaC', 'flac', 'FLAC'],
-    opus: ['Opus', 'opus'],
+    flac: ['flac', 'fLaC', 'FLAC'],
+    opus: ['opus', 'Opus'],
   }[lowerCaseCodec];
 
   for (let i = 0; i < codecsToCheck.length; i++) {


### PR DESCRIPTION
### This PR will...

Allow hls.js to demux and decode FLAC and Opus audio, regardless of whether the browser accepts the MP4-Registered codec entries (`fLaC` and `Opus`, respectively), or if they use a fallback legacy codec entry (`flac`, `FLAC`, and `opus`).

### Why is this Pull Request needed?

See https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices - which lists FLAC as a supported codec.

Opus is not listed for Apple devices, but adding Opus support is about the same as adding FLAC support.

### Are there any points in the code the reviewer needs to double check?

In `stream-controller.ts` - this file contains fallback logic for browsers which aren't able to change the codec type (Safari on iPhone is the only browser with this issue, as far as I know). I'm unsure what should happen there, if anything.

### Resolves issues:

See #4387 - it works in the browsers I've tested that support FLAC and/or Opus (Firefox, Chrome, Safari).

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
