### PR TITLE
Bugfix: Use audio PTS over playlist time when aligned with video

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -706,6 +706,7 @@ export default class MP4Remuxer implements Remuxer {
     const rawMPEG: boolean =
       track.segmentCodec === 'mp3' && this.typeSupported.mpeg;
     const outputSamples: Array<Mp4Sample> = [];
+    const alignedWithVideo = videoTimeOffset !== undefined;
 
     let inputSamples: Array<AudioSample> = track.samples;
     let offset: number = rawMPEG ? 0 : 8;
@@ -753,7 +754,7 @@ export default class MP4Remuxer implements Remuxer {
       if (videoTimeOffset === 0) {
         // Set the start to 0 to match video so that start gaps larger than inputSampleDuration are filled with silence
         nextAudioPts = 0;
-      } else if (accurateTimeOffset) {
+      } else if (accurateTimeOffset && !alignedWithVideo) {
         // When not seeking, not live, and LevelDetails.PTSKnown, use fragment start as predicted next audio PTS
         nextAudioPts = Math.max(0, timeOffsetMpegTS);
       } else {
@@ -769,7 +770,6 @@ export default class MP4Remuxer implements Remuxer {
     // frame.
 
     if (track.segmentCodec === 'aac') {
-      const alignedWithVideo = videoTimeOffset !== undefined;
       const maxAudioFramesDrift = this.config.maxAudioFramesDrift;
       for (let i = 0, nextPts = nextAudioPts; i < inputSamples.length; i++) {
         // First, let's see how far off this frame is from where we expect it to be


### PR DESCRIPTION
### This PR will...
Align audio to video rather than trusting playlist offsets when remuxing MPEG2-TS audio and video samples at the same time.  

### Why is this Pull Request needed?
Long playlists with inaccurate durations can result in incorrect fragment start times. The mp4-remuxer was always using video timestamps in these cases, but for audio was not, leading to cases where appended AV did not even overlap after seeking hours into a playlist with this kind of drift (#4418).

With this fix, the media is appended correctly, even if it's not where it was expected to be based on playlist content.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #4418

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
