### PR TITLE
Handle invalid signed "tfdt" decode time values

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -168,11 +168,12 @@ class PassThroughRemuxer implements Remuxer {
     }
 
     const startDTS = getStartDTS(initData, data);
+    const decodeTime = startDTS === null ? timeOffset : startDTS;
     if (
-      isInvalidInitPts(initPTS, startDTS, timeOffset) ||
+      isInvalidInitPts(initPTS, decodeTime, timeOffset) ||
       (initSegment.timescale !== initPTS.timescale && accurateTimeOffset)
     ) {
-      initSegment.initPTS = startDTS - timeOffset;
+      initSegment.initPTS = decodeTime - timeOffset;
       this.initPTS = initPTS = {
         baseTime: initSegment.initPTS,
         timescale: 1,
@@ -181,7 +182,7 @@ class PassThroughRemuxer implements Remuxer {
 
     const duration = getDuration(data, initData);
     const startTime = audioTrack
-      ? startDTS - initPTS.baseTime / initPTS.timescale
+      ? decodeTime - initPTS.baseTime / initPTS.timescale
       : (lastEndTime as number);
     const endTime = startTime + duration;
     offsetStartDTS(initData, data, initPTS.baseTime / initPTS.timescale);

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -366,6 +366,16 @@ export function getStartDTS(initData: InitData, fmp4: Uint8Array): number {
             if (version === 1) {
               baseTime *= Math.pow(2, 32);
               baseTime += readUint32(tfdt, 8);
+              // If value is too large, assume signed 64-bit. Negative track fragment decode times are invalid, but they exist in the wild.
+              // This prevents large values from being used for initPTS, which can cause playlist sync issues.
+              // https://github.com/video-dev/hls.js/issues/5303
+              if (baseTime > Math.pow(2, 63)) {
+                const signedValue = baseTime - Math.pow(2, 64);
+                logger.warn(
+                  `[mp4-demuxer]: Found large track fragment decode time of ${baseTime}, treating as signed 64-bit int ${signedValue}`
+                );
+                baseTime = signedValue;
+              }
             }
             // assume a 90kHz clock if no timescale was specified
             const scale = track.timescale || 90e3;

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -367,17 +367,17 @@ export function getStartDTS(
           if (track) {
             let baseTime = readUint32(tfdt, 4);
             if (version === 1) {
-              baseTime *= Math.pow(2, 32);
-              baseTime += readUint32(tfdt, 8);
               // If value is too large, assume signed 64-bit. Negative track fragment decode times are invalid, but they exist in the wild.
               // This prevents large values from being used for initPTS, which can cause playlist sync issues.
               // https://github.com/video-dev/hls.js/issues/5303
-              if (baseTime > Math.pow(2, 63)) {
+              if (baseTime === UINT32_MAX) {
                 logger.warn(
-                  `[mp4-demuxer]: Found large track fragment decode time of ${baseTime}, using last result ${result} or playlist time instead.`
+                  `[mp4-demuxer]: Ignoring assumed invalid signed 64-bit track fragment decode time`
                 );
                 return result;
               }
+              baseTime *= UINT32_MAX + 1;
+              baseTime += readUint32(tfdt, 8);
             }
             // assume a 90kHz clock if no timescale was specified
             const scale = track.timescale || 90e3;


### PR DESCRIPTION
### This PR will...
Live to VOD streams from some vendors contain invalid CMAF tfdt (track fragment decode time). We suspect they tried writing a negative value to what is defines as an unsigned 64-bit integer. Assume that is the case when a value above 63-bit is found, and ignore it. Continuing to parse the remaining tfdt atoms if present, or returning null should ensure that the player uses a valid value or fallback to playlist time/passthrough, and prevents the invalid media timecode from shifting the playlist it is found in.

### Why is this Pull Request needed?
If the first fmp4 segment loaded for a playlist has an invalid tfdt base media time the `initPTS` is assigned a bad value and the playlist is shifted. This can cause CMAF audio and video to be completely de-synced (the segments in the playlist affected can no longer be found).

### Resolves issues:
Resolves #5303
