### PR TITLE
Bugfix: segment loading order with gaps

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -502,6 +502,16 @@ export default class BaseStreamController
       }`
     );
     this.state = State.IDLE;
+    if (!media) {
+      return;
+    }
+    if (
+      !this.loadedmetadata &&
+      media.buffered.length &&
+      this.fragCurrent === this.fragPrevious
+    ) {
+      this.loadedmetadata = true;
+    }
     this.tick();
   }
 
@@ -1015,12 +1025,12 @@ export default class BaseStreamController
 
     if (frag) {
       const curSNIdx = frag.sn - levelDetails.startSN;
-      const sameLevel = fragPrevious && frag.level === fragPrevious.level;
-      const nextFrag = fragments[curSNIdx + 1];
       if (fragPrevious && frag.sn === fragPrevious.sn && !loadingParts) {
         // Force the next fragment to load if the previous one was already selected. This can occasionally happen with
         // non-uniform fragment durations
+        const sameLevel = fragPrevious && frag.level === fragPrevious.level;
         if (sameLevel) {
+          const nextFrag = fragments[curSNIdx + 1];
           if (
             frag.sn < endSN &&
             this.fragmentTracker.getState(nextFrag) !== FragmentState.OK


### PR DESCRIPTION
### This PR will...
Stop using `nextLoadPosition` to find fragments as soon as the first media segment is appended. Use media timecode when fragmented MP4 mux input has audio and video.

### Why is this Pull Request needed?
Prevents stream controllers from skipping segments and appending media at the wrong time when the first playlist segment duration is longer than the parsed media segment. This could happen when an audio encoder drops out leaving a large gap which is then added to the segment duration without splitting it into a new segment or marking it with a GAP tag.

### Resolves issues:
#4828

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
