### PR TITLE
import ExtendedSourceBuffer as type

### DIFF
--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -1,5 +1,5 @@
 import { getMediaSource } from './utils/mediasource-helper';
-import { ExtendedSourceBuffer } from './types/buffer';
+import type { ExtendedSourceBuffer } from './types/buffer';
 
 function getSourceBuffer(): typeof self.SourceBuffer {
   return self.SourceBuffer || (self as any).WebKitSourceBuffer;


### PR DESCRIPTION
### Why is this Pull Request needed?
This is a type and should be imported as type.

### Resolves issues:
When importing from nodejs, I get the following error: `The requested module '/node_modules/hls.js/src/types/buffer.ts' does not provide an export named 'ExtendedSourceBuffer'`
### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
