### PR TITLE
Reset the cached clientRect when media is attached

### DIFF
--- a/src/controller/cap-level-controller.ts
+++ b/src/controller/cap-level-controller.ts
@@ -90,6 +90,7 @@ class CapLevelController implements ComponentAPI {
     data: MediaAttachingData
   ) {
     this.media = data.media instanceof HTMLVideoElement ? data.media : null;
+    this.clientRect = null;
   }
 
   protected onManifestParsed(

--- a/tests/unit/controller/cap-level-controller.js
+++ b/tests/unit/controller/cap-level-controller.js
@@ -132,6 +132,34 @@ describe('CapLevelController', function () {
       expect(capLevelController.mediaWidth).to.equal(1280 * pixelRatio);
       expect(capLevelController.mediaHeight).to.equal(720 * pixelRatio);
     });
+
+    it('gets valid width and height when the media element is attached after onManifestParsed', function () {
+      hls = new Hls({ capLevelToPlayerSize: true });
+      capLevelController = new CapLevelController(hls);
+      capLevelController.onManifestParsed(Events.MANIFEST_PARSED, {
+        levels,
+      });
+
+      let bounds = capLevelController.getDimensions();
+      expect(bounds.width).to.equal(0);
+      expect(bounds.height).to.equal(0);
+      expect(capLevelController.mediaWidth).to.equal(0);
+      expect(capLevelController.mediaHeight).to.equal(0);
+
+      media.style.width = '1280px';
+      media.style.height = '720px';
+      document.querySelector('#test-fixture').appendChild(media);
+      capLevelController.onMediaAttaching(Events.MEDIA_ATTACHING, {
+        media,
+      });
+
+      const pixelRatio = capLevelController.contentScaleFactor;
+      bounds = capLevelController.getDimensions();
+      expect(bounds.width).to.equal(1280);
+      expect(bounds.height).to.equal(720);
+      expect(capLevelController.mediaWidth).to.equal(1280 * pixelRatio);
+      expect(capLevelController.mediaHeight).to.equal(720 * pixelRatio);
+    });
   });
 
   describe('initialization', function () {


### PR DESCRIPTION
### This PR will...
Fix an issue where `capLevelToPlayerSize` is not applied when `attachMedia` is called after the `MANIFEST_LOADED` event is fired.

### Resolves issues:
#4522 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
