### PR TITLE
Guard against exceptions caused by destroying player in buffer stall error callbacks

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -15,7 +15,7 @@ export const SKIP_BUFFER_RANGE_START = 0.05;
 
 export default class GapController {
   private config: HlsConfig;
-  private media: HTMLMediaElement;
+  private media: HTMLMediaElement | null = null;
   private fragmentTracker: FragmentTracker;
   private hls: Hls;
   private nudgeRetry: number = 0;
@@ -32,8 +32,9 @@ export default class GapController {
   }
 
   public destroy() {
+    this.media = null;
     // @ts-ignore
-    this.hls = this.fragmentTracker = this.media = null;
+    this.hls = this.fragmentTracker = null;
   }
 
   /**
@@ -44,6 +45,9 @@ export default class GapController {
    */
   public poll(lastCurrentTime: number) {
     const { config, media, stalled } = this;
+    if (media === null) {
+      return;
+    }
     const { currentTime, seeking } = media;
     const seeked = this.seeking && !seeking;
     const beginSeek = !this.seeking && seeking;
@@ -142,7 +146,10 @@ export default class GapController {
     const stalledDuration = tnow - stalled;
     if (!seeking && stalledDuration >= STALL_MINIMUM_DURATION_MS) {
       // Report stalling after trying to fix
-      this._reportStall(bufferInfo.len);
+      this._reportStall(bufferInfo);
+      if (!this.media) {
+        return;
+      }
     }
 
     const bufferedWithHoles = BufferHelper.bufferInfo(
@@ -164,6 +171,9 @@ export default class GapController {
     stalledDurationMs: number
   ) {
     const { config, fragmentTracker, media } = this;
+    if (media === null) {
+      return;
+    }
     const currentTime = media.currentTime;
 
     const partial = fragmentTracker.getPartialFragment(currentTime);
@@ -173,7 +183,7 @@ export default class GapController {
       const targetTime = this._trySkipBufferHole(partial);
       // we return here in this case, meaning
       // the branch below only executes when we don't handle a partial fragment
-      if (targetTime) {
+      if (targetTime || !this.media) {
         return;
       }
     }
@@ -200,19 +210,21 @@ export default class GapController {
    * @param bufferLen - The playhead distance from the end of the current buffer segment.
    * @private
    */
-  private _reportStall(bufferLen) {
+  private _reportStall(bufferInfo: BufferInfo) {
     const { hls, media, stallReported } = this;
-    if (!stallReported) {
+    if (!stallReported && media) {
       // Report stalled error once
       this.stallReported = true;
       logger.warn(
-        `Playback stalling at @${media.currentTime} due to low buffer (buffer=${bufferLen})`
+        `Playback stalling at @${
+          media.currentTime
+        } due to low buffer (${JSON.stringify(bufferInfo)})`
       );
       hls.trigger(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_STALLED_ERROR,
         fatal: false,
-        buffer: bufferLen,
+        buffer: bufferInfo.len,
       });
     }
   }
@@ -224,6 +236,9 @@ export default class GapController {
    */
   private _trySkipBufferHole(partial: Fragment | null): number {
     const { config, hls, media } = this;
+    if (media === null) {
+      return 0;
+    }
     const currentTime = media.currentTime;
     let lastEndTime = 0;
     // Check if currentTime is between unbuffered regions of partial fragments
@@ -266,6 +281,9 @@ export default class GapController {
    */
   private _tryNudgeBuffer() {
     const { config, hls, media, nudgeRetry } = this;
+    if (media === null) {
+      return;
+    }
     const currentTime = media.currentTime;
     this.nudgeRetry++;
 

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -72,7 +72,7 @@ describe('GapController', function () {
 
   describe('_reportStall', function () {
     it('should report a stall with the current buffer length if it has not already been reported', function () {
-      gapController._reportStall(42);
+      gapController._reportStall({ len: 42 });
       expect(triggerSpy).to.have.been.calledWith(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_STALLED_ERROR,
@@ -83,7 +83,7 @@ describe('GapController', function () {
 
     it('should not report a stall if it was already reported', function () {
       gapController.stallReported = true;
-      gapController._reportStall(42);
+      gapController._reportStall({ len: 42 });
       expect(triggerSpy).to.not.have.been.called;
     });
   });


### PR DESCRIPTION
### This PR will...
Guard against exceptions caused by destroying player in buffer stall error callbacks.

### Why is this Pull Request needed?
The `media` property of GapController is cleared when the player is destroyed. Some applications choose to do this on BUFFER_STALLED_ERROR events. Improved type handling and some early returns correct this behavior.

### Other changes?
Prior to triggering BUFFER_STALLED_ERROR, log the full `BufferInfo` object rather than just the buffer length from currentTime. This will help identify stalls in Chrome that occur ~1s after playing through buffer gaps (a new buffered range "start"). This is for issues like #4470.

### Resolves issues:
Fixes #4525
Related to #4478

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
