### PR TITLE
Manage End of Stream state after flushing buffer

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -767,6 +767,8 @@ export class Fragment extends BaseSegment {
     // (undocumented)
     endDTS: number;
     // (undocumented)
+    endList?: boolean;
+    // (undocumented)
     get endProgramDateTime(): number | null;
     // (undocumented)
     endPTS?: number;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -688,6 +688,9 @@ class AudioStreamController
   ) {
     if (type === ElementaryStreamTypes.AUDIO) {
       this.bufferFlushed = true;
+      if (this.state === State.ENDED) {
+        this.state = State.IDLE;
+      }
     }
   }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -143,11 +143,18 @@ export default class BaseStreamController
     this.state = State.STOPPED;
   }
 
-  protected _streamEnded(bufferInfo, levelDetails: LevelDetails): boolean {
-    const { fragCurrent, fragmentTracker } = this;
+  protected _streamEnded(
+    bufferInfo: BufferInfo,
+    levelDetails: LevelDetails
+  ): boolean {
+    const fragmentTracker = this.fragmentTracker;
     // we just got done loading the final fragment and there is no other buffered range after ...
     // rationale is that in case there are any buffered ranges after, it means that there are unbuffered portion in between
     // so we should not switch to ENDED in that case, to be able to buffer them
+    let fragCurrent = this.fragCurrent;
+    if (!fragCurrent || fragCurrent.sn < levelDetails.endSN) {
+      fragCurrent = levelDetails.fragments[levelDetails.fragments.length - 1];
+    }
     if (
       !levelDetails.live &&
       fragCurrent &&

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -201,7 +201,7 @@ export default class BaseStreamController
     return !this._streamEnded(bufferInfo, details);
   }
 
-  private getLevelDetails(): LevelDetails | undefined {
+  protected getLevelDetails(): LevelDetails | undefined {
     if (this.levels && this.levelLastLoaded !== null) {
       return this.levels[this.levelLastLoaded]?.details;
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -174,31 +174,9 @@ export default class BaseStreamController
       return lastPartBuffered;
     }
 
-    const lastFragment =
-      levelDetails.fragments[levelDetails.fragments.length - 1];
-    const fragState = this.fragmentTracker.getState(lastFragment);
-    if (fragState === FragmentState.PARTIAL || fragState === FragmentState.OK) {
-      return true;
-    }
-    return false;
-  }
-
-  private endedNeedsReset() {
-    if (this.state !== State.ENDED || !this.media) {
-      return false;
-    }
-    const pos = this.getLoadPosition();
-    const details = this.getLevelDetails();
-    if (!details || details.edge - pos > details.targetduration * 3) {
-      return true;
-    }
-
-    const bufferInfo = BufferHelper.bufferInfo(
-      this.mediaBuffer || this.media,
-      pos,
-      0
-    );
-    return !this._streamEnded(bufferInfo, details);
+    const playlistType =
+      levelDetails.fragments[levelDetails.fragments.length - 1].type;
+    return this.fragmentTracker.isEndListAppended(playlistType);
   }
 
   protected getLevelDetails(): LevelDetails | undefined {
@@ -259,7 +237,7 @@ export default class BaseStreamController
       }, state: ${state}`
     );
 
-    if (this.endedNeedsReset()) {
+    if (this.state === State.ENDED) {
       this.resetLoadingState();
     } else if (fragCurrent) {
       // Seeking while frag load is in progress
@@ -1422,7 +1400,7 @@ export default class BaseStreamController
       bufferedTimeRanges,
       playlistType
     );
-    if (this.endedNeedsReset()) {
+    if (this.state === State.ENDED) {
       this.resetLoadingState();
     }
   }

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -25,11 +25,13 @@ export enum FragmentState {
 export class FragmentTracker implements ComponentAPI {
   private activeFragment: Fragment | null = null;
   private activeParts: Part[] | null = null;
+  private endListFragments: { [key in PlaylistLevelType]?: FragmentEntity } =
+    Object.create(null);
   private fragments: Partial<Record<string, FragmentEntity>> =
     Object.create(null);
   private timeRanges:
     | {
-        [key in SourceBufferName]: TimeRanges;
+        [key in SourceBufferName]?: TimeRanges;
       }
     | null = Object.create(null);
 
@@ -59,7 +61,13 @@ export class FragmentTracker implements ComponentAPI {
   public destroy() {
     this._unregisterListeners();
     // @ts-ignore
-    this.fragments = this.timeRanges = null;
+    this.fragments =
+      // @ts-ignore
+      this.endListFragments =
+      this.timeRanges =
+      this.activeFragment =
+      this.activeParts =
+        null;
   }
 
   /**
@@ -137,13 +145,16 @@ export class FragmentTracker implements ComponentAPI {
     timeRange: TimeRanges,
     playlistType?: PlaylistLevelType
   ) {
+    if (this.timeRanges) {
+      this.timeRanges[elementaryStream] = timeRange;
+    }
     // Check if any flagged fragments have been unloaded
     Object.keys(this.fragments).forEach((key) => {
       const fragmentEntity = this.fragments[key];
       if (!fragmentEntity) {
         return;
       }
-      if (!fragmentEntity.buffered) {
+      if (!fragmentEntity.buffered && !fragmentEntity.loaded) {
         if (fragmentEntity.body.type === playlistType) {
           this.removeFragment(fragmentEntity.body);
         }
@@ -201,6 +212,9 @@ export class FragmentTracker implements ComponentAPI {
     fragmentEntity.loaded = null;
     if (Object.keys(fragmentEntity.range).length) {
       fragmentEntity.buffered = true;
+      if (fragmentEntity.body.endList) {
+        this.endListFragments[fragmentEntity.body.type] = fragmentEntity;
+      }
     } else {
       // remove fragment if nothing was appended
       this.removeFragment(fragmentEntity.body);
@@ -288,6 +302,14 @@ export class FragmentTracker implements ComponentAPI {
     return bestFragment;
   }
 
+  public isEndListAppended(type: PlaylistLevelType): boolean {
+    const lastFragmentEntity = this.endListFragments[type];
+    return (
+      lastFragmentEntity !== undefined &&
+      (lastFragmentEntity.buffered || isPartial(lastFragmentEntity))
+    );
+  }
+
   public getState(fragment: Fragment): FragmentState {
     const fragKey = getFragmentKey(fragment);
     const fragmentEntity = this.fragments[fragKey];
@@ -367,7 +389,7 @@ export class FragmentTracker implements ComponentAPI {
       }
     }
     // Store the latest timeRanges loaded in the buffer
-    this.timeRanges = timeRanges as { [key in SourceBufferName]: TimeRanges };
+    this.timeRanges = timeRanges;
     Object.keys(timeRanges).forEach((elementaryStream: SourceBufferName) => {
       const timeRange = timeRanges[elementaryStream] as TimeRanges;
       this.detectEvictedFragments(elementaryStream, timeRange);
@@ -426,10 +448,14 @@ export class FragmentTracker implements ComponentAPI {
     fragment.clearElementaryStreamInfo();
     fragment.appendedPTS = undefined;
     delete this.fragments[fragKey];
+    if (fragment.endList) {
+      delete this.endListFragments[fragment.type];
+    }
   }
 
   public removeAllFragments() {
     this.fragments = Object.create(null);
+    this.endListFragments = Object.create(null);
     this.activeFragment = null;
     this.activeParts = null;
   }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -314,8 +314,12 @@ export default class StreamController
         this.audioOnly && !this.altAudio
           ? ElementaryStreamTypes.AUDIO
           : ElementaryStreamTypes.VIDEO;
-      if (media) {
-        this.afterBufferFlushed(media, type, PlaylistLevelType.MAIN);
+      const mediaBuffer =
+        (type === ElementaryStreamTypes.VIDEO
+          ? this.videoBuffer
+          : this.mediaBuffer) || this.media;
+      if (mediaBuffer) {
+        this.afterBufferFlushed(mediaBuffer, type, PlaylistLevelType.MAIN);
       }
       frag = this.getNextFragment(this.nextLoadPosition, levelDetails);
     }
@@ -947,11 +951,11 @@ export default class StreamController
       type !== ElementaryStreamTypes.AUDIO ||
       (this.audioOnly && !this.altAudio)
     ) {
-      const media =
+      const mediaBuffer =
         (type === ElementaryStreamTypes.VIDEO
           ? this.videoBuffer
           : this.mediaBuffer) || this.media;
-      this.afterBufferFlushed(media, type, PlaylistLevelType.MAIN);
+      this.afterBufferFlushed(mediaBuffer, type, PlaylistLevelType.MAIN);
     }
   }
 

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -144,6 +144,8 @@ export class Fragment extends BaseSegment {
   public title: string | null = null;
   // The Media Initialization Section for this segment
   public initSegment: Fragment | null = null;
+  // Fragment is the last fragment in the media playlist
+  public endList?: boolean;
 
   constructor(type: PlaylistLevelType, baseurl: string) {
     super(baseurl);

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -528,6 +528,9 @@ export default class M3U8Parser {
       level.averagetargetduration = totalduration / fragmentLength;
       const lastSn = lastFragment.sn;
       level.endSN = lastSn !== 'initSegment' ? lastSn : 0;
+      if (!level.live) {
+        lastFragment.endList = true;
+      }
       if (firstFragment) {
         level.startCC = firstFragment.cc;
         if (!firstFragment.initSegment) {

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -3,6 +3,7 @@ export type SourceBufferName = 'video' | 'audio' | 'audiovideo';
 // eslint-disable-next-line no-restricted-globals
 export type ExtendedSourceBuffer = SourceBuffer & {
   ended?: boolean;
+  ending?: boolean;
   changeType?: (type: string) => void;
 };
 

--- a/tests/unit/controller/base-stream-controller.js
+++ b/tests/unit/controller/base-stream-controller.js
@@ -13,7 +13,7 @@ describe('BaseStreamController', function () {
     baseStreamController = new BaseStreamController(new Hls({}));
     bufferInfo = {
       nextStart: 0,
-      end: 0,
+      end: 1,
     };
     levelDetails = {
       endSN: 0,
@@ -48,13 +48,6 @@ describe('BaseStreamController', function () {
 
     it('returns false if fragCurrent does not exist', function () {
       baseStreamController.fragCurrent = null;
-      expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
-        .false;
-    });
-
-    it('returns false if fragCurrent is not the last fragment', function () {
-      baseStreamController.fragCurrent = { sn: 9 };
-      levelDetails.endSN = 10;
       expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
         .false;
     });

--- a/tests/unit/controller/base-stream-controller.js
+++ b/tests/unit/controller/base-stream-controller.js
@@ -1,6 +1,5 @@
 import BaseStreamController from '../../../src/controller/stream-controller';
 import Hls from '../../../src/hls';
-import { FragmentState } from '../../../src/controller/fragment-tracker';
 import { TimeRangesMock } from '../../mocks/time-ranges.mock';
 
 describe('BaseStreamController', function () {
@@ -18,10 +17,10 @@ describe('BaseStreamController', function () {
     levelDetails = {
       endSN: 0,
       live: false,
-      fragments() {
+      get fragments() {
         const frags = [];
         for (let i = 0; i < this.endSN; i++) {
-          frags.push({ sn: i });
+          frags.push({ sn: i, type: 'main' });
         }
         return frags;
       },
@@ -33,6 +32,9 @@ describe('BaseStreamController', function () {
       state: null,
       getState() {
         return this.state;
+      },
+      isEndListAppended() {
+        return true;
       },
     };
     baseStreamController.media = media;
@@ -46,40 +48,15 @@ describe('BaseStreamController', function () {
         .false;
     });
 
-    it('returns false if fragCurrent does not exist', function () {
-      baseStreamController.fragCurrent = null;
-      expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
-        .false;
-    });
-
     it('returns false if there is subsequently buffered range', function () {
-      baseStreamController.fragCurrent = { sn: 10 };
       levelDetails.endSN = 10;
       bufferInfo.nextStart = 100;
       expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
         .false;
     });
 
-    it('returns true if fragCurrent is PARTIAL or OK', function () {
-      baseStreamController.fragCurrent = { sn: 10 };
-      levelDetails.endSN = 10;
-
-      fragmentTracker.state = FragmentState.PARTIAL;
-      expect(
-        baseStreamController._streamEnded(bufferInfo, levelDetails),
-        `fragState is ${fragmentTracker.getState()}, expecting PARTIAL`
-      ).to.be.true;
-
-      fragmentTracker.state = FragmentState.OK;
-      expect(
-        baseStreamController._streamEnded(bufferInfo, levelDetails),
-        `fragState is ${fragmentTracker.getState()}, expecting OK`
-      ).to.be.true;
-    });
-
     it('returns true if parts are buffered for low latency content', function () {
       media.buffered = new TimeRangesMock([0, 1]);
-      baseStreamController.fragCurrent = { sn: 10 };
       levelDetails.endSN = 10;
       levelDetails.partList = [{ start: 0, duration: 1 }];
 
@@ -87,14 +64,16 @@ describe('BaseStreamController', function () {
         .true;
     });
 
-    it('returns true even if fragCurrent is after the last fragment due to low latency content modeling', function () {
+    it('depends on fragment-tracker to determine if last fragment is buffered', function () {
       media.buffered = new TimeRangesMock([0, 1]);
-      baseStreamController.fragCurrent = { sn: 11 };
       levelDetails.endSN = 10;
-      levelDetails.partList = [{ start: 0, duration: 1 }];
 
       expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
         .true;
+
+      fragmentTracker.isEndListAppended = () => false;
+      expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
+        .false;
     });
   });
 });

--- a/tests/unit/controller/base-stream-controller.js
+++ b/tests/unit/controller/base-stream-controller.js
@@ -18,6 +18,13 @@ describe('BaseStreamController', function () {
     levelDetails = {
       endSN: 0,
       live: false,
+      fragments() {
+        const frags = [];
+        for (let i = 0; i < this.endSN; i++) {
+          frags.push({ sn: i });
+        }
+        return frags;
+      },
     };
     media = {
       duration: 0,


### PR DESCRIPTION
### This PR will...
- [x] Fix issues in stream ended detection and SourceBuffer ended state around buffer flushing and seeking
- [x] Before resetting from ENDED to IDLE, check for EOS when position is close to end to avoid reloading because of ABR switch
- [x] Log additional information for EOS test

### Why is this Pull Request needed?
The HTMLMediaElement "ended" event intermittently does not fire. A common cause for this is the back buffer removal resetting the buffer ended state just before playback reaches the end. Seeking back to append segments after the last segment is appended also resets the stream controller and MediaSource state. Afterwards the EOS is not set again and "ended" will not fire.

### Resolves issues:
#5000

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
