### PR TITLE
Feature/determine text track kind based on CHARACTERISTICS

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1316,6 +1316,8 @@ export interface LevelAttributes extends AttrList {
     // (undocumented)
     BYTERANGE?: string;
     // (undocumented)
+    CHARACTERISTICS?: string;
+    // (undocumented)
     CODECS?: string;
     // (undocumented)
     DEFAULT?: string;

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -362,8 +362,10 @@ export class TimelineController implements ComponentAPI {
           if (textTrack) {
             clearCurrentCues(textTrack);
           } else {
+            const textTrackKind =
+              this._captionsOrSubtitlesFromCharacteristics(track);
             textTrack = this.createTextTrack(
-              'subtitles',
+              textTrackKind,
               track.name,
               track.lang
             );
@@ -391,6 +393,25 @@ export class TimelineController implements ComponentAPI {
         });
       }
     }
+  }
+
+  private _captionsOrSubtitlesFromCharacteristics(
+    track: MediaPlaylist
+  ): TextTrackKind {
+    if (track.attrs?.CHARACTERISTICS) {
+      const transcribesSpokenDialog = /transcribes-spoken-dialog/gi.test(
+        track.attrs.CHARACTERISTICS
+      );
+      const describesMusicAndSound = /describes-music-and-sound/gi.test(
+        track.attrs.CHARACTERISTICS
+      );
+
+      if (transcribesSpokenDialog && describesMusicAndSound) {
+        return 'captions';
+      }
+    }
+
+    return 'subtitles';
   }
 
   private onManifestLoaded(

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -24,6 +24,7 @@ export interface LevelAttributes extends AttrList {
   BANDWIDTH?: string;
   BYTERANGE?: string;
   'CLOSED-CAPTIONS'?: string;
+  CHARACTERISTICS?: string;
   CODECS?: string;
   DEFAULT?: string;
   FORCED?: string;

--- a/tests/unit/controller/timeline-controller.js
+++ b/tests/unit/controller/timeline-controller.js
@@ -93,4 +93,67 @@ describe('TimelineController', function () {
       expect(timelineController.media.textTracks.length).to.equal(2);
     });
   });
+
+  describe('text track kind', function () {
+    it('should be kind captions when there is both transcribes-spoken-dialog and describes-music-and-sound', function () {
+      hls.subtitleTrackController = { subtitleDisplay: false };
+
+      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
+        subtitleTracks: [
+          {
+            id: 0,
+            name: 'en',
+            attrs: {
+              CHARACTERISTICS:
+                'public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound',
+            },
+          },
+        ],
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order as in manifest
+      expect(timelineController.textTracks[0].kind).to.equal('captions');
+      // text tracks of the media contain the newly added text tracks
+      expect(timelineController.media.textTracks[0].kind).to.equal('captions');
+    });
+
+    it('should be kind subtitles when there is no describes-music-and-sound', function () {
+      hls.subtitleTrackController = { subtitleDisplay: false };
+
+      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
+        subtitleTracks: [
+          {
+            id: 0,
+            name: 'en',
+            attrs: {
+              CHARACTERISTICS: 'public.accessibility.transcribes-spoken-dialog',
+            },
+          },
+        ],
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order as in manifest
+      expect(timelineController.textTracks[0].kind).to.equal('subtitles');
+      // text tracks of the media contain the newly added text tracks
+      expect(timelineController.media.textTracks[0].kind).to.equal('subtitles');
+    });
+
+    it('should be kind subtitles when there is no CHARACTERISTICS', function () {
+      hls.subtitleTrackController = { subtitleDisplay: false };
+
+      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
+        subtitleTracks: [
+          {
+            id: 0,
+            name: 'en',
+          },
+        ],
+      });
+
+      // text tracks model contain only newly added manifest tracks, in same order as in manifest
+      expect(timelineController.textTracks[0].kind).to.equal('subtitles');
+      // text tracks of the media contain the newly added text tracks
+      expect(timelineController.media.textTracks[0].kind).to.equal('subtitles');
+    });
+  });
 });


### PR DESCRIPTION
### This PR will...
will set the text track kind to either `captions` or `subtitles` based on CHARACTERISTICS attribute in the MediaPlaylist for the track.

### Why is this Pull Request needed?
If a text tracks has `CHARACTERISTICS="public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound`, the native video element in Safari will set the `kind` property of the textTrack to `captions` instead of `subtitles`.  

### Are there any points in the code the reviewer needs to double check?
1.  I wasn't sure here if there was any MediaPlaylist information here to analyze to make the distinction between captions and subtitles when making a native text track. https://github.com/video-dev/hls.js/blob/79895a477800147e0b64008e3d01b9f6216453a9/src/controller/timeline-controller.ts#L225-L245.
1. The same goes for a non-native textTrack. I wasn't sure if I should be adding CHARACTERISTICS information to captionsProperties or not. https://github.com/video-dev/hls.js/blob/79895a477800147e0b64008e3d01b9f6216453a9/src/controller/timeline-controller.ts#L247-L266 
### Resolves issues:
Closes https://github.com/video-dev/hls.js/issues/2472

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
