### PR TITLE
Live reload level switch and error handling improvements

### DIFF
--- a/src/utils/error-helper.ts
+++ b/src/utils/error-helper.ts
@@ -61,5 +61,8 @@ export function shouldRetry(
 
 export function retryForHttpStatus(httpStatus: number | undefined) {
   // Do not retry on status 4xx, status 0 (CORS error), or undefined (decrypt/gap/parse error)
-  return !!httpStatus && (httpStatus < 400 || httpStatus > 499);
+  return (
+    (httpStatus === 0 && navigator.onLine === false) ||
+    (!!httpStatus && (httpStatus < 400 || httpStatus > 499))
+  );
 }


### PR DESCRIPTION
### This PR will...
- Maintain live reload pace after level switch
- Only define deliveryDirectives when when blocking reload is available (correct error handling)
- Retry main playlist on status 0 when `navigator.onLine` is false (this policy is not extended to audio and subtitle track media playlists)

### Why is this Pull Request needed?
On level switch the reload interval was being added to the already scheduled time for next reload, which could skip reloads after level switch.

### Related issues:
#5282
#5306

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
