### PR TITLE
Fix seek to live start regression in dev

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -524,9 +524,12 @@ export default class BaseStreamController
       this.fragCurrent === this.fragPrevious
     ) {
       this.loadedmetadata = true;
+      this.seekToStartPos();
     }
     this.tick();
   }
+
+  protected seekToStartPos() {}
 
   protected _handleFragmentLoadComplete(fragLoadedEndData: PartsLoadedData) {
     const { transmuxer } = this;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -917,13 +917,7 @@ export default class StreamController
       return;
     }
 
-    // Check combined buffer
-    const buffered = BufferHelper.getBuffered(media);
-
-    if (!this.loadedmetadata && buffered.length) {
-      this.loadedmetadata = true;
-      this.seekToStartPos();
-    } else {
+    if (this.loadedmetadata || !BufferHelper.getBuffered(media).length) {
       // Resolve gaps using the main buffer, whose ranges are the intersections of the A/V sourcebuffers
       const activeFrag = this.state !== State.IDLE ? this.fragCurrent : null;
       gapController.poll(this.lastCurrentTime, activeFrag);
@@ -972,9 +966,8 @@ export default class StreamController
 
   /**
    * Seeks to the set startPosition if not equal to the mediaElement's current time.
-   * @private
    */
-  private seekToStartPos() {
+  protected seekToStartPos() {
     const { media } = this;
     if (!media) {
       return;

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -377,11 +377,19 @@ describe('StreamController', function () {
       streamController['checkBuffer']();
     });
 
-    it('should seek to start pos when metadata has not yet been loaded', function () {
+    it('should seek to start pos when data is first loaded', function () {
+      const firstFrag = new Fragment(PlaylistLevelType.MAIN, '');
+      firstFrag.duration = 5.0;
+      firstFrag.level = 1;
+      firstFrag.start = 0;
+      firstFrag.sn = 1;
+      firstFrag.cc = 0;
       // @ts-ignore
       const seekStub = sandbox.stub(streamController, 'seekToStartPos');
       streamController['loadedmetadata'] = false;
-      streamController['checkBuffer']();
+      streamController['fragCurrent'] = streamController['fragPrevious'] =
+        firstFrag;
+      streamController['fragBufferedComplete'](firstFrag, null);
       expect(seekStub).to.have.been.calledOnce;
       expect(streamController['loadedmetadata']).to.be.true;
     });


### PR DESCRIPTION
### This PR will...
Fix seek to live start regression introduced in #4864

### Why is this Pull Request needed?
Changes in #4864 that impact when stream-controller `loadedmetadata` is toggled resulted in seek to live start being skipped in many cases. 

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
