### PR TITLE
Update GitHub stale bot rules

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,18 +1,21 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 21
+daysUntilStale: 18
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 3
+daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
+  - good-first-issue
+  - Browser issue
+  - CI
   - Confirmed
   - Chore
   - Enhancement
   - Feature proposal
-  - Question
+  - Missing Feature
   - Needs Triage
 
 # Set to true to ignore issues in a project (defaults to false)


### PR DESCRIPTION
### This PR will...
Update GitHub stale bot rules to exempt more labels and remove "Question" label from the list since once "Needs Triage" is removed from a question, it should be answered.

### Why is this Pull Request needed?
Answered "Question" issues often don't get confirmation and are not closed by originators of the issues so we should let the stale bot take care of them.