### PR TITLE
Parse TARGETDURATION as a decimal-integer assigned a minimum value of 1

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -348,7 +348,7 @@ export default class M3U8Parser {
             break;
           }
           case 'TARGETDURATION':
-            level.targetduration = parseFloat(value1);
+            level.targetduration = Math.max(parseInt(value1), 1);
             break;
           case 'VERSION':
             level.version = parseInt(value1);

--- a/tests/unit/loader/playlist-loader.ts
+++ b/tests/unit/loader/playlist-loader.ts
@@ -312,6 +312,36 @@ http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/
     expect(result.totalduration).to.equal(0);
   });
 
+  it('TARGETDURATION is a decimal-integer', function () {
+    const level = `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:2.5`;
+    const result = M3U8Parser.parseLevelPlaylist(
+      level,
+      'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',
+      0,
+      PlaylistLevelType.MAIN,
+      0
+    );
+    expect(result.targetduration).to.equal(2);
+  });
+
+  it('TARGETDURATION is a decimal-integer which HLS.js assigns a minimum value of 1', function () {
+    const level = `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:0.5`;
+    const result = M3U8Parser.parseLevelPlaylist(
+      level,
+      'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',
+      0,
+      PlaylistLevelType.MAIN,
+      0
+    );
+    expect(result.targetduration).to.equal(1);
+  });
+
   it('parse level with several fragments', function () {
     const level = `#EXTM3U
 #EXT-X-VERSION:3


### PR DESCRIPTION
### This PR will...

Parse TARGETDURATION as a decimal-integer assigned a minimum value of 1.

### Why is this Pull Request needed?

TARGETDURATION is defined as an upper bound on the duration of all Media Segments in the Playlist. HLS.js already only matches the decimal-integer portion of this tags value [here](https://github.com/video-dev/hls.js/blob/v1.3.0/src/loader/m3u8-parser.ts#L47) (`TARGETDURATION|VERSION): *(\d+)/`).

If an Media Playlist provides a sub-second value, HLS.js should use a value of 1 to avoid any errors in handling live playlist reload (#4464).

### Are there any points in the code the reviewer needs to double check?

`computeReloadInterval` already uses the last segment duration when shorter than target duration and near live edge. 

### Resolves issues:
Follow up on #4464

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
