### PR TITLE
Emit and handle FRAG_PARSING_ERROR from transmuxers

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -374,6 +374,8 @@ export interface ErrorData {
     // (undocumented)
     bytes?: number;
     // (undocumented)
+    chunkMeta?: ChunkMetadata;
+    // (undocumented)
     context?: PlaylistLoaderContext;
     // (undocumented)
     details: ErrorDetails;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -628,6 +628,7 @@ class AudioStreamController
     switch (data.details) {
       case ErrorDetails.FRAG_LOAD_ERROR:
       case ErrorDetails.FRAG_LOAD_TIMEOUT:
+      case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.KEY_LOAD_ERROR:
       case ErrorDetails.KEY_LOAD_TIMEOUT:
       case ErrorDetails.KEY_SYSTEM_NO_SESSION:

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -751,7 +751,11 @@ export default class BaseStreamController
   protected _handleTransmuxerFlush(chunkMeta: ChunkMetadata) {
     const context = this.getCurrentContext(chunkMeta);
     if (!context || this.state !== State.PARSING) {
-      if (!this.fragCurrent) {
+      if (
+        !this.fragCurrent &&
+        this.state !== State.STOPPED &&
+        this.state !== State.ERROR
+      ) {
         this.state = State.IDLE;
       }
       return;
@@ -1304,7 +1308,19 @@ export default class BaseStreamController
     data: ErrorData
   ) {
     if (data.fatal) {
+      this.stopLoad();
+      this.state = State.ERROR;
       return;
+    }
+    const config = this.config;
+    if (data.chunkMeta) {
+      // Parsing Error: no retries
+      const context = this.getCurrentContext(data.chunkMeta);
+      if (context) {
+        data.frag = context.frag;
+        data.levelRetry = true;
+        this.fragLoadError = config.fragLoadingMaxRetry;
+      }
     }
     const frag = data.frag;
     // Handle frag error related to caller's filterType
@@ -1319,7 +1335,6 @@ export default class BaseStreamController
         frag.urlId === fragCurrent.urlId,
       'Frag load error must match current frag to retry'
     );
-    const config = this.config;
     // keep retrying until the limit will be reached
     if (this.fragLoadError + 1 <= config.fragLoadingMaxRetry) {
       if (!this.loadedmetadata) {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -362,6 +362,7 @@ export default class LevelController extends BasePlaylistController {
           }
         }
         break;
+      case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.KEY_SYSTEM_NO_SESSION:
       case ErrorDetails.KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED:
         levelIndex =

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -369,7 +369,8 @@ export default class LevelController extends BasePlaylistController {
           data.frag?.type === PlaylistLevelType.MAIN
             ? data.frag.level
             : this.currentLevelIndex;
-        levelError = true;
+        // Do not retry level. Escalate to fatal if switching levels fails.
+        data.levelRetry = false;
         break;
       case ErrorDetails.LEVEL_LOAD_ERROR:
       case ErrorDetails.LEVEL_LOAD_TIMEOUT:
@@ -444,6 +445,9 @@ export default class LevelController extends BasePlaylistController {
           this.warn(`${errorDetails}: switch to ${nextLevel}`);
           errorEvent.levelRetry = true;
           this.hls.nextAutoLevel = nextLevel;
+        } else if (errorEvent.levelRetry === false) {
+          // No levels to switch to and no more retries
+          errorEvent.fatal = true;
         }
       }
     }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -852,6 +852,7 @@ export default class StreamController
     switch (data.details) {
       case ErrorDetails.FRAG_LOAD_ERROR:
       case ErrorDetails.FRAG_LOAD_TIMEOUT:
+      case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.KEY_LOAD_ERROR:
       case ErrorDetails.KEY_LOAD_TIMEOUT:
       case ErrorDetails.KEY_SYSTEM_NO_SESSION:

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -239,10 +239,20 @@ export default class TransmuxerInterface {
         state
       );
       if (isPromise(transmuxResult)) {
-        transmuxResult.then((data) => {
-          this.handleTransmuxComplete(data);
-        });
+        transmuxer.async = true;
+        transmuxResult
+          .then((data) => {
+            this.handleTransmuxComplete(data);
+          })
+          .catch((error) => {
+            this.transmuxerError(
+              error,
+              chunkMeta,
+              'transmuxer-interface push error'
+            );
+          });
       } else {
+        transmuxer.async = false;
         this.handleTransmuxComplete(transmuxResult as TransmuxerResult);
       }
     }
@@ -252,16 +262,29 @@ export default class TransmuxerInterface {
     chunkMeta.transmuxing.start = self.performance.now();
     const { transmuxer, worker } = this;
     if (worker) {
+      1;
       worker.postMessage({
         cmd: 'flush',
         chunkMeta,
       });
     } else if (transmuxer) {
-      const transmuxResult = transmuxer.flush(chunkMeta);
-      if (isPromise(transmuxResult)) {
-        transmuxResult.then((data) => {
-          this.handleFlushResult(data, chunkMeta);
-        });
+      let transmuxResult = transmuxer.flush(chunkMeta);
+      const asyncFlush = isPromise(transmuxResult);
+      if (asyncFlush || transmuxer.async) {
+        if (!isPromise(transmuxResult)) {
+          transmuxResult = Promise.resolve(transmuxResult);
+        }
+        transmuxResult
+          .then((data) => {
+            this.handleFlushResult(data, chunkMeta);
+          })
+          .catch((error) => {
+            this.transmuxerError(
+              error,
+              chunkMeta,
+              'transmuxer-interface flush error'
+            );
+          });
       } else {
         this.handleFlushResult(
           transmuxResult as Array<TransmuxerResult>,
@@ -269,6 +292,25 @@ export default class TransmuxerInterface {
         );
       }
     }
+  }
+
+  private transmuxerError(
+    error: Error,
+    chunkMeta: ChunkMetadata,
+    reason: string
+  ) {
+    if (!this.hls) {
+      return;
+    }
+    this.hls.trigger(Events.ERROR, {
+      type: ErrorTypes.MEDIA_ERROR,
+      details: ErrorDetails.FRAG_PARSING_ERROR,
+      chunkMeta,
+      fatal: false,
+      error,
+      err: error,
+      reason,
+    });
   }
 
   private handleFlushResult(

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -4,6 +4,7 @@ import { ILogFunction, enableLogs, logger } from '../utils/logger';
 import { EventEmitter } from 'eventemitter3';
 import type { RemuxedTrack, RemuxerResult } from '../types/remuxer';
 import type { TransmuxerResult, ChunkMetadata } from '../types/transmuxer';
+import { ErrorDetails, ErrorTypes } from '../errors';
 
 export default function TransmuxerWorker(self) {
   const observer = new EventEmitter();
@@ -59,21 +60,51 @@ export default function TransmuxerWorker(self) {
             data.state
           );
         if (isPromise(transmuxResult)) {
-          transmuxResult.then((data) => {
-            emitTransmuxComplete(self, data);
-          });
+          self.transmuxer.async = true;
+          transmuxResult
+            .then((data) => {
+              emitTransmuxComplete(self, data);
+            })
+            .catch((error) => {
+              forwardMessage(Events.ERROR, {
+                type: ErrorTypes.MEDIA_ERROR,
+                details: ErrorDetails.FRAG_PARSING_ERROR,
+                chunkMeta: data.chunkMeta,
+                fatal: false,
+                error,
+                err: error,
+                reason: `transmuxer-worker push error`,
+              });
+            });
         } else {
+          self.transmuxer.async = false;
           emitTransmuxComplete(self, transmuxResult);
         }
         break;
       }
       case 'flush': {
         const id = data.chunkMeta;
-        const transmuxResult = self.transmuxer.flush(id);
-        if (isPromise(transmuxResult)) {
-          transmuxResult.then((results: Array<TransmuxerResult>) => {
-            handleFlushResult(self, results as Array<TransmuxerResult>, id);
-          });
+        let transmuxResult = self.transmuxer.flush(id);
+        const asyncFlush = isPromise(transmuxResult);
+        if (asyncFlush || self.transmuxer.async) {
+          if (!isPromise(transmuxResult)) {
+            transmuxResult = Promise.resolve(transmuxResult);
+          }
+          transmuxResult
+            .then((results: Array<TransmuxerResult>) => {
+              handleFlushResult(self, results as Array<TransmuxerResult>, id);
+            })
+            .catch((error) => {
+              forwardMessage(Events.ERROR, {
+                type: ErrorTypes.MEDIA_ERROR,
+                details: ErrorDetails.FRAG_PARSING_ERROR,
+                chunkMeta: data.chunkMeta,
+                fatal: false,
+                error,
+                err: error,
+                reason: `transmuxer-worker flush error`,
+              });
+            });
         } else {
           handleFlushResult(
             self,

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -39,6 +39,7 @@ const muxConfig: MuxConfig[] = [
 ];
 
 export default class Transmuxer {
+  public async: boolean = false;
   private observer: HlsEventEmitter;
   private typeSupported: TypeSupported;
   private config: HlsConfig;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -216,6 +216,7 @@ export interface ErrorData {
   fatal: boolean;
   buffer?: number;
   bytes?: number;
+  chunkMeta?: ChunkMetadata;
   context?: PlaylistLoaderContext;
   error?: Error;
   event?: keyof HlsListeners | 'demuxerWorker';


### PR DESCRIPTION
### This PR will...
- Make `transmuxer.flush` results async each time that  `transmuxer.push` returns a promise so that they push->flush results are received in order
- Handle Uncaught Promise Exceptions in transmuxer push and flush by emitting FRAG_PARSING_ERROR event (Example: `MP4Demuxer.demuxSampleAes` returns rejected Promise throwing `"The MP4 demuxer does not support SAMPLE-AES decryption"`
- Route FRAG_PARSING_ERROR (and KEY errors) through level-controller `levelSwitch` error handling and escalate to fatal when switching is not possible

### Are there any points in the code the reviewer needs to double check?
These changes are on top of #4930

### Resolves issues:
Related to #5011 (does not yet handle fall-through probe and empty transmux response flows)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
