### PR TITLE
Fire STEERING_MANIFEST_LOADED event when loading a Content Steering Manifest

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1187,6 +1187,8 @@ export enum Events {
     // (undocumented)
     NON_NATIVE_TEXT_TRACKS_FOUND = "hlsNonNativeTextTracksFound",
     // (undocumented)
+    STEERING_MANIFEST_LOADED = "hlsSteeringManifestLoaded",
+    // (undocumented)
     SUBTITLE_FRAG_PROCESSED = "hlsSubtitleFragProcessed",
     // (undocumented)
     SUBTITLE_TRACK_LOADED = "hlsSubtitleTrackLoaded",
@@ -1767,6 +1769,8 @@ export interface HlsListeners {
     [Events.MEDIA_DETACHING]: (event: Events.MEDIA_DETACHING) => void;
     // (undocumented)
     [Events.NON_NATIVE_TEXT_TRACKS_FOUND]: (event: Events.NON_NATIVE_TEXT_TRACKS_FOUND, data: NonNativeTextTracksData) => void;
+    // (undocumented)
+    [Events.STEERING_MANIFEST_LOADED]: (event: Events.STEERING_MANIFEST_LOADED, data: SteeringManifestLoadedData) => void;
     // (undocumented)
     [Events.SUBTITLE_FRAG_PROCESSED]: (event: Events.SUBTITLE_FRAG_PROCESSED, data: SubtitleFragProcessedData) => void;
     // (undocumented)
@@ -2808,6 +2812,15 @@ export class Part extends BaseSegment {
     stats: LoadStats;
 }
 
+// Warning: (ae-missing-release-tag) "PathwayClone" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type PathwayClone = {
+    'BASE-ID': string;
+    ID: string;
+    'URI-REPLACEMENT': UriReplacement;
+};
+
 // Warning: (ae-missing-release-tag) "PlaylistContextType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2888,6 +2901,27 @@ export type RetryConfig = {
 //
 // @public (undocumented)
 export type SourceBufferName = 'video' | 'audio' | 'audiovideo';
+
+// Warning: (ae-missing-release-tag) "SteeringManifest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SteeringManifest = {
+    VERSION: 1;
+    TTL: number;
+    'RELOAD-URI'?: string;
+    'PATHWAY-PRIORITY': string[];
+    'PATHWAY-CLONES'?: PathwayClone[];
+};
+
+// Warning: (ae-missing-release-tag) "SteeringManifestLoadedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface SteeringManifestLoadedData {
+    // (undocumented)
+    response: SteeringManifest;
+    // (undocumented)
+    url: string;
+}
 
 // Warning: (ae-missing-release-tag) "StreamControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3139,6 +3173,22 @@ export interface TrackSet {
 // @public (undocumented)
 export type TSDemuxerConfig = {
     forceKeyFrameOnDiscontinuity: boolean;
+};
+
+// Warning: (ae-missing-release-tag) "UriReplacement" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type UriReplacement = {
+    HOST?: string;
+    PARAMS?: {
+        [queryParameter: string]: string;
+    };
+    'PER-VARIANT-URIS'?: {
+        [stableVariantId: string]: string;
+    };
+    'PER-RENDITION-URIS'?: {
+        [stableRenditionId: string]: string;
+    };
 };
 
 // Warning: (ae-missing-release-tag) "UserdataSample" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2918,7 +2918,7 @@ export type SteeringManifest = {
 // @public (undocumented)
 export interface SteeringManifestLoadedData {
     // (undocumented)
-    response: SteeringManifest;
+    steeringManifest: SteeringManifest;
     // (undocumented)
     url: string;
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1762,6 +1762,8 @@ Full list of Events is available below:
   - data: { levels : [available quality levels], audioTracks : [available audio tracks], captions? [available closed-captions media], subtitles?: [available subtitle tracks], url : manifestURL, stats : [LoaderStats], sessionData: [parsed #EXT-X-SESSION-DATA], networkDetails: [Loader specific object for debugging (XMLHttpRequest or fetch Response)]}
 - `Hls.Events.MANIFEST_PARSED` - fired after manifest has been parsed
   - data: { levels : [ available quality levels ], firstLevel : index of first quality level appearing in Manifest, audioTracks, subtitleTracks, stats, audio: boolean, video: boolean, altAudio: boolean }
+- `Hls.Events.STEERING_MANIFEST_LOADED` - fired when the Content Steering Manifest is loaded
+  - data: { `url`: steering manifest URL, `response`: SteeringManifest object } }
 - `Hls.Events.LEVEL_SWITCHING` - fired when a level switch is requested
   - data: { `level` and Level object properties (please see [below](#level) for more information) }
 - `Hls.Events.LEVEL_SWITCHED` - fired when a level switch is effective

--- a/docs/API.md
+++ b/docs/API.md
@@ -1763,7 +1763,7 @@ Full list of Events is available below:
 - `Hls.Events.MANIFEST_PARSED` - fired after manifest has been parsed
   - data: { levels : [ available quality levels ], firstLevel : index of first quality level appearing in Manifest, audioTracks, subtitleTracks, stats, audio: boolean, video: boolean, altAudio: boolean }
 - `Hls.Events.STEERING_MANIFEST_LOADED` - fired when the Content Steering Manifest is loaded
-  - data: { `url`: steering manifest URL, `response`: SteeringManifest object } }
+  - data: { `url`: steering manifest URL, `steeringManifest`: SteeringManifest object } }
 - `Hls.Events.LEVEL_SWITCHING` - fired when a level switch is requested
   - data: { `level` and Level object properties (please see [below](#level) for more information) }
 - `Hls.Events.LEVEL_SWITCHED` - fired when a level switch is effective

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger';
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type {
+  SteeringManifestLoadedData,
   ErrorData,
   ManifestLoadedData,
   ManifestParsedData,
@@ -31,13 +32,13 @@ export type SteeringManifest = {
   'PATHWAY-CLONES'?: PathwayClone[];
 };
 
-type PathwayClone = {
+export type PathwayClone = {
   'BASE-ID': string;
   ID: string;
   'URI-REPLACEMENT': UriReplacement;
 };
 
-type UriReplacement = {
+export type UriReplacement = {
   HOST?: string;
   PARAMS?: { [queryParameter: string]: string };
   'PER-VARIANT-URIS'?: { [stableVariantId: string]: string };
@@ -383,6 +384,13 @@ export default class ContentSteeringController implements NetworkComponentAPI {
           'PATHWAY-CLONES': pathwayClones,
           'PATHWAY-PRIORITY': pathwayPriority,
         } = steeringData;
+
+        const loaded_data: SteeringManifestLoadedData = {
+          response: steeringData,
+          url: url.toString(),
+        };
+        this.hls.trigger(Events.STEERING_MANIFEST_LOADED, loaded_data);
+
         if (reloadUri) {
           try {
             this.uri = new self.URL(reloadUri, url).href;

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -385,11 +385,11 @@ export default class ContentSteeringController implements NetworkComponentAPI {
           'PATHWAY-PRIORITY': pathwayPriority,
         } = steeringData;
 
-        const loaded_data: SteeringManifestLoadedData = {
-          response: steeringData,
+        const loadedSteeringData: SteeringManifestLoadedData = {
+          steeringManifest: steeringData,
           url: url.toString(),
         };
-        this.hls.trigger(Events.STEERING_MANIFEST_LOADED, loaded_data);
+        this.hls.trigger(Events.STEERING_MANIFEST_LOADED, loadedSteeringData);
 
         if (reloadUri) {
           try {

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -384,13 +384,6 @@ export default class ContentSteeringController implements NetworkComponentAPI {
           'PATHWAY-CLONES': pathwayClones,
           'PATHWAY-PRIORITY': pathwayPriority,
         } = steeringData;
-
-        const loadedSteeringData: SteeringManifestLoadedData = {
-          steeringManifest: steeringData,
-          url: url.toString(),
-        };
-        this.hls.trigger(Events.STEERING_MANIFEST_LOADED, loadedSteeringData);
-
         if (reloadUri) {
           try {
             this.uri = new self.URL(reloadUri, url).href;
@@ -406,6 +399,13 @@ export default class ContentSteeringController implements NetworkComponentAPI {
         if (pathwayClones) {
           this.clonePathways(pathwayClones);
         }
+
+        const loadedSteeringData: SteeringManifestLoadedData = {
+          steeringManifest: steeringData,
+          url: url.toString(),
+        };
+        this.hls.trigger(Events.STEERING_MANIFEST_LOADED, loadedSteeringData);
+
         if (pathwayPriority) {
           this.updatePathwayPriority(pathwayPriority);
         }

--- a/src/events.ts
+++ b/src/events.ts
@@ -163,7 +163,7 @@ export enum Events {
   LIVE_BACK_BUFFER_REACHED = 'hlsLiveBackBufferReached',
   // fired when the back buffer is reached as defined by the backBufferLength config option - data : { bufferEnd: number }
   BACK_BUFFER_REACHED = 'hlsBackBufferReached',
-  // fired after steering manifest has been loaded - data: { response: SteeringManifest object, url: steering manifest URL }
+  // fired after steering manifest has been loaded - data: { steeringManifest: SteeringManifest object, url: steering manifest URL }
   STEERING_MANIFEST_LOADED = 'hlsSteeringManifestLoaded',
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -47,6 +47,7 @@ import {
   LiveBackBufferData,
   TrackLoadingData,
   BufferFlushedData,
+  SteeringManifestLoadedData,
 } from './types/events';
 
 export enum Events {
@@ -162,6 +163,8 @@ export enum Events {
   LIVE_BACK_BUFFER_REACHED = 'hlsLiveBackBufferReached',
   // fired when the back buffer is reached as defined by the backBufferLength config option - data : { bufferEnd: number }
   BACK_BUFFER_REACHED = 'hlsBackBufferReached',
+  // fired after steering manifest has been loaded - data: { response: SteeringManifest object, url: steering manifest URL }
+  STEERING_MANIFEST_LOADED = 'hlsSteeringManifestLoaded',
 }
 
 /**
@@ -360,6 +363,10 @@ export interface HlsListeners {
   [Events.BACK_BUFFER_REACHED]: (
     event: Events.BACK_BUFFER_REACHED,
     data: BackBufferData
+  ) => void;
+  [Events.STEERING_MANIFEST_LOADED]: (
+    event: Events.STEERING_MANIFEST_LOADED,
+    data: SteeringManifestLoadedData
   ) => void;
 }
 export interface HlsEventEmitter {

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -926,6 +926,11 @@ export type {
 } from './config';
 export type { MediaKeySessionContext } from './controller/eme-controller';
 export type { ILogger } from './utils/logger';
+export type {
+  PathwayClone,
+  SteeringManifest,
+  UriReplacement,
+} from './controller/content-steering-controller';
 export type { SubtitleStreamController } from './controller/subtitle-stream-controller';
 export type { TimelineController } from './controller/timeline-controller';
 export type { CuesInterface } from './utils/cues';
@@ -1036,6 +1041,7 @@ export type {
   MediaAttachingData,
   NonNativeTextTrack,
   NonNativeTextTracksData,
+  SteeringManifestLoadedData,
   SubtitleFragProcessedData,
   SubtitleTrackLoadedData,
   SubtitleTracksUpdatedData,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -29,7 +29,7 @@ import type { HlsListeners } from '../events';
 import type { KeyLoaderInfo } from '../loader/key-loader';
 import type { LevelKey } from '../loader/level-key';
 import type { IErrorAction } from '../controller/error-controller';
-import { SteeringManifest } from '../controller/content-steering-controller';
+import type { SteeringManifest } from '../controller/content-steering-controller';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;
@@ -369,6 +369,6 @@ export interface BackBufferData {
 export interface LiveBackBufferData extends BackBufferData {}
 
 export interface SteeringManifestLoadedData {
-  response: SteeringManifest;
+  steeringManifest: SteeringManifest;
   url: string;
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -29,6 +29,7 @@ import type { HlsListeners } from '../events';
 import type { KeyLoaderInfo } from '../loader/key-loader';
 import type { LevelKey } from '../loader/level-key';
 import type { IErrorAction } from '../controller/error-controller';
+import { SteeringManifest } from '../controller/content-steering-controller';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;
@@ -366,3 +367,8 @@ export interface BackBufferData {
  * @deprecated Use BackBufferData
  */
 export interface LiveBackBufferData extends BackBufferData {}
+
+export interface SteeringManifestLoadedData {
+  response: SteeringManifest;
+  url: string;
+}

--- a/tests/unit/controller/content-steering-controller.ts
+++ b/tests/unit/controller/content-steering-controller.ts
@@ -275,7 +275,9 @@ describe('ContentSteeringController', function () {
       );
       const steeringManifestLoadedEvent = hls.getEventData(1);
       expect(steeringManifestLoadedEvent.payload).to.have.property('url');
-      expect(steeringManifestLoadedEvent.payload).to.have.property('response');
+      expect(steeringManifestLoadedEvent.payload).to.have.property(
+        'steeringManifest'
+      );
 
       expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
       const updatedEvent = hls.getEventData(2);
@@ -359,7 +361,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -429,7 +431,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -471,7 +473,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -634,7 +636,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -700,7 +702,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -738,7 +740,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -777,7 +779,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
@@ -845,7 +847,7 @@ describe('ContentSteeringController', function () {
         const steeringManifestLoadedEvent = hls.getEventData(1);
         expect(steeringManifestLoadedEvent.payload).to.have.property('url');
         expect(steeringManifestLoadedEvent.payload).to.have.property(
-          'response'
+          'steeringManifest'
         );
 
         expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);

--- a/tests/unit/controller/content-steering-controller.ts
+++ b/tests/unit/controller/content-steering-controller.ts
@@ -263,23 +263,30 @@ describe('ContentSteeringController', function () {
         },
         contentSteeringController
       );
-      expect(hls.trigger.callCount, 'events triggered').to.equal(6);
+      expect(hls.trigger.callCount, 'events triggered').to.equal(7);
       expect(hls.getEventData(0).name).to.equal(Events.MANIFEST_PARSED);
       const parsedEvent = hls.getEventData(0);
       expect(parsedEvent.payload)
         .to.have.property('audioTracks')
         .that.has.lengthOf(6, 'MANIFEST_PARSED audioTracks');
 
-      expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-      const updatedEvent = hls.getEventData(1);
+      expect(hls.getEventData(1).name).to.equal(
+        Events.STEERING_MANIFEST_LOADED
+      );
+      const steeringManifestLoadedEvent = hls.getEventData(1);
+      expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+      expect(steeringManifestLoadedEvent.payload).to.have.property('response');
+
+      expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+      const updatedEvent = hls.getEventData(2);
       const eventData = updatedEvent.payload as LevelsUpdatedData;
       expect(eventData)
         .to.have.property('levels')
         .that.has.lengthOf(10, 'LEVELS_UPDATED levels');
       expect(eventData.levels[0].pathwayId).to.equal('Baz');
 
-      expect(hls.getEventData(2).name).to.equal(Events.LEVEL_SWITCHING);
-      const switchingEvent = hls.getEventData(2);
+      expect(hls.getEventData(3).name).to.equal(Events.LEVEL_SWITCHING);
+      const switchingEvent = hls.getEventData(3);
       expect(switchingEvent.payload).to.nested.include({
         'attrs.PATHWAY-ID': 'Baz',
       });
@@ -289,9 +296,9 @@ describe('ContentSteeringController', function () {
         uri: 'http://www.baz.com/tier6.m3u8',
       });
 
-      expect(hls.getEventData(3).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
-      expect(hls.getEventData(4).name).to.equal(Events.AUDIO_TRACK_SWITCHING);
-      expect(hls.getEventData(5).name).to.equal(Events.SUBTITLE_TRACKS_UPDATED);
+      expect(hls.getEventData(4).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
+      expect(hls.getEventData(5).name).to.equal(Events.AUDIO_TRACK_SWITCHING);
+      expect(hls.getEventData(6).name).to.equal(Events.SUBTITLE_TRACKS_UPDATED);
       expect(levelController.levels, 'LevelController levels').to.have.lengthOf(
         10
       );
@@ -345,16 +352,26 @@ describe('ContentSteeringController', function () {
           contentSteeringController.subtitleTracks,
           'Content Steering subtitle tracks'
         ).to.have.lengthOf(8);
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         const eventData = updatedEvent.payload as LevelsUpdatedData;
         expect(eventData)
           .to.have.property('levels')
           .that.has.lengthOf(10, 'LEVELS_UPDATED levels');
         expect(eventData.levels[0].pathwayId).to.equal('Buzz');
 
-        expect(hls.getEventData(2).name).to.equal(Events.LEVEL_SWITCHING);
-        const switchingEvent = hls.getEventData(2);
+        expect(hls.getEventData(3).name).to.equal(Events.LEVEL_SWITCHING);
+        const switchingEvent = hls.getEventData(3);
         expect(switchingEvent.payload).to.nested.include({
           'attrs.PATHWAY-ID': 'Buzz',
         });
@@ -364,9 +381,9 @@ describe('ContentSteeringController', function () {
           uri: 'http://www.buzz.com/tier6.m3u8',
         });
 
-        expect(hls.getEventData(3).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
-        expect(hls.getEventData(4).name).to.equal(Events.AUDIO_TRACK_SWITCHING);
-        expect(hls.getEventData(5).name).to.equal(
+        expect(hls.getEventData(4).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
+        expect(hls.getEventData(5).name).to.equal(Events.AUDIO_TRACK_SWITCHING);
+        expect(hls.getEventData(6).name).to.equal(
           Events.SUBTITLE_TRACKS_UPDATED
         );
 
@@ -405,8 +422,18 @@ describe('ContentSteeringController', function () {
           },
           contentSteeringController
         );
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         const eventData = updatedEvent.payload as LevelsUpdatedData;
         expect(eventData)
           .to.have.property('levels')
@@ -437,8 +464,18 @@ describe('ContentSteeringController', function () {
           },
           contentSteeringController
         );
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         expect(updatedEvent.payload)
           .to.have.property('levels')
           .that.has.lengthOf(10, 'LEVELS_UPDATED levels');
@@ -514,8 +551,8 @@ describe('ContentSteeringController', function () {
           'http://z.buzz.com/audio_ec3.m3u8?fallback=true'
         );
 
-        expect(hls.getEventData(3).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
-        const audioTracksEvent = hls.getEventData(3);
+        expect(hls.getEventData(4).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
+        const audioTracksEvent = hls.getEventData(4);
         const eventData = audioTracksEvent.payload as AudioTracksUpdatedData;
         expect(eventData)
           .to.have.property('audioTracks')
@@ -532,10 +569,10 @@ describe('ContentSteeringController', function () {
           subtitleTrackController.tracks,
           'SubtitleTrackController tracks'
         ).to.have.lengthOf(8);
-        expect(hls.getEventData(5).name).to.equal(
+        expect(hls.getEventData(6).name).to.equal(
           Events.SUBTITLE_TRACKS_UPDATED
         );
-        const subtitleTracksEvent = hls.getEventData(5);
+        const subtitleTracksEvent = hls.getEventData(6);
         const subsEventData =
           subtitleTracksEvent.payload as SubtitleTracksUpdatedData;
         expect(subsEventData)
@@ -590,8 +627,18 @@ describe('ContentSteeringController', function () {
           },
           contentSteeringController
         );
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         expect(updatedEvent.payload)
           .to.have.property('levels')
           .that.has.lengthOf(10, 'LEVELS_UPDATED levels');
@@ -605,8 +652,8 @@ describe('ContentSteeringController', function () {
           'http://www.bear.com/2.m3u8?fallback=true&cloned=buzz'
         );
 
-        expect(hls.getEventData(3).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
-        const audioTracksEvent = hls.getEventData(3);
+        expect(hls.getEventData(4).name).to.equal(Events.AUDIO_TRACKS_UPDATED);
+        const audioTracksEvent = hls.getEventData(4);
         const audioEventData =
           audioTracksEvent.payload as AudioTracksUpdatedData;
         expect(audioEventData.audioTracks[0].attrs['PATHWAY-ID']).to.equal(
@@ -616,10 +663,10 @@ describe('ContentSteeringController', function () {
           'http://www.bear.com/audio_aac.m3u8?cloned=buzz'
         );
 
-        expect(hls.getEventData(5).name).to.equal(
+        expect(hls.getEventData(6).name).to.equal(
           Events.SUBTITLE_TRACKS_UPDATED
         );
-        const subtitleTracksEvent = hls.getEventData(5);
+        const subtitleTracksEvent = hls.getEventData(6);
         const subsEventData =
           subtitleTracksEvent.payload as SubtitleTracksUpdatedData;
         expect(subsEventData.subtitleTracks[0].attrs['PATHWAY-ID']).to.equal(
@@ -646,8 +693,18 @@ describe('ContentSteeringController', function () {
           },
           contentSteeringController
         );
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         const eventData = updatedEvent.payload as LevelsUpdatedData;
         expect(eventData.levels[0].pathwayId).to.equal('Buzz');
         expect(eventData.levels[0].uri).to.equal(
@@ -674,8 +731,18 @@ describe('ContentSteeringController', function () {
           },
           contentSteeringController
         );
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         const eventData = updatedEvent.payload as LevelsUpdatedData;
         expect(eventData.levels[0].pathwayId).to.equal('Buzz');
         expect(eventData.levels[0].uri).to.equal(
@@ -703,8 +770,18 @@ describe('ContentSteeringController', function () {
           contentSteeringController.levels,
           'Content Steering variants'
         ).to.have.lengthOf(30);
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         const eventData = updatedEvent.payload as LevelsUpdatedData;
         expect(eventData.levels[0].pathwayId).to.equal('Foo');
         expect(eventData.levels[0].uri).to.equal(
@@ -761,8 +838,18 @@ describe('ContentSteeringController', function () {
           contentSteeringController.levels,
           'Content Steering variants'
         ).to.have.lengthOf(40);
-        expect(hls.getEventData(1).name).to.equal(Events.LEVELS_UPDATED);
-        const updatedEvent = hls.getEventData(1);
+
+        expect(hls.getEventData(1).name).to.equal(
+          Events.STEERING_MANIFEST_LOADED
+        );
+        const steeringManifestLoadedEvent = hls.getEventData(1);
+        expect(steeringManifestLoadedEvent.payload).to.have.property('url');
+        expect(steeringManifestLoadedEvent.payload).to.have.property(
+          'response'
+        );
+
+        expect(hls.getEventData(2).name).to.equal(Events.LEVELS_UPDATED);
+        const updatedEvent = hls.getEventData(2);
         const eventData = updatedEvent.payload as LevelsUpdatedData;
         expect(eventData.levels[0].pathwayId).to.equal('Buzz');
         expect(eventData.levels[0].uri).to.equal(


### PR DESCRIPTION
### This PR will...
Fire a new event (`STEERING_MANIFEST_LOADED`) when the Steering Manifest is loaded and expose on it the content of the received steering manifest.

### Why is this Pull Request needed?
We may need the application loading the player to react when receiving Content Steering Manifests. In our case and for now, we are using the steering params for debugging purposes, so it was handy to expose them.

### Are there any points in the code the reviewer needs to double check?
Please check the unit tests are enough. As I was using already existing interfaces, I didn't extend much the checks over the event contents. I can do it if I needed.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
