### PR TITLE
Support QUERYPARAM Variable Substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For details on the HLS format and these tags' meanings, see https://datatracker.
 - `#EXT-X-SESSION-KEY:<attribute-list>` EME Key-System selection and preloading
 - `#EXT-X-START:TIME-OFFSET=<n>`
 - `#EXT-X-CONTENT-STEERING:<attribute-list>` Content Steering
-- `#EXT-X-DEFINE:<attribute-list>` Variable Substitution
+- `#EXT-X-DEFINE:<attribute-list>` Variable Substitution (`NAME,VALUE,QUERYPARAM` attributes)
 
 The following properties are added to their respective variants' attribute list but are not implemented in their selection and playback.
 
@@ -109,7 +109,7 @@ The following properties are added to their respective variants' attribute list 
 - `#EXT-X-SKIP:<attribute-list>` Delta Playlists
 - `#EXT-X-RENDITION-REPORT:<attribute-list>`
 - `#EXT-X-DATERANGE:<attribute-list>` Metadata
-- `#EXT-X-DEFINE:<attribute-list>` Variable Import and Substitution
+- `#EXT-X-DEFINE:<attribute-list>` Variable Import and Substitution (`NAME,VALUE,IMPORT,QUERYPARAM` attributes)
 
 The following tags are added to their respective fragment's attribute list but are not implemented in streaming and playback.
 

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -385,7 +385,7 @@ export default class ContentSteeringController implements NetworkComponentAPI {
         } = steeringData;
         if (reloadUri) {
           try {
-            this.uri = new URL(reloadUri, url).href;
+            this.uri = new self.URL(reloadUri, url).href;
           } catch (error) {
             this.enabled = false;
             this.log(

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -224,8 +224,9 @@ export default class M3U8Parser {
               substituteVariablesInAttributes(parsed, variableAttributes, [
                 'NAME',
                 'VALUE',
+                'QUERYPARAM',
               ]);
-              addVariableDefinition(parsed, variableAttributes);
+              addVariableDefinition(parsed, variableAttributes, baseurl);
             }
             break;
           }
@@ -555,6 +556,7 @@ export default class M3U8Parser {
                 'NAME',
                 'VALUE',
                 'IMPORT',
+                'QUERYPARAM',
               ]);
               if ('IMPORT' in variableAttributes) {
                 importVariableDefinition(
@@ -563,7 +565,7 @@ export default class M3U8Parser {
                   multivariantVariableList
                 );
               } else {
-                addVariableDefinition(level, variableAttributes);
+                addVariableDefinition(level, variableAttributes, baseurl);
               }
             }
             break;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,6 +129,7 @@ function getAliasesForLightDist() {
     aliases = Object.assign({}, aliases, {
       './controller/eme-controller': './empty.js',
       './utils/mediakeys-helper': './empty.js',
+      '../utils/mediakeys-helper': '../empty.js',
     });
   }
 
@@ -139,7 +140,7 @@ function getAliasesForLightDist() {
   }
 
   if (!addSubtitleSupport) {
-    aliases = Object.assign(aliases, {
+    aliases = Object.assign({}, aliases, {
       './utils/cues': './empty.js',
       './controller/timeline-controller': './empty.js',
       './controller/subtitle-track-controller': './empty.js',
@@ -148,7 +149,7 @@ function getAliasesForLightDist() {
   }
 
   if (!addAltAudioSupport) {
-    aliases = Object.assign(aliases, {
+    aliases = Object.assign({}, aliases, {
       './controller/audio-track-controller': './empty.js',
       './controller/audio-stream-controller': './empty.js',
     });
@@ -157,6 +158,7 @@ function getAliasesForLightDist() {
   if (!addVariableSubstitutionSupport) {
     aliases = Object.assign({}, aliases, {
       './utils/variable-substitution': './empty.js',
+      '../utils/variable-substitution': '../empty.js',
     });
   }
 


### PR DESCRIPTION
### This PR will...
Implement EXT-X-DEFINE QUERYPARAM support

### Why is this Pull Request needed?
The EXT-X-DEFINE QUERYPARAM attribute is a new HLS feature that allows the definition of HLS variables based on URL search parameter key value pairs. A URL param from the playlist's parent URL can used as a variable to substitute variable declarations (`{$var-name}`) inside URI strings and quoted string attributes anywhere in an HLS playlist following the variable definition, just like variables defined by the EXT-X-DEFINE NAME/VALUE or IMPORT attribute(s) (#5161).

### Resolves issues:
Resolves #5240

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
