### PR TITLE
Fix for SourceBuffer full error handling

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -401,7 +401,10 @@ class AudioStreamController
     if (!mainBufferLength) {
       return maxConfigBuffer;
     }
-    return Math.max(maxConfigBuffer, mainBufferLength);
+    return Math.min(
+      Math.max(maxConfigBuffer, mainBufferLength),
+      this.config.maxMaxBufferLength
+    );
   }
 
   onMediaDetaching() {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1481,10 +1481,11 @@ export default class BaseStreamController
       );
       // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
       // reduce max buf len if current position is buffered
-      let flushBuffer = true;
-      if (bufferedInfo && bufferedInfo.len > 0.5) {
-        flushBuffer = !this.reduceMaxBufferLength(bufferedInfo.len);
+      const buffered = bufferedInfo && bufferedInfo.len > 0.5;
+      if (buffered) {
+        this.reduceMaxBufferLength(bufferedInfo.len);
       }
+      const flushBuffer = !buffered;
       if (flushBuffer) {
         // current position is not buffered, but browser is still complaining about buffer full error
         // this happens on IE/Edge, refer to https://github.com/video-dev/hls.js/pull/708


### PR DESCRIPTION
### This PR will...
Manage appendBuffer SourceBuffer full errors correctly when audio bitrate is higher than video..

### Why is this Pull Request needed?
When the audio bitrate is higher than the video bitrate, SourceBuffer full errors can occur on the audio buffer as the audio-stream-controller tries to keep up with the video buffer length.

The audio-stream-controller was going past `maxMaxBufferLength` when the video buffer exceeded that length prior to its value being reduced after the first buffer full error. Further more, the max length was not being reduced more than the current buffer length on the second error at which point the entire buffer was flushed. The entire buffer should only be flushed when the buffer that errored is starved (to remove back and forward buffer not used for playback). 

### Resolves issues:
Fixes #5328
