### PR TITLE
Fix handling of negative composition timestamps

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -337,10 +337,7 @@ export default class StreamController
     // Check if fragment is not loaded
     const fragState = this.fragmentTracker.getState(frag);
     this.fragCurrent = frag;
-    if (
-      fragState === FragmentState.NOT_LOADED ||
-      fragState === FragmentState.PARTIAL
-    ) {
+    if (fragState === FragmentState.NOT_LOADED) {
       if (frag.sn === 'initSegment') {
         this._loadInitSegment(frag);
       } else if (this.bitrateTest) {

--- a/src/remux/mp4-generator.ts
+++ b/src/remux/mp4-generator.ts
@@ -1084,7 +1084,7 @@ class MP4 {
     offset += 8 + arraylen;
     array.set(
       [
-        0x01, // version 1 to signal signed ctts
+        0x00, // version 0
         0x00,
         0x0f,
         0x01, // flags
@@ -1099,12 +1099,16 @@ class MP4 {
       ],
       0
     );
+    let hasNegativeCompositionTimestamps = false;
     for (i = 0; i < len; i++) {
       sample = samples[i];
       duration = sample.duration;
       size = sample.size;
       flags = sample.flags;
       cts = sample.cts;
+      if (cts < 0) {
+        hasNegativeCompositionTimestamps = true;
+      }
       array.set(
         [
           (duration >>> 24) & 0xff,
@@ -1129,6 +1133,9 @@ class MP4 {
         ],
         12 + 16 * i
       );
+    }
+    if (hasNegativeCompositionTimestamps) {
+      array[0] = 0x01; // version 1
     }
     return MP4.box(MP4.types.trun, array);
   }

--- a/src/remux/mp4-generator.ts
+++ b/src/remux/mp4-generator.ts
@@ -1084,7 +1084,7 @@ class MP4 {
     offset += 8 + arraylen;
     array.set(
       [
-        0x00, // version 0
+        track.type === 'video' ? 0x01 : 0x00, // version 1 for video with signed-int sample_composition_time_offset
         0x00,
         0x0f,
         0x01, // flags
@@ -1099,16 +1099,12 @@ class MP4 {
       ],
       0
     );
-    let hasNegativeCompositionTimestamps = false;
     for (i = 0; i < len; i++) {
       sample = samples[i];
       duration = sample.duration;
       size = sample.size;
       flags = sample.flags;
       cts = sample.cts;
-      if (cts < 0) {
-        hasNegativeCompositionTimestamps = true;
-      }
       array.set(
         [
           (duration >>> 24) & 0xff,
@@ -1133,9 +1129,6 @@ class MP4 {
         ],
         12 + 16 * i
       );
-    }
-    if (hasNegativeCompositionTimestamps) {
-      array[0] = 0x01; // version 1
     }
     return MP4.box(MP4.types.trun, array);
   }

--- a/src/remux/mp4-generator.ts
+++ b/src/remux/mp4-generator.ts
@@ -1084,7 +1084,7 @@ class MP4 {
     offset += 8 + arraylen;
     array.set(
       [
-        0x00, // version 0
+        0x01, // version 1 to signal signed ctts
         0x00,
         0x0f,
         0x01, // flags

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -325,10 +325,10 @@ describe('StreamController', function () {
       assertLoadingState(frag);
     });
 
-    it('should load a partial fragment', function () {
+    it('should not load a partial fragment', function () {
       fragStateStub(FragmentState.PARTIAL);
       streamController['loadFragment'](frag, levelDetails, 0);
-      assertLoadingState(frag);
+      assertNotLoadingState();
     });
 
     it('should not load a fragment which has completely & successfully loaded', function () {


### PR DESCRIPTION
### This PR will...
Fix handling of negative composition timestamps in MPEG-2 TS remuxing.

Remove loading of "partial" segments. If MSE doesn't append the full segment duration this is likely an issue with the media. This avoids loop loading. Reloading of ejected media is still covered by the fragment tracker.

### Why is this Pull Request needed?

This change eliminates the "PTS < DTS" warnings and workarounds. The mp4 "trun" box version is set to 1 to signal that composition timestamps are signed.

### Resolves issues:
Fixes #4878

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
