### PR TITLE
Content-Steering fix: Keep bit identical subtitle content

### DIFF
--- a/src/utils/media-option-attributes.ts
+++ b/src/utils/media-option-attributes.ts
@@ -1,0 +1,45 @@
+import type { Level } from '../types/level';
+import type { MediaAttributes, MediaPlaylist } from '../types/media-playlist';
+
+export function subtitleOptionsIdentical(
+  trackList1: MediaPlaylist[] | Level[],
+  trackList2: MediaPlaylist[]
+): boolean {
+  if (trackList1.length !== trackList2.length) {
+    return false;
+  }
+  for (let i = 0; i < trackList1.length; i++) {
+    if (
+      !subtitleAttributesIdentical(
+        trackList1[i].attrs as MediaAttributes,
+        trackList2[i].attrs
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function subtitleAttributesIdentical(
+  attrs1: MediaAttributes,
+  attrs2: MediaAttributes
+): boolean {
+  // Media options with the same rendition ID must be bit identical
+  const stableRenditionId = attrs1['STABLE-RENDITION-ID'];
+  if (stableRenditionId) {
+    return stableRenditionId === attrs2['STABLE-RENDITION-ID'];
+  }
+  // When rendition ID is not present, compare attributes
+  return ![
+    'LANGUAGE',
+    'NAME',
+    'CHARACTERISTICS',
+    'AUTOSELECT',
+    'DEFAULT',
+    'FORCED',
+  ].some(
+    (subtitleAttribute) =>
+      attrs1[subtitleAttribute] !== attrs2[subtitleAttribute]
+  );
+}

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -12,7 +12,17 @@ const mediaMock = {
   removeEventListener() {},
 };
 
-const tracksMock = [{ id: 0, details: { url: '', fragments: [] } }, { id: 1 }];
+const tracksMock = [
+  {
+    id: 0,
+    details: { url: '', fragments: [] },
+    attrs: {},
+  },
+  {
+    id: 1,
+    attrs: {},
+  },
+];
 
 describe('SubtitleStreamController', function () {
   let hls;
@@ -41,6 +51,7 @@ describe('SubtitleStreamController', function () {
     subtitleStreamController.onMediaDetaching(Events.MEDIA_DETACHING, {
       media: mediaMock,
     });
+    hls.destroy();
   });
 
   describe('onSubtitleTracksUpdate', function () {

--- a/tests/unit/controller/timeline-controller.js
+++ b/tests/unit/controller/timeline-controller.js
@@ -22,8 +22,8 @@ describe('TimelineController', function () {
         Events.SUBTITLE_TRACKS_UPDATED,
         {
           subtitleTracks: [
-            { id: 0, name: 'en' },
-            { id: 1, name: 'ru' },
+            { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
+            { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
           ],
         }
       );
@@ -41,8 +41,8 @@ describe('TimelineController', function () {
         Events.SUBTITLE_TRACKS_UPDATED,
         {
           subtitleTracks: [
-            { id: 0, name: 'en' },
-            { id: 1, name: 'ru' },
+            { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
+            { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
           ],
         }
       );
@@ -62,8 +62,8 @@ describe('TimelineController', function () {
 
       timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
         subtitleTracks: [
-          { id: 0, name: 'en' },
-          { id: 1, name: 'ru' },
+          { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
+          { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
         ],
       });
 
@@ -78,8 +78,8 @@ describe('TimelineController', function () {
 
       timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
         subtitleTracks: [
-          { id: 0, name: 'ru' },
-          { id: 1, name: 'en' },
+          { id: 0, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
+          { id: 1, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
         ],
       });
 
@@ -146,6 +146,7 @@ describe('TimelineController', function () {
           {
             id: 0,
             name: 'en',
+            attrs: {},
           },
         ],
       });


### PR DESCRIPTION
### This PR will...
Do not clear subtitle cues or tracked fragments when updating subtitle tracks with identical tracks.

### Why is this Pull Request needed?
When Content Steering forces a Pathway change, the player updates levels and tracks. Content from matching playlists (where STABLE-RENDITION-ID match) should not be cleared as these playlists are bit-identical.

### Are there any points in the code the reviewer needs to double check?
This change also covers tracks with matching attributes. The assumptions is a new list with the exact same languages and characteristics should match the current list for the same Multivariant Playlist.

### Resolves issues:
Fixes #5361

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
