### PR TITLE
Bugfix: reset remainderData in resetContiguity

### DIFF
--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -87,7 +87,9 @@ class MP4Demuxer implements Demuxer {
     videoTrack.duration = audioTrack.duration = trackDuration;
   }
 
-  public resetContiguity(): void {}
+  public resetContiguity(): void {
+    this.remainderData = null;
+  }
 
   static probe(data: Uint8Array) {
     // ensure we find a moof box in the first 16 kB


### PR DESCRIPTION
### This PR will...
Reset `remainingData` in order to ensure we don't continue appending new fragments on top of old incomplete fragments stored in `remainingData`.

### Why is this Pull Request needed?
On seek, with progressive mode on, the segmentedData can end up with an empty valid segment and large remainder segment. The remainder segment consists of an incomplete moof+mdat from the fragment pre-seek and the complete fragment post-seek. This gets output when flush() is called, triggering an error as the buffer appended to the MediaSource is invalid.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#5409 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
