### PR TITLE
Reset default subtitle track selection when reusing player

### DIFF
--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -31,8 +31,8 @@ describe('SubtitleTrackController', function () {
       {
         id: 1,
         groupId: 'default-text-group',
-        lang: 'en',
-        name: 'English',
+        lang: 'sv',
+        name: 'Swedish',
         type: 'SUBTITLES',
         url: 'bar',
       },
@@ -40,7 +40,7 @@ describe('SubtitleTrackController', function () {
         id: 2,
         groupId: 'default-text-group',
         lang: 'en',
-        name: 'English',
+        name: 'Untitled CC',
         type: 'SUBTITLES',
         url: 'foo',
         details: { live: true },
@@ -48,7 +48,7 @@ describe('SubtitleTrackController', function () {
     ];
 
     const textTrack1 = videoElement.addTextTrack('subtitles', 'English', 'en');
-    const textTrack2 = videoElement.addTextTrack('subtitles', 'Swedish', 'se');
+    const textTrack2 = videoElement.addTextTrack('subtitles', 'Swedish', 'sv');
     const textTrack3 = videoElement.addTextTrack(
       'captions',
       'Untitled CC',
@@ -148,7 +148,7 @@ describe('SubtitleTrackController', function () {
         {
           id: 1,
           groupId: 'default-text-group',
-          name: 'English',
+          name: 'Swedish',
           type: 'SUBTITLES',
           url: 'bar',
         },


### PR DESCRIPTION
### This PR will...
- Reset default subtitle track selection when reusing player
- Match TextTrack language and label to subtitle media option even when TextTrack and media option track are aligned by index
- Reset initPTS on manifest loaded (cherry-picked into v1.4)

### Why is this Pull Request needed?
Some of the settings used to select the default text track are not reset when loading a new source. If not reset, the player will use the selected index with the new source even when languages do not match. HLS.js should always use HLS defaults, but allow the app to change the selection based on user preferences when tracks change.

TODO:
- [ ] TimelineController, SubtitleTrackController, and SubtitleStreamController need to align on which media element TextTracks map to which `hls.subtitleTracks`
- [ ] Create a mapping from media option tracks (`hls.subtitleTrack` index) to TextTrack object (comparing tracks to options in the track controller is a hack to get things working):
```
nextTrack.label !== mediaOptionTrack.name ||
nextTrack.language !== mediaOptionTrack.lang
```
- [ ] Add unit tests that cover subtitle selection when existing video TextTracks do not match subtitle controller tracks


Attempts to resolve #4571
