### PR TITLE
Always use MediaSource returned by utils module

### DIFF
--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -1,3 +1,5 @@
+import { getMediaSource } from './mediasource-helper';
+
 // from http://mp4ra.org/codecs.html
 const sampleEntryCodesISO = {
   audio: {
@@ -71,6 +73,8 @@ const sampleEntryCodesISO = {
   },
 };
 
+const MediaSource = getMediaSource();
+
 export type CodecType = 'audio' | 'video';
 
 export function isCodecType(codec: string, type: CodecType): boolean {
@@ -79,7 +83,8 @@ export function isCodecType(codec: string, type: CodecType): boolean {
 }
 
 export function isCodecSupportedInMp4(codec: string, type: CodecType): boolean {
-  return MediaSource.isTypeSupported(
-    `${type || 'video'}/mp4;codecs="${codec}"`
+  return (
+    MediaSource?.isTypeSupported(`${type || 'video'}/mp4;codecs="${codec}"`) ??
+    false
   );
 }

--- a/tests/unit/controller/content-steering-controller.ts
+++ b/tests/unit/controller/content-steering-controller.ts
@@ -25,9 +25,12 @@ import type { LoaderResponse } from '../../../src/types/loader';
 import sinon from 'sinon';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
+import { getMediaSource } from '../../../src/utils/mediasource-helper';
 
 chai.use(sinonChai);
 const expect = chai.expect;
+
+const MediaSource = getMediaSource();
 
 type ConentSteeringControllerTestable = Omit<
   ContentSteeringController,
@@ -70,6 +73,7 @@ describe('ContentSteeringController', function () {
     contentSteeringController = new ContentSteeringController(
       hls as any
     ) as unknown as ConentSteeringControllerTestable;
+    // @ts-ignore
     sandbox.stub(MediaSource, 'isTypeSupported').returns(true);
   });
 

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -27,9 +27,12 @@ import type { Fragment } from '../../../src/loader/fragment';
 import sinon from 'sinon';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
+import { getMediaSource } from '../../../src/utils/mediasource-helper';
 
 chai.use(sinonChai);
 const expect = chai.expect;
+
+const MediaSource = getMediaSource();
 
 type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
   onManifestLoaded: (event: string, data: Partial<ManifestLoadedData>) => void;
@@ -90,6 +93,7 @@ describe('LevelController', function () {
     ) as unknown as LevelControllerTestable;
     levelController.onParsedComplete = () => {};
     hls.levelController = levelController;
+    // @ts-ignore
     sandbox.stub(MediaSource, 'isTypeSupported').returns(true);
   });
 


### PR DESCRIPTION
### This PR will...
Always use `MediaSource` returned by utils module.

### Why is this Pull Request needed?
`isTypeSupported` should use the same `MediaSource` object returned by `getMediaSource` used in other parts of the player.