### PR TITLE
More rollup PR tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage/
 /cloudflare-pages
 /api-docs
 /api-docs-markdown
+/karma-temp
 
 # eslint
 .eslintcache

--- a/build-config.js
+++ b/build-config.js
@@ -220,6 +220,7 @@ const buildRollupConfig = ({
   allowCircularDeps,
   includeCoverage,
   sourcemap = true,
+  outputFile = null,
 }) => {
   const outputName = buildTypeToOutputName[type];
   const extension = format === FORMAT.esm ? 'mjs' : 'js';
@@ -234,7 +235,9 @@ const buildRollupConfig = ({
     },
     output: {
       name: 'Hls',
-      file: minified
+      file: outputFile
+        ? outputFile
+        : minified
         ? `./dist/${outputName}.min.${extension}`
         : `./dist/${outputName}.${extension}`,
       format,

--- a/build-config.js
+++ b/build-config.js
@@ -220,7 +220,6 @@ const buildRollupConfig = ({
   allowCircularDeps,
   includeCoverage,
   sourcemap = true,
-  outputFile = null,
 }) => {
   const outputName = buildTypeToOutputName[type];
   const extension = format === FORMAT.esm ? 'mjs' : 'js';
@@ -235,9 +234,7 @@ const buildRollupConfig = ({
     },
     output: {
       name: 'Hls',
-      file: outputFile
-        ? outputFile
-        : minified
+      file: minified
         ? `./dist/${outputName}.min.${extension}`
         : `./dist/${outputName}.${extension}`,
       format,

--- a/build-config.js
+++ b/build-config.js
@@ -42,6 +42,8 @@ const addContentSteeringSupport =
 const addVariableSubstitutionSupport =
   !!env.VARIABLE_SUBSTITUTION || !!env.USE_VARIABLE_SUBSTITUTION;
 
+const shouldBundleWorker = (format) => format !== FORMAT.esm;
+
 const buildConstants = (type, additional = {}) => ({
   preventAssignment: true,
   values: {
@@ -241,8 +243,8 @@ const buildRollupConfig = ({
         ? `./dist/${outputName}.min.${extension}`
         : `./dist/${outputName}.${extension}`,
       format,
-      banner: format === FORMAT.esm ? null : workerFnBanner,
-      footer: format === FORMAT.esm ? null : workerFnFooter,
+      banner: shouldBundleWorker(format) ? workerFnBanner : null,
+      footer: shouldBundleWorker(format) ? workerFnFooter : null,
       sourcemap,
       sourcemapFile: minified
         ? `${outputName}.${extension}.min.map`
@@ -251,6 +253,9 @@ const buildRollupConfig = ({
     plugins: [
       ...basePlugins,
       replace(buildConstants(type)),
+      ...(!shouldBundleWorker(format)
+        ? [alias({ entries: { './transmuxer-worker': '../empty.js' } })]
+        : []),
       ...(type === BUILD_TYPE.light
         ? [alias({ entries: getAliasesForLightDist() })]
         : []),

--- a/build-config.js
+++ b/build-config.js
@@ -42,7 +42,7 @@ const addContentSteeringSupport =
 const addVariableSubstitutionSupport =
   !!env.VARIABLE_SUBSTITUTION || !!env.USE_VARIABLE_SUBSTITUTION;
 
-const buildConstants = (type, format) => ({
+const buildConstants = (type, additional = {}) => ({
   preventAssignment: true,
   values: {
     __VERSION__: JSON.stringify(pkgJson.version),
@@ -60,6 +60,7 @@ const buildConstants = (type, format) => ({
     __USE_VARIABLE_SUBSTITUTION__: JSON.stringify(
       type === BUILD_TYPE.full || addVariableSubstitutionSupport
     ),
+    ...additional,
   },
 });
 
@@ -249,7 +250,7 @@ const buildRollupConfig = ({
     },
     plugins: [
       ...basePlugins,
-      replace(buildConstants(type, format)),
+      replace(buildConstants(type)),
       ...(type === BUILD_TYPE.light
         ? [alias({ entries: getAliasesForLightDist() })]
         : []),
@@ -300,14 +301,16 @@ const configs = Object.entries({
       name: 'HlsWorker',
       file: './dist/hls.worker.js',
       format: FORMAT.iife,
-      banner: workerFnBanner,
-      footer: workerFnFooter.replace('false', 'true'),
       sourcemap: true,
       sourcemapFile: 'hls.worker.js.map',
     },
     plugins: [
       ...basePlugins,
-      replace(buildConstants(BUILD_TYPE.full, FORMAT.iife)),
+      replace(
+        buildConstants(BUILD_TYPE.full, {
+          __IN_WORKER__: JSON.stringify(true),
+        })
+      ),
       buildBabelLegacyBrowsers({ stripConsole: true }),
       terser(),
     ],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,6 +11,7 @@ const rollupPreprocessor = buildRollupConfig({
   allowCircularDeps: true,
   includeCoverage,
   sourcemap: false,
+  outputFile: 'temp/tests.js',
 });
 
 // preprocess matching files before serving them to the browser

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,6 @@ const rollupPreprocessor = buildRollupConfig({
   allowCircularDeps: true,
   includeCoverage,
   sourcemap: false,
-  outputFile: 'temp/tests.js',
 });
 
 // preprocess matching files before serving them to the browser

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ const rollupPreprocessor = buildRollupConfig({
   allowCircularDeps: true,
   includeCoverage,
   sourcemap: false,
-  outputFile: 'temp/tests.js',
+  outputFile: 'karma-temp/tests.js',
 });
 
 // preprocess matching files before serving them to the browser

--- a/src/demux/inject-worker.ts
+++ b/src/demux/inject-worker.ts
@@ -1,3 +1,7 @@
+// ensure the worker ends up in the bundle
+// If the worker should not be included this gets aliased to empty.js
+import './transmuxer-worker';
+
 export function hasUMDWorker(): boolean {
   return typeof __HLS_WORKER_BUNDLE__ === 'function';
 }


### PR DESCRIPTION
### This PR will...

Remove the temporary output name for karma because the karma rollup plugin _shouldn't_ be writing anything to disc. It seems fine locally but maybe I'm missing something?

And then remove the need for the wrapping function for the worker build by just replacing the `__IN_WORKER__` var