### PR TITLE
Remove `npm view` "json" arg so that 16.17 does not throw on release

### DIFF
--- a/scripts/check-already-published.js
+++ b/scripts/check-already-published.js
@@ -17,9 +17,7 @@ process.exit(0);
 function versionPublished() {
   // npm view returns empty string if package doesn't exist
   return !!require('child_process')
-    .execSync(
-      'npm view ' + packageJson.name + '@' + packageJson.version
-    )
+    .execSync('npm view ' + packageJson.name + '@' + packageJson.version)
     .toString()
     .trim();
 }

--- a/scripts/check-already-published.js
+++ b/scripts/check-already-published.js
@@ -18,7 +18,7 @@ function versionPublished() {
   // npm view returns empty string if package doesn't exist
   return !!require('child_process')
     .execSync(
-      'npm view ' + packageJson.name + '@' + packageJson.version + ' --json'
+      'npm view ' + packageJson.name + '@' + packageJson.version
     )
     .toString()
     .trim();


### PR DESCRIPTION
Ran into trouble with npm 16.17 publishing v1.2.2:
https://github.com/video-dev/hls.js/runs/8280226435?check_suite_focus=true#step:7:1 (ended up running the scripts locally to publish).

I seems to be related to this issue https://github.com/npm/cli/issues/4724 so I'm hoping that removing the JSON arg will prevent publishing to npm from failing.

Even though publishing failed, the build step did not. Does this happen for interim (canaray) builds too? Should we change the exit code to address this?