### PR TITLE
MPEG-TS probe improvement

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -98,14 +98,24 @@ class TSDemuxer implements Demuxer {
     return syncOffset !== -1;
   }
 
-  static syncOffset(data: Uint8Array) {
+  static syncOffset(data: Uint8Array): number {
     const scanwindow =
-      Math.min(PACKET_LENGTH * 5, data.length - PACKET_LENGTH * 2) + 1;
+      Math.min(PACKET_LENGTH * 5, data.length - PACKET_LENGTH) + 1;
     let i = 0;
     while (i < scanwindow) {
       // a TS init segment should contain at least 2 TS packets: PAT and PMT, each starting with 0x47
-      if (data[i] === 0x47 && data[i + PACKET_LENGTH] === 0x47) {
-        return i;
+      let foundPat = false;
+      for (let j = 0; j < scanwindow; j += PACKET_LENGTH) {
+        if (data[j] === 0x47) {
+          if (!foundPat && parsePID(data, j) === 0) {
+            foundPat = true;
+          }
+          if (foundPat && j + PACKET_LENGTH > scanwindow) {
+            return i;
+          }
+        } else {
+          break;
+        }
       }
       i++;
     }
@@ -245,8 +255,7 @@ class TSDemuxer implements Demuxer {
     for (let start = syncOffset; start < len; start += PACKET_LENGTH) {
       if (data[start] === 0x47) {
         const stt = !!(data[start + 1] & 0x40);
-        // pid is a 13-bit field starting at the last bit of TS[1]
-        const pid = ((data[start + 1] & 0x1f) << 8) + data[start + 2];
+        const pid = parsePID(data, start);
         const atf = (data[start + 3] & 0x30) >> 4;
 
         // if an adaption field is present, its length is specified by the fifth byte of the TS packet header.
@@ -312,6 +321,7 @@ class TSDemuxer implements Demuxer {
             }
 
             pmtId = this._pmtId = parsePAT(data, offset);
+            // logger.log('PMT PID:'  + this._pmtId);
             break;
           case pmtId: {
             if (stt) {
@@ -355,7 +365,7 @@ class TSDemuxer implements Demuxer {
             pmtParsed = this.pmtParsed = true;
             break;
           }
-          case 17:
+          case 0x11:
           case 0x1fff:
             break;
           default:
@@ -988,13 +998,22 @@ function createAVCSample(
   };
 }
 
-function parsePAT(data, offset) {
-  // skip the PSI header and parse the first PMT entry
-  return ((data[offset + 10] & 0x1f) << 8) | data[offset + 11];
-  // logger.log('PMT PID:'  + this._pmtId);
+function parsePID(data: Uint8Array, offset: number): number {
+  // pid is a 13-bit field starting at the last bit of TS[1]
+  return ((data[offset + 1] & 0x1f) << 8) + data[offset + 2];
 }
 
-function parsePMT(data, offset, typeSupported, isSampleAes) {
+function parsePAT(data: Uint8Array, offset: number): number {
+  // skip the PSI header and parse the first PMT entry
+  return ((data[offset + 10] & 0x1f) << 8) | data[offset + 11];
+}
+
+function parsePMT(
+  data: Uint8Array,
+  offset: number,
+  typeSupported: TypeSupported,
+  isSampleAes: boolean
+) {
   const result = { audio: -1, avc: -1, id3: -1, segmentCodec: 'aac' };
   const sectionLength = ((data[offset + 1] & 0x0f) << 8) | data[offset + 2];
   const tableEnd = offset + 3 + sectionLength - 4;
@@ -1005,7 +1024,7 @@ function parsePMT(data, offset, typeSupported, isSampleAes) {
   // advance the offset to the first entry in the mapping table
   offset += 12 + programInfoLength;
   while (offset < tableEnd) {
-    const pid = ((data[offset + 1] & 0x1f) << 8) | data[offset + 2];
+    const pid = parsePID(data, offset);
     switch (data[offset]) {
       case 0xcf: // SAMPLE-AES AAC
         if (!isSampleAes) {


### PR DESCRIPTION
### This PR will...
To prevent false positives in TSDemuxer probe check that all packets in scan window begin with start byte, and confirm that PAT PID is found.

### Why is this Pull Request needed?
Audio files may contain 0x47 byte 188 bytes apart within scan window.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5183

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
