### PR TITLE
Fix audio and subtitle controller loading before player seeks to startPosition (VOD)

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -252,12 +252,6 @@ class AudioStreamController
       // Exit early if we don't have media or if the media hasn't buffered anything yet (readyState 0)
       return;
     }
-    const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
-    const buffered = mediaBuffer.buffered;
-
-    if (!this.loadedmetadata && buffered.length) {
-      this.loadedmetadata = true;
-    }
 
     this.lastCurrentTime = media.currentTime;
   }
@@ -595,6 +589,11 @@ class AudioStreamController
   onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
     const { frag, part } = data;
     if (frag.type !== PlaylistLevelType.AUDIO) {
+      if (!this.loadedmetadata && frag.type === PlaylistLevelType.MAIN) {
+        if ((this.videoBuffer || this.media)?.buffered.length) {
+          this.loadedmetadata = true;
+        }
+      }
       return;
     }
     if (this.fragContextChanged(frag)) {

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -21,6 +21,7 @@ import type {
   TrackSwitchedData,
   BufferFlushingData,
   LevelLoadedData,
+  FragBufferedData,
 } from '../types/events';
 
 const TICK_INTERVAL = 500; // how often to tick in ms
@@ -62,6 +63,7 @@ export class SubtitleStreamController
     hls.on(Events.SUBTITLE_TRACK_LOADED, this.onSubtitleTrackLoaded, this);
     hls.on(Events.SUBTITLE_FRAG_PROCESSED, this.onSubtitleFragProcessed, this);
     hls.on(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
+    hls.on(Events.FRAG_BUFFERED, this.onFragBuffered, this);
   }
 
   private _unregisterListeners() {
@@ -76,13 +78,20 @@ export class SubtitleStreamController
     hls.off(Events.SUBTITLE_TRACK_LOADED, this.onSubtitleTrackLoaded, this);
     hls.off(Events.SUBTITLE_FRAG_PROCESSED, this.onSubtitleFragProcessed, this);
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
+    hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
   }
 
-  startLoad() {
+  startLoad(startPosition: number) {
     this.stopLoad();
     this.state = State.IDLE;
 
     this.setInterval(TICK_INTERVAL);
+
+    this.nextLoadPosition =
+      this.startPosition =
+      this.lastCurrentTime =
+        startPosition;
+
     this.tick();
   }
 
@@ -174,6 +183,14 @@ export class SubtitleStreamController
     }
   }
 
+  onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
+    if (!this.loadedmetadata && data.frag.type === PlaylistLevelType.MAIN) {
+      if (this.media?.buffered.length) {
+        this.loadedmetadata = true;
+      }
+    }
+  }
+
   // If something goes wrong, proceed to next frag, if we were processing one.
   onError(event: Events.ERROR, data: ErrorData) {
     const frag = data.frag;
@@ -244,6 +261,7 @@ export class SubtitleStreamController
       return;
     }
     this.mediaBuffer = this.mediaBufferTimeRanges;
+    let sliding = 0;
     if (newDetails.live || track.details?.live) {
       const mainDetails = this.mainDetails;
       if (newDetails.deltaUpdateFailed || !mainDetails) {
@@ -253,20 +271,27 @@ export class SubtitleStreamController
       if (!track.details) {
         if (newDetails.hasProgramDateTime && mainDetails.hasProgramDateTime) {
           alignMediaPlaylistByPDT(newDetails, mainDetails);
+          sliding = newDetails.fragments[0].start;
         } else if (mainSlidingStartFragment) {
           // line up live playlist with main so that fragments in range are loaded
-          addSliding(newDetails, mainSlidingStartFragment.start);
+          sliding = mainSlidingStartFragment.start;
+          addSliding(newDetails, sliding);
         }
       } else {
-        const sliding = this.alignPlaylists(newDetails, track.details);
+        sliding = this.alignPlaylists(newDetails, track.details);
         if (sliding === 0 && mainSlidingStartFragment) {
           // realign with main when there is no overlap with last refresh
-          addSliding(newDetails, mainSlidingStartFragment.start);
+          sliding = mainSlidingStartFragment.start;
+          addSliding(newDetails, sliding);
         }
       }
     }
     track.details = newDetails;
     this.levelLastLoaded = trackId;
+
+    if (!this.startFragRequested && (this.mainDetails || !newDetails.live)) {
+      this.setStartPosition(track.details, sliding);
+    }
 
     // trigger handler right now
     this.tick();
@@ -353,15 +378,21 @@ export class SubtitleStreamController
       // Expand range of subs loaded by one target-duration in either direction to make up for misaligned playlists
       const trackDetails = levels[currentTrackId].details as LevelDetails;
       const targetDuration = trackDetails.targetduration;
-      const { config, media } = this;
+      const { config } = this;
+      const currentTime = this.getLoadPosition();
       const bufferedInfo = BufferHelper.bufferedInfo(
         this.tracksBuffered[this.currentTrackId] || [],
-        media.currentTime - targetDuration,
+        currentTime - targetDuration,
         config.maxBufferHole
       );
       const { end: targetBufferTime, len: bufferLen } = bufferedInfo;
 
-      const maxBufLen = this.getMaxBufferLength() + targetDuration;
+      const mainBufferInfo = this.getFwdBufferInfo(
+        this.media,
+        PlaylistLevelType.MAIN
+      );
+      const maxBufLen =
+        this.getMaxBufferLength(mainBufferInfo?.len) + targetDuration;
 
       if (bufferLen > maxBufLen) {
         return;
@@ -410,6 +441,14 @@ export class SubtitleStreamController
     }
   }
 
+  protected getMaxBufferLength(mainBufferLength?: number): number {
+    const maxConfigBuffer = super.getMaxBufferLength();
+    if (!mainBufferLength) {
+      return maxConfigBuffer;
+    }
+    return Math.max(maxConfigBuffer, mainBufferLength);
+  }
+
   protected loadFragment(
     frag: Fragment,
     levelDetails: LevelDetails,
@@ -419,6 +458,7 @@ export class SubtitleStreamController
     if (frag.sn === 'initSegment') {
       this._loadInitSegment(frag, levelDetails);
     } else {
+      this.startFragRequested = true;
       super.loadFragment(frag, levelDetails, targetBufferTime);
     }
   }


### PR DESCRIPTION
### This PR will...
1. Set `loadedmetadata` on stream controllers such that:
   - stream-controller `loadedmetadata` is set to `true` first, after which it seeks to `startPosition` (when not `0`)
   - audio and subtitle stream controllers `loadedmetadata` is set to `true` after stream-controller media is buffered (this assumes the previous step is complete)
2. Make the subtitle stream controller fragment selection and max buffer length logic more closely match the audio stream controller

### Why is this Pull Request needed?
`loadedmetadata` determines whether stream controllers use `media.currentTime` or `nextLoadPosition` to find the next segment to load. If set to true before seeking to `startPosition`, audio and subtitle stream controllers would load media at `media.currentTime` (`0`) instead of `startPosition`.

This change prevents the player from loading the first audio and subtitle playlist segments when loading should begin at a `startPosition` further down the playlist.

This change also prevents loading at start positions past the first discontinuity from getting stuck because the segment positions for each controller were out of sync (#5083).

### Are there any points in the code the reviewer needs to double check?

> - stream-controller `loadedmetadata` is set to `true` first, after which it seeks to `startPosition` (when not `0`)
> - audio and subtitle stream controllers `loadedmetadata` is set to `true` after stream-controller media is buffered (this assumes the previous step is complete)

Considering this behavior, it might make more sense to  to set `loadedmetadata` to `true` in base-stream-controller when `onMediaSeeking` fires and there is media in the buffer. The reason HLS.js waits for media to be buffered before seeking is to avoid stalling/seeking twice if on jagged audio/video buffered starts. The seek to live start logic is a bit different since it is concerned with sliding window playlist alignment. User-seeks occurring before media is buffered could benefit from this approach but that is already handled by updating `nextLoadPosition`.

When start position is `0` then HLS.js does not seek on start, so `loadedmetadata` would still need to be set another way. This approach should handle all cases.

### Resolves issues:
Fixes #5083

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
