### PR TITLE
Fix attach/detach and recoverMediaError resume with alt audio

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -136,6 +136,7 @@ class AudioStreamController
           3
         )}`
       );
+      startPosition = lastCurrentTime;
       this.state = State.IDLE;
     } else {
       this.loadedmetadata = false;


### PR DESCRIPTION
### This PR will...
Sync the audio-stream-controller with the stream-controller after reattaching the media element.

### Why is this Pull Request needed?
When calling `hls.recoverMediaError()` or `hls.detachMedia()` followed by `hls.attacheMedia(video)`, the audio-stream-controller should start loading media from the last known currentTime like the stream-controller, so that the player can resume playback by seeking to a buffered starting point. 

### Resolves issues:
Without this fix, after reattaching, alt-audio tracks begin streaming from 0, rather than observed currentTime before media was detached. This can result in audio and video buffered ranges which do not overlap, preventing the combined buffer from growing in length so the `seekToStartPos()` is called to resume playback.

```
    // Check combined buffer
    const buffered = BufferHelper.getBuffered(media);

    if (!this.loadedmetadata && buffered.length) {
      this.loadedmetadata = true;
      this.seekToStartPos();
    } else {
```

This fix will allow `recoverMediaError()` to work when `changeType` is not a viable option for resetting source buffers after a variant or media option change requires it.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
