### PR TITLE
Fix segment error handling with live streams

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -293,15 +293,16 @@ class AbrController implements ComponentAPI {
     const forcedAutoLevel = this._nextAutoLevel;
     const bwEstimator = this.bwEstimator;
     // in case next auto level has been forced, and bw not available or not reliable, return forced value
-    if (
-      forcedAutoLevel !== -1 &&
-      (!bwEstimator || !bwEstimator.canEstimate())
-    ) {
+    if (forcedAutoLevel !== -1 && !bwEstimator.canEstimate()) {
       return forcedAutoLevel;
     }
 
     // compute next level using ABR logic
     let nextABRAutoLevel = this.getNextABRAutoLevel();
+    // use forced auto level when ABR selected level has errored
+    if (forcedAutoLevel !== -1 && this.hls.levels[nextABRAutoLevel].loadError) {
+      return forcedAutoLevel;
+    }
     // if forced auto level has been defined, use it to cap ABR computed quality level
     if (forcedAutoLevel !== -1) {
       nextABRAutoLevel = Math.min(forcedAutoLevel, nextABRAutoLevel);

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -171,6 +171,7 @@ class AudioStreamController
         // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
         if (!retryDate || now >= retryDate || this.media?.seeking) {
           this.log('RetryDate reached, switch back to IDLE state');
+          this.resetStartWhenNotLoaded(this.trackId);
           this.state = State.IDLE;
         }
         break;
@@ -695,7 +696,7 @@ class AudioStreamController
       this.warn(
         `The loading context changed while buffering fragment ${chunkMeta.sn} of level ${chunkMeta.level}. This chunk will not be buffered.`
       );
-      this.resetLiveStartWhenNotLoaded(chunkMeta.level);
+      this.resetStartWhenNotLoaded(chunkMeta.level);
       return;
     }
     const {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -24,7 +24,10 @@ import FragmentLoader, {
   LoadError,
 } from '../loader/fragment-loader';
 import { LevelDetails } from '../loader/level-details';
-import {
+import Decrypter from '../crypt/decrypter';
+import TimeRanges from '../utils/time-ranges';
+import { PlaylistLevelType } from '../types/loader';
+import type {
   BufferAppendingData,
   ErrorData,
   FragLoadedData,
@@ -32,10 +35,8 @@ import {
   KeyLoadedData,
   MediaAttachingData,
   BufferFlushingData,
+  LevelSwitchingData,
 } from '../types/events';
-import Decrypter from '../crypt/decrypter';
-import TimeRanges from '../utils/time-ranges';
-import { PlaylistLevelType } from '../types/loader';
 import type { FragmentTracker } from './fragment-tracker';
 import type { Level } from '../types/level';
 import type { RemuxedTrack } from '../types/remuxer';
@@ -108,6 +109,7 @@ export default class BaseStreamController
     this.config = hls.config;
     this.decrypter = new Decrypter(hls as HlsEventEmitter, hls.config);
     hls.on(Events.KEY_LOADED, this.onKeyLoaded, this);
+    hls.on(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
   }
 
   protected doTick() {
@@ -275,6 +277,13 @@ export default class BaseStreamController
     }
   }
 
+  protected onLevelSwitching(
+    event: Events.LEVEL_SWITCHING,
+    data: LevelSwitchingData
+  ): void {
+    this.fragLoadError = 0;
+  }
+
   protected onHandlerDestroying() {
     this.stopLoad();
     super.onHandlerDestroying();
@@ -283,6 +292,7 @@ export default class BaseStreamController
   protected onHandlerDestroyed() {
     this.state = State.STOPPED;
     this.hls.off(Events.KEY_LOADED, this.onKeyLoaded, this);
+    this.hls.off(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     if (this.fragmentLoader) {
       this.fragmentLoader.destroy();
     }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -183,6 +183,7 @@ export default class StreamController
           // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
           if (!retryDate || now >= retryDate || this.media?.seeking) {
             this.log('retryDate reached, switch back to IDLE state');
+            this.resetStartWhenNotLoaded(this.level);
             this.state = State.IDLE;
           }
         }
@@ -1055,7 +1056,7 @@ export default class StreamController
       this.warn(
         `The loading context changed while buffering fragment ${chunkMeta.sn} of level ${chunkMeta.level}. This chunk will not be buffered.`
       );
-      this.resetLiveStartWhenNotLoaded(chunkMeta.level);
+      this.resetStartWhenNotLoaded(chunkMeta.level);
       return;
     }
     const { frag, part, level } = context;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -140,12 +140,15 @@ export default class Hls implements HlsEventEmitter {
     // fpsController uses streamController to switch when frames are being dropped
     fpsController.setStreamController(streamController);
 
-    const networkControllers = [levelController, streamController];
+    const networkControllers = [
+      playListLoader,
+      keyLoader,
+      levelController,
+      streamController,
+    ];
 
     this.networkControllers = networkControllers;
     const coreComponents = [
-      playListLoader,
-      keyLoader,
       abrController,
       bufferController,
       capLevelController,

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -33,6 +33,7 @@ import type {
   ManifestLoadingData,
   TrackLoadingData,
 } from '../types/events';
+import { NetworkComponentAPI } from '../types/component-api';
 
 function mapContextToLevelType(
   context: PlaylistLoaderContext
@@ -63,7 +64,7 @@ function getResponseUrl(
   return url;
 }
 
-class PlaylistLoader {
+class PlaylistLoader implements NetworkComponentAPI {
   private readonly hls: Hls;
   private readonly loaders: {
     [key: string]: Loader<LoaderContext>;
@@ -72,6 +73,12 @@ class PlaylistLoader {
   constructor(hls: Hls) {
     this.hls = hls;
     this.registerListeners();
+  }
+
+  public startLoad(startPosition: number): void {}
+
+  public stopLoad(): void {
+    this.destroyInternalLoaders();
   }
 
   private registerListeners() {


### PR DESCRIPTION
### This PR will...
- Fix fragment error handling with live streams
- Fix level fail over on alt-audio fragment request errors
- Stop playlist and key loading when `stopLoad` is called 

### Why is this Pull Request needed?
Prevents looping error requests on segment assets in live streams. Live stream fragment errors should observe retry rules, switching levels in ABR mode after retries are exhausted, eventually resulting in the player erroring out if retry rules do not succeed for each level.

Fragment retry counts apply across all media options before a level switch is performed. On the last level to error each playlist's (main, audio, subs) fragments will get the full number of retries.

`hls.stopLoad` should abort active playlist and key loading to prevent activity after `stopLoad` is called or after a fatal player error. 

### Resolves issues:
Fixes #4312
Related to #4312

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
