### PR TITLE
fix(seeking) #4956 - issue with seeking back when video is paused

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -55,7 +55,7 @@ export default class GapController {
     this.seeking = seeking;
 
     // The playhead is moving, no-op
-    if (currentTime !== lastCurrentTime) {
+    if (currentTime !== lastCurrentTime || (media?.paused && seeking)) {
       this.moved = true;
       if (stalled !== null) {
         // The playhead is now moving, but was previously stalled


### PR DESCRIPTION
### This PR will...

Track stuck while paused and seeking back, so that gap-controller will seek over small gaps in this playback state

### Why is this Pull Request needed?

[1] Go to https://hls-js.netlify.app/demo
[2] seek somewhere in the middle and pause the video
[3] add function in the console

```
const seekFrame = () => {
	const video = document.getElementById('video');
	const newCurrentTime = video.currentTime - 0.04; // 25 FRAME seek
	video.currentTime = newCurrentTime;
	console.log(newCurrentTime);
} 
```
[4] call `seekFrame()` from console
[5] keep calling till you reach to
(example)
[warn] > skipping hole, adjusting currentTime from 459.988593 to 460.088593

=> we are frozen there

![Peek 2022-12-06 09-48](https://user-images.githubusercontent.com/3098030/206144885-0ed5d9a4-4217-4740-acad-9307a8d0e09a.gif)


### Resolves issues:

Allows us to see back and avoid freezing

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
