### PR TITLE
mention that you need to be an admin or maintainer to push version tag

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,6 +2,8 @@
 
 Releases are performed automatically with [GitHub actions](https://github.com/video-dev/hls.js/actions?query=workflow%3ABuild+branch%3Amaster).
 
+Note that [protected tags](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules) are configured so you need to be either an admin or maintainer to push the tag.
+
 1. `git tag v<major>.<minor>.<patch>` or `git tag v<major>.<minor>.<patch>-<prerelease>` _('v' required)_ where anything before the first `.` in `<prerelease>` will be become the [npm dist-tag](https://docs.npmjs.com/cli/dist-tag).
 1. `git push`
 1. `git push --tag`


### PR DESCRIPTION
### This PR will...

Mention that you need to be an admin or maintainer to push version tag. I’ve updated the setting already for `v*` tags. If we don’t want this can switch it off again.

### Why is this Pull Request needed?

It restricts the group of people that can publish releases to those with a specific maintainer or admin role to reduce the chance of a compromised account being able to get a package update onto npm.

Also prevents version tags being deleted by anyone other than admins.