### PR TITLE
Light build optimizations and fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -324,7 +324,9 @@ export const hlsDefaultConfig: HlsConfig = {
   widevineLicenseUrl: undefined, // used by eme-controller
   drmSystems: {}, // used by eme-controller
   drmSystemOptions: {}, // used by eme-controller
-  requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
+  requestMediaKeySystemAccessFunc: __USE_EME_DRM__
+    ? requestMediaKeySystemAccess
+    : null, // used by eme-controller
   testBandwidth: true,
   progressive: false,
   lowLatencyMode: true,

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -134,7 +134,7 @@ export default class BufferController implements ComponentAPI {
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
     let codecEvents: number = 2;
-    if ((data.audio && !data.video) || !data.altAudio) {
+    if ((data.audio && !data.video) || !data.altAudio || !__USE_ALT_AUDIO__) {
       codecEvents = 1;
     }
     this.bufferCodecEventsExpected = this._bufferCodecEventsTotal = codecEvents;

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -60,22 +60,24 @@ export class LevelKey implements DecryptData {
       if (this.method === 'AES-128' || this.method === 'NONE') {
         return true;
       }
-      switch (this.keyFormat) {
-        case 'identity':
-          // Maintain support for clear SAMPLE-AES with MPEG-3 TS
-          return this.method === 'SAMPLE-AES';
-        case KeySystemFormats.FAIRPLAY:
-        case KeySystemFormats.WIDEVINE:
-        case KeySystemFormats.PLAYREADY:
-        case KeySystemFormats.CLEARKEY:
-          return (
-            [
-              'ISO-23001-7',
-              'SAMPLE-AES',
-              'SAMPLE-AES-CENC',
-              'SAMPLE-AES-CTR',
-            ].indexOf(this.method) !== -1
-          );
+      if (this.keyFormat === 'identity') {
+        // Maintain support for clear SAMPLE-AES with MPEG-3 TS
+        return this.method === 'SAMPLE-AES';
+      } else if (__USE_EME_DRM__) {
+        switch (this.keyFormat) {
+          case KeySystemFormats.FAIRPLAY:
+          case KeySystemFormats.WIDEVINE:
+          case KeySystemFormats.PLAYREADY:
+          case KeySystemFormats.CLEARKEY:
+            return (
+              [
+                'ISO-23001-7',
+                'SAMPLE-AES',
+                'SAMPLE-AES-CENC',
+                'SAMPLE-AES-CTR',
+              ].indexOf(this.method) !== -1
+            );
+        }
       }
     }
     return false;
@@ -108,6 +110,10 @@ export class LevelKey implements DecryptData {
         iv
       );
       return decryptdata;
+    }
+
+    if (!__USE_EME_DRM__) {
+      return this;
     }
 
     // Initialize keyId if possible

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -611,7 +611,7 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
 
   const entries = Object.entries(streams);
   if (HlsjsLightBuild) {
-    entries.length = 1;
+    entries.length = 10;
   }
 
   entries

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,7 @@ function getAliasesForLightDist() {
   if (!addEMESupport) {
     aliases = Object.assign({}, aliases, {
       './controller/eme-controller': './empty.js',
+      './utils/mediakeys-helper': './empty.js',
     });
   }
 
@@ -238,14 +239,12 @@ const multiConfig = [
       ...mainPlugins,
       new webpack.DefinePlugin({
         __NETLIFY__: JSON.stringify(
-          process.env.NETLIFY === 'true'
+          env.NETLIFY === 'true'
             ? {
-                branch: process.env.BRANCH,
-                commitRef: process.env.COMMIT_REF,
+                branch: env.BRANCH,
+                commitRef: env.COMMIT_REF,
                 reviewID:
-                  process.env.PULL_REQUEST === 'true'
-                    ? parseInt(process.env.REVIEW_ID)
-                    : null,
+                  env.PULL_REQUEST === 'true' ? parseInt(env.REVIEW_ID) : null,
               }
             : {}
         ),


### PR DESCRIPTION
### This PR will...
- Reduce hls.light build size by removing level-key,  mediakeys-helper and `requestMediaKeySystemAccess` code
- Fix: Allow hls.light to play Variant Playlist content while ignoring audio Media Playlists (buffer-controller expected 2 bufferCodec events, preventing playback from starting)
  - Increase number of functional tests for hls.light build to cover this case

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
