### PR TITLE
Eagerly match segments without tolerance offset

### DIFF
--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -82,7 +82,7 @@ export function findFragmentByPTS(
     fragments,
     fragmentWithinToleranceTest.bind(null, bufferEnd, maxFragLookUpTolerance)
   );
-  if (foundFragment) {
+  if (foundFragment && (foundFragment !== fragPrevious || !fragNext)) {
     return foundFragment;
   }
   // If no match was found return the next fragment after fragPrevious, or null

--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -101,6 +101,13 @@ export function fragmentWithinToleranceTest(
   maxFragLookUpTolerance = 0,
   candidate: Fragment
 ) {
+  // eagerly accept an accurate match (no tolerance)
+  if (
+    candidate.start <= bufferEnd &&
+    candidate.start + candidate.duration > bufferEnd
+  ) {
+    return 0;
+  }
   // offset should be within fragment boundary - config.maxFragLookUpTolerance
   // this is to cope with situations like
   // bufferEnd = 9.991

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -77,7 +77,7 @@ describe('Fragment finders', function () {
         {
           deltaPTS: 0,
           cc: 2,
-          duration: 5,
+          duration: 0.033,
           start: 60.234398412698226,
           sn: 12,
           level: 0,

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -77,7 +77,7 @@ describe('Fragment finders', function () {
         {
           deltaPTS: 0,
           cc: 2,
-          duration: 0.033,
+          duration: 5,
           start: 60.234398412698226,
           sn: 12,
           level: 0,
@@ -192,13 +192,38 @@ describe('Fragment finders', function () {
       expect(actual).to.equal(-1);
     });
 
-    it('does not skip very small fragments', function () {
+    it('does not skip very small fragments at the start', function () {
       const frag = {
         start: 0.2,
         duration: 0.1,
         deltaPTS: 0.1,
       };
       const actual = fragmentWithinToleranceTest(0, tolerance, frag);
+      expect(actual).to.equal(0);
+    });
+    it('does not skip very small fragments', function () {
+      const frag = {
+        start: 5,
+        duration: 0.1,
+        deltaPTS: 0.1,
+      };
+      const actual = fragmentWithinToleranceTest(5, tolerance, frag);
+      expect(actual).to.equal(0);
+    });
+    it('does not skip very small fragments without deltaPTS', function () {
+      const frag = {
+        start: 5,
+        duration: 0.1,
+      };
+      const actual = fragmentWithinToleranceTest(5, tolerance, frag);
+      expect(actual).to.equal(0);
+    });
+    it('does not skip fragments when searching near boundaries', function () {
+      const frag = {
+        start: 19.96916,
+        duration: 9.98458,
+      };
+      const actual = fragmentWithinToleranceTest(29, 0.25, frag);
       expect(actual).to.equal(0);
     });
   });


### PR DESCRIPTION
### This PR will...
Make `fragmentWithinToleranceTest` eagerly return a match on an exact match before checking for a match with tolerance.

### Why is this Pull Request needed?
This is needed to not skip over small segments or segments adjacent to small segments.

### Resolves issues:
Fixes #4919

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
