### PR TITLE
Fix AAC overflow when it occurs at ADTS header

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -837,20 +837,26 @@ class TSDemuxer implements Demuxer {
   private parseAACPES(track: DemuxedAudioTrack, pes: PES) {
     let startOffset = 0;
     const aacOverFlow = this.aacOverFlow;
-    const data = pes.data;
+    let data = pes.data;
     if (aacOverFlow) {
       this.aacOverFlow = null;
+      const frameMissingBytes = aacOverFlow.missing;
       const sampleLength = aacOverFlow.sample.unit.byteLength;
-      const frameMissingBytes = Math.min(aacOverFlow.missing, sampleLength);
-      const frameOverflowBytes = sampleLength - frameMissingBytes;
-      aacOverFlow.sample.unit.set(
-        data.subarray(0, frameMissingBytes),
-        frameOverflowBytes
-      );
-      track.samples.push(aacOverFlow.sample);
-
-      // logger.log(`AAC: append overflowing ${frameOverflowBytes} bytes to beginning of new PES`);
-      startOffset = aacOverFlow.missing;
+      // logger.log(`AAC: append overflowing ${sampleLength} bytes to beginning of new PES`);
+      if (frameMissingBytes === -1) {
+        const tmp = new Uint8Array(sampleLength + data.byteLength);
+        tmp.set(aacOverFlow.sample.unit, 0);
+        tmp.set(data, sampleLength);
+        data = tmp;
+      } else {
+        const frameOverflowBytes = sampleLength - frameMissingBytes;
+        aacOverFlow.sample.unit.set(
+          data.subarray(0, frameMissingBytes),
+          frameOverflowBytes
+        );
+        track.samples.push(aacOverFlow.sample);
+        startOffset = aacOverFlow.missing;
+      }
     }
     // look for ADTS header (0xFFFx)
     let offset: number;
@@ -906,26 +912,20 @@ class TSDemuxer implements Demuxer {
 
     // scan for aac samples
     let frameIndex = 0;
+    let frame;
     while (offset < len) {
-      if (ADTS.isHeader(data, offset)) {
-        if (offset + 5 < len) {
-          const frame = ADTS.appendFrame(track, data, offset, pts, frameIndex);
-          if (frame) {
-            if (frame.missing) {
-              this.aacOverFlow = frame;
-            } else {
-              offset += frame.length;
-              frameIndex++;
-              continue;
-            }
+      frame = ADTS.appendFrame(track, data, offset, pts, frameIndex);
+      offset += frame.length;
+      if (!frame.missing) {
+        frameIndex++;
+        for (; offset < len - 1; offset++) {
+          if (ADTS.isHeader(data, offset)) {
+            break;
           }
         }
-        // We are at an ADTS header, but do not have enough data for a frame
-        // Remaining data will be added to aacOverFlow
-        break;
       } else {
-        // nothing found, keep looking
-        offset++;
+        this.aacOverFlow = frame;
+        break;
       }
     }
   }


### PR DESCRIPTION
### This PR will...
Fix playback of HLS streams with MPEGTS segments when AAC overflow occurs within the ADTS header.

### Why is this Pull Request needed?
Without this fix data is dropped before being appended which can lead to buffer/decoder corruption (see #4732).

### Resolves issues:
Fixes #4732
Relates to #4506

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
