### PR TITLE
Remove Internet Explorer 11 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,13 +391,6 @@ jobs:
             ua: chrome
             os: OS X 10.11
             uaVersion: '79.0'
-          - config: internet_explorer-win_10
-            ua: internet explorer
-            os: Windows 10
-          - config: internet_explorer-win_8.1-11.0
-            ua: internet explorer
-            os: Windows 8.1
-            uaVersion: '11.0'
           - config: chrome-win_7-69.0
             ua: chrome
             os: Windows 7

--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ The following tags are added to their respective fragment's attribute list but a
 
 For a complete list of issues, see ["Top priorities" in the Release Planning and Backlog project tab](https://github.com/video-dev/hls.js/projects/6). Codec support is dependent on the runtime environment (for example, not all browsers on the same OS support HEVC).
 
+- FairPlay and PlayReady DRM ( See [#3779](https://github.com/video-dev/hls.js/issues/2360) and [issues labeled DRM](https://github.com/video-dev/hls.js/issues?q=is%3Aissue+is%3Aopen+label%3ADRM))
+- Advanced variant selection based on runtime media capabilities (See issues labeled [`media-capabilities`](https://github.com/video-dev/hls.js/labels/media-capabilities))
+- HLS Content Steering
+- HLS Interstitials
+- `#EXT-X-DEFINE` variable substitution
 - `#EXT-X-GAP` filling [#2940](https://github.com/video-dev/hls.js/issues/2940)
 - `#EXT-X-I-FRAME-STREAM-INF` I-frame Media Playlist files
 - `SAMPLE-AES` with fmp4, aac, mp3, vtt... segments (MPEG-2 TS only)
-- PlayReady and FairPlay DRM ( See [#3779](https://github.com/video-dev/hls.js/issues/2360) and [issues labeled DRM](https://github.com/video-dev/hls.js/issues?q=is%3Aissue+is%3Aopen+label%3ADRM))
-- Advanced variant selection based on runtime media capabilities (See issues labeled [`media-capabilities`](https://github.com/video-dev/hls.js/labels/media-capabilities))
-- MP3 elementary stream audio in IE and Edge (<=18) on Windows 10 (See [#1641](https://github.com/video-dev/hls.js/issues/1641) and [Microsoft answers forum](https://answers.microsoft.com/en-us/ie/forum/all/ie11-on-windows-10-cannot-play-hls-with-mp3/2da994b5-8dec-4ae9-9201-7d138ede49d9))
 
 ### Server-side-rendering (SSR) and `require` from a Node.js runtime
 
@@ -287,7 +289,6 @@ HLS.js is supported on:
 - Chrome 39+ for Desktop
 - Firefox 41+ for Android
 - Firefox 42+ for Desktop
-- IE11 for Windows 8.1+
 - Edge for Windows 10+
 - Safari 8+ for MacOS 10.10+
 - Safari for ipadOS 13+

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "test:func": "BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "test:func:light": "BABEL_ENV=development HLSJS_LIGHT=1 mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "test:func:sauce": "SAUCE=1 UA=safari OS='OS X 10.15' BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
-    "test:func:sauce-ie": "SAUCE=1 UA='internet explorer' OS='Windows 10' BABEL_ENV=development mocha --require @babel/register tests/functional/auto/setup.js --timeout 40000 --exit",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "prepare": "husky install"

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -61,7 +61,6 @@ module.exports = {
     url: 'https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8',
     description: 'Big Buck Bunny - 480p only',
     abr: false,
-    skip_ua: ['internet explorer'],
   },
   arte: {
     url: 'https://test-streams.mux.dev/test_001/stream.m3u8',
@@ -72,14 +71,12 @@ module.exports = {
     url: 'https://test-streams.mux.dev/dai-discontinuity-deltatre/manifest.m3u8',
     description: 'Ad-insertion in event stream',
     abr: false,
-    skip_ua: ['internet explorer'],
   },
   issue666: {
     url: 'https://playertest.longtailvideo.com/adaptive/issue666/playlists/cisq0gim60007xzvi505emlxx.m3u8',
     description:
       'Surveillance footage - https://github.com/video-dev/hls.js/issues/666',
     abr: false,
-    skip_ua: ['internet explorer'],
   },
   closedCaptions: {
     url: 'https://playertest.longtailvideo.com/adaptive/captions/playlist.m3u8',
@@ -110,26 +107,23 @@ module.exports = {
     url: 'https://pl.streamingvideoprovider.com/mp3-playlist/playlist.m3u8',
     description: 'MPEG Audio Only demo',
     abr: false,
-    skip_ua: ['internet explorer', 'MicrosoftEdge', 'firefox'],
+    skip_ua: ['MicrosoftEdge', 'firefox'],
   },
   fmp4: {
     url: 'https://storage.googleapis.com/shaka-demo-assets/angel-one-hls/hls.m3u8',
     description: 'HLS fMP4 Angel-One multiple audio-tracks',
     abr: true,
-    skip_ua: ['internet explorer'],
   },
   fmp4Bitmovin: {
     url: 'https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
     description: 'HLS fMP4 by Bitmovin',
     abr: true,
-    skip_ua: ['internet explorer'],
   },
   fmp4BitmovinHevc: {
     url: 'https://bitmovin-a.akamaihd.net/content/dataset/multi-codec/hevc/stream_fmp4.m3u8',
     description:
       'HLS HEVC fMP4 by Bitmovin (Safari and Edge? only as of 2020-08)',
     abr: true,
-    skip_ua: ['internet explorer'],
     skipFunctionalTests: true,
   },
   offset_pts: {
@@ -143,12 +137,7 @@ module.exports = {
       description:
         'Shaka-packager Widevine DRM (EME) HLS-fMP4 - Angel One Demo',
       abr: true,
-      skip_ua: [
-        'firefox',
-        'safari',
-        'internet explorer',
-        { name: 'chrome', version: '69.0' },
-      ],
+      skip_ua: ['firefox', 'safari', { name: 'chrome', version: '69.0' }],
     },
     {
       widevineLicenseUrl: 'https://cwip-shaka-proxy.appspot.com/no_auth',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,6 @@ const baseConfig = {
                   browsers: [
                     'chrome >= 47',
                     'firefox >= 51',
-                    'ie >= 11',
                     'safari >= 8',
                     'ios >= 8',
                     'android >= 4',


### PR DESCRIPTION
### This PR will...
Remove IE from test configs and build targets.

### Why is this Pull Request needed?
IE 11 EOL was in June of 2022. We shouldn't waste resources running functional tests against it.

It _should_ be safe to remove from the webpack target, although I have not looked at whether this impacts dist/*.js output in any way that could adversely impact uncommon JS runtimes leveraging HLS.js.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict