### PR TITLE
Bugfix: Fragment LoadStats total set to 0 with `progressive: true`

### DIFF
--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -133,7 +133,10 @@ class FetchLoader implements Loader<LoaderContext> {
           self.performance.now(),
           stats.loading.first
         );
-        stats.loaded = stats.total = responseData[LENGTH];
+        const total = responseData[LENGTH];
+        if (total) {
+          stats.loaded = stats.total = total;
+        }
 
         const loaderResponse = {
           url: response.url,


### PR DESCRIPTION
### This PR will...
Prevent `loaded` and `total` bytes stats from being overwritten with `0` when the player is configured to load and append progressively with `progressive: true`.

### Why is this Pull Request needed?
These stats are essential to establishing a bandwidth estimate.

### Resolves issues:
Fixes #5050

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
