### PR TITLE
Initial timestamps must be unsigned for tfdt v1 box

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -33,7 +33,6 @@ const MPEG_AUDIO_SAMPLE_PER_FRAME = 1152;
 
 let chromeVersion: number | null = null;
 let safariWebkitVersion: number | null = null;
-let requiresPositiveDts: boolean = false;
 
 export default class MP4Remuxer implements Remuxer {
   private observer: HlsEventEmitter;
@@ -68,10 +67,6 @@ export default class MP4Remuxer implements Remuxer {
       const result = navigator.userAgent.match(/Safari\/(\d+)/i);
       safariWebkitVersion = result ? parseInt(result[1]) : 0;
     }
-    requiresPositiveDts = !(
-      (!!chromeVersion && chromeVersion >= 75) ||
-      (!!safariWebkitVersion && safariWebkitVersion >= 600)
-    );
   }
 
   destroy() {}
@@ -473,9 +468,8 @@ export default class MP4Remuxer implements Remuxer {
       }
     }
 
-    if (requiresPositiveDts) {
-      firstDTS = Math.max(0, firstDTS);
-    }
+    firstDTS = Math.max(0, firstDTS);
+
     let nbNalu = 0;
     let naluLen = 0;
     for (let i = 0; i < nbSamples; i++) {


### PR DESCRIPTION
### This PR will...
Never use negative start times in m2ts remuxer.

### Why is this Pull Request needed?
The remuxed mp4 output includes a tfdt box with base media decode timestamp which is expected to be an unsigned int(64) based on the box version of 1. This does not allow for negative values. The UA checks are not reliable enough to prevent us from using negative values in places where they could break playback.

### Resolves issues:
Fixes #4893 #4899

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
