### PR TITLE
Fix M2TS probing when PAT packet is not found in first three packets

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -512,8 +512,8 @@ export default class BaseStreamController
         part ? ' part: ' + part.index : ''
       } of ${this.logPrefix === '[stream-controller]' ? 'level' : 'track'} ${
         frag.level
-      } (frag:[${(frag.startPTS || NaN).toFixed(3)}-${(
-        frag.endPTS || NaN
+      } (frag:[${(frag.startPTS ?? NaN).toFixed(3)}-${(
+        frag.endPTS ?? NaN
       ).toFixed(3)}] > buffer:${
         media
           ? TimeRanges.toString(BufferHelper.getBuffered(media))

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -99,13 +99,14 @@ class TSDemuxer implements Demuxer {
   }
 
   static syncOffset(data: Uint8Array): number {
+    const length = data.length;
     const scanwindow =
       Math.min(PACKET_LENGTH * 5, data.length - PACKET_LENGTH) + 1;
     let i = 0;
     while (i < scanwindow) {
       // a TS init segment should contain at least 2 TS packets: PAT and PMT, each starting with 0x47
       let foundPat = false;
-      for (let j = 0; j < scanwindow; j += PACKET_LENGTH) {
+      for (let j = i; j < length; j += PACKET_LENGTH) {
         if (data[j] === 0x47) {
           if (!foundPat && parsePID(data, j) === 0) {
             foundPat = true;
@@ -353,7 +354,9 @@ class TSDemuxer implements Demuxer {
             }
 
             if (unknownPID !== null && !pmtParsed) {
-              logger.log(`unknown PID '${unknownPID}' in TS found`);
+              logger.warn(
+                `MPEG-TS PMT found at ${start} after unknown PID '${unknownPID}'. Backtracking to sync byte @${syncOffset} to parse all TS packets.`
+              );
               unknownPID = null;
               // we set it to -188, the += 188 in the for loop will reset start to 0
               start = syncOffset - 188;


### PR DESCRIPTION
### This PR will...
Fix MPEG2-TS probing when PAT packet is not found in the first three packets.

### Why is this Pull Request needed?
Sometimes HLS assets with segmented M2TS streams have segments that do not begin with PAT and PMT packets. Despite this not being spec compliant it is widely supported. Recent changes to TS probing in v1.3 broke support for segments like this (#5251). 

### Are there any points in the code the reviewer needs to double check?

As long as we find a sync byte and every following 188 byte packet starts with the same sync byte, keep looking for the PAT packet before passing the probe test. TS segments without a PAT (and no MAP in the Playlist to provide it) are not usable. It's worth noting that HLS.js does not support M2TS MAP init segments or implicit init segments when byteranges are used, but this is only commonly found in I-FRAME Playlists which also remain unsupported.

### Resolves issues:
Fixes regression in #5251

### Checklist

- [x] changes have been done against master branch, and PR does not conflict