### PR TITLE
Schedule live reload based on start of last update request

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -240,6 +240,7 @@ class AudioTrackController extends BasePlaylistController {
   }
 
   protected loadPlaylist(hlsUrlParameters?: HlsUrlParameters): void {
+    super.loadPlaylist();
     const audioTrack = this.tracksInGroup[this.trackId];
     if (this.shouldLoadTrack(audioTrack)) {
       const id = audioTrack.id;

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -241,19 +241,19 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           estimatedTimeUntilUpdate
         )} ms`
       );
-      this.log(
-        `live reload ${details.updated ? 'REFRESHED' : 'MISSED'}
-  reload in ${estimatedTimeUntilUpdate / 1000}
-  round trip ${(stats.loading.end - stats.loading.start) / 1000}
-  diff ${
-    (reloadInterval -
-      (estimatedTimeUntilUpdate + stats.loading.end - stats.loading.start)) /
-    1000
-  }
-  reload interval ${reloadInterval / 1000}
-  target duration ${details.targetduration}
-  distance to edge ${distanceToLiveEdgeMs / 1000}`
-      );
+      //     this.log(
+      //       `live reload ${details.updated ? 'REFRESHED' : 'MISSED'}
+      // reload in ${estimatedTimeUntilUpdate / 1000}
+      // round trip ${(stats.loading.end - stats.loading.start) / 1000}
+      // diff ${
+      //   (reloadInterval -
+      //     (estimatedTimeUntilUpdate + stats.loading.end - stats.loading.start)) /
+      //   1000
+      // }
+      // reload interval ${reloadInterval / 1000}
+      // target duration ${details.targetduration}
+      // distance to edge ${distanceToLiveEdgeMs / 1000}`
+      //     );
 
       this.timer = self.setTimeout(
         () => this.loadPlaylist(deliveryDirectives),

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -17,6 +17,7 @@ import { ErrorTypes } from '../errors';
 export default class BasePlaylistController implements NetworkComponentAPI {
   protected hls: Hls;
   protected timer: number = -1;
+  protected requestScheduled: number = -1;
   protected canLoad: boolean = false;
   protected retryCount: number = 0;
   protected log: (msg: any) => void;
@@ -48,6 +49,7 @@ export default class BasePlaylistController implements NetworkComponentAPI {
   public startLoad(): void {
     this.canLoad = true;
     this.retryCount = 0;
+    this.requestScheduled = -1;
     this.loadPlaylist();
   }
 
@@ -89,7 +91,11 @@ export default class BasePlaylistController implements NetworkComponentAPI {
     }
   }
 
-  protected loadPlaylist(hlsUrlParameters?: HlsUrlParameters): void {}
+  protected loadPlaylist(hlsUrlParameters?: HlsUrlParameters): void {
+    if (this.requestScheduled === -1) {
+      this.requestScheduled = self.performance.now();
+    }
+  }
 
   protected shouldLoadTrack(track: MediaPlaylist): boolean {
     return (
@@ -108,8 +114,9 @@ export default class BasePlaylistController implements NetworkComponentAPI {
     const { details, stats } = data;
 
     // Set last updated date-time
-    const elapsed = stats.loading.end
-      ? Math.max(0, self.performance.now() - stats.loading.end)
+    const now = self.performance.now();
+    const elapsed = stats.loading.first
+      ? Math.max(0, now - stats.loading.first)
       : 0;
     details.advancedDateTime = Date.now() - elapsed;
 
@@ -204,22 +211,53 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           part
         );
       }
-      const position = this.hls.mainForwardBufferInfo?.start || 0;
+      const bufferInfo = this.hls.mainForwardBufferInfo;
+      const position = bufferInfo ? bufferInfo.end - bufferInfo.len : 0;
       const distanceToLiveEdgeMs = (details.edge - position) * 1000;
-      let reloadInterval = computeReloadInterval(
+      const reloadInterval = computeReloadInterval(
         details,
-        stats,
         distanceToLiveEdgeMs
       );
-      if (msn !== undefined && details.canBlockReload) {
-        reloadInterval -= details.partTarget || 1;
+      if (!details.updated) {
+        this.requestScheduled = -1;
+      } else if (now > this.requestScheduled + reloadInterval) {
+        this.requestScheduled = stats.loading.start;
       }
+
+      if (msn !== undefined && details.canBlockReload) {
+        this.requestScheduled =
+          stats.loading.first +
+          reloadInterval -
+          (details.partTarget * 1000 || 1000);
+      } else {
+        this.requestScheduled =
+          (this.requestScheduled === -1 ? now : this.requestScheduled) +
+          reloadInterval;
+      }
+      let estimatedTimeUntilUpdate = this.requestScheduled - now;
+      estimatedTimeUntilUpdate = Math.max(0, estimatedTimeUntilUpdate);
       this.log(
-        `reload live playlist ${index} in ${Math.round(reloadInterval)} ms`
+        `reload live playlist ${index} in ${Math.round(
+          estimatedTimeUntilUpdate
+        )} ms`
       );
+      this.log(
+        `live reload ${details.updated ? 'REFRESHED' : 'MISSED'}
+  reload in ${estimatedTimeUntilUpdate / 1000}
+  round trip ${(stats.loading.end - stats.loading.start) / 1000}
+  diff ${
+    (reloadInterval -
+      (estimatedTimeUntilUpdate + stats.loading.end - stats.loading.start)) /
+    1000
+  }
+  reload interval ${reloadInterval / 1000}
+  target duration ${details.targetduration}
+  distance to edge ${distanceToLiveEdgeMs / 1000}`
+      );
+
       this.timer = self.setTimeout(
         () => this.loadPlaylist(deliveryDirectives),
-        reloadInterval
+        estimatedTimeUntilUpdate
       );
     } else {
       this.clearTimer();
@@ -245,6 +283,7 @@ export default class BasePlaylistController implements NetworkComponentAPI {
     const { config } = this.hls;
     const retry = this.retryCount < config.levelLoadingMaxRetry;
     if (retry) {
+      this.requestScheduled = -1;
       this.retryCount++;
       if (
         errorEvent.details.indexOf('LoadTimeOut') > -1 &&

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -204,7 +204,13 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           part
         );
       }
-      let reloadInterval = computeReloadInterval(details, stats);
+      const position = this.hls.mainForwardBufferInfo?.start || 0;
+      const distanceToLiveEdgeMs = (details.edge - position) * 1000;
+      let reloadInterval = computeReloadInterval(
+        details,
+        stats,
+        distanceToLiveEdgeMs
+      );
       if (msn !== undefined && details.canBlockReload) {
         reloadInterval -= details.partTarget || 1;
       }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -518,6 +518,7 @@ export default class LevelController extends BasePlaylistController {
   }
 
   protected loadPlaylist(hlsUrlParameters?: HlsUrlParameters) {
+    super.loadPlaylist();
     const level = this.currentLevelIndex;
     const currentLevel = this._levels[level];
 

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -7,7 +7,6 @@ import { logger } from '../utils/logger';
 import { Fragment, Part } from '../loader/fragment';
 import { LevelDetails } from '../loader/level-details';
 import type { Level } from '../types/level';
-import type { LoaderStats } from '../types/loader';
 import type { MediaPlaylist } from '../types/media-playlist';
 import { DateRange } from '../loader/date-range';
 
@@ -441,7 +440,11 @@ export function computeReloadInterval(
   if (newDetails.updated) {
     // Use last segment duration when shorter than target duration and near live edge
     const fragments = newDetails.fragments;
-    if (fragments.length && reloadInterval * 3 > distanceToLiveEdgeMs) {
+    const liveEdgeMaxTargetDurations = 4;
+    if (
+      fragments.length &&
+      reloadInterval * liveEdgeMaxTargetDurations > distanceToLiveEdgeMs
+    ) {
       const lastSegmentDuration =
         fragments[fragments.length - 1].duration * 1000;
       if (lastSegmentDuration < reloadInterval) {

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -275,6 +275,7 @@ class SubtitleTrackController extends BasePlaylistController {
   }
 
   protected loadPlaylist(hlsUrlParameters?: HlsUrlParameters): void {
+    super.loadPlaylist();
     const currentTrack = this.tracksInGroup[this.trackId];
     if (this.shouldLoadTrack(currentTrack)) {
       const id = currentTrack.id;

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -279,7 +279,7 @@ expect: ${JSON.stringify(merged.fragments[i])}`
       const newPlaylist = generatePlaylist([3, 4], 0, 6);
       newPlaylist.targetduration = 5;
       newPlaylist.updated = true;
-      const actual = computeReloadInterval(newPlaylist, new LoadStats());
+      const actual = computeReloadInterval(newPlaylist);
       expect(actual).to.equal(5000);
     });
 
@@ -287,7 +287,7 @@ expect: ${JSON.stringify(merged.fragments[i])}`
       const newPlaylist = generatePlaylist([1, 2]);
       newPlaylist.updated = false;
       newPlaylist.targetduration = 5;
-      const actual = computeReloadInterval(newPlaylist, new LoadStats());
+      const actual = computeReloadInterval(newPlaylist);
       expect(actual).to.equal(2500);
     });
 
@@ -295,43 +295,25 @@ expect: ${JSON.stringify(merged.fragments[i])}`
       const newPlaylist = generatePlaylist([3, 4], 0, 10);
       newPlaylist.targetduration = 5.9999;
       newPlaylist.updated = true;
-      const actual = computeReloadInterval(newPlaylist, new LoadStats());
+      const actual = computeReloadInterval(newPlaylist);
       expect(actual).to.equal(6000);
-    });
-
-    it('subtracts the request time of the last level load from the reload interval', function () {
-      const newPlaylist = generatePlaylist([3, 4]);
-      newPlaylist.targetduration = 5;
-      newPlaylist.updated = true;
-      const stats = new LoadStats();
-      stats.loading.start = 0;
-      stats.loading.end = 1000;
-      const actual = computeReloadInterval(newPlaylist, stats);
-      expect(actual).to.equal(4000);
     });
 
     it('returns a minimum of half the target duration', function () {
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.targetduration = 5;
       newPlaylist.updated = false;
-      const stats = new LoadStats();
-      stats.loading.start = 0;
-      stats.loading.end = 1000;
-      const actual = computeReloadInterval(newPlaylist, stats);
+      const actual = computeReloadInterval(newPlaylist);
       expect(actual).to.equal(2500);
     });
 
-    it('returns the last fragment duration when distance to live edge is less than two target durations', function () {
+    it('returns the last fragment duration when distance to live edge is less than three target durations', function () {
       const newPlaylist = generatePlaylist([3, 4], 0, 2);
       newPlaylist.targetduration = 5;
       newPlaylist.updated = true;
-      const actual = computeReloadInterval(newPlaylist, new LoadStats(), 11000);
+      const actual = computeReloadInterval(newPlaylist, 15000);
       expect(actual).to.equal(5000);
-      const actualLow = computeReloadInterval(
-        newPlaylist,
-        new LoadStats(),
-        9000
-      );
+      const actualLow = computeReloadInterval(newPlaylist, 14000);
       expect(actualLow).to.equal(2000);
     });
   });

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -307,11 +307,11 @@ expect: ${JSON.stringify(merged.fragments[i])}`
       expect(actual).to.equal(2500);
     });
 
-    it('returns the last fragment duration when distance to live edge is less than three target durations', function () {
+    it('returns the last fragment duration when distance to live edge is less than or equal to four target durations', function () {
       const newPlaylist = generatePlaylist([3, 4], 0, 2);
       newPlaylist.targetduration = 5;
       newPlaylist.updated = true;
-      const actual = computeReloadInterval(newPlaylist, 15000);
+      const actual = computeReloadInterval(newPlaylist, 20000);
       expect(actual).to.equal(5000);
       const actualLow = computeReloadInterval(newPlaylist, 14000);
       expect(actualLow).to.equal(2000);


### PR DESCRIPTION
### This PR will...
- Schedule live reload time measuring from the last _scheduled_ time the client began loading the Playlist file
- Use last fragment duration rather than target duration when playhead is less than three target durations from the live edge
- Eliminate any latency in refresh interval added by `setTimeout` or JavaScript execution
- Move clock logic out of `computeReloadInterval` and into `playlistLoaded` where timer is set and last request request time (`requestScheduled`) is maintained
- Fix blocking reload schedule when low latency mode is disabled to start one part duration or one second from when an update is expected (Improves upon #3792)

### Why is this Pull Request needed?
Prevent saw-tooth forward buffer length pattern as playlist refreshes drift from playlist update interval or target duration. 

### Resolves issues:
Data provided by @wilaw showing CMCD forward buffer length on playlist requests getting shorter overtime until the difference wraps by one target duration.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
