### PR TITLE
fix Netlify redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:watch": "webpack --progress --env debug --env demo --watch",
     "build:types": "tsc --build tsconfig-lib.json && api-extractor run --local",
     "dev": "webpack serve --progress --env debug --env demo --port 8000 --static .",
-    "docs": "doctoc ./docs/API.md && api-documenter markdown -i api-extractor -o api-extractor/api-documenter && npm run docs-md-to-html",
+    "docs": "doctoc ./docs/API.md && api-documenter markdown -i api-extractor -o api-extractor/api-documenter && rm api-extractor/api-documenter/index.md && npm run docs-md-to-html",
     "docs-md-to-html": "generate-md --layout github --input api-extractor/api-documenter --output api-docs",
     "lint": "eslint src/ tests/ --ext .js --ext .ts",
     "lint:fix": "npm run lint -- --fix",

--- a/scripts/build-netlify.sh
+++ b/scripts/build-netlify.sh
@@ -11,6 +11,7 @@ echo "Building netlify..."
 # redirect / to /demo
 echo "/ /demo" > "$root/_redirects"
 echo "/api-docs/ /api-docs/hls.js.hls.html" >> "$root/_redirects"
+echo "/api-docs/index.html /api-docs/hls.js.hls.html" >> "$root/_redirects"
 cp -r "./dist" "$root/dist"
 cp -r "./demo" "$root/demo"
 cp -r "./api-docs" "$root/api-docs"

--- a/scripts/build-netlify.sh
+++ b/scripts/build-netlify.sh
@@ -10,7 +10,6 @@ echo "Building netlify..."
 
 # redirect / to /demo
 echo "/ /demo" > "$root/_redirects"
-echo "/api-docs/ /api-docs/hls.js.hls.html" >> "$root/_redirects"
 cp -r "./dist" "$root/dist"
 cp -r "./demo" "$root/demo"
 cp -r "./api-docs" "$root/api-docs"

--- a/scripts/build-netlify.sh
+++ b/scripts/build-netlify.sh
@@ -10,7 +10,7 @@ echo "Building netlify..."
 
 # redirect / to /demo
 echo "/ /demo" > "$root/_redirects"
-echo "/api-docs /api-docs/hls.js.hls.html" > "$root/_redirects"
+echo "/api-docs/ /api-docs/hls.js.hls.html" >> "$root/_redirects"
 cp -r "./dist" "$root/dist"
 cp -r "./demo" "$root/demo"
 cp -r "./api-docs" "$root/api-docs"

--- a/scripts/build-netlify.sh
+++ b/scripts/build-netlify.sh
@@ -10,6 +10,7 @@ echo "Building netlify..."
 
 # redirect / to /demo
 echo "/ /demo" > "$root/_redirects"
+echo "/api-docs/ /api-docs/hls.js.hls.html" >> "$root/_redirects"
 cp -r "./dist" "$root/dist"
 cp -r "./demo" "$root/demo"
 cp -r "./api-docs" "$root/api-docs"


### PR DESCRIPTION
### This PR will...

Fix Netlify root redirect. The problem was the second line to setup the api-docs redirect was replacing the file contents instead of appending (`>>`).

Second reason it wasn't working is because netlify won't redirect by default if a file already exists, so now we delete the index file.

### Why is this Pull Request needed?
New commit deployments and https://hls-js-dev.netlify.com/ go to a 404 at the root and api docs redirect doesn’t work