### PR TITLE
Improve bandwidth estimation and adaptive switching

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -219,6 +219,16 @@ export interface BufferFlushingData {
     type: SourceBufferName | null;
 }
 
+// Warning: (ae-missing-release-tag) "BufferInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BufferInfo = {
+    len: number;
+    start: number;
+    end: number;
+    nextStart?: number;
+};
+
 // Warning: (ae-missing-release-tag) "CapLevelControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -963,8 +973,6 @@ class Hls implements HlsEventEmitter {
     get lowLatencyMode(): boolean;
     // Warning: (ae-setter-with-docs) The doc comment for the property "lowLatencyMode" must appear on the getter, not the setter.
     set lowLatencyMode(mode: boolean);
-    // Warning: (ae-forgotten-export) The symbol "BufferInfo" needs to be exported by the entry point hls.d.ts
-    //
     // (undocumented)
     get mainForwardBufferInfo(): BufferInfo | null;
     get manualLevel(): number;
@@ -1013,6 +1021,7 @@ class Hls implements HlsEventEmitter {
     get targetLatency(): number | null;
     // (undocumented)
     trigger<E extends keyof HlsListeners>(event: E, eventObject: Parameters<HlsListeners[E]>[1]): boolean;
+    get ttfbEstimate(): number;
     // (undocumented)
     readonly userConfig: Partial<HlsConfig>;
     // (undocumented)

--- a/demo/main.js
+++ b/demo/main.js
@@ -1212,6 +1212,7 @@ function checkBuffer() {
           log += `Dropped frames: ${video.webkitDroppedFrameCount}\n`;
         }
       }
+      log += `TTFB Estimate: ${hls.ttfbEstimate.toFixed(3)}\n`;
       log += `Bandwidth Estimate: ${hls.bandwidthEstimate.toFixed(3)}\n`;
       if (events.isLive) {
         log +=

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -181,13 +181,11 @@ class AbrController implements ComponentAPI {
       nextLoadLevel--
     ) {
       // compute time to load next fragment at lower level
-      // 0.8 : consider only 80% of current bw to be conservative
       // 8 = bits per byte (bps/Bps)
       const levelNextBitrate = levels[nextLoadLevel].maxBitrate;
-      fragLevelNextLoadedDelay = loadRate
-        ? (duration * levelNextBitrate) / (8 * 0.8 * loadRate)
-        : (duration * levelNextBitrate) / bwEstimate + ttfbEstimate / 1000;
-
+      const bwe = loadRate ? loadRate * 8 : bwEstimate;
+      fragLevelNextLoadedDelay =
+        (duration * levelNextBitrate) / bwe + ttfbEstimate / 1000;
       if (fragLevelNextLoadedDelay < bufferStarvationDelay) {
         break;
       }

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -166,7 +166,7 @@ class AbrController implements ComponentAPI {
     // fragLoadDelay is an estimate of the time (in seconds) it will take to buffer the remainder of the fragment
     const fragLoadedDelay = loadRate
       ? (expectedLen - stats.loaded) / loadRate
-      : (expectedLen * 8) / bwEstimate + ttfbEstimate;
+      : (expectedLen * 8) / bwEstimate + ttfbEstimate / 1000;
     // Only downswitch if the time to finish loading the current fragment is greater than the amount of buffer left
     if (fragLoadedDelay <= bufferStarvationDelay) {
       return;
@@ -186,7 +186,7 @@ class AbrController implements ComponentAPI {
       const levelNextBitrate = levels[nextLoadLevel].maxBitrate;
       fragLevelNextLoadedDelay = loadRate
         ? (duration * levelNextBitrate) / (8 * 0.8 * loadRate)
-        : (duration * levelNextBitrate) / bwEstimate + ttfbEstimate;
+        : (duration * levelNextBitrate) / bwEstimate + ttfbEstimate / 1000;
 
       if (fragLevelNextLoadedDelay < bufferStarvationDelay) {
         break;

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -20,7 +20,7 @@ class AbrController implements ComponentAPI {
   protected hls: Hls;
   private lastLoadedFragLevel: number = 0;
   private _nextAutoLevel: number = -1;
-  private timer?: number;
+  private timer: number = -1;
   private onCheck: Function = this._abandonRulesCheck.bind(this);
   private fragCurrent: Fragment | null = null;
   private partCurrent: Part | null = null;
@@ -69,13 +69,13 @@ class AbrController implements ComponentAPI {
 
   protected onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {
     const frag = data.frag;
-    if (frag.type === PlaylistLevelType.MAIN) {
-      if (!this.timer) {
-        this.fragCurrent = frag;
-        this.partCurrent = data.part ?? null;
-        this.timer = self.setInterval(this.onCheck, 100);
-      }
+    if (this.ignoreFragment(frag)) {
+      return;
     }
+    this.fragCurrent = frag;
+    this.partCurrent = data.part ?? null;
+    this.clearTimer();
+    this.timer = self.setInterval(this.onCheck, 100);
   }
 
   protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
@@ -98,8 +98,10 @@ class AbrController implements ComponentAPI {
       return;
     }
 
+    const now = performance.now();
     const stats: LoaderStats = part ? part.stats : frag.stats;
     const duration = part ? part.duration : frag.duration;
+    const timeLoading = now - stats.loading.start;
     // If frag loading is aborted, complete, or from lowest level, stop timer and return
     if (
       stats.aborted ||
@@ -127,30 +129,40 @@ class AbrController implements ComponentAPI {
       return;
     }
 
-    const requestDelay = performance.now() - stats.loading.start;
+    const ttfbEstimate = this.bwEstimator.getEstimateTTFB();
     const playbackRate = Math.abs(media.playbackRate);
-    // In order to work with a stable bandwidth, only begin monitoring bandwidth after half of the fragment has been loaded
-    if (requestDelay <= (500 * duration) / playbackRate) {
+    // To maintain stable adaptive playback, only begin monitoring frag loading after half or more of its playback duration has passed
+    if (
+      timeLoading <=
+      Math.max(ttfbEstimate, 1000 * (duration / (playbackRate * 2)))
+    ) {
       return;
     }
 
-    const loadedFirstByte = stats.loaded && stats.loading.first;
+    // bufferStarvationDelay is an estimate of the amount time (in seconds) it will take to exhaust the buffer
+    const bufferStarvationDelay = bufferInfo.len / playbackRate;
+    // Only downswitch if less than 2 fragment lengths are buffered
+    if (bufferStarvationDelay >= (2 * duration) / playbackRate) {
+      return;
+    }
+
+    const ttfb = stats.loading.first
+      ? stats.loading.first - stats.loading.start
+      : -1;
+    const loadedFirstByte = stats.loaded && ttfb > -1;
     const bwEstimate: number = this.bwEstimator.getEstimate();
     const { levels, minAutoLevel } = hls;
     const level = levels[frag.level];
     const expectedLen =
       stats.total ||
       Math.max(stats.loaded, Math.round((duration * level.maxBitrate) / 8));
-    const loadRate = loadedFirstByte ? (stats.loaded * 1000) / requestDelay : 0;
-
+    const loadRate = loadedFirstByte
+      ? (stats.loaded * 1000) / (timeLoading - ttfb)
+      : 0;
     // fragLoadDelay is an estimate of the time (in seconds) it will take to buffer the remainder of the fragment
     const fragLoadedDelay = loadRate
       ? (expectedLen - stats.loaded) / loadRate
-      : (expectedLen * 8) / bwEstimate;
-
-    // bufferStarvationDelay is an estimate of the amount time (in seconds) it will take to exhaust the buffer
-    const bufferStarvationDelay = bufferInfo.len / playbackRate;
-
+      : expectedLen / bwEstimate + ttfbEstimate;
     // Only downswitch if the time to finish loading the current fragment is greater than the amount of buffer left
     if (fragLoadedDelay <= bufferStarvationDelay) {
       return;
@@ -170,7 +182,7 @@ class AbrController implements ComponentAPI {
       const levelNextBitrate = levels[nextLoadLevel].maxBitrate;
       fragLevelNextLoadedDelay = loadRate
         ? (duration * levelNextBitrate) / (8 * 0.8 * loadRate)
-        : (duration * levelNextBitrate) / bwEstimate;
+        : duration / bwEstimate + ttfbEstimate;
 
       if (fragLevelNextLoadedDelay < bufferStarvationDelay) {
         break;
@@ -181,26 +193,41 @@ class AbrController implements ComponentAPI {
     if (fragLevelNextLoadedDelay >= fragLoadedDelay) {
       return;
     }
-    logger.warn(`Fragment ${frag.sn}${
+
+    // if estimated load time of new segment is completely unreasonable, ignore and do not emergency switch down
+    if (fragLevelNextLoadedDelay > duration * 10) {
+      return;
+    }
+    hls.nextLoadLevel = nextLoadLevel;
+    if (loadedFirstByte) {
+      // If there has been loading progress, sample bandwidth using loading time offset by minimum TTFB time
+      this.bwEstimator.sample(
+        timeLoading - Math.min(ttfbEstimate, ttfb),
+        stats.loaded
+      );
+    } else {
+      // If there has been no loading progress, sample TTFB
+      this.bwEstimator.sampleTTFB(timeLoading);
+    }
+
+    this.clearTimer();
+    logger.warn(`[abr] Fragment ${frag.sn}${
       part ? ' part ' + part.index : ''
-    } of level ${
-      frag.level
-    } is loading too slowly and will cause an underbuffer; aborting and switching to level ${nextLoadLevel}
+    } of level ${frag.level} is loading too slowly;
+      Time to underbuffer: ${bufferStarvationDelay.toFixed(3)} s
+      Estimated load time for current fragment: ${fragLoadedDelay.toFixed(3)} s
+      Estimated load time for down switch fragment: ${fragLevelNextLoadedDelay.toFixed(
+        3
+      )} s
+      TTFB estimate: ${ttfb}
       Current BW estimate: ${
         Number.isFinite(bwEstimate) ? (bwEstimate / 1024).toFixed(3) : 'Unknown'
       } Kb/s
-      Estimated load time for current fragment: ${fragLoadedDelay.toFixed(3)} s
-      Estimated load time for the next fragment: ${fragLevelNextLoadedDelay.toFixed(
+      New BW estimate: ${(this.bwEstimator.getEstimate() / 1024).toFixed(
         3
-      )} s
-      Time to underbuffer: ${bufferStarvationDelay.toFixed(3)} s`);
-    hls.nextLoadLevel = nextLoadLevel;
-    if (loadedFirstByte) {
-      // If there has been loading progress, sample bandwidth
-      this.bwEstimator.sample(requestDelay, stats.loaded);
-    }
-    this.clearTimer();
-    if (frag.loader || frag.keyLoader) {
+      )} Kb/s
+      Aborting and switching to level ${nextLoadLevel}`);
+    if (frag.loader) {
       this.fragCurrent = this.partCurrent = null;
       frag.abortRequests();
     }
@@ -211,38 +238,39 @@ class AbrController implements ComponentAPI {
     event: Events.FRAG_LOADED,
     { frag, part }: FragLoadedData
   ) {
-    if (
-      frag.type === PlaylistLevelType.MAIN &&
-      Number.isFinite(frag.sn as number)
-    ) {
-      const stats = part ? part.stats : frag.stats;
-      const duration = part ? part.duration : frag.duration;
-      // stop monitoring bw once frag loaded
-      this.clearTimer();
-      // store level id after successful fragment load
-      this.lastLoadedFragLevel = frag.level;
-      // reset forced auto level value so that next level will be selected
-      this._nextAutoLevel = -1;
+    if (this.ignoreFragment(frag)) {
+      return;
+    }
+    const stats = part ? part.stats : frag.stats;
+    const duration = part ? part.duration : frag.duration;
+    // stop monitoring bw once frag loaded
+    this.clearTimer();
+    // store level id after successful fragment load
+    this.lastLoadedFragLevel = frag.level;
+    // reset forced auto level value so that next level will be selected
+    this._nextAutoLevel = -1;
 
-      // compute level average bitrate
-      if (this.hls.config.abrMaxWithRealBitrate) {
-        const level = this.hls.levels[frag.level];
-        const loadedBytes =
-          (level.loaded ? level.loaded.bytes : 0) + stats.loaded;
-        const loadedDuration =
-          (level.loaded ? level.loaded.duration : 0) + duration;
-        level.loaded = { bytes: loadedBytes, duration: loadedDuration };
-        level.realBitrate = Math.round((8 * loadedBytes) / loadedDuration);
-      }
-      if (frag.bitrateTest) {
-        const fragBufferedData: FragBufferedData = {
-          stats,
-          frag,
-          part,
-          id: frag.type,
-        };
-        this.onFragBuffered(Events.FRAG_BUFFERED, fragBufferedData);
-      }
+    this.bwEstimator.sampleTTFB(stats.loading.first - stats.loading.start);
+
+    // compute level average bitrate
+    if (this.hls.config.abrMaxWithRealBitrate) {
+      const level = this.hls.levels[frag.level];
+      const loadedBytes =
+        (level.loaded ? level.loaded.bytes : 0) + stats.loaded;
+      const loadedDuration =
+        (level.loaded ? level.loaded.duration : 0) + duration;
+      level.loaded = { bytes: loadedBytes, duration: loadedDuration };
+      level.realBitrate = Math.round((8 * loadedBytes) / loadedDuration);
+    }
+    if (frag.bitrateTest) {
+      const fragBufferedData: FragBufferedData = {
+        stats,
+        frag,
+        part,
+        id: frag.type,
+      };
+      this.onFragBuffered(Events.FRAG_BUFFERED, fragBufferedData);
+      frag.bitrateTest = false;
     }
   }
 
@@ -251,19 +279,24 @@ class AbrController implements ComponentAPI {
     data: FragBufferedData
   ) {
     const { frag, part } = data;
-    const stats = part ? part.stats : frag.stats;
+    const stats = part?.stats.loaded ? part.stats : frag.stats;
 
     if (stats.aborted) {
       return;
     }
-    // Only count non-alt-audio frags which were actually buffered in our BW calculations
-    if (frag.type !== PlaylistLevelType.MAIN || frag.sn === 'initSegment') {
+    if (this.ignoreFragment(frag)) {
       return;
     }
     // Use the difference between parsing and request instead of buffering and request to compute fragLoadingProcessing;
     // rationale is that buffer appending only happens once media is attached. This can happen when config.startFragPrefetch
     // is used. If we used buffering in that case, our BW estimate sample will be very large.
-    const processingMs = stats.parsing.end - stats.loading.start;
+    const processingMs =
+      stats.parsing.end -
+      stats.loading.start -
+      Math.min(
+        stats.loading.first - stats.loading.start,
+        this.bwEstimator.getEstimateTTFB()
+      );
     this.bwEstimator.sample(processingMs, stats.loaded);
     stats.bwEstimate = this.bwEstimator.getEstimate();
     if (frag.bitrateTest) {
@@ -293,9 +326,13 @@ class AbrController implements ComponentAPI {
     }
   }
 
-  clearTimer() {
+  private ignoreFragment(frag: Fragment): boolean {
+    // Only count non-alt-audio frags which were actually buffered in our BW calculations
+    return frag.type !== PlaylistLevelType.MAIN || frag.sn === 'initSegment';
+  }
+
+  public clearTimer() {
     self.clearInterval(this.timer);
-    this.timer = undefined;
   }
 
   // return next auto level
@@ -321,7 +358,7 @@ class AbrController implements ComponentAPI {
     return nextABRAutoLevel;
   }
 
-  private getNextABRAutoLevel() {
+  private getNextABRAutoLevel(): number {
     const { fragCurrent, partCurrent, hls } = this;
     const { maxAutoLevel, config, minAutoLevel, media } = hls;
     const currentFragDuration = partCurrent
@@ -355,7 +392,7 @@ class AbrController implements ComponentAPI {
       return bestLevel;
     }
     logger.trace(
-      `${
+      `[abr] ${
         bufferStarvationDelay ? 'rebuffering expected' : 'buffer is empty'
       }, finding optimal quality level`
     );
@@ -381,7 +418,7 @@ class AbrController implements ComponentAPI {
           : config.maxLoadingDelay;
         maxStarvationDelay = maxLoadingDelay - bitrateTestDelay;
         logger.trace(
-          `bitrate test took ${Math.round(
+          `[abr] bitrate test took ${Math.round(
             1000 * bitrateTestDelay
           )}ms, set first fragment max fetchDuration to ${Math.round(
             1000 * maxStarvationDelay
@@ -454,13 +491,19 @@ class AbrController implements ComponentAPI {
         adjustedbw = bwUpFactor * currentBw;
       }
 
+      const ttfbEstimate = this.bwEstimator.getEstimateTTFB();
       const bitrate: number = levels[i].maxBitrate;
-      const fetchDuration: number = (bitrate * avgDuration) / adjustedbw;
+      const fetchDuration: number =
+        (bitrate * avgDuration) / adjustedbw + ttfbEstimate / 1000;
 
       logger.trace(
-        `level/adjustedbw/bitrate/avgDuration/maxFetchDuration/fetchDuration: ${i}/${Math.round(
-          adjustedbw
-        )}/${bitrate}/${avgDuration}/${maxFetchDuration}/${fetchDuration}`
+        `[abr] level:${i} adjustedbw-bitrate:${Math.round(
+          adjustedbw - bitrate
+        )} avgDuration:${avgDuration.toFixed(
+          1
+        )} maxFetchDuration:${maxFetchDuration.toFixed(
+          1
+        )} fetchDuration:${fetchDuration.toFixed(1)}`
       );
       // if adjusted bw is greater than level bitrate AND
       if (

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -362,7 +362,7 @@ class AudioStreamController
       return;
     }
 
-    this.loadFragment(frag, trackDetails, targetBufferTime);
+    this.loadFragment(frag, levelInfo, targetBufferTime);
   }
 
   protected getMaxBufferLength(mainBufferLength?: number): number {
@@ -821,7 +821,7 @@ class AudioStreamController
 
   protected loadFragment(
     frag: Fragment,
-    trackDetails: LevelDetails,
+    track: Level,
     targetBufferTime: number
   ) {
     // only load if fragment is not loaded or if in audio switch
@@ -835,15 +835,18 @@ class AudioStreamController
       fragState === FragmentState.PARTIAL
     ) {
       if (frag.sn === 'initSegment') {
-        this._loadInitSegment(frag, trackDetails);
-      } else if (trackDetails.live && !Number.isFinite(this.initPTS[frag.cc])) {
+        this._loadInitSegment(frag, track);
+      } else if (
+        track.details?.live &&
+        !Number.isFinite(this.initPTS[frag.cc])
+      ) {
         this.log(
           `Waiting for video PTS in continuity counter ${frag.cc} of live stream before loading audio fragment ${frag.sn} of level ${this.trackId}`
         );
         this.state = State.WAITING_INIT_PTS;
       } else {
         this.startFragRequested = true;
-        super.loadFragment(frag, trackDetails, targetBufferTime);
+        super.loadFragment(frag, track, targetBufferTime);
       }
     }
   }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -558,12 +558,14 @@ export default class BaseStreamController
     targetBufferTime: number | null = null,
     progressCallback?: FragmentLoadProgressCallback
   ): Promise<PartsLoadedData | FragLoadedData | null> {
-    if (!this.levels) {
-      throw new Error('frag load aborted, missing levels');
-    }
     const details = level?.details;
+    if (!this.levels || !details) {
+      throw new Error(
+        `frag load aborted, missing level${details ? '' : ' detail'}s`
+      );
+    }
     let keyLoadingPromise: Promise<KeyLoadedData | void> | null = null;
-    if (frag.encrypted && !frag.decryptdata?.key && details) {
+    if (frag.encrypted && !frag.decryptdata?.key) {
       this.log(
         `Loading key for ${frag.sn} of [${details.startSN}-${details.endSN}], ${
           this.logPrefix === '[stream-controller]' ? 'level' : 'track'
@@ -584,7 +586,7 @@ export default class BaseStreamController
     }
 
     targetBufferTime = Math.max(frag.start, targetBufferTime || 0);
-    if (this.config.lowLatencyMode && details) {
+    if (this.config.lowLatencyMode) {
       const partList = details.partList;
       if (partList && progressCallback) {
         if (targetBufferTime > frag.end && details.fragmentHint) {

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -493,7 +493,14 @@ export function getPartWith(
   if (!level || !level.details) {
     return null;
   }
-  const partList = level.details.partList;
+  return findPart(level.details?.partList, sn, partIndex);
+}
+
+export function findPart(
+  partList: Part[] | null | undefined,
+  sn: number,
+  partIndex: number
+): Part | null {
   if (partList) {
     for (let i = partList.length; i--; ) {
       const part = partList[i];

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -333,12 +333,12 @@ export default class StreamController
       frag = frag.initSegment;
     }
 
-    this.loadFragment(frag, levelDetails, targetBufferTime);
+    this.loadFragment(frag, levelInfo, targetBufferTime);
   }
 
   protected loadFragment(
     frag: Fragment,
-    levelDetails: LevelDetails,
+    level: Level,
     targetBufferTime: number
   ) {
     // Check if fragment is not loaded
@@ -346,15 +346,15 @@ export default class StreamController
     this.fragCurrent = frag;
     if (fragState === FragmentState.NOT_LOADED) {
       if (frag.sn === 'initSegment') {
-        this._loadInitSegment(frag, levelDetails);
+        this._loadInitSegment(frag, level);
       } else if (this.bitrateTest) {
         this.log(
           `Fragment ${frag.sn} of level ${frag.level} is being downloaded to test bitrate and will not be buffered`
         );
-        this._loadBitrateTestFrag(frag, levelDetails);
+        this._loadBitrateTestFrag(frag, level);
       } else {
         this.startFragRequested = true;
-        super.loadFragment(frag, levelDetails, targetBufferTime);
+        super.loadFragment(frag, level, targetBufferTime);
       }
     } else if (fragState === FragmentState.APPENDING) {
       // Lower the buffer size and try again
@@ -1025,9 +1025,9 @@ export default class StreamController
     return audioCodec;
   }
 
-  private _loadBitrateTestFrag(frag: Fragment, levelDetails: LevelDetails) {
+  private _loadBitrateTestFrag(frag: Fragment, level: Level) {
     frag.bitrateTest = true;
-    this._doFragLoad(frag, levelDetails).then((data) => {
+    this._doFragLoad(frag, level).then((data) => {
       const { hls } = this;
       if (!data || hls.nextLoadLevel || this.fragContextChanged(frag)) {
         return;

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -372,16 +372,13 @@ export class SubtitleStreamController
 
     if (this.state === State.IDLE) {
       const { currentTrackId, levels } = this;
-      if (
-        !levels.length ||
-        !levels[currentTrackId] ||
-        !levels[currentTrackId].details
-      ) {
+      const track = levels[currentTrackId];
+      if (!levels.length || !track || !track.details) {
         return;
       }
 
       // Expand range of subs loaded by one target-duration in either direction to make up for misaligned playlists
-      const trackDetails = levels[currentTrackId].details as LevelDetails;
+      const trackDetails = track.details as LevelDetails;
       const targetDuration = trackDetails.targetduration;
       const { config } = this;
       const currentTime = this.getLoadPosition();
@@ -440,7 +437,7 @@ export class SubtitleStreamController
         this.fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED
       ) {
         // only load if fragment is not loaded
-        this.loadFragment(foundFrag, trackDetails, targetBufferTime);
+        this.loadFragment(foundFrag, track, targetBufferTime);
       }
     }
   }
@@ -455,15 +452,15 @@ export class SubtitleStreamController
 
   protected loadFragment(
     frag: Fragment,
-    levelDetails: LevelDetails,
+    level: Level,
     targetBufferTime: number
   ) {
     this.fragCurrent = frag;
     if (frag.sn === 'initSegment') {
-      this._loadInitSegment(frag, levelDetails);
+      this._loadInitSegment(frag, level);
     } else {
       this.startFragRequested = true;
-      super.loadFragment(frag, levelDetails, targetBufferTime);
+      super.loadFragment(frag, level, targetBufferTime);
     }
   }
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -25,7 +25,7 @@ import type { MediaPlaylist } from './types/media-playlist';
 import type { HlsConfig } from './config';
 import { HdcpLevel, HdcpLevels, Level } from './types/level';
 import type { Fragment } from './loader/fragment';
-import { BufferInfo } from './utils/buffer-helper';
+import type { BufferInfo } from './utils/buffer-helper';
 
 /**
  * @module Hls
@@ -583,6 +583,18 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
+   * get time to first byte estimate
+   * @type {number}
+   */
+  get ttfbEstimate(): number {
+    const { bwEstimator } = this.abrController;
+    if (!bwEstimator) {
+      return NaN;
+    }
+    return bwEstimator.getEstimateTTFB();
+  }
+
+  /**
    * Capping/max level value that should be used by automatic level selection algorithm (`ABRController`)
    * @type {number}
    */
@@ -998,3 +1010,4 @@ export type {
   SubtitleTrackSwitchData,
 } from './types/events';
 export type { AttrList } from './utils/attr-list';
+export type { BufferInfo } from './utils/buffer-helper';

--- a/src/utils/ewma-bandwidth-estimator.ts
+++ b/src/utils/ewma-bandwidth-estimator.ts
@@ -14,22 +14,34 @@ class EwmaBandWidthEstimator {
   private minDelayMs_: number;
   private slow_: EWMA;
   private fast_: EWMA;
+  private defaultTTFB_: number;
+  private ttfb_: EWMA;
 
-  constructor(slow: number, fast: number, defaultEstimate: number) {
+  constructor(
+    slow: number,
+    fast: number,
+    defaultEstimate: number,
+    defaultTTFB: number = 100
+  ) {
     this.defaultEstimate_ = defaultEstimate;
     this.minWeight_ = 0.001;
     this.minDelayMs_ = 50;
     this.slow_ = new EWMA(slow);
     this.fast_ = new EWMA(fast);
+    this.defaultTTFB_ = defaultTTFB;
+    this.ttfb_ = new EWMA(slow);
   }
 
   update(slow: number, fast: number) {
-    const { slow_, fast_ } = this;
-    if (this.slow_.halfLife !== slow) {
+    const { slow_, fast_, ttfb_ } = this;
+    if (slow_.halfLife !== slow) {
       this.slow_ = new EWMA(slow, slow_.getEstimate(), slow_.getTotalWeight());
     }
-    if (this.fast_.halfLife !== fast) {
+    if (fast_.halfLife !== fast) {
       this.fast_ = new EWMA(fast, fast_.getEstimate(), fast_.getTotalWeight());
+    }
+    if (ttfb_.halfLife !== slow) {
+      this.ttfb_ = new EWMA(slow, ttfb_.getEstimate(), ttfb_.getTotalWeight());
     }
   }
 
@@ -44,9 +56,16 @@ class EwmaBandWidthEstimator {
     this.slow_.sample(durationS, bandwidthInBps);
   }
 
+  sampleTTFB(ttfb: number) {
+    // weight is frequency curve applied to TTFB in seconds
+    // (longer times have less weight with expected input under 1 second)
+    const seconds = ttfb / 1000;
+    const weight = Math.sqrt(2) * Math.exp(-Math.pow(seconds, 2) / 2);
+    this.ttfb_.sample(weight, Math.max(ttfb, 5));
+  }
+
   canEstimate(): boolean {
-    const fast = this.fast_;
-    return fast && fast.getTotalWeight() >= this.minWeight_;
+    return this.fast_.getTotalWeight() >= this.minWeight_;
   }
 
   getEstimate(): number {
@@ -58,6 +77,14 @@ class EwmaBandWidthEstimator {
       return Math.min(this.fast_.getEstimate(), this.slow_.getEstimate());
     } else {
       return this.defaultEstimate_;
+    }
+  }
+
+  getEstimateTTFB(): number {
+    if (this.ttfb_.getTotalWeight() >= this.minWeight_) {
+      return this.ttfb_.getEstimate();
+    } else {
+      return this.defaultTTFB_;
     }
   }
 

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -288,7 +288,7 @@ describe('StreamController', function () {
 
     let triggerSpy;
     let frag;
-    let levelDetails;
+    let level;
     beforeEach(function () {
       streamController['levels'] = [
         new Level({
@@ -302,8 +302,14 @@ describe('StreamController', function () {
       frag = new Fragment(PlaylistLevelType.MAIN, '');
       frag.level = 0;
       frag.url = 'file';
-      levelDetails = new LevelDetails('');
-      levelDetails.fragments.push(frag);
+      level = new Level({
+        attrs: new AttrList({}),
+        bitrate: 1,
+        name: '',
+        url: '',
+      });
+      level.details = new LevelDetails('');
+      level.details.fragments.push(frag);
     });
 
     function assertLoadingState(frag) {
@@ -321,25 +327,25 @@ describe('StreamController', function () {
 
     it('should load a complete fragment which has not been previously appended', function () {
       fragStateStub(FragmentState.NOT_LOADED);
-      streamController['loadFragment'](frag, levelDetails, 0);
+      streamController['loadFragment'](frag, level, 0);
       assertLoadingState(frag);
     });
 
     it('should not load a partial fragment', function () {
       fragStateStub(FragmentState.PARTIAL);
-      streamController['loadFragment'](frag, levelDetails, 0);
+      streamController['loadFragment'](frag, level, 0);
       assertNotLoadingState();
     });
 
     it('should not load a fragment which has completely & successfully loaded', function () {
       fragStateStub(FragmentState.OK);
-      streamController['loadFragment'](frag, levelDetails, 0);
+      streamController['loadFragment'](frag, level, 0);
       assertNotLoadingState();
     });
 
     it('should not load a fragment while it is appending', function () {
       fragStateStub(FragmentState.APPENDING);
-      streamController['loadFragment'](frag, levelDetails, 0);
+      streamController['loadFragment'](frag, level, 0);
       assertNotLoadingState();
     });
   });


### PR DESCRIPTION
### This PR will...
Improve bandwidth estimation and adaptive switching with smaller segments and higher TTFB

### Why is this Pull Request needed?
Estimating time-to-first-byte exclusive from the time used to estimate bandwidth, allows us to more accurately predict the time it takes to load segments, especially those with shorter durations closer to the average round trip time of a request.

There were also several issues with loading stats, combined vs main video buffer observation, and calculation of inflight BW performed before bytes were loaded that all contributed to bad emergency down-switch and BWE corruption in `_abandonRulesCheck`. Thanks to @Pri12890 for pointing many of these out.

### Are there any points in the code the reviewer needs to double check?

There are two new public methods on the player instance that I have left undocumented:

1. `get mainForwardBufferInfo(): BufferInfo | null` Allows the ABR controller to access the stream controller's media buffer. Since it only deals with main variant fragment traffic, this allows it to compare that activity to the buffer it appends to rather than the combined buffer which could be stalled if alt-audio does not keep ahead.
2. `get ttfbEstimate(): number` Similar to `hls.bandwidthEstimate`, `hls.ttfbEstimate` provides the latest time-to-first-byte estimate. 

The TTFB sampling only uses one EWMA instance with the same slow half life as that used for bandwidth. The default estimate is 100(ms) and is not configurable. It is weighted on a curve that favors shorter values so that the occasional request RTT hiccup does not have as much impact on the estimate.

These changes will remain up for at least 1-2 minor releases and will not be released in v1.3. This is to give contributors time to review and test these changes and provide feedback.

### Resolves issues:
Fixes #3578 (special thanks to @Oleksandr0xB for submitting #4283)
Fixes #3563 and Closes #3595 (special thanks to @kanongil for early testing and feedback on the Low-Latency HLS implementation)
Fixes #5094
Closes #4291 (`_abandonRulesCheck` govern whether fragment loading is completed or aborted based on timeouts - not active throughput)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
