### PR TITLE
Emit FRAG_PARSED when parsed fragment has no media

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1333,9 +1333,8 @@ export default class BaseStreamController
             // The new transmuxer will be configured with a time offset matching the next fragment start,
             // preventing the timeline from shifting.
             this.warn(
-              `Could not parse fragment ${frag.sn} ${type} duration reliably (${parsedDuration}) resetting transmuxer to fallback to playlist timing`
+              `Could not parse fragment ${frag.sn} ${type} duration reliably (${parsedDuration})`
             );
-            this.resetTransmuxer();
             return result || false;
           }
           const drift = partial
@@ -1363,12 +1362,14 @@ export default class BaseStreamController
       },
       false
     );
-    if (parsed) {
-      this.state = State.PARSED;
-      this.hls.trigger(Events.FRAG_PARSED, { frag, part });
-    } else {
-      this.resetLoadingState();
+    if (!parsed) {
+      this.warn(
+        `Found no media in fragment ${frag.sn} of level ${level.id} resetting transmuxer to fallback to playlist timing`
+      );
+      this.resetTransmuxer();
     }
+    this.state = State.PARSED;
+    this.hls.trigger(Events.FRAG_PARSED, { frag, part });
   }
 
   protected resetTransmuxer() {

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -858,14 +858,14 @@ export default class BufferController implements ComponentAPI {
   // resolve, the onUnblocked function is executed. Functions calling this method do not need to unblock the queue
   // upon completion, since we already do it here
   private blockBuffers(
-    onUnblocked: Function,
+    onUnblocked: () => void,
     buffers: Array<SourceBufferName> = this.getSourceBufferTypes()
   ) {
     if (!buffers.length) {
       logger.log(
         '[buffer-controller]: Blocking operation requested, but no SourceBuffers exist'
       );
-      Promise.resolve(onUnblocked);
+      Promise.resolve().then(onUnblocked);
       return;
     }
     const { operationQueue } = this;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -97,7 +97,7 @@ export class Fragment extends BaseSegment {
   public programDateTime: number | null = null;
   public tagList: Array<string[]> = [];
 
-  // EXTINF has to be present for a m38 to be considered valid
+  // EXTINF has to be present for a m3u8 to be considered valid
   public duration: number = 0;
   // sn notates the sequence number for a segment, and if set to a string can be 'initSegment'
   public sn: number | 'initSegment' = 0;


### PR DESCRIPTION
### This PR will...
- Emit FRAG_PARSED when parsed fragment has no media. This will update the fragment tracker state so that the stream controller is not stuck on empty fragments and can load the next segment.
- Fix the early return and unblock case in the buffer controller. The empty parsed result is sent here and no append occurs so we should run the `onUnblocked` callback immediately. (Fixed `Promise.resolve(onUnblocked)` which does not invoke `onUnblocked`).
- Reset transmuxer any time a result comes back with no media or the duration of all tracks could not be determined
- Always post at least one "transmuxComplete" message from transmuxer-worker to update stream-controller state from FRAG_LOADING to PARSING so that we do not return early from `_handleTransmuxerFlush` and ultimately emit FRAG_PARSED.

### Why is this Pull Request needed?
Gracefully handles HLS streams with TS segments that have no media samples.

### Resolves issues:
Fixes #4799

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
