### PR TITLE
Fix audio demuxer contiguity with segments not carrying ID3 timestamps

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -240,6 +240,11 @@ class AudioStreamController
     }
   }
 
+  protected resetLoadingState() {
+    this.clearWaitingFragment();
+    super.resetLoadingState();
+  }
+
   protected onTickEnd() {
     const { media } = this;
     if (!media || !media.readyState) {

--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -79,7 +79,7 @@ class AACDemuxer extends BaseAudioDemuxer {
       track,
       data,
       offset,
-      this.initPTS as number,
+      this.basePTS as number,
       this.frameIndex
     );
     if (frame && frame.missing === 0) {

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -57,14 +57,14 @@ class MP3Demuxer extends BaseAudioDemuxer {
   }
 
   appendFrame(track, data, offset) {
-    if (this.initPTS === null) {
+    if (this.basePTS === null) {
       return;
     }
     return MpegAudio.appendFrame(
       track,
       data,
       offset,
-      this.initPTS,
+      this.basePTS,
       this.frameIndex
     );
   }

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -166,8 +166,14 @@ export default class TransmuxerInterface {
     const trackSwitch = !(lastFrag && chunkMeta.level === lastFrag.level);
     const snDiff = lastFrag ? chunkMeta.sn - (lastFrag.sn as number) : -1;
     const partDiff = this.part ? chunkMeta.part - this.part.index : -1;
+    const progressive =
+      snDiff === 0 &&
+      chunkMeta.id > 1 &&
+      chunkMeta.id === lastFrag?.stats.chunkCount;
     const contiguous =
-      !trackSwitch && (snDiff === 1 || (snDiff === 0 && partDiff === 1));
+      !trackSwitch &&
+      (snDiff === 1 ||
+        (snDiff === 0 && (partDiff === 1 || (progressive && partDiff <= 0))));
     const now = self.performance.now();
 
     if (trackSwitch || snDiff || frag.stats.parsing.start === 0) {

--- a/tests/unit/demuxer/base-audio-demuxer.ts
+++ b/tests/unit/demuxer/base-audio-demuxer.ts
@@ -3,19 +3,19 @@ import { expect } from 'chai';
 
 describe('BaseAudioDemuxer', function () {
   describe('initPTSFn', function () {
-    it('should use the timestamp if it is valid', function (done) {
-      expect(initPTSFn(1, -1)).to.be.above(0);
-      expect(initPTSFn(5, -1)).to.be.above(0);
-      expect(initPTSFn(0, -1)).to.be.eq(0);
-
-      done();
+    it('should use the timestamp if it is valid', function () {
+      expect(initPTSFn(1, 1, 0)).to.be.eq(90);
+      expect(initPTSFn(5, 1, 0)).to.be.eq(450);
+      expect(initPTSFn(0, 1, 0)).to.be.eq(0);
     });
-    it('should use the timeOffset if timestamp is undefined or not finite', function (done) {
-      expect(initPTSFn(undefined, -1)).to.be.below(0);
-      expect(initPTSFn(NaN, -1)).to.be.below(0);
-      expect(initPTSFn(Infinity, -1)).to.be.below(0);
-
-      done();
+    it('should use the timeOffset if timestamp is undefined or not finite', function () {
+      expect(initPTSFn(undefined, 1, 0)).to.be.eq(90000);
+      expect(initPTSFn(NaN, 1, 0)).to.be.eq(90000);
+      expect(initPTSFn(Infinity, 1, 0)).to.be.eq(90000);
+    });
+    it('should add initPTS to timeOffset when timestamp is undefined or not finite', function () {
+      expect(initPTSFn(undefined, 1, 42)).to.be.eq(90042);
+      expect(initPTSFn(NaN, 1, 42)).to.be.eq(90042);
     });
   });
 });


### PR DESCRIPTION
### This PR will...
1. Fix audio demuxer contiguity with segments not carrying ID3 timestamps
1. Clear audio stream controller waiting for init PTS data when loading state is reset
1. Fix progressive mode contiguity mux flag

### Why is this Pull Request needed?
1. Audio segments missing ID3 timestamps were assigned incorrect start times and not appended correctly. 
1. When seeking in streams with discontinuities while waiting for video to load in the previous discontinuity for the first time, processing of audio segments was not handled correctly.
1. When "progressive" mode was enabled, the transmuxer was reset on each chunk loaded leading to gaps in appended video.

### Resolves issues:
Fixes #4835

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
