### PR TITLE
Make gap controller wait for active fragments while seeking

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -5,8 +5,8 @@ import { Events } from '../events';
 import { logger } from '../utils/logger';
 import type Hls from '../hls';
 import type { HlsConfig } from '../config';
+import type { Fragment } from '../loader/fragment';
 import type { FragmentTracker } from './fragment-tracker';
-import { Fragment } from '../loader/fragment';
 
 export const STALL_MINIMUM_DURATION_MS = 250;
 export const MAX_START_GAP_JUMP = 2.0;
@@ -43,7 +43,7 @@ export default class GapController {
    *
    * @param {number} lastCurrentTime Previously read playhead position
    */
-  public poll(lastCurrentTime: number) {
+  public poll(lastCurrentTime: number, activeFrag: Fragment | null) {
     const { config, media, stalled } = this;
     if (media === null) {
       return;
@@ -104,6 +104,7 @@ export default class GapController {
       // Next buffered range is too far ahead to jump to while still seeking
       const noBufferGap =
         !nextStart ||
+        (activeFrag && activeFrag.start <= currentTime) ||
         (nextStart - currentTime > MAX_START_GAP_JUMP &&
           !this.fragmentTracker.getPartialFragment(currentTime));
       if (hasEnoughBuffer || noBufferGap) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -925,7 +925,8 @@ export default class StreamController
       this.seekToStartPos();
     } else {
       // Resolve gaps using the main buffer, whose ranges are the intersections of the A/V sourcebuffers
-      gapController.poll(this.lastCurrentTime);
+      const activeFrag = this.state !== State.IDLE ? this.fragCurrent : null;
+      gapController.poll(this.lastCurrentTime, activeFrag);
     }
 
     this.lastCurrentTime = media.currentTime;

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -269,6 +269,30 @@ describe('GapController', function () {
       wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
     });
 
+    it('should not detect stalls when loading an earlier fragment while seeking', function () {
+      wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
+      mockMedia.currentTime += 0.1;
+      gapController.poll(0);
+      expect(gapController.stalled).to.equal(null, 'buffered start');
+
+      wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
+      mockMedia.currentTime += 5;
+      mockMedia.seeking = true;
+      mockTimeRangesData.length = 1;
+      mockTimeRangesData[0] = [5.5, 10];
+      gapController.poll(mockMedia.currentTime - 5);
+      expect(gapController.stalled).to.equal(null, 'new seek position');
+
+      wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
+      gapController.poll(mockMedia.currentTime, {
+        start: 5,
+      });
+      expect(gapController.stalled).to.equal(
+        null,
+        'seeking while loading fragment'
+      );
+    });
+
     it('should trigger reportStall when stalling for 250ms or longer', function () {
       setStalling();
       wallClock.tick(250);


### PR DESCRIPTION
### This PR will...
Make the gap controller wait for active fragments that start before current position while seeking.

### Why is this Pull Request needed?
When seeking to a point with 2 seconds (`MAX_START_GAP_JUMP`) before a buffered range, the gap-controller will seek to the start of that range without waiting for fragments to be loaded and appended that would fill the buffer. This change makes the gap controller wait so that rather than skipping ahead, it seeks to and plays the media from the main playlist at the initial seek point.

### Are there any points in the code the reviewer needs to double check?
Only active fragments from the stream-controller (main playlist) are considered. Alternate audio track fragments are not included in the check. Generally audio segments are smaller and are delivered ahead of video, but this might not always be the case, so passing in both could be a good future enhancement (once the stream controller can monitor the audio stream controller, or the gap controller operates with access to both).

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
