### PR TITLE
add a link to open in stackblitz to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ You can safely require this library in Node and **absolutely nothing will happen
 
 ## Getting started with development
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/video-dev/hls.js/tree/master?title=HLS.JS)
+
 First, checkout the repository and install the required dependencies
 
 ```sh


### PR DESCRIPTION
### This PR will...

Add a link that loads the repo in stackblitz with the demo running.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/3259993/225920280-5d266560-f017-46ac-bbe4-485bed4d35c1.png">

At the moment it initially loads `/` not `/demo` so you get an index of the files in the root. We can improve this but I think it would make sense to get the rollup switch done first than keep messing with webpack things.

### Why is this Pull Request needed?

It's a quick way of getting a dev env running and allows running the demo locally in the browser.
