### PR TITLE
fix: partial audiovideo fragments not being treated as partial

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -492,7 +492,8 @@ function isPartial(fragmentEntity: FragmentEntity): boolean {
     fragmentEntity.buffered &&
     (fragmentEntity.body.gap ||
       fragmentEntity.range.video?.partial ||
-      fragmentEntity.range.audio?.partial)
+      fragmentEntity.range.audio?.partial ||
+      fragmentEntity.range.audiovideo?.partial)
   );
 }
 


### PR DESCRIPTION
Fragments which contain both audio and video also need to be checked if they are partial. We check for them individually, but there are cases when only the one flag is set.

### This PR will...

Fix an edge case with the fragment loader

### Why is this Pull Request needed?

Bug fix on an edge case.

### Are there any points in the code the reviewer needs to double check?

Not really.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
