### PR TITLE
WebVTT EXT-X-MAP support

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -854,9 +854,13 @@ export default class BaseStreamController
       frag = this.getFragmentAtPosition(pos, end, levelDetails);
     }
 
+    return this.mapToInitFragWhenRequired(frag);
+  }
+
+  mapToInitFragWhenRequired(frag: Fragment | null): typeof frag {
     // If an initSegment is present, it must be buffered first
     if (frag?.initSegment && !frag?.initSegment.data && !this.bitrateTest) {
-      frag = frag.initSegment;
+      return frag.initSegment;
     }
 
     return frag;

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -9,6 +9,7 @@ import {
   removeCuesInRange,
 } from '../utils/texttrack-utils';
 import { parseIMSC1, IMSC1_CODEC } from '../utils/imsc1-ttml-parser';
+import { appendUint8Array } from '../utils/mp4-tools';
 import { PlaylistLevelType } from '../types/loader';
 import { Fragment } from '../loader/fragment';
 import {
@@ -533,8 +534,11 @@ export class TimelineController implements ComponentAPI {
   private _parseVTTs(frag: Fragment, payload: ArrayBuffer, vttCCs: any) {
     const hls = this.hls;
     // Parse the WebVTT file contents.
+    const payloadWebVTT = frag.initSegment?.data
+      ? appendUint8Array(frag.initSegment.data, new Uint8Array(payload))
+      : payload;
     parseWebVTT(
-      payload,
+      payloadWebVTT,
       this.initPTS[frag.cc],
       this.timescale[frag.cc],
       vttCCs,


### PR DESCRIPTION
### This PR will...
- Load subtitle playlist EXT-X-MAP segments
- Prepend WebVTT segment payload with init segment payload prior to parsing

### Why is this Pull Request needed?
HLS spec compliance and support of WebVTT segments with header(s) in init segment(s).

### Resolves issues:
Fixes #4836

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
