### PR TITLE
Fix consistency of FRAG_CHANGED and LEVEL_SWITCHED events

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -352,7 +352,10 @@ export class FragmentTracker implements ComponentAPI {
   ) {
     const { frag, part, timeRanges } = data;
     if (frag.type === PlaylistLevelType.MAIN) {
-      this.activeFragment = frag;
+      if (this.activeFragment !== frag) {
+        this.activeFragment = frag;
+        frag.appendedPTS = undefined;
+      }
       if (part) {
         let activeParts = this.activeParts;
         if (!activeParts) {
@@ -368,11 +371,17 @@ export class FragmentTracker implements ComponentAPI {
     Object.keys(timeRanges).forEach((elementaryStream: SourceBufferName) => {
       const timeRange = timeRanges[elementaryStream] as TimeRanges;
       this.detectEvictedFragments(elementaryStream, timeRange);
-      if (!part) {
+      if (!part && frag.type === PlaylistLevelType.MAIN) {
+        const streamInfo = frag.elementaryStreams[elementaryStream];
+        if (!streamInfo) {
+          return;
+        }
         for (let i = 0; i < timeRange.length; i++) {
           const rangeEnd = timeRange.end(i);
-          if (rangeEnd < frag.end) {
+          if (rangeEnd <= streamInfo.endPTS && rangeEnd > streamInfo.startPTS) {
             frag.appendedPTS = Math.max(rangeEnd, frag.appendedPTS || 0);
+          } else {
+            frag.appendedPTS = streamInfo.endPTS;
           }
         }
       }
@@ -415,6 +424,7 @@ export class FragmentTracker implements ComponentAPI {
     const fragKey = getFragmentKey(fragment);
     fragment.stats.loaded = 0;
     fragment.clearElementaryStreamInfo();
+    fragment.appendedPTS = undefined;
     delete this.fragments[fragKey];
   }
 

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -370,7 +370,10 @@ export class FragmentTracker implements ComponentAPI {
       this.detectEvictedFragments(elementaryStream, timeRange);
       if (!part) {
         for (let i = 0; i < timeRange.length; i++) {
-          frag.appendedPTS = Math.max(timeRange.end(i), frag.appendedPTS || 0);
+          const rangeEnd = timeRange.end(i);
+          if (rangeEnd < frag.end) {
+            frag.appendedPTS = Math.max(rangeEnd, frag.appendedPTS || 0);
+          }
         }
       }
     });

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -122,7 +122,6 @@ export function updateFragPTSDTS(
   frag.duration = endPTS - startPTS;
 
   const drift = startPTS - frag.start;
-  frag.appendedPTS = endPTS;
   frag.start = frag.startPTS = startPTS;
   frag.maxStartPTS = maxStartPTS;
   frag.startDTS = startDTS;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1321,13 +1321,13 @@ export default class StreamController
           fragPlaying.level !== fragCurrentLevel ||
           fragPlayingCurrent.urlId !== fragPlaying.urlId
         ) {
+          this.fragPlaying = fragPlayingCurrent;
           this.hls.trigger(Events.FRAG_CHANGED, { frag: fragPlayingCurrent });
           if (!fragPlaying || fragPlaying.level !== fragCurrentLevel) {
             this.hls.trigger(Events.LEVEL_SWITCHED, {
               level: fragCurrentLevel,
             });
           }
-          this.fragPlaying = fragPlayingCurrent;
         }
       }
     }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1088,7 +1088,7 @@ export default class StreamController
             endDTS,
           };
         } else {
-          if (video.firstKeyFrame && video.independent) {
+          if (video.firstKeyFrame && video.independent && chunkMeta.id === 1) {
             this.couldBacktrack = true;
           }
           if (video.dropped && video.independent) {


### PR DESCRIPTION
### This PR will...
Fix consistency of FRAG_CHANGED and LEVEL_SWITCHED events after seeking back (#5077)
and update source of `currentLevel` getter prior to emitting these events (#5082)

### Why is this PR needed:
The player uses the fragment-tracker's `activeFragment.appendedPTS` in `getAppendedFrag` to determine which fragment (and level) is currently playing. The method for updating `appendedPTS` only worked when playing and buffering media forward; If segments were appended ahead of the current one, `appendedPTS` would be assigned a value outside the segment's range. The method also used TimeRanges from alternate buffers, and  `appendedPTS` was being set on alt audio segments even though it is never used on them.

### Resolves issues:
Fixes #5077

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
