### PR TITLE
Fix long VOD looping or seeking back to 0 after buffer ejection

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -138,7 +138,7 @@ export class FragmentTracker implements ComponentAPI {
     }
     // Check if any flagged fragments have been unloaded
     // excluding anything newer than appendedPartSn
-    const appendedPartSn = (appendedPart?.fragment.sn || 0) as number;
+    const appendedPartSn = (appendedPart?.fragment.sn || -1) as number;
     Object.keys(this.fragments).forEach((key) => {
       const fragmentEntity = this.fragments[key];
       if (!fragmentEntity) {


### PR DESCRIPTION
### This PR will...
Fix reloading of first fragment after ejected.

### Why is this Pull Request needed?
Fixes v1.4.1 regression with seeking back to 0 (loop) when first media sequence number is 0 after buffer has been ejected by user agent.

### Resolves Issues
Fixes #5482
