### PR TITLE
Fix fallback to inline worker when exception is thrown in worker

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -404,6 +404,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected onvseeking: EventListener | null;
     // (undocumented)
+    protected recoverWorkerError(data: ErrorData): void;
+    // (undocumented)
     protected reduceMaxBufferLength(threshold?: number): boolean;
     // (undocumented)
     protected resetFragmentErrors(filterType: PlaylistLevelType): void;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -693,6 +693,9 @@ class AudioStreamController
           this.resetLoadingState();
         }
         break;
+      case ErrorDetails.INTERNAL_EXCEPTION:
+        this.recoverWorkerError(data);
+        break;
       default:
         break;
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1551,6 +1551,13 @@ export default class BaseStreamController
     }
   }
 
+  protected recoverWorkerError(data: ErrorData) {
+    if (data.event === 'demuxerWorker') {
+      this.resetTransmuxer();
+      this.resetLoadingState();
+    }
+  }
+
   set state(nextState) {
     const previousState = this._state;
     if (previousState !== nextState) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -904,6 +904,9 @@ export default class StreamController
           this.resetLoadingState();
         }
         break;
+      case ErrorDetails.INTERNAL_EXCEPTION:
+        this.recoverWorkerError(data);
+        break;
       default:
         break;
     }


### PR DESCRIPTION
### This PR will...
Fix fallback to inline worker when exception is thrown in worker

### Why is this Pull Request needed?
When the injected worker fails,`worker.onerror` callback triggers an internal error event that is not handled properly. These changes set config.enableWorker to false and resets the stream controller loading state and transmuxer instance so that audio and main stream controllers can retry with inline transmuxer.

### Related issues:
Related to #5107