### PR TITLE
Fix Low-Latency HLS next part selection when switching mid segment

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -995,8 +995,9 @@ export default class BaseStreamController
         break;
       }
       const loaded = part.loaded;
-      if (
-        !loaded &&
+      if (loaded) {
+        nextPart = -1;
+      } else if (
         (contiguous || part.independent || independentAttrOmitted) &&
         part.fragment === frag
       ) {


### PR DESCRIPTION
### This PR will...
Fix an issue in `nextPartIndex` where the first independent part index is returned after newer parts have been loaded, but the next part needed is not yet listed.

### Why is this Pull Request needed?
Instead of waiting for the next needed part, the player was selecting the first part, then skipping the ones that were loaded, leading to freezing of video or stalling of playback.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
Fixes #5111

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
