### PR TITLE
do not use optional chain operator for functional tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,6 +309,7 @@ jobs:
     needs: [config, test_unit]
     if: needs.config.outputs.canUseSauce == 'true'
     runs-on: ubuntu-latest
+    name: test_functional_required (${{ matrix.config }})
     strategy:
       fail-fast: true
       max-parallel: 8
@@ -382,6 +383,7 @@ jobs:
     needs: test_functional_required
     runs-on: ubuntu-latest
     continue-on-error: true
+    name: test_functional_optional (${{ matrix.config }})
     strategy:
       fail-fast: false
       max-parallel: 8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,12 +313,18 @@ jobs:
       fail-fast: true
       max-parallel: 8
       matrix:
-        config: [chrome-win_10]
-
         include:
           - config: chrome-win_10
             ua: chrome
             os: Windows 10
+          - config: chrome-osx_10.11-79.0
+            ua: chrome
+            os: OS X 10.11
+            uaVersion: '79.0'
+          - config: chrome-win_7-75.0
+            ua: chrome
+            os: Windows 7
+            uaVersion: '75.0'
 
     steps:
       - uses: actions/checkout@v3
@@ -380,12 +386,6 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        config:
-          - safari-macOS_10.15
-          - firefox-win_10
-          - chrome-osx_10.11-79.0
-          - chrome-win_7-75.0
-
         include:
           - config: safari-macOS_10.15
             ua: safari
@@ -393,14 +393,6 @@ jobs:
           - config: firefox-win_10
             ua: firefox
             os: Windows 10
-          - config: chrome-osx_10.11-79.0
-            ua: chrome
-            os: OS X 10.11
-            uaVersion: '79.0'
-          - config: chrome-win_7-75.0
-            ua: chrome
-            os: Windows 7
-            uaVersion: '75.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -596,7 +596,7 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
   after(async function () {
     if (useSauce && this.currentTest && this.currentTest.parent) {
       const tests = this.currentTest.parent.tests;
-      if (tests?.length && tests.every((test) => test.isPassed())) {
+      if (tests && tests.length && tests.every((test) => test.isPassed())) {
         browser.executeScript('sauce:job-result=passed');
       }
     }
@@ -621,7 +621,8 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
       const url = stream.url;
       const config = stream.config || {};
       if (
-        stream.skip_ua?.some((browserInfo) => {
+        stream.skip_ua &&
+        stream.skip_ua.some((browserInfo) => {
           if (typeof browserInfo === 'string') {
             return browserInfo === browserConfig.name;
           }

--- a/tests/functional/auto/testbench.js
+++ b/tests/functional/auto/testbench.js
@@ -72,7 +72,7 @@ function objectAssign(target) {
     ) {
       var nextKey = keysArray[nextIndex];
       var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
-      if (desc?.enumerable) {
+      if (desc && desc.enumerable) {
         to[nextKey] = nextSource[nextKey];
       }
     }


### PR DESCRIPTION
### This PR will...

Stop using the optional chain operator for functional tests, and move the older chrome browser tests to the required list given they have been more stable recently, and would have caught this bug introduced in #5243 

### Why is this Pull Request needed?

Because they need to be es5 for older chrome.