### PR TITLE
Relax TTFB timeout on manifest request

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -405,7 +405,7 @@ export const hlsDefaultConfig: HlsConfig = {
   },
   manifestLoadPolicy: {
     default: {
-      maxTimeToFirstByteMs: 10000,
+      maxTimeToFirstByteMs: Infinity,
       maxLoadTimeMs: 20000,
       timeoutRetry: {
         maxNumRetry: 2,

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -84,13 +84,17 @@ class FetchLoader implements Loader<LoaderContext> {
       callbacks.onProgress;
     const isArrayBuffer = context.responseType === 'arraybuffer';
     const LENGTH = isArrayBuffer ? 'byteLength' : 'length';
+    const { maxTimeToFirstByteMs, maxLoadTimeMs } = config.loadPolicy;
 
     this.context = context;
     this.config = config;
     this.callbacks = callbacks;
     this.request = this.fetchSetup(context, initParams);
     self.clearTimeout(this.requestTimeout);
-    config.timeout = config.loadPolicy.maxTimeToFirstByteMs;
+    config.timeout =
+      maxTimeToFirstByteMs && Number.isFinite(maxTimeToFirstByteMs)
+        ? maxTimeToFirstByteMs
+        : maxLoadTimeMs;
     this.requestTimeout = self.setTimeout(() => {
       this.abortInternal();
       callbacks.onTimeout(stats, context, this.response);
@@ -104,11 +108,11 @@ class FetchLoader implements Loader<LoaderContext> {
         const first = Math.max(self.performance.now(), stats.loading.start);
 
         self.clearTimeout(this.requestTimeout);
-        config.timeout = config.loadPolicy.maxLoadTimeMs;
+        config.timeout = maxLoadTimeMs;
         this.requestTimeout = self.setTimeout(() => {
           this.abortInternal();
           callbacks.onTimeout(stats, context, this.response);
-        }, config.loadPolicy.maxLoadTimeMs - (first - stats.loading.start));
+        }, maxLoadTimeMs - (first - stats.loading.start));
 
         if (!response.ok) {
           const { status, statusText } = response;

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -203,8 +203,10 @@ describe('ErrorController Integration Tests', function () {
             )
           )
         );
-        timers.tick(hls.config.playlistLoadPolicy.default.maxLoadTimeMs);
-        timers.tick(hls.config.playlistLoadPolicy.default.maxLoadTimeMs);
+        // tick 3 times to trigger 2 retries and then an error
+        timers.tick(hls.config.manifestLoadPolicy.default.maxLoadTimeMs + 1);
+        timers.tick(hls.config.manifestLoadPolicy.default.maxLoadTimeMs + 1);
+        timers.tick(hls.config.manifestLoadPolicy.default.maxLoadTimeMs);
       }).then(
         expectFatalErrorEventToStopPlayer(
           hls,


### PR DESCRIPTION
### This PR will...
- Relax TTFB timeout on manifest request
- Add support for LoadPolicy `maxTimeToFirstByteMs` of Infinity and similarly ignore value of 0

### Why is this Pull Request needed?
Demonstrates how to setup  and allows for a single timeout for requests and reduces the number of timeouts created in the critical path.

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
