### PR TITLE
Fix bitrate test with variants under ~500kbps

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -506,11 +506,13 @@ export default class BaseStreamController
         part ? ' part: ' + part.index : ''
       } of ${this.logPrefix === '[stream-controller]' ? 'level' : 'track'} ${
         frag.level
-      } ${
+      } (frag:[${(frag.startPTS || NaN).toFixed(3)}-${(
+        frag.endPTS || NaN
+      ).toFixed(3)}] > buffer:${
         media
           ? TimeRanges.toString(BufferHelper.getBuffered(media))
           : '(detached)'
-      }`
+      })`
     );
     this.state = State.IDLE;
     if (!media) {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -583,7 +583,7 @@ export default class LevelController extends BasePlaylistController {
 
       this.log(
         `Attempt loading level index ${level}${
-          hlsUrlParameters
+          hlsUrlParameters?.msn !== undefined
             ? ' at sn ' +
               hlsUrlParameters.msn +
               ' part ' +

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1029,7 +1029,7 @@ export default class StreamController
     frag.bitrateTest = true;
     this._doFragLoad(frag, levelDetails).then((data) => {
       const { hls } = this;
-      if (!data || hls.nextLoadLevel || this.fragContextChanged(frag)) {
+      if (!data || this.fragContextChanged(frag)) {
         return;
       }
       this.fragLoadError = 0;

--- a/src/utils/time-ranges.ts
+++ b/src/utils/time-ranges.ts
@@ -7,7 +7,7 @@ const TimeRanges = {
     let log = '';
     const len = r.length;
     for (let i = 0; i < len; i++) {
-      log += '[' + r.start(i).toFixed(3) + ',' + r.end(i).toFixed(3) + ']';
+      log += `[${r.start(i).toFixed(3)}-${r.end(i).toFixed(3)}]`;
     }
 
     return log;


### PR DESCRIPTION
### This PR will...
Remove the `hls.nextLoadLevel` check that blocks bitrate test fragment loading from completing.

Also improves log lines:
- `Attempt loading level index` (removes LL-HLS msn and part directives when none are added)
- `stream-controller]: Buffered` (includes fragment time range as compared to buffered time range `(frag:[210.001-220.066] > buffer:[100.066-220.009])`)

### Why is this Pull Request needed?
When HLS Playlists include Variants under ~500kbps, a value higher than `0` for `hls.nextLoadLevel` is returned blocking the bitrate test from completing. 

### Are there any points in the code the reviewer needs to double check?
The purpose of the check was lost after https://github.com/video-dev/hls.js/blame/5d532bde70f188263bef2661090ecd7d740d8910/src/controller/stream-controller.js#L847 and likely went unchecked because a `hls.nextLoadLevel` of `0` is expected if the second lowest bitrate is around 500kbps (460560 on BB test clip and `hls.nextLoadLevel` always returns 0 before the test completes).

### Resolves issues:
Fixes #5189

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
