### PR TITLE
Feature/forward worker logs to main thread logs

### DIFF
--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -291,6 +291,13 @@ export default class TransmuxerInterface {
         break;
       }
 
+      // pass logs from the worker thread to the main logger
+      case 'workerLog':
+        if (logger[data.data.logType]) {
+          logger[data.data.logType](data.data.message);
+        }
+        break;
+
       /* falls through */
       default: {
         data.data = data.data || {};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,4 @@
-interface ILogFunction {
+export interface ILogFunction {
   (message?: any, ...optionalParams: any[]): void;
 }
 

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -12,8 +12,11 @@ import { logger } from '../../../src/utils/logger';
 
 chai.use(sinonChai);
 const expect = chai.expect;
-
 describe('TransmuxerInterface tests', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
   const onTransmuxComplete = (res: TransmuxerResult) => {};
   const onFlush = (meta: ChunkMetadata) => {};
 

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -8,6 +8,7 @@ import Hls from '../../../src/hls';
 import * as sinon from 'sinon';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
+import { logger } from '../../../src/utils/logger';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -295,5 +296,31 @@ describe('TransmuxerInterface tests', function () {
     const spy = sinon.spy(self.URL, 'revokeObjectURL');
     transmuxerInterfacePrivates.onWorkerMessage(evt);
     expect(spy).to.have.been.calledOnce;
+  });
+
+  it('Handles logger events from the worker', function () {
+    const config = { enableWorker: true }; // Option debug : true crashes mocha
+    const hls = new Hls(config);
+    sinon.stub(hls, 'trigger');
+    const transmuxerInterface = new TransmuxerInterface(
+      hls,
+      PlaylistLevelType.MAIN,
+      onTransmuxComplete,
+      onFlush
+    );
+    const transmuxerInterfacePrivates = transmuxerInterface as any;
+    const evt = {
+      data: {
+        event: 'workerLog',
+        data: {
+          logType: 'log',
+          message: 'testing logger',
+        },
+      },
+    };
+
+    const spy = sinon.spy(logger, 'log');
+    transmuxerInterfacePrivates.onWorkerMessage(evt);
+    expect(spy).to.have.been.calledWith(evt.data.data.message);
   });
 });


### PR DESCRIPTION
### This PR will...
 forward logs from the transmuxer-worker.ts to the main thread via the transmuxer-interface.ts. Logs are forwarded via a `postMessage` and the transmuxer-interface then sends them to the main thread `logger` 

### Why is this Pull Request needed?
Currently, logs from the worker thread do not flow through custom `debug` configuration loggers. If a user has a custom logger that captures logs and stores them, worker logs are not caught and will also leak to the browser console. 

### Are there any points in the code the reviewer needs to double check?
Not that I'm aware of

### Resolves issues:
Closes https://github.com/video-dev/hls.js/issues/2701

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
