### PR TITLE
Error and switch on SourceBuffer append requests for non-existing tracks

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -715,8 +715,13 @@ class AudioStreamController
           this.state = State.IDLE;
         }
         break;
+      case ErrorDetails.BUFFER_APPEND_ERROR:
       case ErrorDetails.BUFFER_FULL_ERROR:
         if (!data.parent || data.parent !== 'audio') {
+          return;
+        }
+        if (data.details === ErrorDetails.BUFFER_APPEND_ERROR) {
+          this.resetLoadingState();
           return;
         }
         if (this.reduceLengthAndFlushBuffer(data)) {
@@ -862,7 +867,7 @@ class AudioStreamController
       this.hls.trigger(Events.BUFFER_APPENDING, segment);
     }
     // trigger handler right now
-    this.tick();
+    this.tickImmediate();
   }
 
   protected loadFragment(

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -508,7 +508,7 @@ export default class BaseStreamController
         return data;
       })
       .then((data: FragLoadedData) => {
-        const { fragCurrent, hls, levels } = this;
+        const { levels } = this;
         if (!levels) {
           throw new Error('init load aborted, missing levels');
         }
@@ -519,16 +519,6 @@ export default class BaseStreamController
         frag.data = new Uint8Array(data.payload);
         stats.parsing.start = stats.buffering.start = self.performance.now();
         stats.parsing.end = stats.buffering.end = self.performance.now();
-
-        // Silence FRAG_BUFFERED event if fragCurrent is null
-        if (data.frag === fragCurrent) {
-          hls.trigger(Events.FRAG_BUFFERED, {
-            stats,
-            frag: fragCurrent,
-            part: null,
-            id: frag.type,
-          });
-        }
         this.tick();
       })
       .catch((reason) => {
@@ -1522,13 +1512,17 @@ export default class BaseStreamController
       this.resetFragmentErrors(filterType);
       if (retryCount < retryConfig.maxNumRetry) {
         // Network retry is skipped when level switch is preferred
-        if (!gapTagEncountered) {
+        if (
+          !gapTagEncountered &&
+          action !== NetworkErrorAction.RemoveAlternatePermanently
+        ) {
           errorAction.resolved = true;
         }
       } else {
         logger.warn(
           `${data.details} reached or exceeded max retry (${retryCount})`
         );
+        return;
       }
     } else {
       this.state = State.ERROR;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -412,10 +412,6 @@ export default class BufferController implements ComponentAPI {
       },
       onError: (err) => {
         // in case any error occured while appending, put back segment in segments table
-        logger.error(
-          `[buffer-controller]: Error encountered while trying to append to the ${type} SourceBuffer`,
-          err
-        );
         const event = {
           type: ErrorTypes.MEDIA_ERROR,
           parent: frag.type,
@@ -896,14 +892,11 @@ export default class BufferController implements ComponentAPI {
 
   // This method must result in an updateend event; if append is not called, _onSBUpdateEnd must be called manually
   private appendExecutor(data: Uint8Array, type: SourceBufferName) {
-    const { operationQueue, sourceBuffer } = this;
-    const sb = sourceBuffer[type];
+    const sb = this.sourceBuffer[type];
     if (!sb) {
-      logger.warn(
-        `[buffer-controller]: Attempting to append to the ${type} SourceBuffer, but it does not exist`
+      throw new Error(
+        `Attempting to append to the ${type} SourceBuffer, but it does not exist`
       );
-      operationQueue.shiftAndExecuteNext(type);
-      return;
     }
 
     sb.ended = false;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -326,7 +326,7 @@ export default class BufferController implements ComponentAPI {
       },
     };
 
-    operationQueue.append(operation, type);
+    operationQueue.append(operation, type, !!this.pendingTracks[type]);
   }
 
   protected onBufferAppending(
@@ -444,7 +444,7 @@ export default class BufferController implements ComponentAPI {
         hls.trigger(Events.ERROR, event);
       },
     };
-    operationQueue.append(operation, type);
+    operationQueue.append(operation, type, !!this.pendingTracks[type]);
   }
 
   protected onBufferFlushing(
@@ -894,9 +894,12 @@ export default class BufferController implements ComponentAPI {
   private appendExecutor(data: Uint8Array, type: SourceBufferName) {
     const sb = this.sourceBuffer[type];
     if (!sb) {
-      throw new Error(
-        `Attempting to append to the ${type} SourceBuffer, but it does not exist`
-      );
+      if (!this.pendingTracks[type]) {
+        throw new Error(
+          `Attempting to append to the ${type} SourceBuffer, but it does not exist`
+        );
+      }
+      return;
     }
 
     sb.ended = false;

--- a/src/controller/buffer-operation-queue.ts
+++ b/src/controller/buffer-operation-queue.ts
@@ -18,10 +18,14 @@ export default class BufferOperationQueue {
     this.buffers = sourceBufferReference;
   }
 
-  public append(operation: BufferOperation, type: SourceBufferName) {
+  public append(
+    operation: BufferOperation,
+    type: SourceBufferName,
+    pending?: boolean
+  ) {
     const queue = this.queues[type];
     queue.push(operation);
-    if (queue.length === 1) {
+    if (queue.length === 1 && !pending) {
       this.executeNext(type);
     }
   }

--- a/src/controller/buffer-operation-queue.ts
+++ b/src/controller/buffer-operation-queue.ts
@@ -21,7 +21,7 @@ export default class BufferOperationQueue {
   public append(operation: BufferOperation, type: SourceBufferName) {
     const queue = this.queues[type];
     queue.push(operation);
-    if (queue.length === 1 && this.buffers[type]) {
+    if (queue.length === 1) {
       this.executeNext(type);
     }
   }
@@ -49,25 +49,23 @@ export default class BufferOperationQueue {
   }
 
   public executeNext(type: SourceBufferName) {
-    const { buffers, queues } = this;
-    const sb = buffers[type];
-    const queue = queues[type];
+    const queue = this.queues[type];
     if (queue.length) {
       const operation: BufferOperation = queue[0];
       try {
         // Operations are expected to result in an 'updateend' event being fired. If not, the queue will lock. Operations
         // which do not end with this event must call _onSBUpdateEnd manually
         operation.execute();
-      } catch (e) {
+      } catch (error) {
         logger.warn(
-          '[buffer-operation-queue]: Unhandled exception executing the current operation'
+          `[buffer-operation-queue]: Exception executing "${type}" SourceBuffer operation: ${error}`
         );
-        operation.onError(e);
+        operation.onError(error);
 
         // Only shift the current operation off, otherwise the updateend handler will do this for us
+        const sb = this.buffers[type];
         if (!sb?.updating) {
-          queue.shift();
-          this.executeNext(type);
+          this.shiftAndExecuteNext(type);
         }
       }
     }

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -93,11 +93,11 @@ export default class ErrorController implements NetworkComponentAPI {
     this.penalizedRenditions = {};
   }
 
-  startLoad(startPosition: number): void {
+  startLoad(startPosition: number): void {}
+
+  stopLoad(): void {
     this.playlistError = 0;
   }
-
-  stopLoad(): void {}
 
   private getVariantLevelIndex(frag: Fragment | undefined): number {
     return frag?.type === PlaylistLevelType.MAIN
@@ -210,6 +210,7 @@ export default class ErrorController implements NetworkComponentAPI {
         return;
       case ErrorDetails.BUFFER_ADD_CODEC_ERROR:
       case ErrorDetails.REMUX_ALLOC_ERROR:
+      case ErrorDetails.BUFFER_APPEND_ERROR:
         data.errorAction = this.getLevelSwitchAction(
           data,
           data.level ?? hls.loadLevel
@@ -217,7 +218,6 @@ export default class ErrorController implements NetworkComponentAPI {
         return;
       case ErrorDetails.INTERNAL_EXCEPTION:
       case ErrorDetails.BUFFER_APPENDING_ERROR:
-      case ErrorDetails.BUFFER_APPEND_ERROR:
       case ErrorDetails.BUFFER_FULL_ERROR:
       case ErrorDetails.LEVEL_SWITCH_ERROR:
       case ErrorDetails.BUFFER_STALLED_ERROR:

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -75,7 +75,7 @@ export default class LevelController extends BasePlaylistController {
     super.destroy();
   }
 
-  public startLoad(): void {
+  public stopLoad(): void {
     const levels = this._levels;
 
     // clean up live level details to force reload them, and reset load errors
@@ -84,7 +84,7 @@ export default class LevelController extends BasePlaylistController {
       level.fragmentError = 0;
     });
 
-    super.startLoad();
+    super.stopLoad();
   }
 
   private resetLevels() {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -905,8 +905,13 @@ export default class StreamController
           this.state = State.IDLE;
         }
         break;
+      case ErrorDetails.BUFFER_APPEND_ERROR:
       case ErrorDetails.BUFFER_FULL_ERROR:
         if (!data.parent || data.parent !== 'main') {
+          return;
+        }
+        if (data.details === ErrorDetails.BUFFER_APPEND_ERROR) {
+          this.resetLoadingState();
           return;
         }
         if (this.reduceLengthAndFlushBuffer(data)) {
@@ -1292,7 +1297,7 @@ export default class StreamController
       }
     });
     // trigger handler right now
-    this.tick();
+    this.tickImmediate();
   }
 
   public getMainFwdBufferInfo(): BufferInfo | null {

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -225,13 +225,15 @@ describe('BufferController', function () {
 
     it('should cycle the SourceBuffer operation queue if the sourceBuffer does not exist while appending', function () {
       const queueAppendSpy = sandbox.spy(operationQueue, 'append');
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      const chunkMeta = new ChunkMetadata(0, 0, 0, 0);
       queueNames.forEach((name, i) => {
         bufferController.sourceBuffer = {};
         bufferController.onBufferAppending(Events.BUFFER_APPENDING, {
           type: name,
           data: new Uint8Array(),
-          frag: new Fragment(PlaylistLevelType.MAIN, ''),
-          chunkMeta: new ChunkMetadata(0, 0, 0, 0),
+          frag,
+          chunkMeta,
         });
 
         expect(
@@ -243,8 +245,20 @@ describe('BufferController', function () {
           'The queue should have been cycled'
         ).to.have.callCount(i + 1);
       });
-      expect(triggerSpy, 'No event should have been triggered').to.have.not.been
-        .called;
+      expect(
+        triggerSpy,
+        'Buffer append error event should have been triggered'
+      ).to.have.been.calledWith(Events.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.BUFFER_APPEND_ERROR,
+        parent: 'main',
+        frag,
+        part: undefined,
+        chunkMeta,
+        error: triggerSpy.getCall(0).lastArg.error,
+        err: triggerSpy.getCall(0).lastArg.error,
+        fatal: false,
+      });
     });
   });
 


### PR DESCRIPTION
### This PR will...
Error and switch on SourceBuffer append requests for non-existing tracks.

### Why is this Pull Request needed?
Prevents the player from stalling when encountering muxed "audiovideo" (mp4) after setting up with unmuxed "video" and "audio" SourceBuffers (TS or unmuxed main and alt-audio mp4)

### Are there any points in the code the reviewer needs to double check?
There may be cases where muxed mp4 content could be appended into either a "video" or "audio" SourceBuffer (but not both). Only some MSE implementations handle this, ignoring the unrecognized tracks, but some devices do not (iPad for example). Either way, that is not correct behavior, or behavior we should support. Mixing content in HLS this way is not the best for compatibility an should not be supported.

Feature requests for unmuxing muxed mp4 when needed could be entertained (file an issue). There also may be future work that involves resetting SourceBuffers on an as-needed basis, but this comes with very obvious DOM and rendering side-effects that degrade UX. For now, handling this as an error and switching back down to a supported variant is the behavior HLS.js should take.

### Resolves issues:
 Related to #1510

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
