### PR TITLE
Setup npm provenance statements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,9 @@ jobs:
     needs: [config, test_unit]
     if: needs.config.outputs.tag || needs.config.outputs.isMainBranch == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,6 @@ jobs:
     if: needs.config.outputs.tag || needs.config.outputs.isMainBranch == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v3

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -6,7 +6,7 @@ if [[ $(node ./scripts/check-already-published.js) = "not published" ]]; then
   # see https://docs.npmjs.com/private-modules/ci-server-config
   echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
   if [[  -z "$TAG" ]]; then
-    npm publish --tag canary
+    npm publish --provenance --tag canary
     echo "Published canary."
     curl https://purge.jsdelivr.net/npm/hls.js@canary
     curl https://purge.jsdelivr.net/npm/hls.js@canary/dist/hls-demo.js
@@ -19,7 +19,7 @@ if [[ $(node ./scripts/check-already-published.js) = "not published" ]]; then
       exit 1
     fi
     echo "Publishing tag: ${tag}"
-    npm publish --tag "${tag}"
+    npm publish --provenance --tag "${tag}"
     curl "https://purge.jsdelivr.net/npm/hls.js@${tag}"
     echo "Published."
   fi


### PR DESCRIPTION
### This PR will...

Setup npm provenance statements.

Easiest way to test it will be with the canary release when this is merged

### Why is this Pull Request needed?

Adds a signature to the package in npm that lets users verify the package was built and published from this action.

see https://docs.npmjs.com/generating-provenance-statements/