### PR TITLE
Implement `maxHdcpLevel` HDCP-LEVEL capping and EME error handling

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -893,6 +893,16 @@ export interface FragParsingUserdataData {
     samples: UserdataSample[];
 }
 
+// Warning: (ae-missing-release-tag) "HdcpLevel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HdcpLevel = typeof HdcpLevels[number];
+
+// Warning: (ae-missing-release-tag) "HdcpLevels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const HdcpLevels: readonly ["NONE", "TYPE-0", "TYPE-1", "TYPE-2", null];
+
 // Warning: (ae-missing-release-tag) "Hls" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -959,6 +969,9 @@ class Hls implements HlsEventEmitter {
     get mainForwardBufferInfo(): BufferInfo | null;
     get manualLevel(): number;
     get maxAutoLevel(): number;
+    // (undocumented)
+    get maxHdcpLevel(): HdcpLevel;
+    set maxHdcpLevel(value: HdcpLevel);
     get maxLatency(): number;
     // (undocumented)
     get media(): HTMLMediaElement | null;
@@ -1357,13 +1370,21 @@ export class Level {
 // @public (undocumented)
 export interface LevelAttributes extends AttrList {
     // (undocumented)
+    'ALLOWED-CPC'?: string;
+    // (undocumented)
     'AVERAGE-BANDWIDTH'?: string;
     // (undocumented)
     'CLOSED-CAPTIONS'?: string;
     // (undocumented)
     'FRAME-RATE'?: string;
     // (undocumented)
+    'HDCP-LEVEL'?: string;
+    // (undocumented)
+    'PATHWAY-ID'?: string;
+    // (undocumented)
     'PROGRAM-ID'?: string;
+    // (undocumented)
+    'VIDEO-RANGE'?: string;
     // (undocumented)
     AUDIO?: string;
     // (undocumented)
@@ -1386,6 +1407,8 @@ export interface LevelAttributes extends AttrList {
     NAME?: string;
     // (undocumented)
     RESOLUTION?: string;
+    // (undocumented)
+    SCORE?: string;
     // (undocumented)
     SUBTITLES?: string;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -115,6 +115,7 @@
   - [`hls.startLevel`](#hlsstartlevel)
   - [`hls.autoLevelEnabled`](#hlsautolevelenabled)
   - [`hls.autoLevelCapping`](#hlsautolevelcapping)
+  - [`hls.maxHdcpLevel`](#hlsmaxhdcplevel)
   - [`hls.capLevelToPlayerSize`](#hlscapleveltoplayersize)
   - [`hls.bandwidthEstimate`](#hlsbandwidthestimate)
   - [`hls.removeLevel(levelIndex, urlId)`](#hlsremoveLevel)
@@ -1419,6 +1420,12 @@ Default value is `hls.firstLevel`.
 
 Default value is `-1` (no level capping).
 
+### `hls.maxHdcpLevel`
+
+- get/set: The maximum HDCP-LEVEL allowed to be selected by auto level selection. Must be a valid HDCP-LEVEL value ('NONE', 'TYPE-0', 'TYPE-1', 'TYPE-2'), or null (default). `hls.maxHdcpLevel` is automatically set to the next lowest value when a `KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED` error occurs. To prevent manual selection of levels with specific HDCP-LEVEL attribute values, use `hls.removeLevel()` on `MANIFEST_LOADED` or on error.
+
+Default value is null (no level capping based on HDCP-LEVEL)
+
 ### `hls.capLevelToPlayerSize`
 
 - get: Enables or disables level capping. If disabled after previously enabled, `nextLevelSwitch` will be immediately called.
@@ -1432,7 +1439,7 @@ get: Returns the current bandwidth estimate in bits/s, if available. Otherwise, 
 
 ### `hls.removeLevel(levelIndex, urlId)`
 
-Remove a loaded level from the list of levels, or a level url in from a list of redundant level urls.
+Remove a loaded level from the list of levels, or a url from a level's list of redundant urls.
 This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user
 or hls.js can choose from.
 

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -11,7 +11,7 @@ import {
   ErrorData,
   LevelSwitchingData,
 } from '../types/events';
-import { Level } from '../types/level';
+import { HdcpLevel, HdcpLevels, Level } from '../types/level';
 import { Events } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { isCodecSupportedInMp4 } from '../utils/codecs';
@@ -162,8 +162,27 @@ export default class LevelController extends BasePlaylistController {
     if (levels.length > 0) {
       // start bitrate is the first bitrate of the manifest
       bitrateStart = levels[0].bitrate;
-      // sort level on bitrate
-      levels.sort((a, b) => a.bitrate - b.bitrate);
+      // sort levels from lowest to highest
+      levels.sort((a, b) => {
+        if (a.attrs['HDCP-LEVEL'] !== b.attrs['HDCP-LEVEL']) {
+          return (a.attrs['HDCP-LEVEL'] || '') > (b.attrs['HDCP-LEVEL'] || '')
+            ? 1
+            : -1;
+        }
+        if (a.bitrate !== b.bitrate) {
+          return a.bitrate - b.bitrate;
+        }
+        if (a.attrs.SCORE !== b.attrs.SCORE) {
+          return (
+            a.attrs.decimalFloatingPoint('SCORE') -
+            b.attrs.decimalFloatingPoint('SCORE')
+          );
+        }
+        if (resolutionFound && a.height !== b.height) {
+          return a.height - b.height;
+        }
+        return 0;
+      });
       this._levels = levels;
       // find index of first level in sorted levels
       for (let i = 0; i < levels.length; i++) {
@@ -364,9 +383,21 @@ export default class LevelController extends BasePlaylistController {
           }
         }
         break;
+      case ErrorDetails.KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED: {
+        const restrictedHdcpLevel = level.attrs['HDCP-LEVEL'];
+        if (restrictedHdcpLevel) {
+          this.hls.maxHdcpLevel =
+            HdcpLevels[
+              HdcpLevels.indexOf(restrictedHdcpLevel as HdcpLevel) - 1
+            ];
+          this.warn(
+            `Restricting playback to HDCP-LEVEL of "${this.hls.maxHdcpLevel}" or lower`
+          );
+        }
+      }
+      // eslint-disable-next-line no-fallthrough
       case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.KEY_SYSTEM_NO_SESSION:
-      case ErrorDetails.KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED:
         levelIndex =
           data.frag?.type === PlaylistLevelType.MAIN
             ? data.frag.level

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -18,6 +18,7 @@ export interface LevelParsed {
 }
 
 export interface LevelAttributes extends AttrList {
+  'ALLOWED-CPC'?: string;
   AUDIO?: string;
   AUTOSELECT?: string;
   'AVERAGE-BANDWIDTH'?: string;
@@ -29,14 +30,21 @@ export interface LevelAttributes extends AttrList {
   DEFAULT?: string;
   FORCED?: string;
   'FRAME-RATE'?: string;
+  'HDCP-LEVEL'?: string;
   LANGUAGE?: string;
   NAME?: string;
+  'PATHWAY-ID'?: string;
   'PROGRAM-ID'?: string;
   RESOLUTION?: string;
+  SCORE?: string;
   SUBTITLES?: string;
   TYPE?: string;
   URI?: string;
+  'VIDEO-RANGE'?: string;
 }
+
+export const HdcpLevels = ['NONE', 'TYPE-0', 'TYPE-1', 'TYPE-2', null] as const;
+export type HdcpLevel = typeof HdcpLevels[number];
 
 export enum HlsSkip {
   No = '',


### PR DESCRIPTION
### This PR will...
- Implement `hls.maxHdcpLevel` getter/setter API for HDCP-LEVEL capping and EME error handling.
- Sort levels primarily by HDCP level, followed by `bitrate` (AVERAGE-BANDWIDTH or BANDWIDTH - this is the current behavior), followed by SCORE, followed by RESOLUTION (height).

### Why is this Pull Request needed?
Allows for playback of DRM protected streams with HDCP restriction to recover from output-restricted EME Key errors (`ErrorDetails.KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED`).

### Are there any points in the code the reviewer needs to double check?
1. Setting `hls.maxHdcpLevel` does not prevent levels from being manually selected by setting one of the manual level selection setters. Use `hls.removeLevel()` to remove all levels of a particular HDCP-LEVEL as selection options.
2. Setting `hls.maxHdcpLevel` does not immediately force a level change.  To do do, set `hls.currentLevel` to `-1` after setting `hls.maxHdcpLevel`.
3. Levels will not be sorted in bitrate order when variants with lower HDCP-LEVELs have higher BANDWIDTH values than their counterparts with higher HDCP-LEVELs. As this will typically only the be the case with variants containing different codecs it should not present a problem bitrate adaptation which is currently restricted to the renditions using the compatible codecs.

### Resolves issues:
- Resolves #4923
- Closes #4966

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
