### PR TITLE
Allow live level loading to recover from network being suspended

### DIFF
--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -255,21 +255,12 @@ export default class ErrorController implements NetworkComponentAPI {
         retryCount,
       };
     }
-    // Do not perform level switch if an error occurred using delivery directives
-    // Allow reload without directives (handled in playlist-loader)
-    if (data.context?.deliveryDirectives) {
-      return {
-        action: NetworkErrorAction.DoNothing,
-        flags: ErrorActionFlags.None,
-        retryConfig: retryConfig || {
-          maxNumRetry: 0,
-          retryDelayMs: 0,
-          maxRetryDelayMs: 0,
-        },
-        retryCount,
-      };
+    const errorAction = this.getLevelSwitchAction(data, levelIndex);
+    if (retryConfig) {
+      errorAction.retryConfig = retryConfig;
+      errorAction.retryCount = retryCount;
     }
-    return this.getLevelSwitchAction(data, levelIndex);
+    return errorAction;
   }
 
   private getFragRetryOrSwitchAction(data: ErrorData): IErrorAction {


### PR DESCRIPTION
### This PR will...
Allow live level loading to recover from net::ERR_NETWORK_IO_SUSPENDED errors

### Why is this Pull Request needed?
Error handling changes in v1.4.0 were initially too strict about escalating non-retry errors (status 0 when navigator.onLine is true are assumed to be non-recoverable CORS errors). This change allows retries so that audio and main playlists continue to be reloaded after they error when network operations are suspended while a device is locked (close laptop lid).