### PR TITLE
Prioritize MP4 demux probe over MPEG-TS

### DIFF
--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -26,14 +26,14 @@ try {
 }
 
 type MuxConfig =
-  | { demux: typeof TSDemuxer; remux: typeof MP4Remuxer }
   | { demux: typeof MP4Demuxer; remux: typeof PassThroughRemuxer }
+  | { demux: typeof TSDemuxer; remux: typeof MP4Remuxer }
   | { demux: typeof AACDemuxer; remux: typeof MP4Remuxer }
   | { demux: typeof MP3Demuxer; remux: typeof MP4Remuxer };
 
 const muxConfig: MuxConfig[] = [
-  { demux: TSDemuxer, remux: MP4Remuxer },
   { demux: MP4Demuxer, remux: PassThroughRemuxer },
+  { demux: TSDemuxer, remux: MP4Remuxer },
   { demux: AACDemuxer, remux: MP4Remuxer },
   { demux: MP3Demuxer, remux: MP4Remuxer },
 ];


### PR DESCRIPTION
### This PR will...
Prioritize MP4 demux probe over MPEG-TS.

### Why is this Pull Request needed?
I found MP4 segments containing 2 TS sync bytes (0x47) exactly one TS packet apart (188 bytes). They're not at the start of the stream but since we allow for some scanning of segment bytes this could make HLS.js treat mp4 segments as TS segment resulting in playback failure.

HLS.js should start with the more robust mp4 probe that looks for a moov atom before looking for TS packets.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
