### PR TITLE
Bugfix: IMSC subtitles default formatting

### DIFF
--- a/src/utils/imsc1-ttml-parser.ts
+++ b/src/utils/imsc1-ttml-parser.ts
@@ -104,11 +104,6 @@ function parseTTML(ttml: string, syncTime: number): Array<VTTCue> {
       const region = regionElements[cueElement.getAttribute('region')];
       const style = styleElements[cueElement.getAttribute('style')];
 
-      // TODO: Add regions to track and cue (origin and extend)
-      // These values are hard-coded (for now) to simulate region settings in the demo
-      cue.position = 10;
-      cue.size = 80;
-
       // Apply styles to cue
       const styles = getTtmlStyles(region, style, styleElements);
       const { textAlign } = styles;


### PR DESCRIPTION
### This PR will...
Remove predefined values for cue.size and cue.position

### Why is this Pull Request needed?
If the subtitles do not contain styles, the subtitles are shifted to the left.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
#4914 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
