### PR TITLE
Include Panasonic Smart TVs and other old browsers in positive DTS gate

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -67,9 +67,10 @@ export default class MP4Remuxer implements Remuxer {
       const result = navigator.userAgent.match(/Safari\/(\d+)/i);
       safariWebkitVersion = result ? parseInt(result[1]) : 0;
     }
-    requiresPositiveDts =
-      (!!chromeVersion && chromeVersion < 75) ||
-      (!!safariWebkitVersion && safariWebkitVersion < 600);
+    requiresPositiveDts = !(
+      (!!chromeVersion && chromeVersion >= 75) ||
+      (!!safariWebkitVersion && safariWebkitVersion >= 600)
+    );
   }
 
   destroy() {}


### PR DESCRIPTION
### This PR will...

Prevent us from using negative DTS values in AVC moof atoms in Panasonic Smart TVs.

### Why is this Pull Request needed?

Some new Panasonic Smart TVs have a `navigator.userAgent` string like this one:

`HbbTV/1.4.1 (;Panasonic;VIERA 2020;a.393;4301-0003 0008-0000;) PanasonicSDK/2017`

These Smart TVs use an old version of Chrome like Chrome 51, and this browser needs the positive DTS gate. It's like the following pull requests for Panasonic Smart TVs:

https://github.com/video-dev/hls.js/pull/3224
https://github.com/video-dev/hls.js/pull/2995

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
