### PR TITLE
TypeScript enum optimizations

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -844,7 +844,7 @@ export type ElementaryStreams = Record<ElementaryStreamTypes, ElementaryStreamIn
 // Warning: (ae-missing-release-tag) "ElementaryStreamTypes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum ElementaryStreamTypes {
+export const enum ElementaryStreamTypes {
     // (undocumented)
     AUDIO = "audio",
     // (undocumented)
@@ -884,7 +884,7 @@ export type EMEControllerConfig = {
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum ErrorActionFlags {
+export const enum ErrorActionFlags {
     // (undocumented)
     MoveAllAlternatesMatchingHDCP = 2,
     // (undocumented)
@@ -1791,7 +1791,7 @@ export interface HlsProgressivePerformanceTiming extends HlsPerformanceTiming {
 // Warning: (ae-missing-release-tag) "HlsSkip" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum HlsSkip {
+export const enum HlsSkip {
     // (undocumented)
     No = "",
     // (undocumented)
@@ -1885,7 +1885,7 @@ export interface KeyLoadingData {
 // Warning: (ae-missing-release-tag) "KeySystemFormats" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum KeySystemFormats {
+export const enum KeySystemFormats {
     // (undocumented)
     CLEARKEY = "org.w3.clearkey",
     // (undocumented)
@@ -1899,7 +1899,7 @@ export enum KeySystemFormats {
 // Warning: (ae-missing-release-tag) "KeySystems" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum KeySystems {
+export const enum KeySystems {
     // (undocumented)
     CLEARKEY = "org.w3.clearkey",
     // (undocumented)
@@ -2681,7 +2681,7 @@ export interface MetadataSample {
 // Warning: (ae-missing-release-tag) "MetadataSchema" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum MetadataSchema {
+export const enum MetadataSchema {
     // (undocumented)
     audioId3 = "org.id3",
     // (undocumented)
@@ -2711,7 +2711,7 @@ export interface NetworkComponentAPI extends ComponentAPI {
 // Warning: (ae-missing-release-tag) "NetworkErrorAction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum NetworkErrorAction {
+export const enum NetworkErrorAction {
     // (undocumented)
     DoNothing = 0,
     // (undocumented)
@@ -2784,7 +2784,7 @@ export class Part extends BaseSegment {
 // Warning: (ae-missing-release-tag) "PlaylistContextType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum PlaylistContextType {
+export const enum PlaylistContextType {
     // (undocumented)
     AUDIO_TRACK = "audioTrack",
     // (undocumented)
@@ -2798,7 +2798,7 @@ export enum PlaylistContextType {
 // Warning: (ae-missing-release-tag) "PlaylistLevelType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export enum PlaylistLevelType {
+export const enum PlaylistLevelType {
     // (undocumented)
     AUDIO = "audio",
     // (undocumented)

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -2,6 +2,9 @@ import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
 import { getSkipValue, HlsSkip, HlsUrlParameters, Level } from '../types/level';
 import { computeReloadInterval, mergeDetails } from './level-helper';
+import { ErrorData } from '../types/events';
+import { getRetryDelay, isTimeoutError } from '../utils/error-helper';
+import { NetworkErrorAction } from './error-controller';
 import { logger } from '../utils/logger';
 import type { LevelDetails } from '../loader/level-details';
 import type { MediaPlaylist } from '../types/media-playlist';
@@ -10,9 +13,6 @@ import type {
   LevelLoadedData,
   TrackLoadedData,
 } from '../types/events';
-import { ErrorData } from '../types/events';
-import { NetworkErrorAction } from '../errors';
-import { getRetryDelay, isTimeoutError } from '../utils/error-helper';
 
 export default class BasePlaylistController implements NetworkComponentAPI {
   protected hls: Hls;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -3,7 +3,7 @@ import { FragmentState } from './fragment-tracker';
 import { Bufferable, BufferHelper, BufferInfo } from '../utils/buffer-helper';
 import { logger } from '../utils/logger';
 import { Events } from '../events';
-import { ErrorDetails, ErrorTypes, NetworkErrorAction } from '../errors';
+import { ErrorDetails, ErrorTypes } from '../errors';
 import { ChunkMetadata } from '../types/transmuxer';
 import { appendUint8Array } from '../utils/mp4-tools';
 import { alignStream } from '../utils/discontinuities';
@@ -29,6 +29,8 @@ import { LevelDetails } from '../loader/level-details';
 import Decrypter from '../crypt/decrypter';
 import TimeRanges from '../utils/time-ranges';
 import { PlaylistLevelType } from '../types/loader';
+import { getRetryDelay } from '../utils/error-helper';
+import { NetworkErrorAction } from './error-controller';
 import type {
   BufferAppendingData,
   ErrorData,
@@ -47,7 +49,6 @@ import type { HlsConfig } from '../config';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type { SourceBufferName } from '../types/buffer';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
-import { getRetryDelay } from '../utils/error-helper';
 
 type ResolveFragLoaded = (FragLoadedEndData) => void;
 type RejectFragLoaded = (LoadError) => void;

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -4,7 +4,7 @@ import {
   CMCD,
   CMCDHeaders,
   CMCDObjectType,
-  CMCDStreamingFormat,
+  CMCDStreamingFormatHLS,
   CMCDVersion,
 } from '../types/cmcd';
 import { BufferHelper } from '../utils/buffer-helper';
@@ -132,7 +132,7 @@ export default class CMCDController implements ComponentAPI {
   private createData(): CMCD {
     return {
       v: CMCDVersion,
-      sf: CMCDStreamingFormat.HLS,
+      sf: CMCDStreamingFormatHLS,
       sid: this.sid,
       cid: this.cid,
       pr: this.media?.playbackRate,

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -2,7 +2,7 @@ import { Events } from '../events';
 import { Level } from '../types/level';
 import { AttrList } from '../utils/attr-list';
 import { addGroupId } from './level-controller';
-import { ErrorActionFlags, NetworkErrorAction } from '../errors';
+import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
 import { logger } from '../utils/logger';
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -1,23 +1,44 @@
 import { Events } from '../events';
-import {
-  ErrorActionFlags,
-  ErrorDetails,
-  ErrorTypes,
-  IErrorAction,
-  NetworkErrorAction,
-} from '../errors';
+import { ErrorDetails, ErrorTypes } from '../errors';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import {
   getRetryConfig,
   isTimeoutError,
   shouldRetry,
 } from '../utils/error-helper';
-import { HdcpLevels } from '../types/level';
+import { HdcpLevel, HdcpLevels } from '../types/level';
 import { logger } from '../utils/logger';
 import type Hls from '../hls';
+import type { RetryConfig } from '../config';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type { ErrorData } from '../types/events';
 import type { Fragment } from '../loader/fragment';
+
+export const enum NetworkErrorAction {
+  DoNothing = 0,
+  SendEndCallback = 1, // Reserved for future use
+  SendAlternateToPenaltyBox = 2,
+  RemoveAlternatePermanently = 3, // Reserved for future use
+  InsertDiscontinuity = 4, // Reserved for future use
+  RetryRequest = 5,
+}
+
+export const enum ErrorActionFlags {
+  None = 0,
+  MoveAllAlternatesMatchingHost = 1,
+  MoveAllAlternatesMatchingHDCP = 1 << 1,
+  SwitchToSDR = 1 << 2, // Reserved for future use
+}
+
+export type IErrorAction = {
+  action: NetworkErrorAction;
+  flags: ErrorActionFlags;
+  retryCount?: number;
+  retryConfig?: RetryConfig;
+  hdcpLevel?: HdcpLevel;
+  nextAutoLevel?: number;
+  resolved?: boolean;
+};
 
 export default class ErrorController implements NetworkComponentAPI {
   private readonly hls: Hls;

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -15,7 +15,7 @@ import type {
 } from '../types/events';
 import type Hls from '../hls';
 
-export enum FragmentState {
+export const enum FragmentState {
   NOT_LOADED = 'NOT_LOADED',
   APPENDING = 'APPENDING',
   PARTIAL = 'PARTIAL',

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -5,7 +5,11 @@ import {
   removeCuesInRange,
 } from '../utils/texttrack-utils';
 import * as ID3 from '../demux/id3';
-import { DateRange, DateRangeAttribute } from '../loader/date-range';
+import {
+  DateRange,
+  isDateRangeCueAttribute,
+  isSCTE35Attribute,
+} from '../loader/date-range';
 import { MetadataSchema } from '../types/demuxer';
 import type {
   BufferFlushingData,
@@ -337,14 +341,7 @@ class ID3TrackController implements ComponentAPI {
       const attributes = Object.keys(dateRange.attr);
       for (let j = 0; j < attributes.length; j++) {
         const key = attributes[j];
-        if (
-          key === DateRangeAttribute.ID ||
-          key === DateRangeAttribute.CLASS ||
-          key === DateRangeAttribute.START_DATE ||
-          key === DateRangeAttribute.DURATION ||
-          key === DateRangeAttribute.END_DATE ||
-          key === DateRangeAttribute.END_ON_NEXT
-        ) {
+        if (!isDateRangeCueAttribute(key)) {
           continue;
         }
         let cue = cues[key] as any;
@@ -355,10 +352,7 @@ class ID3TrackController implements ComponentAPI {
         } else {
           let data = dateRange.attr[key];
           cue = new Cue(startTime, endTime, '');
-          if (
-            key === DateRangeAttribute.SCTE35_OUT ||
-            key === DateRangeAttribute.SCTE35_IN
-          ) {
+          if (isSCTE35Attribute(key)) {
             data = hexToArrayBuffer(data);
           }
           cue.value = { key, data };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -90,7 +90,7 @@ export enum ErrorDetails {
   UNKNOWN = 'unknown',
 }
 
-export enum NetworkErrorAction {
+export const enum NetworkErrorAction {
   DoNothing = 0,
   SendEndCallback = 1, // Reserved for future use
   SendAlternateToPenaltyBox = 2,
@@ -99,7 +99,7 @@ export enum NetworkErrorAction {
   RetryRequest = 5,
 }
 
-export enum ErrorActionFlags {
+export const enum ErrorActionFlags {
   None = 0,
   MoveAllAlternatesMatchingHost = 1,
   MoveAllAlternatesMatchingHDCP = 1 << 1,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,3 @@
-import { RetryConfig } from './config';
-import { HdcpLevel } from './types/level';
-
 export enum ErrorTypes {
   // Identifier for a network error (loading error / timeout ...)
   NETWORK_ERROR = 'networkError',
@@ -89,29 +86,3 @@ export enum ErrorDetails {
   // Uncategorized error
   UNKNOWN = 'unknown',
 }
-
-export const enum NetworkErrorAction {
-  DoNothing = 0,
-  SendEndCallback = 1, // Reserved for future use
-  SendAlternateToPenaltyBox = 2,
-  RemoveAlternatePermanently = 3, // Reserved for future use
-  InsertDiscontinuity = 4, // Reserved for future use
-  RetryRequest = 5,
-}
-
-export const enum ErrorActionFlags {
-  None = 0,
-  MoveAllAlternatesMatchingHost = 1,
-  MoveAllAlternatesMatchingHDCP = 1 << 1,
-  SwitchToSDR = 1 << 2, // Reserved for future use
-}
-
-export type IErrorAction = {
-  action: NetworkErrorAction;
-  flags: ErrorActionFlags;
-  retryCount?: number;
-  retryConfig?: RetryConfig;
-  hdcpLevel?: HdcpLevel;
-  nextAutoLevel?: number;
-  resolved?: boolean;
-};

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1037,8 +1037,8 @@ export type {
   SubtitleTrackSwitchData,
 } from './types/events';
 export type {
-  IErrorAction,
   NetworkErrorAction,
   ErrorActionFlags,
-} from './errors';
+  IErrorAction,
+} from './controller/error-controller';
 export type { AttrList } from './utils/attr-list';

--- a/src/loader/date-range.ts
+++ b/src/loader/date-range.ts
@@ -1,7 +1,8 @@
 import { AttrList } from '../utils/attr-list';
 import { logger } from '../utils/logger';
 
-export enum DateRangeAttribute {
+// Avoid exporting const enum so that these values can be inlined
+const enum DateRangeAttribute {
   ID = 'ID',
   CLASS = 'CLASS',
   START_DATE = 'START-DATE',
@@ -11,6 +12,24 @@ export enum DateRangeAttribute {
   PLANNED_DURATION = 'PLANNED-DURATION',
   SCTE35_OUT = 'SCTE35-OUT',
   SCTE35_IN = 'SCTE35-IN',
+}
+
+export function isDateRangeCueAttribute(attrName: string): boolean {
+  return (
+    attrName !== DateRangeAttribute.ID &&
+    attrName !== DateRangeAttribute.CLASS &&
+    attrName !== DateRangeAttribute.START_DATE &&
+    attrName !== DateRangeAttribute.DURATION &&
+    attrName !== DateRangeAttribute.END_DATE &&
+    attrName !== DateRangeAttribute.END_ON_NEXT
+  );
+}
+
+export function isSCTE35Attribute(attrName: string): boolean {
+  return (
+    attrName === DateRangeAttribute.SCTE35_OUT ||
+    attrName === DateRangeAttribute.SCTE35_IN
+  );
 }
 
 export class DateRange {

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -10,7 +10,7 @@ import type {
 } from '../types/loader';
 import type { KeySystemFormats } from '../utils/mediakeys-helper';
 
-export enum ElementaryStreamTypes {
+export const enum ElementaryStreamTypes {
   AUDIO = 'audio',
   VIDEO = 'video',
   AUDIOVIDEO = 'audiovideo',

--- a/src/types/cmcd.ts
+++ b/src/types/cmcd.ts
@@ -6,7 +6,7 @@ export const CMCDVersion = 1;
 /**
  * CMCD Object Type
  */
-export enum CMCDObjectType {
+export const enum CMCDObjectType {
   MANIFEST = 'm',
   AUDIO = 'a',
   VIDEO = 'v',
@@ -21,17 +21,12 @@ export enum CMCDObjectType {
 /**
  * CMCD Streaming Format
  */
-export enum CMCDStreamingFormat {
-  DASH = 'd',
-  HLS = 'h',
-  SMOOTH = 's',
-  OTHER = 'o',
-}
+export const CMCDStreamingFormatHLS = 'h';
 
 /**
  * CMCD Streaming Type
  */
-export enum CMCDStreamType {
+const enum CMCDStreamType {
   VOD = 'v',
   LIVE = 'l',
 }
@@ -212,7 +207,7 @@ export interface CMCD {
    *
    * If the streaming format being requested is unknown, then this key MUST NOT be used.
    */
-  sf?: CMCDStreamingFormat;
+  sf?: typeof CMCDStreamingFormatHLS;
 
   /**
    * Session ID

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -90,7 +90,7 @@ export interface DemuxedUserdataTrack extends DemuxedTrack {
   samples: UserdataSample[];
 }
 
-export enum MetadataSchema {
+export const enum MetadataSchema {
   audioId3 = 'org.id3',
   dateRange = 'com.apple.quicktime.HLS',
   emsg = 'https://aomedia.org/emsg/ID3',

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -22,12 +22,13 @@ import type { Track, TrackSet } from './track';
 import type { SourceBufferName } from './buffer';
 import type { ChunkMetadata } from './transmuxer';
 import type { LoadStats } from '../loader/load-stats';
-import type { ErrorDetails, ErrorTypes, IErrorAction } from '../errors';
+import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type { AttrList } from '../utils/attr-list';
 import type { HlsListeners } from '../events';
 import type { KeyLoaderInfo } from '../loader/key-loader';
 import type { LevelKey } from '../loader/level-key';
+import type { IErrorAction } from '../controller/error-controller';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -41,7 +41,7 @@ export type HdcpLevel = (typeof HdcpLevels)[number];
 
 export type VariableMap = Record<string, string>;
 
-export enum HlsSkip {
+export const enum HlsSkip {
   No = '',
   Yes = 'YES',
   v2 = 'v2',

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -164,14 +164,14 @@ export interface Loader<T extends LoaderContext> {
   stats: LoaderStats;
 }
 
-export enum PlaylistContextType {
+export const enum PlaylistContextType {
   MANIFEST = 'manifest',
   LEVEL = 'level',
   AUDIO_TRACK = 'audioTrack',
   SUBTITLE_TRACK = 'subtitleTrack',
 }
 
-export enum PlaylistLevelType {
+export const enum PlaylistLevelType {
   MAIN = 'main',
   AUDIO = 'audio',
   SUBTITLE = 'subtitle',

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -208,7 +208,7 @@ const backgroundColors = [
   'transparent',
 ];
 
-enum VerboseLevel {
+const enum VerboseLevel {
   ERROR = 0,
   TEXT = 1,
   WARNING = 2,

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -3,7 +3,7 @@ import type { DRMSystemOptions, EMEControllerConfig } from '../config';
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess
  */
-export enum KeySystems {
+export const enum KeySystems {
   CLEARKEY = 'org.w3.clearkey',
   FAIRPLAY = 'com.apple.fps',
   PLAYREADY = 'com.microsoft.playready',
@@ -11,7 +11,7 @@ export enum KeySystems {
 }
 
 // Playlist #EXT-X-KEY KEYFORMAT values
-export enum KeySystemFormats {
+export const enum KeySystemFormats {
   CLEARKEY = 'org.w3.clearkey',
   FAIRPLAY = 'com.apple.streamingkeydelivery',
   PLAYREADY = 'com.microsoft.playready',
@@ -34,7 +34,7 @@ export function keySystemFormatToKeySystemDomain(
 }
 
 // System IDs for which we can extract a key ID from "encrypted" event PSSH
-export enum KeySystemIds {
+export const enum KeySystemIds {
   // CENC = '1077efecc0b24d02ace33c1e52e2fb4b'
   // CLEARKEY = 'e2719d58a985b3c9781ab030af78d30e',
   // FAIRPLAY = '94ce86fb07ff4f43adb893d2fa968ca2',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* global process:false, __dirname:false */
 const pkgJson = require('./package.json');
 const path = require('path');
 const webpack = require('webpack');
@@ -64,7 +65,12 @@ const baseConfig = {
         options: {
           babelrc: false,
           presets: [
-            '@babel/preset-typescript',
+            [
+              '@babel/preset-typescript',
+              {
+                optimizeConstEnums: true,
+              },
+            ],
             [
               '@babel/preset-env',
               {


### PR DESCRIPTION
### This PR will...
Inline existing enums as much as possible by using const enums and limiting export scope.

### Why is this Pull Request needed?
Reduces bundle size and module complexity.

See babel's [babel-preset-typescript `optimizeConstEnums`](https://babeljs.io/docs/babel-preset-typescript#optimizeconstenums) for optimizations. Many of the enums in the library are exported as types and thus are not completely inlined. This change at least replaces IFFE output with object literals and inlines where possible.