### PR TITLE
Fix: Rendition Report switching with unnormalized relative URLs

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -64,17 +64,25 @@ export default class BasePlaylistController implements NetworkComponentAPI {
 
   protected switchParams(
     playlistUri: string,
-    previous?: LevelDetails
+    previous: LevelDetails | undefined
   ): HlsUrlParameters | undefined {
     const renditionReports = previous?.renditionReports;
     if (renditionReports) {
       for (let i = 0; i < renditionReports.length; i++) {
         const attr = renditionReports[i];
-        const uri = '' + attr.URI;
+        let uri: string;
+        try {
+          uri = new self.URL(attr.URI, previous.url).href;
+        } catch (error) {
+          logger.warn(
+            `Could not construct new URL for Rendition Report: ${error}`
+          );
+          uri = attr.URI || '';
+        }
         if (uri === playlistUri.slice(-uri.length)) {
           const msn = parseInt(attr['LAST-MSN']) || previous?.lastPartSn;
           let part = parseInt(attr['LAST-PART']) || previous?.lastPartIndex;
-          if (previous && this.hls.config.lowLatencyMode) {
+          if (this.hls.config.lowLatencyMode) {
             const currentGoal = Math.min(
               previous.age - previous.partTarget,
               previous.targetduration

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -78,7 +78,7 @@ export class HlsUrlParameters {
     if (this.skip) {
       url.searchParams.set('_HLS_skip', this.skip);
     }
-    return url.toString();
+    return url.href;
   }
 }
 


### PR DESCRIPTION
### This PR will...
Add support for Rendition Report switching when their relative urls contain dot segments

### Why is this Pull Request needed?
Rendition Report URLs can be absolute or relative to the playlist they are in. When the relative URLs contain dot segments (../) then the comparison to the selected level fails and the Rendition Report is not used.

### Resolves issues:
Fixes #3572

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
