### PR TITLE
Resume streaming after bitrate test with low max buffer

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -240,7 +240,6 @@ class AbrController implements ComponentAPI {
           id: frag.type,
         };
         this.onFragBuffered(Events.FRAG_BUFFERED, fragBufferedData);
-        frag.bitrateTest = false;
       }
     }
   }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -343,7 +343,6 @@ export default class StreamController
       if (frag.sn === 'initSegment') {
         this._loadInitSegment(frag);
       } else if (this.bitrateTest) {
-        frag.bitrateTest = true;
         this.log(
           `Fragment ${frag.sn} of level ${frag.level} is being downloaded to test bitrate and will not be buffered`
         );
@@ -1024,6 +1023,7 @@ export default class StreamController
   }
 
   private _loadBitrateTestFrag(frag: Fragment) {
+    frag.bitrateTest = true;
     this._doFragLoad(frag).then((data) => {
       const { hls } = this;
       if (!data || hls.nextLoadLevel || this.fragContextChanged(frag)) {
@@ -1041,6 +1041,7 @@ export default class StreamController
         stats.buffering.end =
           self.performance.now();
       hls.trigger(Events.FRAG_LOADED, data as FragLoadedData);
+      frag.bitrateTest = false;
     });
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -120,7 +120,7 @@ export default class StreamController
         // determine load level
         let startLevel = hls.startLevel;
         if (startLevel === -1) {
-          if (hls.config.testBandwidth) {
+          if (hls.config.testBandwidth && this.levels.length > 1) {
             // -1 : guess start Level by doing a bitrate test by loading first fragment of lowest quality level
             startLevel = 0;
             this.bitrateTest = true;

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -26,6 +26,7 @@ describe('StreamController', function () {
   let hls: Hls;
   let fragmentTracker: FragmentTracker;
   let streamController: StreamController;
+  const attrs: LevelAttributes = new AttrList({});
 
   beforeEach(function () {
     hls = new Hls({});
@@ -289,7 +290,6 @@ describe('StreamController', function () {
     let frag;
     let levelDetails;
     beforeEach(function () {
-      const attrs: LevelAttributes = new AttrList({});
       streamController['levels'] = [
         new Level({
           name: '',
@@ -421,7 +421,20 @@ describe('StreamController', function () {
 
     describe('startLoad', function () {
       beforeEach(function () {
-        streamController['levels'] = [];
+        streamController['levels'] = [
+          new Level({
+            name: '',
+            url: '',
+            attrs,
+            bitrate: 500000,
+          }),
+          new Level({
+            name: '',
+            url: '',
+            attrs,
+            bitrate: 250000,
+          }),
+        ];
         streamController['media'] = null;
       });
       it('should not start when controller does not have level data', function () {
@@ -477,6 +490,23 @@ describe('StreamController', function () {
         hls.startLevel = -1;
         hls.nextAutoLevel = 3;
         hls.config.testBandwidth = false;
+
+        streamController.startLoad(-1);
+        expect(streamController['level']).to.equal(hls.nextAutoLevel);
+        expect(streamController['bitrateTest']).to.be.false;
+      });
+
+      it('should not signal a bandwidth test with only one level', function () {
+        streamController['startFragRequested'] = false;
+        streamController['levels'] = [
+          new Level({
+            name: '',
+            url: '',
+            attrs,
+            bitrate: 250000,
+          }),
+        ];
+        hls.startLevel = -1;
 
         streamController.startLoad(-1);
         expect(streamController['level']).to.equal(hls.nextAutoLevel);


### PR DESCRIPTION
### This PR will...
1. Fix a bug where the bitrate test depended on a [buffer full error workaround](https://github.com/video-dev/hls.js/blob/v1.2.1/src/controller/stream-controller.ts#L355-L358) to resume loading.
2. Always skip the bitrate test when only one level is available.

### Why is this Pull Request needed?
The bitrate test fragment should never be added to the fragment tracker or set to "APPENDING" state. The abr controller cleared the fragment's `bitrateTest` flag before the event was received by the fragment tracker.

### Resolves issues:
Fixes #4865

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
