### PR TITLE
Log additional information for EOS test

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -306,18 +306,7 @@ class AudioStreamController
     if (bufferInfo === null) {
       return;
     }
-    const mainBufferInfo = this.getFwdBufferInfo(
-      this.videoBuffer ? this.videoBuffer : this.media,
-      PlaylistLevelType.MAIN
-    );
-    const bufferLen = bufferInfo.len;
-    const maxBufLen = this.getMaxBufferLength(mainBufferInfo?.len);
     const audioSwitch = this.audioSwitch;
-
-    // if buffer length is less than maxBufLen try to load a new fragment
-    if (bufferLen >= maxBufLen && !audioSwitch) {
-      return;
-    }
 
     if (!audioSwitch && this._streamEnded(bufferInfo, trackDetails)) {
       hls.trigger(Events.BUFFER_EOS, { type: 'audio' });
@@ -325,6 +314,17 @@ class AudioStreamController
       return;
     }
 
+    const mainBufferInfo = this.getFwdBufferInfo(
+      this.videoBuffer ? this.videoBuffer : this.media,
+      PlaylistLevelType.MAIN
+    );
+    const bufferLen = bufferInfo.len;
+    const maxBufLen = this.getMaxBufferLength(mainBufferInfo?.len);
+
+    // if buffer length is less than maxBufLen try to load a new fragment
+    if (bufferLen >= maxBufLen && !audioSwitch) {
+      return;
+    }
     const fragments = trackDetails.fragments;
     const start = fragments[0].start;
     let targetBufferTime = bufferInfo.end;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1403,6 +1403,7 @@ export default class BaseStreamController
   }
 
   protected resetLoadingState() {
+    this.log('Reset loading state');
     this.fragCurrent = null;
     this.fragPrevious = null;
     this.state = State.IDLE;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -528,8 +528,14 @@ export default class BufferController implements ComponentAPI {
       this.blockBuffers(() => {
         const { mediaSource } = this;
         if (!mediaSource || mediaSource.readyState !== 'open') {
+          if (mediaSource) {
+            logger.warn(
+              `[buffer-controller]: Could not call mediaSource.endOfStream(). mediaSource.readyState: ${mediaSource.readyState}`
+            );
+          }
           return;
         }
+        logger.log(`[buffer-controller]: Calling mediaSource.endOfStream()`);
         // Allow this to throw and be caught by the enqueueing function
         mediaSource.endOfStream();
       });

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -253,15 +253,6 @@ export default class StreamController
     if (bufferInfo === null) {
       return;
     }
-    const bufferLen = bufferInfo.len;
-
-    // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
-    const maxBufLen = this.getMaxBufferLength(levelInfo.maxBitrate);
-
-    // Stay idle if we are still with buffer margins
-    if (bufferLen >= maxBufLen) {
-      return;
-    }
 
     if (this._streamEnded(bufferInfo, levelDetails)) {
       const data: BufferEOSData = {};
@@ -271,6 +262,16 @@ export default class StreamController
 
       this.hls.trigger(Events.BUFFER_EOS, data);
       this.state = State.ENDED;
+      return;
+    }
+
+    const bufferLen = bufferInfo.len;
+
+    // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
+    const maxBufLen = this.getMaxBufferLength(levelInfo.maxBitrate);
+
+    // Stay idle if we are still with buffer margins
+    if (bufferLen >= maxBufLen) {
       return;
     }
 


### PR DESCRIPTION
### This PR will...
- Log additional information for EOS test
- Move up `_streamEnded` checks for `BUFFER_EOS` event triggers in stream-controllers to ensure they run event after max buffer length conditions are met

### Why is this Pull Request needed?
The HTMLMediaElement "ended" event intermittently does not fire or does not fire at all in certain browsers with certain streams.

The info added to our CI tests will help determine if it is an issue with audio and video buffer alignment, MediaSource readyState, stream-controller state re-opening MediaSource, or something else.

### Related to issues:
#5000

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
