### PR TITLE
Remove SIDX playlist MAP patching

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1469,8 +1469,6 @@ export class LevelDetails {
     // (undocumented)
     misses: number;
     // (undocumented)
-    needSidxRanges: boolean;
-    // (undocumented)
     get partEnd(): number;
     // (undocumented)
     partHoldBack: number;
@@ -2097,8 +2095,6 @@ export interface PlaylistLoaderContext extends LoaderContext {
     groupId: string | null;
     // (undocumented)
     id: number | null;
-    // (undocumented)
-    isSidxRequest?: boolean;
     // (undocumented)
     level: number | null;
     // (undocumented)

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -22,7 +22,6 @@ export class LevelDetails {
   public advanced: boolean = true;
   public availabilityDelay?: number; // Manifest reload synchronization
   public misses: number = 0;
-  public needSidxRanges: boolean = false;
   public startCC: number = 0;
   public startSN: number = 0;
   public startTimeOffset: number | null = null;

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -12,7 +12,6 @@
 import { Events } from '../events';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { logger } from '../utils/logger';
-import { parseSegmentIndex, findBox } from '../utils/mp4-tools';
 import M3U8Parser from './m3u8-parser';
 import type { LevelParsed } from '../types/level';
 import type {
@@ -316,12 +315,6 @@ class PlaylistLoader implements NetworkComponentAPI {
     context: PlaylistLoaderContext,
     networkDetails: any = null
   ): void {
-    if (context.isSidxRequest) {
-      this.handleSidxRequest(response, context);
-      this.handlePlaylistLoaded(response, stats, context, networkDetails);
-      return;
-    }
-
     this.resetInternalLoader(context.type);
 
     const string = response.data as string;
@@ -524,69 +517,10 @@ class PlaylistLoader implements NetworkComponentAPI {
     // save parsing time
     stats.parsing.end = performance.now();
 
-    // in case we need SIDX ranges
-    // return early after calling load for
-    // the SIDX box.
-    if (levelDetails.needSidxRanges) {
-      const sidxUrl = levelDetails.fragments[0].initSegment?.url as string;
-      this.load({
-        url: sidxUrl,
-        isSidxRequest: true,
-        type,
-        level,
-        levelDetails,
-        id,
-        groupId: null,
-        rangeStart: 0,
-        rangeEnd: 2048,
-        responseType: 'arraybuffer',
-        deliveryDirectives: null,
-      });
-      return;
-    }
-
     // extend the context with the new levelDetails property
     context.levelDetails = levelDetails;
 
     this.handlePlaylistLoaded(response, stats, context, networkDetails);
-  }
-
-  private handleSidxRequest(
-    response: LoaderResponse,
-    context: PlaylistLoaderContext
-  ): void {
-    const data = new Uint8Array(response.data as ArrayBuffer);
-    const sidxBox = findBox(data, ['sidx'])[0];
-    // if provided fragment does not contain sidx, early return
-    if (!sidxBox) {
-      return;
-    }
-    const sidxInfo = parseSegmentIndex(sidxBox);
-    if (!sidxInfo) {
-      return;
-    }
-    const sidxReferences = sidxInfo.references;
-    const levelDetails = context.levelDetails as LevelDetails;
-    sidxReferences.forEach((segmentRef, index) => {
-      const segRefInfo = segmentRef.info;
-      const frag = levelDetails.fragments[index];
-      if (!frag) {
-        logger.error(`no fragment for sidx index ${index}`);
-        return;
-      }
-      if (frag.byteRange.length === 0) {
-        frag.setByteRange(
-          String(1 + segRefInfo.end - segRefInfo.start) +
-            '@' +
-            String(segRefInfo.start)
-        );
-      }
-      if (frag.initSegment) {
-        const moovBox = findBox(data, ['moov'])[0];
-        const moovEndOffset = moovBox ? moovBox.length : null;
-        frag.initSegment.setByteRange(String(moovEndOffset) + '@0');
-      }
-    });
   }
 
   private handleManifestParsingError(

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -166,8 +166,6 @@ export interface PlaylistLoaderContext extends LoaderContext {
   id: number | null;
   // track group id
   groupId: string | null;
-  // defines if the loader is handling a sidx request for the playlist
-  isSidxRequest?: boolean;
   // internal representation of a parsed m3u8 level playlist
   levelDetails?: LevelDetails;
   // Blocking playlist request delivery directives (or null id none were added to playlist url


### PR DESCRIPTION
### This PR will...
Remove code that makes additional byte-range requests when media playlists are missing a MAP tag and have file extensions that suggest MP4 container format.

### Why is this Pull Request needed?
Segment file extensions should not impact player behavior. EXT-X-MAP tags are required by fMP4 segments in HLS media playlists. 

The code being removed was added in #1442. It is not needed for the stream in the description. This suggests it was added to support an early version of shaka-packager or DASH streams ported to HLS without the required MAP tags.

### Are there any points in the code the reviewer needs to double check?
Is anyone depending on the code being removed?
Are there such HLS streams and are they supported in other HLS clients?

I am assuming no to both and if wrong then would prefer to see an fmp4 specific demuxer error which included sidx data so that this fix could be applied as a fallback (slower but would not result in issues like #4274).
 
### Resolves issues:
Resolves #4274

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
