### PR TITLE
Support partial RENDITION-REPORT URI matches fallback

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -80,7 +80,8 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           );
           uri = attr.URI || '';
         }
-        // Return exact match, or if none, partial when playlist url included query params
+        // Use exact match. Otherwise, the last partial match, if any, will be used
+        // (Playlist URI includes a query string that the Rendition Report does not)
         if (uri === playlistUri) {
           foundIndex = i;
           break;

--- a/tests/unit/controller/base-stream-controller.ts
+++ b/tests/unit/controller/base-stream-controller.ts
@@ -1,33 +1,34 @@
-import BaseStreamController from '../../../src/controller/stream-controller';
 import Hls from '../../../src/hls';
+import { hlsDefaultConfig } from '../../../src/config';
+import BaseStreamController from '../../../src/controller/stream-controller';
+import KeyLoader from '../../../src/loader/key-loader';
 import { TimeRangesMock } from '../../mocks/time-ranges.mock';
+import type { BufferInfo } from '../../../src/utils/buffer-helper';
+import type { Fragment, LevelDetails, Part } from '../../../src/hls';
+
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+type BaseStreamControllerTestable = Omit<
+  BaseStreamController,
+  'media' | '_streamEnded'
+> & {
+  media: HTMLMediaElement | null;
+  _streamEnded: (bufferInfo: BufferInfo, levelDetails: LevelDetails) => boolean;
+};
 
 describe('BaseStreamController', function () {
-  let baseStreamController;
-  let bufferInfo;
-  let levelDetails;
+  let hls: Hls;
+  let baseStreamController: BaseStreamControllerTestable;
+  let bufferInfo: BufferInfo;
+  let levelDetails: LevelDetails;
   let fragmentTracker;
   let media;
   beforeEach(function () {
-    baseStreamController = new BaseStreamController(new Hls({}));
-    bufferInfo = {
-      nextStart: 0,
-      end: 1,
-    };
-    levelDetails = {
-      endSN: 0,
-      live: false,
-      get fragments() {
-        const frags = [];
-        for (let i = 0; i < this.endSN; i++) {
-          frags.push({ sn: i, type: 'main' });
-        }
-        return frags;
-      },
-    };
-    media = {
-      duration: 0,
-    };
+    hls = new Hls({});
     fragmentTracker = {
       state: null,
       getState() {
@@ -37,8 +38,33 @@ describe('BaseStreamController', function () {
         return true;
       },
     };
+    baseStreamController = new BaseStreamController(
+      hls,
+      fragmentTracker,
+      new KeyLoader(hlsDefaultConfig)
+    ) as unknown as BaseStreamControllerTestable;
+    bufferInfo = {
+      len: 1,
+      nextStart: 0,
+      start: 0,
+      end: 1,
+    };
+    levelDetails = {
+      endSN: 0,
+      live: false,
+      get fragments() {
+        const frags: Fragment[] = [];
+        for (let i = 0; i < this.endSN; i++) {
+          frags.push({ sn: i, type: 'main' } as unknown as Fragment);
+        }
+        return frags;
+      },
+    } as unknown as LevelDetails;
+    media = {
+      duration: 0,
+      buffered: new TimeRangesMock(),
+    } as unknown as HTMLMediaElement;
     baseStreamController.media = media;
-    baseStreamController.fragmentTracker = fragmentTracker;
   });
 
   describe('_streamEnded', function () {
@@ -58,7 +84,7 @@ describe('BaseStreamController', function () {
     it('returns true if parts are buffered for low latency content', function () {
       media.buffered = new TimeRangesMock([0, 1]);
       levelDetails.endSN = 10;
-      levelDetails.partList = [{ start: 0, duration: 1 }];
+      levelDetails.partList = [{ start: 0, duration: 1 } as unknown as Part];
 
       expect(baseStreamController._streamEnded(bufferInfo, levelDetails)).to.be
         .true;

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -4,7 +4,9 @@ import { Events } from '../../../src/events';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import { Level } from '../../../src/types/level';
 import { AttrList } from '../../../src/utils/attr-list';
-
+import { PlaylistLevelType } from '../../../src/types/loader';
+import M3U8Parser from '../../../src/loader/m3u8-parser';
+import type { LevelDetails } from '../../../src/loader/level-details';
 import type {
   ManifestLoadedData,
   ManifestParsedData,
@@ -21,6 +23,14 @@ import * as sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 const expect = chai.expect;
+
+type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
+  onManifestLoaded: (event: string, data: Partial<ManifestLoadedData>) => void;
+  switchParams: (
+    playlistUri: string,
+    previous: LevelDetails | undefined
+  ) => void;
+};
 
 function parsedLevel(
   options: Partial<LevelParsed> & { bitrate: number }
@@ -49,19 +59,19 @@ function mediaPlaylist(options: Partial<MediaPlaylist>): MediaPlaylist {
 describe('LevelController', function () {
   const sandbox = sinon.createSandbox();
   let hls;
-  let levelController;
+  let levelController: LevelControllerTestable;
   let triggerSpy;
 
   beforeEach(function () {
     hls = new HlsMock({}, sandbox);
-    levelController = new LevelController(hls);
+    levelController = new LevelController(
+      hls
+    ) as unknown as LevelControllerTestable;
     levelController.onParsedComplete = () => {};
     triggerSpy = hls.trigger;
   });
 
   afterEach(function () {
-    hls = null;
-    levelController = null;
     sandbox.restore();
   });
 
@@ -450,6 +460,104 @@ describe('LevelController', function () {
       expect(payload.video).to.equal(true);
       expect(payload.audio).to.equal(false);
       expect(payload.altAudio).to.equal(false);
+    });
+  });
+
+  describe('switchParams', function () {
+    const mediaPlaylist = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=3.000000
+#EXT-X-PART-INF:PART-TARGET=1.000000
+#EXT-X-TARGETDURATION:3
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-PROGRAM-DATE-TIME:2023-01-20T08:21:50.887Z
+#EXTINF:3.000000,
+vfrag2500.stream_3153718435_1674202910887_4_0_1.m4v?type=hls&bitrate=193521&filetype=.m4v
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_1351418703_1674202913887_7_0_2_0.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_1351418703_1674202913887_7_0_2_1.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_1351418703_1674202913887_7_0_2_2.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXTINF:3.000000,
+vfrag2500.stream_1351418703_1674202913887_7_0_2.m4v?type=hls&bitrate=209021&filetype=.m4v
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_1875648429_1674202916887_10_0_3_0.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_1875648429_1674202916887_10_0_3_1.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_1875648429_1674202916887_10_0_3_2.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXTINF:3.000000,
+vfrag2500.stream_1875648429_1674202916887_10_0_3.m4v?type=hls&bitrate=200661&filetype=.m4v
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_3900694400_1674202919887_13_0_4_0.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXT-X-PART:DURATION=1.000000,URI="vfrag2500.stream_3900694400_1674202919887_13_0_4_1.m4v?type=hls&mode=cmaf&filetype=.m4v",INDEPENDENT=YES
+#EXT-X-PRELOAD-HINT:TYPE=PART,URI="vfrag2500.stream_3900694400_1674202919887_13_0_4_2.m4v?type=hls&mode=cmaf&filetype=.m4v"
+#EXT-X-RENDITION-REPORT:URI="chunklist_vfrag1500.m3u8",LAST-MSN=4,LAST-PART=1
+#EXT-X-RENDITION-REPORT:URI="chunklist_vfrag400.m3u8",LAST-MSN=4,LAST-PART=1
+#EXT-X-RENDITION-REPORT:URI="chunklist_vfrag100.m3u8",LAST-MSN=4,LAST-PART=1`;
+
+    it('returns RENDITION-REPORT query values for the selected playlist URI', function () {
+      const levelDetails = M3U8Parser.parseLevelPlaylist(
+        mediaPlaylist,
+        'http://example.com/playlist.m3u8?abc=deg',
+        0,
+        PlaylistLevelType.MAIN,
+        0,
+        {}
+      );
+      const selectedUri = 'http://example.com/chunklist_vfrag1500.m3u8';
+      const hlsUrlParameters = levelController.switchParams(
+        selectedUri,
+        levelDetails
+      );
+      expect(hlsUrlParameters).to.have.property('msn').which.equals(4);
+      expect(hlsUrlParameters).to.have.property('part').which.equals(1);
+      expect(hlsUrlParameters).to.have.property('skip').which.equals('');
+    });
+
+    it('returns RENDITION-REPORT query values for the selected playlist URI with additional query params', function () {
+      const levelDetails = M3U8Parser.parseLevelPlaylist(
+        mediaPlaylist,
+        'http://example.com/playlist.m3u8?abc=deg',
+        0,
+        PlaylistLevelType.MAIN,
+        0,
+        {}
+      );
+      const selectedUriWithQuery =
+        'http://example.com/chunklist_vfrag1500.m3u8?abc=123';
+      const hlsUrlParameters = levelController.switchParams(
+        selectedUriWithQuery,
+        levelDetails
+      );
+      expect(hlsUrlParameters).to.not.be.undefined;
+      expect(hlsUrlParameters).to.have.property('msn').which.equals(4);
+      expect(hlsUrlParameters).to.have.property('part').which.equals(1);
+      expect(hlsUrlParameters).to.have.property('skip').which.equals('');
+    });
+
+    it('returns RENDITION-REPORT exact URI match over partial match for playlist URIs with additional query params', function () {
+      const levelDetails = M3U8Parser.parseLevelPlaylist(
+        `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES
+#EXT-X-TARGETDURATION:3
+#EXTINF:3.0,
+#EXTINF:3.0,
+#EXTINF:3.0,
+#EXT-X-RENDITION-REPORT:URI="chunklist.m3u8?token=1234",LAST-MSN=4
+#EXT-X-RENDITION-REPORT:URI="chunklist.m3u8?token=1",LAST-MSN=5
+#EXT-X-RENDITION-REPORT:URI="chunklist.m3u8?token=123",LAST-MSN=6
+#EXT-X-RENDITION-REPORT:URI="chunklist.m3u8?token=foo",LAST-MSN=7
+#EXT-X-RENDITION-REPORT:URI="chunklist.m3u8",LAST-MSN=8`,
+        'http://example.com/playlist.m3u8?abc=deg',
+        0,
+        PlaylistLevelType.MAIN,
+        0,
+        {}
+      );
+      const selectedUriWithQuery =
+        'http://example.com/chunklist.m3u8?token=123';
+      const hlsUrlParameters = levelController.switchParams(
+        selectedUriWithQuery,
+        levelDetails
+      );
+      expect(hlsUrlParameters).to.not.be.undefined;
+      expect(hlsUrlParameters).to.have.property('msn').which.equals(6);
     });
   });
 });


### PR DESCRIPTION
### This PR will...
When performing a switch, if no exact URI match to a RENDITION-REPORT is found, use the last RENDITION-REPORT URI that matches the target Playlist URI from start to Rendition URI length.

### Why is this Pull Request needed?
Switches will be performed using RENDITION-REPORT Delivery Directives when Media Playlist URI has a query string, and the RENDITION-REPORT URI does not.

### Are there any points in the code the reviewer needs to double check?
It could be worth considering simply using the current Playlist's last msn and part index when a matching RENDITION-REPORT cannot be found. A failed attempt would fall back to a request without Delivery Directives. However, the player should avoid making requests that could cause errors to get cached on edge servers.

### Resolves issues:
Fixes #5174

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
