### PR TITLE
bugfix: Check for undefined audio track attribute in findTrackId()

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -236,8 +236,9 @@ class AudioTrackController extends BasePlaylistController {
       if (!this.selectDefaultTrack || track.default) {
         if (
           !currentTrack ||
-          currentTrack.attrs['STABLE-RENDITION-ID'] ===
-            track.attrs['STABLE-RENDITION-ID']
+          (currentTrack.attrs['STABLE-RENDITION-ID'] !== undefined &&
+            currentTrack.attrs['STABLE-RENDITION-ID'] ===
+              track.attrs['STABLE-RENDITION-ID'])
         ) {
           return track.id;
         }


### PR DESCRIPTION
Sometimes STABLE-RENDITION_ID of tracks is undefined. Adding a guard for it, otherwise audio track doesn't switch.

### This PR will...
Fix the initial audio track selection issue by guarding for `undefined` value. It will allow us to set initial audio track.

### Resolves issues:
See [issue/5430](https://github.com/video-dev/hls.js/issues/5430)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
