### PR TITLE
Add playlist RTT and time-to-load given buffer ahead

### DIFF
--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -203,6 +203,8 @@ class XhrLoader implements Loader<LoaderContext> {
           const len =
             xhr.responseType === 'arraybuffer' ? data.byteLength : data.length;
           stats.loaded = stats.total = len;
+          stats.bwEstimate =
+            (stats.total * 8000) / (stats.loading.end - stats.loading.first);
           if (!this.callbacks) {
             return;
           }


### PR DESCRIPTION
### This PR will...
Add playlist load times and TTFB to load time calculations when switching levels. Refactor time-to-load calculations into a separate function.

### Why is this Pull Request needed?
Account for playlist connect + load times when considering level switch to get a more accurate estimate of the time required to change levels.