### PR TITLE
Log error and detach if MediaSource 'sourceopen' is interrupted

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -814,9 +814,8 @@ export default class BufferController implements ComponentAPI {
     const { media, _objectUrl } = this;
     if (media && media.src !== _objectUrl) {
       logger.error(
-        `Media reset while attaching MediaSource, detaching media (${_objectUrl} > ${media.src})`
+        `Media element src was set while attaching MediaSource (${_objectUrl} > ${media.src})`
       );
-      this.hls.detachMedia();
     }
   };
 

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -61,6 +61,8 @@ class MockMediaElement {
   public currentTime: number = 0;
   public duration: number = Infinity;
   public textTracks: any[] = [];
+  addEventListener() {}
+  removeEventListener() {}
 }
 
 const queueNames: Array<SourceBufferName> = ['audio', 'video'];


### PR DESCRIPTION
### This PR will...
Listen for "emptied" event on media element while attaching MediaSource. If the media `src` attribute does not match the  object URL being attached log an error and detach the media element (this will emit MEDIA_DETACHING).

### Why is this Pull Request needed?
#4952 Users are unsure why calling `hls.attachMedia(HTMLMediaElement)` does not always resolve with the player emitting `MEDIA_ATTACHED` after MediaSource is attached and open. My best guess is that something is changing the video.src externally while attaching, which interrupts the MediaSource from dispatching the 'sourceopen' event HLS.js depends on to complete the attachMedia operation. 

With this change-set, `detachMedia` will be called if attaching the MediaSource is interrupted ("emptied" event with src change detected). The detaching event following an attach attempt could allow application to retry attaching.

For v2.0, `attachMedia` could be made to return a Promise, which resolved on attached and is rejected if interrupted or the media element errors.

### Resolves issues:
Resolves #4952

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
