### PR TITLE
GAP Tag/Attribute Support with FRAG_GAP Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ The following properties are added to their respective variants' attribute list 
 - `#EXT-X-RENDITION-REPORT:<attribute-list>`
 - `#EXT-X-DATERANGE:<attribute-list>` Metadata
 - `#EXT-X-DEFINE:<attribute-list>` Variable Import and Substitution (`NAME,VALUE,IMPORT,QUERYPARAM` attributes)
+- `#EXT-X-GAP` (Skips loading GAP segments and parts. Skips playback of unbuffered program containing only GAP content and no suitable alternates. See [#2940](https://github.com/video-dev/hls.js/issues/2940))
 
 The following tags are added to their respective fragment's attribute list but are not implemented in streaming and playback.
 
 - `#EXT-X-BITRATE` (Not used in ABR controller)
-- `#EXT-X-GAP` (Not implemented. See [#2940](https://github.com/video-dev/hls.js/issues/2940))
 
 Parsed but missing feature support
 

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -991,6 +991,8 @@ export enum ErrorDetails {
     // (undocumented)
     FRAG_DECRYPT_ERROR = "fragDecryptError",
     // (undocumented)
+    FRAG_GAP = "fragGap",
+    // (undocumented)
     FRAG_LOAD_ERROR = "fragLoadError",
     // (undocumented)
     FRAG_LOAD_TIMEOUT = "fragLoadTimeOut",
@@ -1342,6 +1344,8 @@ export class Fragment extends BaseSegment {
     get endProgramDateTime(): number | null;
     // (undocumented)
     endPTS?: number;
+    // (undocumented)
+    gap?: boolean;
     // (undocumented)
     initSegment: Fragment | null;
     // Warning: (ae-forgotten-export) The symbol "KeyLoaderContext" needs to be exported by the entry point hls.d.ts

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -330,6 +330,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected getFwdBufferInfo(bufferable: Bufferable | null, type: PlaylistLevelType): BufferInfo | null;
     // (undocumented)
+    protected getFwdBufferInfoAtPos(bufferable: Bufferable | null, pos: number, type: PlaylistLevelType): BufferInfo | null;
+    // (undocumented)
     protected getInitialLiveFragment(levelDetails: LevelDetails, fragments: Array<Fragment>): Fragment | null;
     // (undocumented)
     protected getLevelDetails(): LevelDetails | undefined;
@@ -406,7 +408,9 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected recoverWorkerError(data: ErrorData): void;
     // (undocumented)
-    protected reduceMaxBufferLength(threshold?: number): boolean;
+    protected reduceLengthAndFlushBuffer(data: ErrorData): boolean;
+    // (undocumented)
+    protected reduceMaxBufferLength(threshold: number): boolean;
     // (undocumented)
     protected resetFragmentErrors(filterType: PlaylistLevelType): void;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1949,6 +1949,8 @@ export class Level {
     // (undocumented)
     readonly audioCodec: string | undefined;
     // (undocumented)
+    get audioGroupId(): string | undefined;
+    // (undocumented)
     audioGroupIds?: (string | undefined)[];
     // (undocumented)
     readonly bitrate: number;
@@ -1977,6 +1979,8 @@ export class Level {
     get pathwayId(): string;
     // (undocumented)
     realBitrate: number;
+    // (undocumented)
+    get textGroupId(): string | undefined;
     // (undocumented)
     textGroupIds?: (string | undefined)[];
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -342,6 +342,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected getNextFragment(pos: number, levelDetails: LevelDetails): Fragment | null;
     // (undocumented)
+    protected getNextFragmentLoopLoading(frag: Fragment, levelDetails: LevelDetails, bufferInfo: BufferInfo, playlistType: PlaylistLevelType, maxBufLen: number): Fragment | null;
+    // (undocumented)
     getNextPart(partList: Part[], frag: Fragment, targetBufferTime: number): number;
     // Warning: (ae-forgotten-export) The symbol "PartsLoadedData" needs to be exported by the entry point hls.d.ts
     //
@@ -357,6 +359,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     //
     // (undocumented)
     protected initPTS: RationalTimestamp[];
+    // (undocumented)
+    protected isLoopLoading(frag: Fragment, targetBufferTime: number): boolean;
     // (undocumented)
     protected keyLoader: KeyLoader;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1726,14 +1726,14 @@ Full list of errors is described below:
   - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.MANIFEST_LOAD_TIMEOUT`, fatal : `true`, url : manifest URL, loader : URL loader }
 - `Hls.ErrorDetails.MANIFEST_PARSING_ERROR` - raised when manifest parsing failed to find proper content
   - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.MANIFEST_PARSING_ERROR`, fatal : `true`, url : manifest URL, reason : parsing error reason }
-- `Hls.ErrorDetails.LEVEL_EMPTY_ERROR` - raised when loaded level contains no fragments
-  - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_EMPTY_ERROR`, url: playlist URL, reason: error reason, level: index of the bad level }
+- `Hls.ErrorDetails.LEVEL_EMPTY_ERROR` - raised when loaded level contains no fragments (applies to levels and audio and subtitle tracks)
+  - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_EMPTY_ERROR`, url: playlist URL, reason: error reason, level: index of the bad level or undefined, parent: PlaylistLevelType }
 - `Hls.ErrorDetails.LEVEL_LOAD_ERROR` - raised when level loading fails because of a network error
   - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_LOAD_ERROR`, fatal : `true`, url : level URL, response : { code: error code, text: error text }, loader : URL loader }
 - `Hls.ErrorDetails.LEVEL_LOAD_TIMEOUT` - raised when level loading fails because of a timeout
   - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_LOAD_TIMEOUT`, fatal : `false`, url : level URL, loader : URL loader }
-- `Hls.ErrorDetails.LEVEL_PARSING_ERROR` - raised when level parsing failed or found invalid content
-  - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_PARSING_ERROR`, fatal : `false`, url : level URL, error: Error }
+- `Hls.ErrorDetails.LEVEL_PARSING_ERROR` - raised when playlist parsing failed or found invalid content (applies to levels and audio and subtitle tracks)
+  - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.LEVEL_PARSING_ERROR`, fatal : `false`, url : level URL, error: Error, parent: PlaylistLevelType }
 - `Hls.ErrorDetails.AUDIO_TRACK_LOAD_ERROR` - raised when audio playlist loading fails because of a network error
   - data: { type : `NETWORK_ERROR`, details : `Hls.ErrorDetails.AUDIO_TRACK_LOAD_ERROR`, fatal : `false`, url : audio URL, response : { code: error code, text: error text }, loader : URL loader }
 - `Hls.ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT` - raised when audio playlist loading fails because of a timeout
@@ -1759,6 +1759,8 @@ Full list of errors is described below:
   - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.FRAG_DECRYPT_ERROR`, fatal : `true`, reason : failure reason }
 - `Hls.ErrorDetails.FRAG_PARSING_ERROR` - raised when fragment parsing fails
   - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.FRAG_PARSING_ERROR`, fatal : `true` or `false`, reason : failure reason }
+- `Hls.ErrorDetails.FRAG_GAP` - raised when segment loading is skipped because a fragment with a GAP tag or part with GAP=YES attribute was encountered
+  - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.FRAG_GAP`, fatal : `false`, frag : fragment object, part? : part object (if any) }
 - `Hls.ErrorDetails.BUFFER_ADD_CODEC_ERROR` - raised when MediaSource fails to add new sourceBuffer
   - data: { type : `MEDIA_ERROR`, details : `Hls.ErrorDetails.BUFFER_ADD_CODEC_ERROR`, fatal : `false`, error : error raised by MediaSource, mimeType: mimeType on which the failure happened }
 - `Hls.ErrorDetails.BUFFER_INCOMPATIBLE_CODECS_ERROR` - raised when no MediaSource(s) could be created based on track codec(s)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -356,7 +356,13 @@ class AudioStreamController
     }
     // wait for main buffer after buffing some audio
     if (!mainBufferInfo?.len && bufferInfo.len) {
-      return;
+      if (
+        !mainBufferInfo?.nextStart ||
+        mainBufferInfo.nextStart >
+          bufferInfo.end + trackDetails.targetduration * 2
+      ) {
+        return;
+      }
     }
 
     const frag = this.getNextFragment(targetBufferTime, trackDetails);
@@ -643,6 +649,7 @@ class AudioStreamController
       return;
     }
     switch (data.details) {
+      case ErrorDetails.FRAG_GAP:
       case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.FRAG_DECRYPT_ERROR:
       case ErrorDetails.FRAG_LOAD_ERROR:

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -347,28 +347,50 @@ class AudioStreamController
       }
     }
 
-    // buffer audio up to one target duration ahead of main buffer
-    if (
-      mainBufferInfo &&
-      targetBufferTime > mainBufferInfo.end + trackDetails.targetduration
-    ) {
-      return;
+    let frag = this.getNextFragment(targetBufferTime, trackDetails);
+    let atGap = false;
+    // Avoid loop loading by using nextLoadPosition set for backtracking and skipping consecutive GAP tags
+    if (frag && this.isLoopLoading(frag, targetBufferTime)) {
+      atGap = !!frag.gap;
+      frag = this.getNextFragmentLoopLoading(
+        frag,
+        trackDetails,
+        bufferInfo,
+        PlaylistLevelType.MAIN,
+        maxBufLen
+      );
     }
-    // wait for main buffer after buffing some audio
-    if (!mainBufferInfo?.len && bufferInfo.len) {
-      if (
-        !mainBufferInfo?.nextStart ||
-        mainBufferInfo.nextStart >
-          bufferInfo.end + trackDetails.targetduration * 2
-      ) {
-        return;
-      }
-    }
-
-    const frag = this.getNextFragment(targetBufferTime, trackDetails);
     if (!frag) {
       this.bufferFlushed = true;
       return;
+    }
+
+    // Buffer audio up to one target duration ahead of main buffer
+    const atBufferSyncLimit =
+      mainBufferInfo &&
+      frag.start > mainBufferInfo.end + trackDetails.targetduration;
+    if (
+      atBufferSyncLimit ||
+      // Or wait for main buffer after buffing some audio
+      (!mainBufferInfo?.len && bufferInfo.len)
+    ) {
+      // Check fragment-tracker for main fragments since GAP segments do not show up in bufferInfo
+      const mainFrag = this.fragmentTracker.getBufferedFrag(
+        frag.start,
+        PlaylistLevelType.MAIN
+      );
+      if (mainFrag === null) {
+        return;
+      }
+      // Bridge gaps in main buffer
+      atGap ||=
+        !!mainFrag.gap || (!!atBufferSyncLimit && mainBufferInfo.len === 0);
+      if (
+        (atBufferSyncLimit && !atGap) ||
+        (atGap && bufferInfo.nextStart && bufferInfo.nextStart < mainFrag.end)
+      ) {
+        return;
+      }
     }
 
     this.loadFragment(frag, levelInfo, targetBufferTime);

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1161,7 +1161,10 @@ export default class BaseStreamController
       const curSNIdx = frag.sn - levelDetails.startSN;
       // Move fragPrevious forward to support forcing the next fragment to load
       // when the buffer catches up to a previously buffered range.
-      if (this.fragmentTracker.getState(frag) === FragmentState.OK) {
+      if (
+        this.fragmentTracker.getState(frag) === FragmentState.OK ||
+        (frag.gap && frag.stats.aborted)
+      ) {
         fragPrevious = frag;
       }
       if (fragPrevious && frag.sn === fragPrevious.sn && !loadingParts) {
@@ -1371,6 +1374,9 @@ export default class BaseStreamController
         `Frag load error must match current frag to retry ${frag.url} > ${this.fragCurrent?.url}`
       );
       return;
+    }
+    if (data.details === ErrorDetails.FRAG_GAP) {
+      this.fragmentTracker.fragBuffered(frag, true);
     }
     // keep retrying until the limit will be reached
     const errorAction = data.errorAction;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1167,9 +1167,10 @@ export default class BaseStreamController
       const curSNIdx = frag.sn - levelDetails.startSN;
       // Move fragPrevious forward to support forcing the next fragment to load
       // when the buffer catches up to a previously buffered range.
+      const fragState = this.fragmentTracker.getState(frag);
       if (
-        this.fragmentTracker.getState(frag) === FragmentState.OK ||
-        (frag.gap && frag.stats.aborted)
+        fragState === FragmentState.OK ||
+        (fragState === FragmentState.PARTIAL && frag.gap)
       ) {
         fragPrevious = frag;
       }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1425,7 +1425,8 @@ export default class BaseStreamController
       );
       return;
     }
-    if (data.details === ErrorDetails.FRAG_GAP) {
+    const gapTagEncountered = data.details === ErrorDetails.FRAG_GAP;
+    if (gapTagEncountered) {
       this.fragmentTracker.fragBuffered(frag, true);
     }
     // keep retrying until the limit will be reached
@@ -1455,7 +1456,9 @@ export default class BaseStreamController
       this.resetFragmentErrors(filterType);
       if (retryCount < retryConfig.maxNumRetry) {
         // Network retry is skipped when level switch is preferred
-        errorAction.resolved = true;
+        if (!gapTagEncountered) {
+          errorAction.resolved = true;
+        }
       } else {
         logger.warn(
           `${data.details} reached or exceeded max retry (${retryCount})`

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -24,7 +24,7 @@ import { base64Decode } from '../utils/numeric-encoding-utils';
 import { DecryptData, LevelKey } from '../loader/level-key';
 import Hex from '../utils/hex';
 import { bin2str, parsePssh, parseSinf } from '../utils/mp4-tools';
-import EventEmitter from 'eventemitter3';
+import { EventEmitter } from 'eventemitter3';
 import type Hls from '../hls';
 import type { ComponentAPI } from '../types/component-api';
 import type {

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -96,6 +96,7 @@ export default class ErrorController implements NetworkComponentAPI {
       case ErrorDetails.KEY_LOAD_TIMEOUT:
         data.errorAction = this.getFragRetryOrSwitchAction(data);
         return;
+      case ErrorDetails.FRAG_GAP:
       case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.FRAG_DECRYPT_ERROR: {
         // Switch level if possible, otherwise allow retry count to reach max error retries
@@ -264,7 +265,9 @@ export default class ErrorController implements NetworkComponentAPI {
     );
     // Switch levels when out of retried or level index out of bounds
     if (level) {
-      level.fragmentError++;
+      if (data.details !== ErrorDetails.FRAG_GAP) {
+        level.fragmentError++;
+      }
       const httpStatus = data.response?.code;
       const retry = shouldRetry(
         retryConfig,

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -324,7 +324,7 @@ export default class ErrorController implements NetworkComponentAPI {
             candidate !== hls.loadLevel &&
             levels[candidate].loadError === 0
           ) {
-            // Skip level switch if GAP tag is found in next level
+            // Skip level switch if GAP tag is found in next level at same position
             if (data.details === ErrorDetails.FRAG_GAP && data.frag) {
               const levelDetails = hls.levels[candidate].details;
               if (levelDetails) {

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -220,9 +220,18 @@ export class FragmentTracker implements ComponentAPI {
     }
   }
 
-  public fragBuffered(frag: Fragment) {
+  public fragBuffered(frag: Fragment, force?: boolean) {
     const fragKey = getFragmentKey(frag);
-    const fragmentEntity = this.fragments[fragKey];
+    let fragmentEntity = this.fragments[fragKey];
+    if (!fragmentEntity && force) {
+      fragmentEntity = this.fragments[fragKey] = {
+        body: frag,
+        appendedPTS: null,
+        loaded: null,
+        buffered: false,
+        range: Object.create(null),
+      };
+    }
     if (fragmentEntity) {
       fragmentEntity.loaded = null;
       fragmentEntity.buffered = true;
@@ -482,7 +491,9 @@ export class FragmentTracker implements ComponentAPI {
 function isPartial(fragmentEntity: FragmentEntity): boolean {
   return (
     fragmentEntity.buffered &&
-    (fragmentEntity.range.video?.partial || fragmentEntity.range.audio?.partial)
+    (fragmentEntity.body.gap ||
+      fragmentEntity.range.video?.partial ||
+      fragmentEntity.range.audio?.partial)
   );
 }
 

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -77,6 +77,7 @@ export default class GapController {
     // Clear stalled state when beginning or finishing seeking so that we don't report stalls coming out of a seek
     if (beginSeek || seeked) {
       this.stalled = null;
+      return;
     }
 
     // The playhead should not be moving

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -131,7 +131,11 @@ export default class GapController {
       const maxStartGapJump = isLive
         ? level!.details!.targetduration * 2
         : MAX_START_GAP_JUMP;
-      if (startJump > 0 && startJump <= maxStartGapJump) {
+      if (
+        startJump > 0 &&
+        (startJump <= maxStartGapJump ||
+          this.fragmentTracker.getPartialFragment(0))
+      ) {
         this._trySkipBufferHole(null);
         return;
       }
@@ -194,7 +198,9 @@ export default class GapController {
     // needs to cross some sort of threshold covering all source-buffers content
     // to start playing properly.
     if (
-      bufferInfo.len > config.maxBufferHole &&
+      (bufferInfo.len > config.maxBufferHole ||
+        (bufferInfo.nextStart &&
+          bufferInfo.nextStart - currentTime < config.maxBufferHole)) &&
       stalledDurationMs > config.highBufferWatchdogPeriod * 1000
     ) {
       logger.warn('Trying to nudge playhead over buffer-hole');

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -184,9 +184,11 @@ export default class LatencyController implements ComponentAPI {
       return;
     }
     this.stallCount++;
-    logger.warn(
-      '[playback-rate-controller]: Stall detected, adjusting target latency'
-    );
+    if (this.levelDetails?.live) {
+      logger.warn(
+        '[playback-rate-controller]: Stall detected, adjusting target latency'
+      );
+    }
   }
 
   private timeupdate() {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -479,7 +479,7 @@ export default class LevelController extends BasePlaylistController {
     const audioGroupId = this.hls.audioTracks[data.id].groupId;
     if (
       currentLevel.audioGroupIds &&
-      currentLevel.audioGroupIds[currentLevel.urlId] !== audioGroupId
+      currentLevel.audioGroupId !== audioGroupId
     ) {
       let urlId = -1;
       for (let i = 0; i < currentLevel.audioGroupIds.length; i++) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -327,13 +327,16 @@ export default class StreamController
         }
         frag = this.getNextFragment(this.nextLoadPosition, levelDetails);
         if (gapStart && frag && !frag.gap && bufferInfo.nextStart) {
-          // Make sure this doesn't make the next buffer timerange exceed forward buffer length after a gap
+          // Media buffered after GAP tags should not make the next buffer timerange exceed forward buffer length
           const nextbufferInfo = this.getFwdBufferInfoAtPos(
             this.mediaBuffer ? this.mediaBuffer : this.media,
             bufferInfo.nextStart,
             PlaylistLevelType.MAIN
           );
-          if (nextbufferInfo !== null && nextbufferInfo.len > maxBufLen) {
+          if (
+            nextbufferInfo !== null &&
+            bufferLen + nextbufferInfo.len >= maxBufLen
+          ) {
             return;
           }
         }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -855,6 +855,7 @@ export default class StreamController
       return;
     }
     switch (data.details) {
+      case ErrorDetails.FRAG_GAP:
       case ErrorDetails.FRAG_PARSING_ERROR:
       case ErrorDetails.FRAG_DECRYPT_ERROR:
       case ErrorDetails.FRAG_LOAD_ERROR:

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -557,6 +557,17 @@ export default class StreamController
       this.log(`Media seeked to ${(currentTime as number).toFixed(3)}`);
     }
 
+    // If seeked was issued before buffer was appended do not tick immediately
+    const bufferInfo = this.getMainFwdBufferInfo();
+    if (bufferInfo === null || bufferInfo.len === 0) {
+      this.warn(
+        `Main forward buffer length on "seeked" event ${
+          bufferInfo ? bufferInfo.len : 'empty'
+        })`
+      );
+      return;
+    }
+
     // tick to speed up FRAG_CHANGED triggering
     this.tick();
   }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -220,7 +220,11 @@ export class SubtitleStreamController
     this.levels = subtitleTracks.map(
       (mediaPlaylist) => new Level(mediaPlaylist)
     );
-    this.fragmentTracker.removeAllFragments();
+    this.fragmentTracker.removeFragmentsInRange(
+      0,
+      Number.POSITIVE_INFINITY,
+      PlaylistLevelType.SUBTITLE
+    );
     this.fragPrevious = null;
     this.levels.forEach((level: Level) => {
       this.tracksBuffered[level.id] = [];

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -57,6 +57,8 @@ export enum ErrorDetails {
   // Identifier for a fragment parsing error event - data: { id : demuxer Id, reason : parsing error description }
   // will be renamed DEMUX_PARSING_ERROR and switched to MUX_ERROR in the next major release
   FRAG_PARSING_ERROR = 'fragParsingError',
+  // Identifier for a fragment or part load skipped because of a GAP tag or attribute
+  FRAG_GAP = 'fragGap',
   // Identifier for a remux alloc error event - data: { id : demuxer Id, frag : fragment object, bytes : nb of bytes on which allocation failed , reason : error text }
   REMUX_ALLOC_ERROR = 'remuxAllocError',
   // Identifier for decrypt key load error - data: { frag : fragment object, response : { code: error code, text: error text }}

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -68,6 +68,21 @@ export default class FragmentLoader {
       if (this.loader) {
         this.loader.destroy();
       }
+      if (frag.gap) {
+        frag.stats.aborted = true;
+        frag.stats.retry++;
+        reject(
+          new LoadError({
+            type: ErrorTypes.MEDIA_ERROR,
+            details: ErrorDetails.FRAG_GAP,
+            fatal: false,
+            frag,
+            error: new Error('GAP tag found'),
+            networkDetails: null,
+          })
+        );
+        return;
+      }
       const loader =
         (this.loader =
         frag.loader =
@@ -174,6 +189,22 @@ export default class FragmentLoader {
     return new Promise((resolve, reject) => {
       if (this.loader) {
         this.loader.destroy();
+      }
+      if (frag.gap || part.gap) {
+        frag.stats.aborted = true;
+        frag.stats.retry++;
+        reject(
+          new LoadError({
+            type: ErrorTypes.MEDIA_ERROR,
+            details: ErrorDetails.FRAG_GAP,
+            fatal: false,
+            frag,
+            part,
+            error: new Error(`GAP ${frag.gap ? 'tag' : 'attribute'} found`),
+            networkDetails: null,
+          })
+        );
+        return;
       }
       const loader =
         (this.loader =

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -69,18 +69,7 @@ export default class FragmentLoader {
         this.loader.destroy();
       }
       if (frag.gap) {
-        frag.stats.aborted = true;
-        frag.stats.retry++;
-        reject(
-          new LoadError({
-            type: ErrorTypes.MEDIA_ERROR,
-            details: ErrorDetails.FRAG_GAP,
-            fatal: false,
-            frag,
-            error: new Error('GAP tag found'),
-            networkDetails: null,
-          })
-        );
+        reject(createGapLoadError(frag));
         return;
       }
       const loader =
@@ -191,19 +180,7 @@ export default class FragmentLoader {
         this.loader.destroy();
       }
       if (frag.gap || part.gap) {
-        frag.stats.aborted = true;
-        frag.stats.retry++;
-        reject(
-          new LoadError({
-            type: ErrorTypes.MEDIA_ERROR,
-            details: ErrorDetails.FRAG_GAP,
-            fatal: false,
-            frag,
-            part,
-            error: new Error(`GAP ${frag.gap ? 'tag' : 'attribute'} found`),
-            networkDetails: null,
-          })
-        );
+        reject(createGapLoadError(frag, part));
         return;
       }
       const loader =
@@ -371,6 +348,22 @@ function createLoaderContext(
     loaderContext.rangeEnd = byteRangeEnd;
   }
   return loaderContext;
+}
+
+function createGapLoadError(frag: Fragment, part?: Part): LoadError {
+  const error = new Error(`GAP ${frag.gap ? 'tag' : 'attribute'} found`);
+  const errorData: FragLoadFailResult = {
+    type: ErrorTypes.MEDIA_ERROR,
+    details: ErrorDetails.FRAG_GAP,
+    fatal: false,
+    frag,
+    error,
+    networkDetails: null,
+  };
+  if (part) {
+    errorData.part = part;
+  }
+  return new LoadError(errorData);
 }
 
 export class LoadError extends Error {

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -363,6 +363,7 @@ function createGapLoadError(frag: Fragment, part?: Part): LoadError {
   if (part) {
     errorData.part = part;
   }
+  (part ? part : frag).stats.aborted = true;
   return new LoadError(errorData);
 }
 

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -147,6 +147,8 @@ export class Fragment extends BaseSegment {
   public initSegment: Fragment | null = null;
   // Fragment is the last fragment in the media playlist
   public endList?: boolean;
+  // Fragment is marked by an EXT-X-GAP tag indicating that it does not contain media data and should not be loaded
+  public gap?: boolean;
 
   constructor(type: PlaylistLevelType, baseurl: string) {
     super(baseurl);

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -513,6 +513,7 @@ export default class M3U8Parser {
             frag.tagList.push(['DIS']);
             break;
           case 'GAP':
+            frag.gap = true;
             frag.tagList.push([tag]);
             break;
           case 'BITRATE':

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -155,6 +155,14 @@ export class Level {
     }
   }
 
+  get audioGroupId(): string | undefined {
+    return this.audioGroupIds?.[this.urlId];
+  }
+
+  get textGroupId(): string | undefined {
+    return this.textGroupIds?.[this.urlId];
+  }
+
   addFallback(data: LevelParsed) {
     this.url.push(data.url);
     this._attrs.push(data.attrs);

--- a/tests/unit/controller/audio-track-controller.ts
+++ b/tests/unit/controller/audio-track-controller.ts
@@ -208,7 +208,7 @@ describe('AudioTrackController', function () {
     });
 
     const newLevelInfo = hls.levels[0];
-    const newGroupId = newLevelInfo.audioGroupIds?.[newLevelInfo.urlId];
+    const newGroupId = newLevelInfo.audioGroupId;
 
     audioTrackController.tracks = tracks;
     // Update the level to set audioGroupId
@@ -325,7 +325,7 @@ describe('AudioTrackController', function () {
       };
 
       const newLevelInfo = hls.levels[levelLoadedEvent.level];
-      const newGroupId = newLevelInfo.audioGroupIds?.[newLevelInfo.urlId];
+      const newGroupId = newLevelInfo.audioGroupId;
 
       audioTrackController.tracks = tracks;
       audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -737,7 +737,7 @@ segment.mp4
           expect(
             errors.length,
             'fragment errors after yeilding to second error event'
-          ).to.equal(4);
+          ).to.equal(6);
           expect(hls.levels[0].uri).to.equal('http://www.baz.com/tier6.m3u8');
           return new Promise((resolve, reject) => {
             hls.on(Events.FRAG_LOADED, (event, data) => {
@@ -847,7 +847,7 @@ segment.mp4
           expect(
             errors.length,
             'fragment errors after yeilding to second error event'
-          ).to.equal(4);
+          ).to.equal(6);
           expect(hls.levels[0].uri).to.equal('http://www.baz.com/tier6.m3u8');
           return new Promise((resolve, reject) => {
             hls.on(Events.FRAG_LOADED, (event, data) => {

--- a/tests/unit/loader/playlist-loader.ts
+++ b/tests/unit/loader/playlist-loader.ts
@@ -1582,7 +1582,7 @@ fileSequence2.ts
     ]);
   });
 
-  it('adds GAP to fragment.tagList', function () {
+  it('adds GAP to fragment.tagList and sets fragment.gap', function () {
     const playlist = `#EXTM3U
 #EXT-X-TARGETDURATION:5
 #EXT-X-VERSION:3
@@ -1613,6 +1613,9 @@ fileSequence2.ts
       ['GAP'],
     ]);
     expectWithJSONMessage(fragments[2].tagList).to.deep.equal([['INF', '5']]);
+    expect(fragments[0].gap).to.equal(undefined);
+    expect(fragments[1].gap).to.equal(true);
+    expect(fragments[2].gap).to.equal(undefined);
   });
 
   it('adds unhandled tags (DATERANGE) and comments to fragment.tagList', function () {


### PR DESCRIPTION
### This PR will...
Do not load GAP segments or parts. Error when encountering a segment with a GAP in a level to trigger a level switch (clients are expected to look for alternate segments to load when a GAP is encountered). Track segments with a GAP as partially buffered in fragment-tracker to avoid reload looping and expedite finding of the next available fragment. Allow the gap-controller to skip over unbufferable gaps (when level switch is not an option).

- Segments with a GAP tag are not requested
- Parts with a GAP=YES attribute are not requested
- The first time a stream-controller goes to select a GAP segment for loading in a level a FRAG_GAP Error will be emitted
- The FRAG_GAP error is handled by switching variants when possible
- When no alternates are available, the next segment/part is selected

### Why is this Pull Request needed?
Skips over content with gaps.

### Are there any points in the code the reviewer needs to double check?
Future enhancements may include appending silence and/or still frames. Such enhancements are not in scope for this release.

### Resolves issues:
#2940 (avoid loading and skips)