### PR TITLE
Update functional test targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,8 +376,6 @@ jobs:
           - safari-osx_10.15
           - firefox-win_10
           - chrome-osx_10.11-79.0
-          - internet_explorer-win_10
-          - internet_explorer-win_8.1-11.0
           - chrome-win_7-69.0
 
         include:

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -137,7 +137,12 @@ module.exports = {
       description:
         'Shaka-packager Widevine DRM (EME) HLS-fMP4 - Angel One Demo',
       abr: true,
-      skip_ua: ['firefox', 'safari', { name: 'chrome', version: '69.0' }],
+      skip_ua: [
+        'firefox',
+        'safari',
+        { name: 'chrome', version: '69.0' },
+        { name: 'chrome', version: '79.0' },
+      ],
     },
     {
       widevineLicenseUrl: 'https://cwip-shaka-proxy.appspot.com/no_auth',


### PR DESCRIPTION
### This PR will...
- Remove remaining internet explorer targets missed in #4802
- Exclude Chrome 79 from Widevine test

### Why is this Pull Request needed?
Improve the usefulness of functional test results by excluding a test that should fail (Widevine no longer supported in older versions of Chrome).

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
