### PR TITLE
Fix Low-Latency part and fragment tracking

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -322,6 +322,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected fragPrevious: Fragment | null;
     // (undocumented)
+    protected getAppendedFrag(position: number, playlistType?: PlaylistLevelType): Fragment | null;
+    // (undocumented)
     protected getCurrentContext(chunkMeta: ChunkMetadata): {
         frag: Fragment;
         part: Part | null;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -383,10 +383,7 @@ class AudioStreamController
       (!mainBufferInfo?.len && bufferInfo.len)
     ) {
       // Check fragment-tracker for main fragments since GAP segments do not show up in bufferInfo
-      const mainFrag = this.fragmentTracker.getBufferedFrag(
-        frag.start,
-        PlaylistLevelType.MAIN
-      );
+      const mainFrag = this.getAppendedFrag(frag.start, PlaylistLevelType.MAIN);
       if (mainFrag === null) {
         return;
       }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -470,6 +470,7 @@ class AudioStreamController
     this.bufferFlushed = false;
     this.bufferedTrack = null;
     this.switchingTrack = null;
+    this.startFragRequested = false;
   }
 
   onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
@@ -492,7 +493,11 @@ class AudioStreamController
       return;
     }
     this.log(
-      `Track ${trackId} loaded [${newDetails.startSN},${newDetails.endSN}],duration:${newDetails.totalduration}`
+      `Track ${trackId} loaded [${newDetails.startSN},${newDetails.endSN}]${
+        newDetails.lastPartSn
+          ? `[part-${newDetails.lastPartSn}-${newDetails.lastPartIndex}]`
+          : ''
+      },duration:${newDetails.totalduration}`
     );
 
     const track = levels[trackId];
@@ -760,9 +765,10 @@ class AudioStreamController
     }
 
     if (initSegment?.tracks) {
-      this._bufferInitSegment(initSegment.tracks, frag, chunkMeta);
+      const mapFragment = frag.initSegment || frag;
+      this._bufferInitSegment(initSegment.tracks, mapFragment, chunkMeta);
       hls.trigger(Events.FRAG_PARSING_INIT_SEGMENT, {
-        frag,
+        frag: mapFragment,
         id,
         tracks: initSegment.tracks,
       });

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -464,13 +464,18 @@ class AudioStreamController
   }
 
   onManifestLoading() {
-    this.mainDetails = null;
     this.fragmentTracker.removeAllFragments();
     this.startPosition = this.lastCurrentTime = 0;
     this.bufferFlushed = false;
-    this.bufferedTrack = null;
-    this.switchingTrack = null;
+    this.levels =
+      this.mainDetails =
+      this.waitingData =
+      this.bufferedTrack =
+      this.cachedTrackLoadedData =
+      this.switchingTrack =
+        null;
     this.startFragRequested = false;
+    this.trackId = this.videoTrackCC = this.waitingVideoCC = -1;
   }
 
   onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1003,6 +1003,20 @@ export default class BaseStreamController
     return false;
   }
 
+  protected getAppendedFrag(
+    position: number,
+    playlistType: PlaylistLevelType = PlaylistLevelType.MAIN
+  ): Fragment | null {
+    const fragOrPart = this.fragmentTracker.getAppendedFrag(
+      position,
+      PlaylistLevelType.MAIN
+    );
+    if (fragOrPart && 'fragment' in fragOrPart) {
+      return fragOrPart.fragment;
+    }
+    return fragOrPart;
+  }
+
   protected getNextFragment(
     pos: number,
     levelDetails: LevelDetails

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -136,7 +136,7 @@ export default class BaseStreamController
 
   public stopLoad() {
     this.fragmentLoader.abort();
-    this.keyLoader.abort();
+    this.keyLoader.abort(this.playlistType);
     const frag = this.fragCurrent;
     if (frag?.loader) {
       frag.abortRequests();

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -88,6 +88,7 @@ export default class BufferController implements ComponentAPI {
     const { hls } = this;
     hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+    hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.on(Events.BUFFER_RESET, this.onBufferReset, this);
     hls.on(Events.BUFFER_APPENDING, this.onBufferAppending, this);
@@ -103,6 +104,7 @@ export default class BufferController implements ComponentAPI {
     const { hls } = this;
     hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+    hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.MANIFEST_PARSED, this.onManifestParsed, this);
     hls.off(Events.BUFFER_RESET, this.onBufferReset, this);
     hls.off(Events.BUFFER_APPENDING, this.onBufferAppending, this);
@@ -125,6 +127,11 @@ export default class BufferController implements ComponentAPI {
     this.lastMpegAudioChunk = null;
   }
 
+  private onManifestLoading() {
+    this.bufferCodecEventsExpected = this._bufferCodecEventsTotal = 0;
+    this.details = null;
+  }
+
   protected onManifestParsed(
     event: Events.MANIFEST_PARSED,
     data: ManifestParsedData
@@ -138,7 +145,6 @@ export default class BufferController implements ComponentAPI {
       codecEvents = 1;
     }
     this.bufferCodecEventsExpected = this._bufferCodecEventsTotal = codecEvents;
-    this.details = null;
     logger.log(
       `${this.bufferCodecEventsExpected} bufferCodec event(s) expected`
     );

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -123,12 +123,14 @@ class EMEController implements ComponentAPI {
   private registerListeners() {
     this.hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     this.hls.on(Events.MEDIA_DETACHED, this.onMediaDetached, this);
+    this.hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     this.hls.on(Events.MANIFEST_LOADED, this.onManifestLoaded, this);
   }
 
   private unregisterListeners() {
     this.hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     this.hls.off(Events.MEDIA_DETACHED, this.onMediaDetached, this);
+    this.hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     this.hls.off(Events.MANIFEST_LOADED, this.onManifestLoaded, this);
   }
 
@@ -1179,6 +1181,10 @@ class EMEController implements ComponentAPI {
           `Could not close sessions and clear media keys: ${error}. media.src: ${media?.src}`
         );
       });
+  }
+
+  private onManifestLoading() {
+    this.keyFormatPromise = null;
   }
 
   private onManifestLoaded(

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -92,11 +92,6 @@ export class FragmentTracker implements ComponentAPI {
           appendedPTS !== null &&
           position <= appendedPTS
         ) {
-          // Remove other fragment parts from lookup after a match
-          const snToKeep = activePart.fragment.sn;
-          this.activePartLists[levelType] = activeParts.filter(
-            (part) => part.fragment.sn === snToKeep
-          );
           return activePart;
         }
       }
@@ -208,10 +203,24 @@ export class FragmentTracker implements ComponentAPI {
       if (fragmentEntity.body.endList) {
         this.endListFragments[fragmentEntity.body.type] = fragmentEntity;
       }
+      if (!isPartial(fragmentEntity)) {
+        // Remove older fragment parts from lookup after frag is tracked as buffered
+        this.removeParts((frag.sn as number) - 1, frag.type);
+      }
     } else {
       // remove fragment if nothing was appended
       this.removeFragment(fragmentEntity.body);
     }
+  }
+
+  private removeParts(snToKeep: number, levelType: PlaylistLevelType) {
+    const activeParts = this.activePartLists[levelType];
+    if (!activeParts) {
+      return;
+    }
+    this.activePartLists[levelType] = activeParts.filter(
+      (part) => (part.fragment.sn as number) >= snToKeep
+    );
   }
 
   public fragBuffered(frag: Fragment, force?: true) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -374,17 +374,6 @@ export default class StreamController
     }
   }
 
-  private getAppendedFrag(position): Fragment | null {
-    const fragOrPart = this.fragmentTracker.getAppendedFrag(
-      position,
-      PlaylistLevelType.MAIN
-    );
-    if (fragOrPart && 'fragment' in fragOrPart) {
-      return fragOrPart.fragment;
-    }
-    return fragOrPart;
-  }
-
   private getBufferedFrag(position) {
     return this.fragmentTracker.getBufferedFrag(
       position,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -579,8 +579,8 @@ export default class StreamController
     this.fragmentTracker.removeAllFragments();
     this.couldBacktrack = false;
     this.startPosition = this.lastCurrentTime = 0;
-    this.fragPlaying = null;
-    this.backtrackFragment = null;
+    this.levels = this.fragPlaying = this.backtrackFragment = null;
+    this.altAudio = this.audioOnly = false;
   }
 
   private onManifestParsed(

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -380,8 +380,7 @@ export default class Hls implements HlsEventEmitter {
     if (
       media &&
       loadedSource &&
-      loadedSource !== loadingSource &&
-      this.bufferController.hasSourceTypes()
+      (loadedSource !== loadingSource || this.bufferController.hasSourceTypes())
     ) {
       this.detachMedia();
       this.attachMedia(media);

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -6,6 +6,7 @@ import {
   LoaderCallbacks,
   Loader,
   KeyLoaderContext,
+  PlaylistLevelType,
 } from '../types/loader';
 import { LoadError } from './fragment-loader';
 import type { HlsConfig } from '../config';
@@ -32,10 +33,13 @@ export default class KeyLoader implements ComponentAPI {
     this.config = config;
   }
 
-  abort() {
+  abort(type?: PlaylistLevelType) {
     for (const uri in this.keyUriToKeyInfo) {
       const loader = this.keyUriToKeyInfo[uri].loader;
       if (loader) {
+        if (type && type !== loader.context.frag.type) {
+          return;
+        }
         loader.abort();
       }
     }

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -667,5 +667,6 @@ function createMockFragment(
       data.endPTS
     );
   });
+  frag.relurl = 'not-frag-hint';
   return frag;
 }

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -416,12 +416,6 @@ describe('StreamController', function () {
       assertLoadingState(frag);
     });
 
-    it('should not load a partial fragment', function () {
-      fragStateStub(FragmentState.PARTIAL);
-      streamController['loadFragment'](frag, level, 0);
-      assertNotLoadingState();
-    });
-
     it('should not load a fragment which has completely & successfully loaded', function () {
       fragStateStub(FragmentState.OK);
       streamController['loadFragment'](frag, level, 0);

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import Hls from '../../../src/hls';
 import { Events } from '../../../src/events';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
+import { Fragment } from '../../../src/loader/fragment';
+import { PlaylistLevelType } from '../../../src/types/loader';
 import KeyLoader from '../../../src/loader/key-loader';
 import { SubtitleStreamController } from '../../../src/controller/subtitle-stream-controller';
 
@@ -142,19 +144,16 @@ describe('SubtitleStreamController', function () {
 
   describe('onMediaSeeking', function () {
     it('nulls fragPrevious when seeking away from fragCurrent', function () {
-      subtitleStreamController.fragCurrent = {
-        start: 1000,
-        duration: 10,
-        loader: {
-          abort: () => {
-            this.state.aborted = true;
-          },
-          stats: {
-            aborted: false,
-          },
-        },
-      };
-      subtitleStreamController.fragPrevious = {};
+      subtitleStreamController.fragCurrent = new Fragment(
+        PlaylistLevelType.MAIN,
+        ''
+      );
+      subtitleStreamController.fragCurrent.start = 1000;
+      subtitleStreamController.fragCurrent.duration = 10;
+      subtitleStreamController.fragPrevious = new Fragment(
+        PlaylistLevelType.MAIN,
+        ''
+      );
       subtitleStreamController.onMediaSeeking();
       expect(subtitleStreamController.fragPrevious).to.not.exist;
     });


### PR DESCRIPTION
### This PR will...
Fix Low-Latency part and fragment tracking issues introduced in v1.3.5 with #5102
- #5102
  - Introduced regression: stalling when playing back over segment where some parts were loaded seeking back
  - Introduced regression: unnecessary loading of fragments over parts during Low-Latency playback

Additional enhancements:
- Prevents flushing the forward buffer on smooth switch in live playback when buffer conditions are low
- Fixes loading of live streams with alt-audio using an `Hls` instance that is already playing an asset with alt-audio
- Return MAP segment (when present) for event `frag` value in `FRAG_PARSING_INIT_SEGMENT` events
- Prevents fragment and part requests from being unnecessarily aborted on seeking events
- Fix issues with reuse of player instance when loading additional assets (#5425)

### Why is this Pull Request needed?
Fixes reloading of full segments in Low-Latency HLS streams where some parts of the segment were loaded, but now the part list is no longer available, after seeking back to an earlier time in the playlist. This worked in v1.3.5, but regressed in v1.4.0 with this change to tracking of buffered fragments.

### Are there any points in the code the reviewer needs to double check?
The fragment-tracker implementation has been cleaned up to better support part loading. This required the stream-controller to now accept loading of fragments that are being tracked as partially buffered (`FragmentState.PARTIAL`). This has been the case for the audio stream controller. This was likely not allowed to avoid loop loading on segments that do not start with key-frames or require back-tracking. Some additional testing is needed to verify that this is no longer required.

### Resolves issues:
v1.4.0 regression: Reloading of incomplete segments where some parts were loaded is not performed after seeking back.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
