### PR TITLE
id3: add duration to metadata samples, mimic Safari behavior on unbounded cues

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1897,6 +1897,8 @@ export interface MetadataSample {
     // (undocumented)
     dts: number;
     // (undocumented)
+    duration: number;
+    // (undocumented)
     len?: number;
     // (undocumented)
     pts: number;

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -33,6 +33,18 @@ function getCueClass() {
   return (self.WebKitDataCue || self.VTTCue || self.TextTrackCue) as any;
 }
 
+// VTTCue latest draft allows an infinite duration, fallback
+// to MAX_VALUE if necessary
+const MAX_CUE_ENDTIME = (() => {
+  const Cue = getCueClass();
+  try {
+    new Cue(0, Number.POSITIVE_INFINITY, '');
+  } catch (e) {
+    return Number.MAX_VALUE;
+  }
+  return Number.POSITIVE_INFINITY;
+})();
+
 function dateRangeDateToTimelineSeconds(date: Date, offset: number): number {
   return date.getTime() / 1000 - offset;
 }
@@ -158,11 +170,8 @@ class ID3TrackController implements ComponentAPI {
       this.id3Track = this.createTrack(this.media);
     }
 
-    // VTTCue end time must be finite, so use playlist edge or fragment end until next fragment with same frame type is found
-    const maxCueTime = details.edge || fragment.end;
     const Cue = getCueClass();
-    let updateCueRanges = false;
-    const frameTypesAdded: Record<string, number | null> = {};
+    let updateCueRanges = true;
 
     for (let i = 0; i < samples.length; i++) {
       const type = samples[i].type;
@@ -176,7 +185,11 @@ class ID3TrackController implements ComponentAPI {
       const frames = ID3.getID3Frames(samples[i].data);
       if (frames) {
         const startTime = samples[i].pts;
-        let endTime: number = maxCueTime;
+        let endTime: number = startTime + samples[i].duration;
+
+        if (endTime > MAX_CUE_ENDTIME) {
+          endTime = MAX_CUE_ENDTIME;
+        }
 
         const timeDiff = endTime - startTime;
         if (timeDiff <= 0) {
@@ -187,36 +200,30 @@ class ID3TrackController implements ComponentAPI {
           const frame = frames[j];
           // Safari doesn't put the timestamp frame in the TextTrack
           if (!ID3.isTimeStampFrame(frame)) {
+            // Only update cue ranges once, before adding new cues
+            if (updateCueRanges) {
+              updateCueRanges = false;
+              this.updateId3CueEnds(startTime);
+            }
             const cue = new Cue(startTime, endTime, '');
             cue.value = frame;
             if (type) {
               cue.type = type;
             }
             this.id3Track.addCue(cue);
-            frameTypesAdded[frame.key] = null;
-            updateCueRanges = true;
           }
         }
       }
     }
-    if (updateCueRanges) {
-      this.updateId3CueEnds(frameTypesAdded);
-    }
   }
 
-  updateId3CueEnds(frameTypesAdded: Record<string, number | null>) {
-    // Update endTime of previous cue with same IDR frame.type (Ex: TXXX cue spans to next TXXX)
+  updateId3CueEnds(startTime: number) {
     const cues = this.id3Track?.cues;
     if (cues) {
       for (let i = cues.length; i--; ) {
         const cue = cues[i] as any;
-        const frameType = cue.value?.key;
-        if (frameType && frameType in frameTypesAdded) {
-          const startTime = frameTypesAdded[frameType];
-          if (startTime && cue.endTime !== startTime) {
-            cue.endTime = startTime;
-          }
-          frameTypesAdded[frameType] = cue.startTime;
+        if (cue.endTime === MAX_CUE_ENDTIME) {
+          cue.endTime = startTime;
         }
       }
     }
@@ -290,7 +297,6 @@ class ID3TrackController implements ComponentAPI {
 
     const dateTimeOffset =
       (lastFragment.programDateTime as number) / 1000 - lastFragment.start;
-    const maxCueTime = details.edge || lastFragment.end;
     const Cue = getCueClass();
 
     for (let i = 0; i < ids.length; i++) {
@@ -303,7 +309,7 @@ class ID3TrackController implements ComponentAPI {
         dateRange.startDate,
         dateTimeOffset
       );
-      let endTime = maxCueTime;
+      let endTime = MAX_CUE_ENDTIME;
       const endDate = dateRange.endDate;
       if (endDate) {
         endTime = dateRangeDateToTimelineSeconds(endDate, dateTimeOffset);

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -171,7 +171,6 @@ class ID3TrackController implements ComponentAPI {
     }
 
     const Cue = getCueClass();
-    let updateCueRanges = true;
 
     for (let i = 0; i < samples.length; i++) {
       const type = samples[i].type;
@@ -200,11 +199,9 @@ class ID3TrackController implements ComponentAPI {
           const frame = frames[j];
           // Safari doesn't put the timestamp frame in the TextTrack
           if (!ID3.isTimeStampFrame(frame)) {
-            // Only update cue ranges once, before adding new cues
-            if (updateCueRanges) {
-              updateCueRanges = false;
-              this.updateId3CueEnds(startTime);
-            }
+            // add a bounds to any unbounded cues
+            this.updateId3CueEnds(startTime);
+
             const cue = new Cue(startTime, endTime, '');
             cue.value = frame;
             if (type) {
@@ -222,7 +219,7 @@ class ID3TrackController implements ComponentAPI {
     if (cues) {
       for (let i = cues.length; i--; ) {
         const cue = cues[i] as any;
-        if (cue.endTime === MAX_CUE_ENDTIME) {
+        if (cue.startTime < startTime && cue.endTime === MAX_CUE_ENDTIME) {
           cue.endTime = startTime;
         }
       }

--- a/src/demux/base-audio-demuxer.ts
+++ b/src/demux/base-audio-demuxer.ts
@@ -89,6 +89,7 @@ class BaseAudioDemuxer implements Demuxer {
         dts: this.basePTS,
         data: id3Data,
         type: MetadataSchema.audioId3,
+        duration: Number.POSITIVE_INFINITY,
       });
     }
 
@@ -113,6 +114,7 @@ class BaseAudioDemuxer implements Demuxer {
           dts: pts,
           data: id3Data,
           type: MetadataSchema.audioId3,
+          duration: Number.POSITIVE_INFINITY,
         });
         offset += id3Data.length;
         lastDataIndex = offset;

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -159,6 +159,14 @@ class MP4Demuxer implements Demuxer {
               ? emsgInfo.presentationTime! / emsgInfo.timeScale
               : timeOffset +
                 emsgInfo.presentationTimeDelta! / emsgInfo.timeScale;
+            let duration =
+              emsgInfo.eventDuration === 0xffffffff
+                ? Number.POSITIVE_INFINITY
+                : emsgInfo.eventDuration / emsgInfo.timeScale;
+            // Safari takes anything <= 0.001 seconds and maps it to Infinity
+            if (duration <= 0.001) {
+              duration = Number.POSITIVE_INFINITY;
+            }
             const payload = emsgInfo.payload;
             id3Track.samples.push({
               data: payload,
@@ -166,6 +174,7 @@ class MP4Demuxer implements Demuxer {
               dts: pts,
               pts: pts,
               type: MetadataSchema.emsg,
+              duration: duration,
             });
           }
         });

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -939,6 +939,7 @@ class TSDemuxer implements Demuxer {
     }
     const id3Sample = Object.assign({}, pes as Required<PES>, {
       type: this._avcTrack ? MetadataSchema.emsg : MetadataSchema.audioId3,
+      duration: Number.POSITIVE_INFINITY,
     });
     id3Track.samples.push(id3Sample);
   }

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -96,6 +96,7 @@ export enum MetadataSchema {
 export interface MetadataSample {
   pts: number;
   dts: number;
+  duration: number;
   len?: number;
   data: Uint8Array;
   type: MetadataSchema;


### PR DESCRIPTION
### This PR will...

* Add a duration field to Metadata Samples.
* Set the duration to Infinite from sources that don't carry a duration.
* Set the duration to Infinite from fragmented MP4 files with an `event_duration` of 0xffffffff or <= .001 seconds.
* Create Cues from ID3 tags with an Infinite duration (where possible), or `Number.MAX_VALUE` as a fallback.
* On new ID3 tags, update any existing, unbounded Cues

### Why is this Pull Request needed?

On Safari, when an ID3 track is present, unbounded cues are initially created with an Infinite endTime. As new ID3 tags come in, all previous cues have the endTime updated. Cues may also have a valid endTime, if the underlying source supports it (fragmented mp4).

The current implementation is tracking for changes on the individual ID3 frame level, but Safari will update all existing, unbounded Cues, not just cues with the same ID3 frame ID.

Additionally, current implementation uses the playlist length - on a live playlist this is often quite short, and the Cue expires earlier than intended, especially if ID3 tags aren't being inserted often.

I have a short demo here comparing native, latest release, and this branch: https://jrjrtech.com/mpegts-loop/

### Are there any points in the code the reviewer needs to double check?

The section that checks for a negative duration and sets a minimum duration. Infinity - (anything) is still infinity, so in the future I don't think it will be possible for that case to occur.

### Resolves issues:

#4964 (fully)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [] API or design changes are documented in API.md
