### PR TITLE
Fix incorrect HEVC main profile codec id

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -266,7 +266,7 @@ function getParsedTrackCodec(
   // Provide defaults based on codec type
   // This allows for some playback of some fmp4 playlists without CODECS defined in manifest
   if (parsedCodec === 'hvc1' || parsedCodec === 'hev1') {
-    return 'hvc1.1.c.L120.90';
+    return 'hvc1.1.6.L120.90';
   }
   if (parsedCodec === 'av01') {
     return 'av01.0.04M.08';


### PR DESCRIPTION
As HEVC Spec A.3.2 defined, when `general_profile_compatibility_flag[1]` is equal to 1, `general_profile_compatibility_flag[2]` should be equal to 1 as well, thus a valid HEVC 
main profile codec id should be: `hvc1.1.6.L120.90` instead of `hvc1.1.c.L120.90`.
