### PR TITLE
Documentation - Add interface for AbrController

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -907,10 +907,9 @@ var config = {
 
 Customized Adaptive Bitrate Streaming Controller.
 
-Parameter should be a class providing a getter/setter, a `clearTimer` method, and a `destroy()` method:
+Parameter should be a class providing a getter/setter and a `destroy()` method:
 
 - get/set `nextAutoLevel`: return next auto-quality level/force next auto-quality level that should be returned (currently used for emergency switch down)
-- `clearTimer()` - Stops the abandon rules check polling until another fragment is loaded
 - `destroy()`: should clean-up all used resources
 
 For `hls.bandwidthEstimate()` to return an estimate from your custom controller, it will also need to satisfy `abrController.bwEstimator.getEstimate()`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -907,10 +907,10 @@ var config = {
 
 Customized Adaptive Bitrate Streaming Controller.
 
-Parameter should be a class providing 2 getters, 2 setters and a `destroy()` method:
+Parameter should be a class providing a getter/setter, a `clearTimer` method, and a `destroy()` method:
 
 - get/set `nextAutoLevel`: return next auto-quality level/force next auto-quality level that should be returned (currently used for emergency switch down)
-- get/set `autoLevelCapping`: capping/max level value that could be used by ABR Controller
+- `clearTimer()` - Stops the abandon rules check polling until another fragment is loaded
 - `destroy()`: should clean-up all used resources
 
 For `hls.bandwidthEstimate()` to return an estimate from your custom controller, it will also need to satisfy `abrController.bwEstimator.getEstimate()`.

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -16,9 +16,9 @@ import type {
   ErrorData,
   LevelLoadedData,
 } from '../types/events';
-import type { ComponentAPI } from '../types/component-api';
+import type { AbrComponentAPI } from '../types/component-api';
 
-class AbrController implements ComponentAPI {
+class AbrController implements AbrComponentAPI {
   protected hls: Hls;
   private lastLoadedFragLevel: number = 0;
   private _nextAutoLevel: number = -1;

--- a/src/types/component-api.ts
+++ b/src/types/component-api.ts
@@ -1,5 +1,13 @@
+import EwmaBandWidthEstimator from '../utils/ewma-bandwidth-estimator';
+
 export interface ComponentAPI {
   destroy(): void;
+}
+
+export interface AbrComponentAPI extends ComponentAPI {
+  nextAutoLevel: Number;
+  clearTimer(): void;
+  readonly bwEstimator?: EwmaBandWidthEstimator;
 }
 
 export interface NetworkComponentAPI extends ComponentAPI {

--- a/src/types/component-api.ts
+++ b/src/types/component-api.ts
@@ -6,7 +6,6 @@ export interface ComponentAPI {
 
 export interface AbrComponentAPI extends ComponentAPI {
   nextAutoLevel: Number;
-  clearTimer(): void;
   readonly bwEstimator?: EwmaBandWidthEstimator;
 }
 


### PR DESCRIPTION
### This PR will...
Create a type interface for the AbrController

### Why is this Pull Request needed?
Users can implement their own Custom AbrController. Having a typed interface for Abr Controllers will help developers understand what properties and methods their Custom AbrControllers must implement to operate with hls.js

### Are there any points in the code the reviewer needs to double check?
re: https://github.com/video-dev/hls.js/issues/4824#issuecomment-1208530220
> If you could define an interface for abr controller classes to implement in src/types and link to it in the docs, that would be most helpful

I didn't see any prior art for linking directly to src/types in the API documentation, so I just updated the API.md file directly, but am willing to link directly to src/types if that's preferred. 

---

It wasn't specified in the above comment, but because the [docs also mention](https://github.com/video-dev/hls.js/blob/master/docs/API.md#abrcontroller):

> For hls.bandwidthEstimate() to return an estimate from your custom controller, it will also need to satisfy abrController.bwEstimator.getEstimate().

I added the `bwEstimator` to the interface. This could probably use some 👀, since I'm not sure if that was correct or not.  

### Resolves issues:
Closes https://github.com/video-dev/hls.js/issues/4824

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
