### PR TITLE
Config options to disable metadata TextTrack Cue processing

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1010,7 +1010,7 @@ export type HlsConfig = {
     fpsController: typeof FPSController;
     progressive: boolean;
     lowLatencyMode: boolean;
-} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & FragmentLoaderConfig & LevelControllerConfig & MP4RemuxerConfig & PlaylistLoaderConfig & StreamControllerConfig & LatencyControllerConfig & TimelineControllerConfig & TSDemuxerConfig;
+} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & FragmentLoaderConfig & LevelControllerConfig & MP4RemuxerConfig & PlaylistLoaderConfig & StreamControllerConfig & LatencyControllerConfig & MetadataControllerConfig & TimelineControllerConfig & TSDemuxerConfig;
 
 // Warning: (ae-missing-release-tag) "HlsEventEmitter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1861,6 +1861,15 @@ export interface MediaPlaylist extends LevelParsed {
 // @public (undocumented)
 export type MediaPlaylistType = MainPlaylistType | SubtitlePlaylistType;
 
+// Warning: (ae-missing-release-tag) "MetadataControllerConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MetadataControllerConfig = {
+    enableDateRangeMetadataCues: boolean;
+    enableEmsgMetadataCues: boolean;
+    enableID3MetadataCues: boolean;
+};
+
 // Warning: (ae-missing-release-tag) "MetadataSample" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2100,9 +2109,9 @@ export interface SubtitleTrackSwitchData {
 // @public (undocumented)
 export type TimelineControllerConfig = {
     cueHandler: CuesInterface;
-    enableCEA708Captions: boolean;
     enableWebVTT: boolean;
     enableIMSC1: boolean;
+    enableCEA708Captions: boolean;
     captionsTextTrack1Label: string;
     captionsTextTrack1LanguageCode: string;
     captionsTextTrack2Label: string;
@@ -2207,18 +2216,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:163:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:173:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:176:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:178:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:180:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:183:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:185:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:188:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:169:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:179:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:180:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:182:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:183:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:186:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:189:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:191:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:192:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:193:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:194:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -66,7 +66,11 @@
   - [`capLevelController`](#capLevelController)
   - [`fpsController`](#fpsController)
   - [`timelineController`](#timelinecontroller)
+  - [`enableDateRangeMetadataCues`](#enabledaterangemetadatacues)
+  - [`enableEmsgMetadataCues`](#enableemsgmetadatacues)
+  - [`enableID3MetadataCues`](#enableid3metadatacues)
   - [`enableWebVTT`](#enablewebvtt)
+  - [`enableIMSC1`](#enableimsc1)
   - [`enableCEA708Captions`](#enablecea708captions)
   - [`captionsTextTrack1Label`](#captionstexttrack1label)
   - [`captionsTextTrack1LanguageCode`](#captionstexttrack1languagecode)
@@ -373,6 +377,9 @@ var config = {
   capLevelController: CapLevelController,
   fpsController: FPSController,
   timelineController: TimelineController,
+  enableDateRangeMetadataCues: true,
+  enableEmsgMetadataCues: true,
+  enableID3MetadataCues: true,
   enableWebVTT: true,
   enableIMSC1: true,
   enableCEA708Captions: true,
@@ -943,11 +950,43 @@ Parameter should be a class with a `destroy()` method:
 
 - `destroy()` : should clean-up all used resources
 
+### `enableDateRangeMetadataCues`
+
+(default: `true`)
+
+whether or not to add, update, and remove cues from the metadata TextTrack for EXT-X-DATERANGE playlist tags
+
+parameter should be a boolean
+
+### `enableEmsgMetadataCues`
+
+(default: `true`)
+
+whether or not to add, update, and remove cues from the metadata TextTrack for ID3 Timed Metadata found in CMAF Event Message (emsg) boxes
+
+parameter should be a boolean
+
+### `enableID3MetadataCues`
+
+(default: `true`)
+
+whether or not to add, update, and remove cues from the metadata TextTrack for ID3 Timed Metadata found in audio and MPEG-TS containers
+
+parameter should be a boolean
+
 ### `enableWebVTT`
 
 (default: `true`)
 
 whether or not to enable WebVTT captions on HLS
+
+parameter should be a boolean
+
+### `enableIMSC1`
+
+(default: `true`)
+
+whether or not to enable IMSC1 captions on HLS
 
 parameter should be a boolean
 
@@ -1490,8 +1529,8 @@ Full list of Events is available below:
   - data: { id: demuxer id, frag : fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment }
 - `Hls.Events.FRAG_PARSING_USERDATA` - fired when parsing sei text is completed
   - data: { id : demuxer id, frag: fragment object, samples : [ sei samples pes ], details: `levelDetails` object (please see [below](#leveldetails) for more information) }
-- `Hls.Events.FRAG_PARSING_METADATA` - fired when parsing id3 is completed
-  - data: { id: demuxer id, frag : fragment object, samples : [ id3 pes - pts and dts timestamp are relative, values are in seconds], details: `levelDetails` object (please see [below](#leveldetails) for more information) }
+- `Hls.Events.FRAG_PARSING_METADATA` - fired when parsing ID3 is completed
+  - data: { id: demuxer id, frag : fragment object, samples : [ ID3 pes - pts and dts timestamp are relative, values are in seconds], details: `levelDetails` object (please see [below](#leveldetails) for more information) }
 - `Hls.Events.FRAG_PARSING_DATA` - [deprecated]
 - `Hls.Events.FRAG_PARSED` - fired when fragment parsing is completed
   - data: { frag : fragment object, partIndex }

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,11 +139,17 @@ export type LatencyControllerConfig = {
   maxLiveSyncPlaybackRate: number;
 };
 
+export type MetadataControllerConfig = {
+  enableDateRangeMetadataCues: boolean;
+  enableEmsgMetadataCues: boolean;
+  enableID3MetadataCues: boolean;
+};
+
 export type TimelineControllerConfig = {
   cueHandler: CuesInterface;
-  enableCEA708Captions: boolean;
   enableWebVTT: boolean;
   enableIMSC1: boolean;
+  enableCEA708Captions: boolean;
   captionsTextTrack1Label: string;
   captionsTextTrack1LanguageCode: string;
   captionsTextTrack2Label: string;
@@ -199,6 +205,7 @@ export type HlsConfig = {
   PlaylistLoaderConfig &
   StreamControllerConfig &
   LatencyControllerConfig &
+  MetadataControllerConfig &
   TimelineControllerConfig &
   TSDemuxerConfig;
 
@@ -282,6 +289,9 @@ export const hlsDefaultConfig: HlsConfig = {
   progressive: false,
   lowLatencyMode: true,
   cmcd: undefined,
+  enableDateRangeMetadataCues: true,
+  enableEmsgMetadataCues: true,
+  enableID3MetadataCues: true,
 
   // Dynamic Modules
   ...timelineConfig(),
@@ -301,9 +311,9 @@ export const hlsDefaultConfig: HlsConfig = {
 function timelineConfig(): TimelineControllerConfig {
   return {
     cueHandler: Cues, // used by timeline-controller
-    enableCEA708Captions: __USE_SUBTITLES__, // used by timeline-controller
     enableWebVTT: __USE_SUBTITLES__, // used by timeline-controller
     enableIMSC1: __USE_SUBTITLES__, // used by timeline-controller
+    enableCEA708Captions: __USE_SUBTITLES__, // used by timeline-controller
     captionsTextTrack1Label: 'English', // used by timeline-controller
     captionsTextTrack1LanguageCode: 'en', // used by timeline-controller
     captionsTextTrack2Label: 'Spanish', // used by timeline-controller

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -859,6 +859,7 @@ export type {
   PlaylistLoaderConstructor,
   StreamControllerConfig,
   LatencyControllerConfig,
+  MetadataControllerConfig,
   TimelineControllerConfig,
   TSDemuxerConfig,
 } from './config';


### PR DESCRIPTION
### This PR will...
Add configuration options to disable metadata TextTrack Cue processing by type.

### Why is this Pull Request needed?
With the additional support for new types of metadata parsing being added in v1.2.0 (emsg #4458, DATERANGE #4720), the performance and functionality of existing implementations could be impacted by upgrading to the new version. Developers will benefit from being able to disable cue processing at player instantiation when their app does not intend to use TextTracks for specific types of metadata. Their app may already parse certain types of metadata using HLS.js events. Avoiding cycles used to parse and update unused cues and overlap with cues they add outside of HLS.js will allow for a more straightforward transition to v1.2.0.

HLS.js events such as `FRAG_PARSING_METADATA` (signals ID3/emsg parsed) and `LEVEL_UPDATED` (signals new playlist content used to extract DATERANGE) are not changed and can continue to be used to extract metadata info without the use of TextTrack cues.

The new options all default to `true` and are named `enableDateRangeMetadataCues`,  `enableEmsgMetadataCues`, `enableID3MetadataCues`. HLS.js will create and manage metadata TextTrack cues for all types by default in v1.2.0.

When all new config options are set to `false` (set to disable all metadata types), there should be no TextTrack of kind "metadata". Or, when there is one, no cues will be added to it by HLS.js.

### New configuration options
- `enableDateRangeMetadataCues` (default: `true`) whether or not to add, update, and remove cues from the metadata TextTrack for EXT-X-DATERANGE playlist tags
- `enableEmsgMetadataCues` (default: `true`) whether or not to add, update, and remove cues from the metadata TextTrack for ID3 Timed Metadata found in CMAF Event Message (emsg) boxes
- `enableID3MetadataCues` (default: `true`) whether or not to add, update, and remove cues from the metadata TextTrack for ID3 Timed Metadata found in audio and MPEG-TS containers


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
