### PR TITLE
Simplify backtracking logic to handle segments without keyframes

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -154,6 +154,7 @@ export default class MP4Remuxer implements Remuxer {
 
       const isVideoContiguous = this.isVideoContiguous;
       let firstKeyFrameIndex = -1;
+      let firstKeyFramePTS;
 
       if (enoughVideoSamples) {
         firstKeyFrameIndex = findKeyframeIndex(videoTrack.samples);
@@ -168,7 +169,8 @@ export default class MP4Remuxer implements Remuxer {
             videoTrack.dropped += firstKeyFrameIndex;
             videoTimeOffset +=
               (videoTrack.samples[0].pts - startPTS) /
-              (videoTrack.timescale || 90000);
+              videoTrack.inputTimeScale;
+            firstKeyFramePTS = videoTimeOffset;
           } else if (firstKeyFrameIndex === -1) {
             logger.warn(
               `[mp4-remuxer]: No keyframe found out of ${length} video samples`
@@ -239,6 +241,7 @@ export default class MP4Remuxer implements Remuxer {
         if (video) {
           video.firstKeyFrame = firstKeyFrameIndex;
           video.independent = firstKeyFrameIndex !== -1;
+          video.firstKeyFramePTS = firstKeyFramePTS;
         }
       }
     }

--- a/src/types/fragment-tracker.ts
+++ b/src/types/fragment-tracker.ts
@@ -5,7 +5,6 @@ import type { FragLoadedData } from './events';
 export interface FragmentEntity {
   body: Fragment;
   loaded: FragLoadedData | null;
-  backtrack: FragLoadedData | null;
   buffered: boolean;
   range: { [key in SourceBufferName]: FragmentBufferedRange };
 }

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -43,6 +43,7 @@ export interface RemuxedTrack {
   hasVideo: boolean;
   independent?: boolean;
   firstKeyFrame?: number;
+  firstKeyFramePTS?: number;
   nb: number;
   transferredData1?: ArrayBuffer;
   transferredData2?: ArrayBuffer;


### PR DESCRIPTION
### This PR will...
- Replace older backtracking logic with a simpler solution that can continue loading earlier segments until it finds one with a keyframe suitable for the target buffer position.
- Avoid backtracking when the parsed segment's first IDR frame comes before or is at target buffer position (~currentTime).

### Why is this Pull Request needed?
After testing #4801 against streams with non-independent segments I found that the older backtracking logic was still loop loading when the previous segment was unusable because it had no keyframes. This resolves that issue.

### Resolves issues:
Fixes untracked regressions in backtracking through HLS streams. The test stream with segments missing keyframes was produced using ffmpeg options that produce segments which are shorter than the minimum keyframe distance:
`-r 30 -keyint_min 150 -g 150 -f hls -hls_time 2 -hls_flags split_by_time`

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
