### PR TITLE
set the git user email when updating deployments file

### DIFF
--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -37,7 +37,7 @@ git clone --depth 1 "https://${GITHUB_TOKEN}@github.com/video-dev/hls.js.git" -b
 cd "$root/deployments"
 echo "- [\`$idShort\`](https://github.com/video-dev/hls.js/commit/$id): [https://$commitSiteName.netlify.app/](https://$commitSiteName.netlify.app/)" >> "README.md"
 git add "README.md"
-git -c user.name="HLS.JS CI" commit -m "update for $id"
+git -c user.name="hlsjs-ci" -c user.email="40664919+hlsjs-ci@users.noreply.github.com" commit -m "update for $id"
 git push "https://${GITHUB_TOKEN}@github.com/video-dev/hls.js.git"
 cd ..
 echo "Updated deployments branch."


### PR DESCRIPTION
### This PR will...
Set the git user email when updating deployments file

### Why is this Pull Request needed?
Without this it tries to come up with a sensible default but recently this failed in https://github.com/video-dev/hls.js/actions/runs/4217828503/jobs/7321920416 with

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@fv-az581-156.(none)')
Error: Process completed with exit code 128.
```
I've set it to the email of the CI user it's actually using.