### PR TITLE
Add codec string parsing for h264, h265, and mp4a

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -238,7 +238,7 @@ function getParsedTrackCodec(
   // Provide defaults based on codec type
   // This allows for some playback of some fmp4 playlists without CODECS defined in manifest
   if (parsedCodec === 'hvc1' || parsedCodec === 'hev1') {
-    return 'hvc1.1.c.L120.90';
+    return 'hvc1.1.6.L120.90';
   }
   if (parsedCodec === 'av01') {
     return 'av01.0.04M.08';

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -234,7 +234,6 @@ function getParsedTrackCodec(
   if (parsedCodec && parsedCodec.length > 4) {
     return parsedCodec;
   }
-  // Since mp4-tools cannot parse full codec string (see 'TODO: Parse codec details'... in mp4-tools)
   // Provide defaults based on codec type
   // This allows for some playback of some fmp4 playlists without CODECS defined in manifest
   if (parsedCodec === 'hvc1' || parsedCodec === 'hev1') {

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -242,6 +242,8 @@ export function parseInitSegment(initSegment: Uint8Array): InitData {
             let codec;
             if (stsd) {
               codec = bin2str(stsd.subarray(12, 16));
+              // Parse codec details to be able to build MIME type
+              // TODO: Codec parsing support for AV1
               const toHex = (x: number): string => {
                 return ('0' + x.toString(16).toUpperCase()).slice(-2);
               };


### PR DESCRIPTION
### This PR will...
Add codec string parsing for avc, hevc, and mp4a.

### Why is this Pull Request needed?

When testing the new HEVC playback on using hls.js on Chrome 107 for Windows, I noticed that some playlists were failing. These playlists have been working fine with hls.js on MS Edge on the same machine for quite some time, and they continue to work there. They also previously worked fine using hls.js on Chrome 104 for Windows also on the same machine (with the `PlatformHEVCDecoderSupport` flag set). Additionally, the playlists work fine on MacOS and on Android Webview 107 using hls.js.
After poking around a bit it seems that this regression seems to be due to a change in Chrome's MSE (of which I know very little) - it looks like the default `hvc1.1.c.L120.90` codec string hls.js uses for HEVC is getting rejected.

To reproduce, try playing https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/v10/prog_index.m3u8 (the specific variant playlist and not the master playlist) with hls.js in Chrome 107 on Windows. It should return a `Buffer add codec error for video/mp4;codecs=hvc1.1.c.L120.90:Failed to execute 'addSourceBuffer' on 'MediaSource': The type provided ('video/mp4;codecs=hvc1.1.c.L120.90') is unsupported.` error. (I reproduced this on two Windows 10 machines both with Intel graphics.)

This PR adds some simple codec string parsing for AVC, HEVC, and mp4a. The code is essentially translated from code we have been using for over 2 years at https://github.com/home-assistant/core/blob/dev/homeassistant/components/stream/fmp4utils.py (thanks to @hunterjm). I haven't tested all the strings that get generated by this PR, but it does seem to resolve the issue I noted above.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
