### PR TITLE
fix: move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "types": "./dist/hls.js.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/hls.js.d.ts",
       "import": "./dist/hls.mjs",
-      "require": "./dist/hls.js",
-      "types": "./dist/hls.js.d.ts"
+      "require": "./dist/hls.js"
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=hls.js%401.1.0)