### PR TITLE
Error on unsupported media

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1500,7 +1500,7 @@ export default class BaseStreamController
         `Found no media in fragment ${frag.sn} of level ${level.id} resetting transmuxer to fallback to playlist timing`
       );
       this.fragLoadError++;
-      const penalizeLevel = this.fragLoadError > 3;
+      const penalizeLevel = this.fragLoadError > config.fragLoadingMaxRetry;
       this.hls.trigger(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.FRAG_PARSING_ERROR,

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -403,8 +403,10 @@ export default class LevelController extends BasePlaylistController {
           data.frag?.type === PlaylistLevelType.MAIN
             ? data.frag.level
             : this.currentLevelIndex;
-        // Do not retry level. Escalate to fatal if switching levels fails.
-        data.levelRetry = false;
+        if (data.levelRetry !== true) {
+          // Do not retry level. Escalate to fatal if switching levels fails.
+          data.levelRetry = false;
+        }
         break;
       case ErrorDetails.LEVEL_LOAD_ERROR:
       case ErrorDetails.LEVEL_LOAD_TIMEOUT:

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -412,11 +412,15 @@ export default class Transmuxer {
       }
     }
     if (!mux) {
-      // If probing previous configs fail, use mp4 passthrough
-      logger.warn(
-        'Failed to find demuxer by probing frag, treating as mp4 passthrough'
-      );
-      mux = { demux: MP4Demuxer, remux: PassThroughRemuxer };
+      this.demuxer = undefined;
+      this.remuxer = undefined;
+      this.observer.emit(Events.ERROR, Events.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.FRAG_PARSING_ERROR,
+        fatal: true,
+        reason: 'Failed to find demuxer by probing frag',
+      });
+      return;
     }
     // so let's check that current remuxer and demuxer are still valid
     const demuxer = this.demuxer;


### PR DESCRIPTION
### This PR will...
Error when media probing fails, as well as when probing segments fails three times in a row.

### Why is this Pull Request needed?
HLS.js should error on bad or unsupported streams after 1-3 failed segment parsing attempts.

### Are there any points in the code the reviewer needs to double check?
HLS.js would ignore any number of empty segments prior to this change, potentially loading an entire playlist of media with no samples. Now, only three consecutive failures will be allowed. 

Any probe attempt that fails will fail immediately. This change could be removed, in favor of falling back to the empty error that still advances through the playlist up to three times.

### Resolves issues:
Fixes #5011

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
