### PR TITLE
Catches exception when byteLength is null

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -163,14 +163,19 @@ class XhrLoader implements Loader<LoaderContext> {
         xhr.onprogress = null;
         const status = xhr.status;
         // http status between 200 to 299 are all successful
-        if (status >= 200 && status < 300) {
+        const isArrayBuffer = xhr.responseType === 'arraybuffer';
+        if (
+          status >= 200 &&
+          status < 300 &&
+          ((isArrayBuffer && xhr.response) || xhr.responseText !== null)
+        ) {
           stats.loading.end = Math.max(
             self.performance.now(),
             stats.loading.first
           );
           let data;
           let len: number;
-          if (context.responseType === 'arraybuffer') {
+          if (isArrayBuffer) {
             data = xhr.response;
             len = data.byteLength;
           } else {


### PR DESCRIPTION

### This PR will...
catch exception when `data.byteLength` is null and won't stop the video from playing.
(solution was made by [shnjp](https://github.com/video-dev/hls.js/issues/1723#issuecomment-990782845))

### Resolves issues:
https://github.com/video-dev/hls.js/issues/1723

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
