### PR TITLE
fix: don't trim line breaks

### DIFF
--- a/src/utils/webvtt-parser.ts
+++ b/src/utils/webvtt-parser.ts
@@ -103,7 +103,6 @@ export function parseWebVTT(
   // Convert byteArray into string, replacing any somewhat exotic linefeeds with "\n", then split on that character.
   // Uint8Array.prototype.reduce is not implemented in IE11
   const vttLines = utf8ArrayToStr(new Uint8Array(vttByteArray))
-    .trim()
     .replace(LINEBREAKS, '\n')
     .split('\n');
   const cues: VTTCue[] = [];
@@ -150,14 +149,14 @@ export function parseWebVTT(
     cue.endTime = Math.max(startTime + duration, 0);
 
     //trim trailing webvtt block whitespaces
-    const text = cue.text.trim();
+    const text = cue.text;
 
     // Fix encoding of special characters
     cue.text = decodeURIComponent(encodeURIComponent(text));
 
     // If the cue was not assigned an id from the VTT file (line above the content), create one.
     if (!cue.id) {
-      cue.id = generateCueId(cue.startTime, cue.endTime, text);
+      cue.id = generateCueId(cue.startTime, cue.endTime, text.trim());
     }
 
     if (cue.endTime > 0) {


### PR DESCRIPTION
### This PR will...

Allow empty line break lines as subtitle rows.

### Why is this Pull Request needed?

In SRT they have no means to define line height. So they use line breaks to define where subtitles should be in video.

### Are there any points in the code the reviewer needs to double check?

I am unsure how row 106 `.trim()` will effect overall, but in this case it allows for empty line breaks to exist. The other `trim()`relocation trims the subtitle row for extra white spaces.

### Resolves issues:

[#5337](https://github.com/video-dev/hls.js/issues/5337)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
