### PR TITLE
Clear subtitle-stream-controller buffered list on detach

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2947,6 +2947,8 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData): void;
     // (undocumented)
     onManifestLoading(): void;
+    // (undocumented)
+    onMediaDetaching(): void;
     // Warning: (ae-forgotten-export) The symbol "SubtitleFragProcessed" needs to be exported by the entry point hls.d.ts
     //
     // (undocumented)

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -106,6 +106,11 @@ export class SubtitleStreamController
     this.fragmentTracker.removeAllFragments();
   }
 
+  onMediaDetaching(): void {
+    this.tracksBuffered = [];
+    super.onMediaDetaching();
+  }
+
   onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
     this.mainDetails = data.details;
   }


### PR DESCRIPTION
### This PR will...
Display subtitles that have been loaded before detaching and reattaching the media element (or using `recoverMediaError`).
 
### Why is this Pull Request needed?
The subtitle-stream-controller keeps track of which subtitle segments have been loaded using  `tracksBuffered`. This data must be cleared on detach since the cues containing the loaded subtitles are removed at the same time. If we do not do this then subtitles that have been loaded previously will not be reloaded or displayed after reattaching the media element (#5353).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5353

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
