### PR TITLE
Fix subtitle buffered check

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -1,6 +1,6 @@
 import BaseStreamController, { State } from './base-stream-controller';
 import { Events } from '../events';
-import { BufferHelper } from '../utils/buffer-helper';
+import { Bufferable, BufferHelper } from '../utils/buffer-helper';
 import { FragmentState } from './fragment-tracker';
 import { Level } from '../types/level';
 import { PlaylistLevelType } from '../types/loader';
@@ -46,7 +46,7 @@ class AudioStreamController
   extends BaseStreamController
   implements NetworkComponentAPI
 {
-  private videoBuffer: any | null = null;
+  private videoBuffer: Bufferable | null = null;
   private videoTrackCC: number = -1;
   private waitingVideoCC: number = -1;
   private audioSwitch: boolean = false;
@@ -289,17 +289,18 @@ class AudioStreamController
       return;
     }
 
-    if (this.bufferFlushed) {
+    const bufferable = this.mediaBuffer ? this.mediaBuffer : this.media;
+    if (this.bufferFlushed && bufferable) {
       this.bufferFlushed = false;
       this.afterBufferFlushed(
-        this.mediaBuffer ? this.mediaBuffer : this.media,
+        bufferable,
         ElementaryStreamTypes.AUDIO,
         PlaylistLevelType.AUDIO
       );
     }
 
     const bufferInfo = this.getFwdBufferInfo(
-      this.mediaBuffer ? this.mediaBuffer : this.media,
+      bufferable,
       PlaylistLevelType.AUDIO
     );
     if (bufferInfo === null) {
@@ -328,7 +329,7 @@ class AudioStreamController
     const start = fragments[0].start;
     let targetBufferTime = bufferInfo.end;
 
-    if (audioSwitch) {
+    if (audioSwitch && media) {
       const pos = this.getLoadPosition();
       targetBufferTime = pos;
       // if currentTime (pos) is less than alt audio playlist start time, it means that alt audio is ahead of currentTime
@@ -587,10 +588,10 @@ class AudioStreamController
   onBufferCreated(event: Events.BUFFER_CREATED, data: BufferCreatedData) {
     const audioTrack = data.tracks.audio;
     if (audioTrack) {
-      this.mediaBuffer = audioTrack.buffer;
+      this.mediaBuffer = audioTrack.buffer || null;
     }
     if (data.tracks.video) {
-      this.videoBuffer = data.tracks.video.buffer;
+      this.videoBuffer = data.tracks.video.buffer || null;
     }
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -307,7 +307,9 @@ export default class StreamController
         this.audioOnly && !this.altAudio
           ? ElementaryStreamTypes.AUDIO
           : ElementaryStreamTypes.VIDEO;
-      this.afterBufferFlushed(media, type, PlaylistLevelType.MAIN);
+      if (media) {
+        this.afterBufferFlushed(media, type, PlaylistLevelType.MAIN);
+      }
       frag = this.getNextFragment(this.nextLoadPosition, levelDetails);
     }
     if (!frag) {
@@ -509,7 +511,7 @@ export default class StreamController
 
   protected onMediaDetaching() {
     const { media } = this;
-    if (media) {
+    if (media && this.onvplaying && this.onvseeked) {
       media.removeEventListener('playing', this.onvplaying);
       media.removeEventListener('seeked', this.onvseeked);
       this.onvplaying = this.onvseeked = null;
@@ -532,7 +534,7 @@ export default class StreamController
     const media = this.media;
     const currentTime = media ? media.currentTime : null;
     if (Number.isFinite(currentTime)) {
-      this.log(`Media seeked to ${currentTime.toFixed(3)}`);
+      this.log(`Media seeked to ${(currentTime as number).toFixed(3)}`);
     }
 
     // tick to speed up FRAG_CHANGED triggering
@@ -974,6 +976,9 @@ export default class StreamController
    */
   private seekToStartPos() {
     const { media } = this;
+    if (!media) {
+      return;
+    }
     const currentTime = media.currentTime;
     let startPosition = this.startPosition;
     // only adjust currentTime if different from startPosition or if startPosition not buffered

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -1,5 +1,5 @@
 import { Events } from '../events';
-import { BufferHelper } from '../utils/buffer-helper';
+import { Bufferable, BufferHelper } from '../utils/buffer-helper';
 import { findFragmentByPTS } from './fragment-finders';
 import { alignMediaPlaylistByPDT } from '../utils/discontinuities';
 import { addSliding } from './level-helper';
@@ -351,7 +351,7 @@ export class SubtitleStreamController
       const targetDuration = trackDetails.targetduration;
       const { config, media } = this;
       const bufferedInfo = BufferHelper.bufferedInfo(
-        this.mediaBufferTimeRanges,
+        this.tracksBuffered[this.currentTrackId] || [],
         media.currentTime - targetDuration,
         config.maxBufferHole
       );
@@ -421,7 +421,40 @@ export class SubtitleStreamController
     }
   }
 
-  get mediaBufferTimeRanges(): TimeRange[] {
-    return this.tracksBuffered[this.currentTrackId] || [];
+  get mediaBufferTimeRanges(): Bufferable {
+    return new BufferableInstance(
+      this.tracksBuffered[this.currentTrackId] || []
+    );
+  }
+}
+
+class BufferableInstance implements Bufferable {
+  public readonly buffered: TimeRanges;
+
+  constructor(timeranges: TimeRange[]) {
+    const getRange = (
+      name: 'start' | 'end',
+      index: number,
+      length: number
+    ): number => {
+      index = index >>> 0;
+      if (index > length - 1) {
+        throw new DOMException(
+          `Failed to execute '${name}' on 'TimeRanges': The index provided (${index}) is greater than the maximum bound (${length})`
+        );
+      }
+      return timeranges[index][name];
+    };
+    this.buffered = {
+      get length() {
+        return timeranges.length;
+      },
+      end(index: number): number {
+        return getRange('end', index, timeranges.length);
+      },
+      start(index: number): number {
+        return getRange('start', index, timeranges.length);
+      },
+    };
   }
 }

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -358,11 +358,14 @@ describe('StreamController', function () {
           start() {
             return bufStart;
           },
+          end() {
+            return bufStart;
+          },
           length: 1,
         },
         currentTime: 0,
         readyState: 4,
-      };
+      } as any as HTMLMediaElement;
       streamController['mediaBuffer'] = null;
     });
     afterEach(function () {
@@ -395,7 +398,7 @@ describe('StreamController', function () {
     it('should not seek to start pos when nothing has been buffered', function () {
       // @ts-ignore
       const seekStub = sandbox.stub(streamController, 'seekToStartPos');
-      streamController['media'].buffered.length = 0;
+      (streamController['media']!.buffered as any).length = 0;
       streamController['checkBuffer']();
       expect(seekStub).to.have.not.been.called;
       expect(streamController['loadedmetadata']).to.be.false;
@@ -405,14 +408,14 @@ describe('StreamController', function () {
       it('should seek to startPosition when startPosition is not buffered & the media is not seeking', function () {
         streamController['startPosition'] = 5;
         streamController['seekToStartPos']();
-        expect(streamController['media'].currentTime).to.equal(5);
+        expect(streamController['media']!.currentTime).to.equal(5);
       });
 
       it('should not seek to startPosition when it is buffered', function () {
         streamController['startPosition'] = 5;
-        streamController['media'].currentTime = 5;
+        streamController['media']!.currentTime = 5;
         streamController['seekToStartPos']();
-        expect(streamController['media'].currentTime).to.equal(5);
+        expect(streamController['media']!.currentTime).to.equal(5);
       });
     });
 


### PR DESCRIPTION
### This PR will...
Fix an issue where `BufferHelper.bufferInfo` throws when it is passed an array of `TimeRange` objects from the subtitle-stream-controller. 

### Why is this Pull Request needed?
`BufferHelper.bufferInfo` and `getBuffered` expect an `HTMLMediaElement` or `SourceBuffer` (or something implementing the `Bufferable` interface) and not an array of TimeRanges, which subtitle-stream-controller was setting on `mediaBuffer`.

The stronger typing on `media`, `mediaBuffer`, and `videoBuffer` informed all of the changes in this PR, which will prevent exceptions when checking if subtitles are buffered while seeking or when the player is detached in certain event loops.

While the exception in `BufferHelper.bufferInfo` is caught, it can be reproduced by enabling "Pause on caught exceptions" and seeking outside the buffered range on any HLS stream with an active subtitle track and playlist. A result is that without an accurate reading on the buffered range for sub, active requests would not be aborted when seeking to prioritize newer requests like they are for audio and video.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
