### PR TITLE
Bugfix: load one fragment in infinite loop (WebVTT AES-128) 

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -399,10 +399,7 @@ export class SubtitleStreamController
 
       if (foundFrag.encrypted) {
         this.loadKey(foundFrag, trackDetails);
-      } else if (
-        this.fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED
-      ) {
-        // only load if fragment is not loaded
+      } else {
         this.loadFragment(foundFrag, trackDetails, targetBufferTime);
       }
     }
@@ -413,6 +410,11 @@ export class SubtitleStreamController
     levelDetails: LevelDetails,
     targetBufferTime: number
   ) {
+    // only load if fragment is not loaded
+    if (this.fragmentTracker.getState(frag) !== FragmentState.NOT_LOADED) {
+      return;
+    }
+
     this.fragCurrent = frag;
     if (frag.sn === 'initSegment') {
       this._loadInitSegment(frag);

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -397,6 +397,13 @@ export class SubtitleStreamController
         return;
       }
 
+      // only load if fragment is not loaded
+      if (
+        this.fragmentTracker.getState(foundFrag) !== FragmentState.NOT_LOADED
+      ) {
+        return;
+      }
+
       if (foundFrag.encrypted) {
         this.loadKey(foundFrag, trackDetails);
       } else {
@@ -410,11 +417,6 @@ export class SubtitleStreamController
     levelDetails: LevelDetails,
     targetBufferTime: number
   ) {
-    // only load if fragment is not loaded
-    if (this.fragmentTracker.getState(frag) !== FragmentState.NOT_LOADED) {
-      return;
-    }
-
     this.fragCurrent = frag;
     if (frag.sn === 'initSegment') {
       this._loadInitSegment(frag);


### PR DESCRIPTION
### This PR will...
Improves checking if a fragment of subtitles needs to be loaded.

### Why is this Pull Request needed?
Fixes a bug causing the same subtitle fragments to load. 

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
#4898

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
