### PR TITLE
base audio demuxer: track PTS of last sample for ID3 frames

### DIFF
--- a/src/demux/base-audio-demuxer.ts
+++ b/src/demux/base-audio-demuxer.ts
@@ -21,6 +21,7 @@ class BaseAudioDemuxer implements Demuxer {
   protected cachedData: Uint8Array | null = null;
   protected basePTS: number | null = null;
   protected initPTS: number | null = null;
+  protected lastPTS: number | null = null;
 
   resetInitSegment(
     initSegment: Uint8Array | undefined,
@@ -46,6 +47,7 @@ class BaseAudioDemuxer implements Demuxer {
 
   resetContiguity(): void {
     this.basePTS = null;
+    this.lastPTS = null;
     this.frameIndex = 0;
   }
 
@@ -69,7 +71,6 @@ class BaseAudioDemuxer implements Demuxer {
     let id3Data: Uint8Array | undefined = ID3.getID3Data(data, 0);
     let offset = id3Data ? id3Data.length : 0;
     let lastDataIndex;
-    let pts;
     const track = this._audioTrack;
     const id3Track = this._id3Track;
     const timestamp = id3Data ? ID3.getTimeStamp(id3Data) : undefined;
@@ -80,27 +81,30 @@ class BaseAudioDemuxer implements Demuxer {
       (this.frameIndex === 0 && Number.isFinite(timestamp))
     ) {
       this.basePTS = initPTSFn(timestamp, timeOffset, this.initPTS);
+      this.lastPTS = this.basePTS;
+    }
+
+    if (this.lastPTS === null) {
+      this.lastPTS = this.basePTS;
     }
 
     // more expressive than alternative: id3Data?.length
     if (id3Data && id3Data.length > 0) {
       id3Track.samples.push({
-        pts: this.basePTS,
-        dts: this.basePTS,
+        pts: this.lastPTS,
+        dts: this.lastPTS,
         data: id3Data,
         type: MetadataSchema.audioId3,
         duration: Number.POSITIVE_INFINITY,
       });
     }
 
-    pts = this.basePTS;
-
     while (offset < length) {
       if (this.canParse(data, offset)) {
         const frame = this.appendFrame(track, data, offset);
         if (frame) {
           this.frameIndex++;
-          pts = frame.sample.pts;
+          this.lastPTS = frame.sample.pts;
           offset += frame.length;
           lastDataIndex = offset;
         } else {
@@ -110,8 +114,8 @@ class BaseAudioDemuxer implements Demuxer {
         // after a ID3.canParse, a call to ID3.getID3Data *should* always returns some data
         id3Data = ID3.getID3Data(data, offset)!;
         id3Track.samples.push({
-          pts: pts,
-          dts: pts,
+          pts: this.lastPTS,
+          dts: this.lastPTS,
           data: id3Data,
           type: MetadataSchema.audioId3,
           duration: Number.POSITIVE_INFINITY,


### PR DESCRIPTION
### This PR will...

* Add a new field to the base audio demuxer (`lastPTS`), which tracks the PTS of the most recently added audio frame.
* Use lastPTS as the PTS time when adding ID3 frames

### Why is this Pull Request needed?

Changes in #4847 (to fix #4835) caused the basePTS value to only update on discontinuity events, which causes ID3 frames to all have the same PTS.

This tracks the PTS of added frames in a new field, which is then used when adding ID3 frames. This field is reset anytime on discontinuities and defaults to the basePTS value when no other value is available (first sample, etc).

### Are there any points in the code the reviewer needs to double check?

Not that I'm aware of

### Resolves issues:

#4963

Additional note, I also tested with the test video in #4835 and confirmed it still plays correctly as well.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
