### PR TITLE
Document new gap controller behaviour on v1.x

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -40,6 +40,8 @@ with only a single GoP or less.
 
 - Setting `hls.currentLevel` no longer pauses the media element while clearing the buffer and loading the new level. This can result in a stall error if playback doesn't start within a quarter of a second. Applications implementing manual quality switching with `hls.currentLevel` that do not want a stall reported should either pause or set `video.playbackRate` to `0` until the level switch is complete.
 
+- The maximum gap that will be jumped is now driven via the GapController `MAX_START_GAP_JUMP`. By default this value is set to two seconds, to match with the value that browsers will automatically skip when the `autoplay` attribute on the `<video>` element is set to true.
+
 ## Event Changes
 
 Event order and content have changed in some places. See **Breaking Changes** below, and please report any issues with breaking changes that impact your integrations


### PR DESCRIPTION
### This PR will...

Document on the migration documentation that  what seems to be unexpected / buggy behaviour is intentional. We no longer skip start gaps of any size, limiting it to a maximum of a 2s gap.

### Why is this Pull Request needed?

https://github.com/video-dev/hls.js/issues/4066

It appears based on some googling that default FFmpeg output should now begin somewhere around ~0.7s, so our gap of 2 should work for any defaults well.

```
-muxdelay seconds (output)
Set the maximum demux-decode delay.
```
https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffmpeg_opt.c#L141

```
-muxpreload seconds (output)
Set the initial demux-decode delay.
```

### Are there any points in the code the reviewer needs to double check?

Is there any additional information that should be added to the README.md for folks as generalized advice to handle this case as it seems to be a common stream issue?

Is anything said here incorrect?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
