### PR TITLE
issue/4888-ccOffset

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -745,7 +745,7 @@ function newVTTCCs(): VTTCCs {
     0: {
       start: 0,
       prevCC: -1,
-      new: false,
+      new: true,
     },
   };
 }


### PR DESCRIPTION
Ensure the first continuity segment is processed in `webvtt-parser`'s `oncue` handler. 

The first continuity segment is hard coded with `new: false`. This prevents `webvtt-parser` from correctly calculating the `ccOffset` when you seek back to the first continuity segment after starting in a later segment:

[webvtt-parser](https://github.com/video-dev/hls.js/blob/6216ab91fd79564af4236bdd788d8b7ca7bba409/src/utils/webvtt-parser.ts#L115-L131)
```ts
  parser.oncue = function (cue: VTTCue) {
    // Adjust cue timing; clamp cues to start no earlier than - and drop cues that don't end after - 0 on timeline.
    const currCC = vttCCs[cc];
    let cueOffset = vttCCs.ccOffset;


    // Calculate subtitle PTS offset
    const webVttMpegTsMapOffset = (timestampMapMPEGTS - initPTS90Hz) / 90000;

    /////////////////////////////////////////////////////
    // Only "new" CCs get their cue offsets calculated.
    // This makes sense if you start playback from 0,
    // but causes a problem when `startPosition` is set
    // to a later continuity segment. When you seek back
    // the `cueOffset` remains at the later playhead time
    // and new cues are added at the wrong time.
    /////////////////////////////////////////////////////

    // Update offsets for new discontinuities
    if (currCC?.new) {
      if (timestampMapLOCAL !== undefined) {
        // When local time is provided, offset = discontinuity start time - local time
        cueOffset = vttCCs.ccOffset = currCC.start;
      } else {
        calculateOffset(vttCCs, cc, webVttMpegTsMapOffset);
      }
    }
```

### Resolves issues:
#4888 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
