### PR TITLE
TS->MP4 Remuxer Fix

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -452,19 +452,21 @@ export default class MP4Remuxer implements Remuxer {
             )} ms (${delta}dts) overlapping between fragments detected`
           );
         }
-        firstDTS = nextAvcDts;
-        const firstPTS = inputSamples[0].pts - delta;
-        inputSamples[0].dts = firstDTS;
-        inputSamples[0].pts = firstPTS;
-        logger.log(
-          `Video: First PTS/DTS adjusted: ${toMsFromMpegTsClock(
-            firstPTS,
-            true
-          )}/${toMsFromMpegTsClock(
-            firstDTS,
-            true
-          )}, delta: ${toMsFromMpegTsClock(delta, true)} ms`
-        );
+        if (!foundOverlap || nextAvcDts > inputSamples[0].pts) {
+          firstDTS = nextAvcDts;
+          const firstPTS = inputSamples[0].pts - delta;
+          inputSamples[0].dts = firstDTS;
+          inputSamples[0].pts = firstPTS;
+          logger.log(
+            `Video: First PTS/DTS adjusted: ${toMsFromMpegTsClock(
+              firstPTS,
+              true
+            )}/${toMsFromMpegTsClock(
+              firstDTS,
+              true
+            )}, delta: ${toMsFromMpegTsClock(delta, true)} ms`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
### This PR will...
Avoid adjusting TS media timestamps when a dts overlap is found that does not overlap pts 

### Resolves issues:
Fixes #4976

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
