### PR TITLE
Decrypter cleanup

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -43,7 +43,6 @@ import type { Level } from '../types/level';
 import type { RemuxedTrack } from '../types/remuxer';
 import type Hls from '../hls';
 import type { HlsConfig } from '../config';
-import type { HlsEventEmitter } from '../events';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type { SourceBufferName } from '../types/buffer';
 
@@ -110,7 +109,7 @@ export default class BaseStreamController
     this.keyLoader = new KeyLoader(hls.config);
     this.fragmentTracker = fragmentTracker;
     this.config = hls.config;
-    this.decrypter = new Decrypter(hls as HlsEventEmitter, hls.config);
+    this.decrypter = new Decrypter(hls.config);
     hls.on(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
   }
 
@@ -409,7 +408,7 @@ export default class BaseStreamController
           const startTime = self.performance.now();
           // decrypt the subtitles
           return this.decrypter
-            .webCryptoDecrypt(
+            .decrypt(
               new Uint8Array(payload),
               decryptData.key.buffer,
               decryptData.iv.buffer

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -311,7 +311,7 @@ export class SubtitleStreamController
       const startTime = performance.now();
       // decrypt the subtitles
       this.decrypter
-        .webCryptoDecrypt(
+        .decrypt(
           new Uint8Array(payload),
           decryptData.key.buffer,
           decryptData.iv.buffer

--- a/src/crypt/aes-crypto.ts
+++ b/src/crypt/aes-crypto.ts
@@ -1,8 +1,8 @@
 export default class AESCrypto {
   private subtle: SubtleCrypto;
-  private aesIV: ArrayBuffer;
+  private aesIV: Uint8Array;
 
-  constructor(subtle: SubtleCrypto, iv: ArrayBuffer) {
+  constructor(subtle: SubtleCrypto, iv: Uint8Array) {
     this.subtle = subtle;
     this.aesIV = iv;
   }

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -55,11 +55,18 @@ export default class Decrypter {
     return this.useSoftware;
   }
 
-  public flush(): Uint8Array | void {
-    const { currentResult } = this;
-    if (!currentResult) {
+  public flush(): Uint8Array | null {
+    const { currentResult, remainderData } = this;
+    if (!currentResult || remainderData) {
+      logger.error(
+        `[softwareDecrypt] ${
+          remainderData
+            ? 'overflow bytes: ' + remainderData.byteLength
+            : 'no result'
+        }`
+      );
       this.reset();
-      return;
+      return null;
     }
     const data = new Uint8Array(currentResult);
     this.reset();
@@ -166,7 +173,7 @@ export default class Decrypter {
       })
       .catch((err) => {
         logger.warn(
-          `[decrypter.ts]: WebCrypto Error, disable WebCrypto API, ${err.name}: ${err.message}`
+          `[decrypter]: WebCrypto Error, disable WebCrypto API, ${err.name}: ${err.message}`
         );
 
         return this.onWebCryptoError(data, key, iv);
@@ -198,7 +205,7 @@ export default class Decrypter {
     if (!this.logEnabled) {
       return;
     }
-    logger.log(`[decrypter.ts]: ${msg}`);
+    logger.log(`[decrypter]: ${msg}`);
     this.logEnabled = false;
   }
 }

--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -20,20 +20,16 @@ class SampleAesDecrypter {
 
   constructor(observer: HlsEventEmitter, config: HlsConfig, keyData: KeyData) {
     this.keyData = keyData;
-    this.decrypter = new Decrypter(observer, config, {
+    this.decrypter = new Decrypter(config, {
       removePKCS7Padding: false,
     });
   }
 
-  decryptBuffer(
-    encryptedData: Uint8Array | ArrayBuffer,
-    callback: (decryptedData: ArrayBuffer) => void
-  ) {
-    this.decrypter.decrypt(
+  decryptBuffer(encryptedData: Uint8Array | ArrayBuffer): Promise<ArrayBuffer> {
+    return this.decrypter.decrypt(
       encryptedData,
       this.keyData.key.buffer,
-      this.keyData.iv.buffer,
-      callback
+      this.keyData.iv.buffer
     );
   }
 
@@ -41,8 +37,7 @@ class SampleAesDecrypter {
   private decryptAacSample(
     samples: AudioSample[],
     sampleIndex: number,
-    callback: () => void,
-    sync: boolean
+    callback: () => void
   ) {
     const curUnit = samples[sampleIndex].unit;
     if (curUnit.length <= 16) {
@@ -59,13 +54,12 @@ class SampleAesDecrypter {
       encryptedData.byteOffset + encryptedData.length
     );
 
-    const localthis = this;
-    this.decryptBuffer(encryptedBuffer, (decryptedBuffer: ArrayBuffer) => {
+    this.decryptBuffer(encryptedBuffer).then((decryptedBuffer: ArrayBuffer) => {
       const decryptedData = new Uint8Array(decryptedBuffer);
       curUnit.set(decryptedData, 16);
 
-      if (!sync) {
-        localthis.decryptAacSamples(samples, sampleIndex + 1, callback);
+      if (!this.decrypter.isSync()) {
+        this.decryptAacSamples(samples, sampleIndex + 1, callback);
       }
     });
   }
@@ -85,11 +79,9 @@ class SampleAesDecrypter {
         continue;
       }
 
-      const sync = this.decrypter.isSync();
+      this.decryptAacSample(samples, sampleIndex, callback);
 
-      this.decryptAacSample(samples, sampleIndex, callback, sync);
-
-      if (!sync) {
+      if (!this.decrypter.isSync()) {
         return;
       }
     }
@@ -140,28 +132,17 @@ class SampleAesDecrypter {
     sampleIndex: number,
     unitIndex: number,
     callback: () => void,
-    curUnit: AvcSampleUnit,
-    sync: boolean
+    curUnit: AvcSampleUnit
   ) {
     const decodedData = discardEPB(curUnit.data);
     const encryptedData = this.getAvcEncryptedData(decodedData);
-    const localthis = this;
 
-    this.decryptBuffer(
-      encryptedData.buffer,
-      function (decryptedBuffer: ArrayBuffer) {
-        curUnit.data = localthis.getAvcDecryptedUnit(
-          decodedData,
-          decryptedBuffer
-        );
+    this.decryptBuffer(encryptedData.buffer).then(
+      (decryptedBuffer: ArrayBuffer) => {
+        curUnit.data = this.getAvcDecryptedUnit(decodedData, decryptedBuffer);
 
-        if (!sync) {
-          localthis.decryptAvcSamples(
-            samples,
-            sampleIndex,
-            unitIndex + 1,
-            callback
-          );
+        if (!this.decrypter.isSync()) {
+          this.decryptAvcSamples(samples, sampleIndex, unitIndex + 1, callback);
         }
       }
     );
@@ -197,18 +178,15 @@ class SampleAesDecrypter {
           continue;
         }
 
-        const sync = this.decrypter.isSync();
-
         this.decryptAvcSample(
           samples,
           sampleIndex,
           unitIndex,
           callback,
-          curUnit,
-          sync
+          curUnit
         );
 
-        if (!sync) {
+        if (!this.decrypter.isSync()) {
           return;
         }
       }

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -83,7 +83,7 @@ export default class Transmuxer {
     stats.executeStart = now();
 
     let uintData: Uint8Array = new Uint8Array(data);
-    const { config, currentTransmuxState, transmuxConfig } = this;
+    const { currentTransmuxState, transmuxConfig } = this;
     if (state) {
       this.currentTransmuxState = state;
     }
@@ -121,7 +121,7 @@ export default class Transmuxer {
     if (keyData && keyData.method === 'AES-128') {
       const decrypter = this.getDecrypter();
       // Software decryption is synchronous; webCrypto is not
-      if (config.enableSoftwareAES) {
+      if (decrypter.isSync()) {
         // Software decryption is progressive. Progressive decryption may not return a result on each call. Any cached
         // data is handled in the flush() call
         const decryptedData = decrypter.softwareDecrypt(
@@ -445,7 +445,7 @@ export default class Transmuxer {
   private getDecrypter(): Decrypter {
     let decrypter = this.decrypter;
     if (!decrypter) {
-      decrypter = this.decrypter = new Decrypter(this.observer, this.config);
+      decrypter = this.decrypter = new Decrypter(this.config);
     }
     return decrypter;
   }


### PR DESCRIPTION
### This PR will...
Perform needed cleanup on the Decrypter interface:
- Do not modify `config.enableSoftwareAES` outside of "progressive" check (each instance has its own `useSoftware` property and can fallback from Web crypto to software independently)
- Make `decrypter.decrypt` async so that it can be used in stream controllers in place of `webCryptoDecrypt`
- Removed unused `observer` from `Decrypter`
- Check `decrypter.isSync()` after calling `decrypt` so that it reflects correct state after webCryptoDecrypt error fallback

Follow up to #4902

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
