### PR TITLE
Update fragPrevious when attempting to load an already-buffered fragment

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1058,7 +1058,8 @@ export default class BaseStreamController
     end: number,
     levelDetails: LevelDetails
   ): Fragment | null {
-    const { config, fragPrevious } = this;
+    const { config } = this;
+    let { fragPrevious } = this;
     let { fragments, endSN } = levelDetails;
     const { fragmentHint } = levelDetails;
     const tolerance = config.maxFragLookUpTolerance;
@@ -1092,6 +1093,11 @@ export default class BaseStreamController
 
     if (frag) {
       const curSNIdx = frag.sn - levelDetails.startSN;
+      // Move fragPrevious forward to support forcing the next fragment to load
+      // when the buffer catches up to a previously buffered range.
+      if (this.fragmentTracker.getState(frag) === FragmentState.OK) {
+        fragPrevious = frag;
+      }
       if (fragPrevious && frag.sn === fragPrevious.sn && !loadingParts) {
         // Force the next fragment to load if the previous one was already selected. This can occasionally happen with
         // non-uniform fragment durations

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -351,6 +351,12 @@ export default class StreamController
     } else if (this.media?.buffered.length === 0) {
       // Stop gap for bad tracker / buffer flush behavior
       this.fragmentTracker.removeAllFragments();
+    } else if (fragState === FragmentState.OK) {
+      // Move fragPrevious forward to support forcing the next fragment to load
+      // when the buffer catches up to a previously buffered range.
+      if (frag.sn !== 'initSegment') {
+        this.fragPrevious = frag;
+      }
     }
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -351,12 +351,6 @@ export default class StreamController
     } else if (this.media?.buffered.length === 0) {
       // Stop gap for bad tracker / buffer flush behavior
       this.fragmentTracker.removeAllFragments();
-    } else if (fragState === FragmentState.OK) {
-      // Move fragPrevious forward to support forcing the next fragment to load
-      // when the buffer catches up to a previously buffered range.
-      if (frag.sn !== 'initSegment') {
-        this.fragPrevious = frag;
-      }
     }
   }
 


### PR DESCRIPTION
### This PR will...

Fix https://github.com/video-dev/hls.js/issues/5012


### Why is this Pull Request needed?


When we use `maxFragLookUpTolerance: 0` and the range that's currently buffering catches up to a previously buffered range the stream-controller may get stuck in a loop trying to load a previously loaded fragment. 

This adjusts the logic in the stream-controller so that if an attempt is made to load a fragment that was already successfully downloaded, the `fragPrevious` field is updated as if the fragment had just been downloaded. 

In the case of small `maxFragLookUpTolerance` this will allow the logic in [`getFragmentAtPosition`](https://github.com/video-dev/hls.js/blob/98d4ab329827bfb2104a882cd13a4df8e983cbe8/src/controller/base-stream-controller.ts#L1039-L1057) to move past the already downloaded fragment.

https://github.com/video-dev/hls.js/blob/98d4ab329827bfb2104a882cd13a4df8e983cbe8/src/controller/base-stream-controller.ts#L1039-L1057

### Are there any points in the code the reviewer needs to double check?


I've run the unit tests and functional tests and they all pass, but this is my first time looking at the stream-controller logic so there very well may be a situation I'm overlooking.

### Resolves issues:

https://github.com/video-dev/hls.js/issues/5012

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
