### PR TITLE
Bugfix: Playlist loading errors must be fatal after all levels and retries exhausted

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -652,8 +652,12 @@ class AudioStreamController
     const { frag, part } = data;
     if (frag.type !== PlaylistLevelType.AUDIO) {
       if (!this.loadedmetadata && frag.type === PlaylistLevelType.MAIN) {
-        if ((this.videoBuffer || this.media)?.buffered.length) {
-          this.loadedmetadata = true;
+        const bufferable = this.videoBuffer || this.media;
+        if (bufferable) {
+          const bufferedTimeRanges = BufferHelper.getBuffered(bufferable);
+          if (bufferedTimeRanges.length) {
+            this.loadedmetadata = true;
+          }
         }
       }
       return;

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -316,6 +316,9 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           action === NetworkErrorAction.SendAlternateToPenaltyBox));
     if (retry) {
       this.requestScheduled = -1;
+      if (retryCount >= retryConfig.maxNumRetry) {
+        return false;
+      }
       if (isTimeout && errorEvent.context?.deliveryDirectives) {
         // The LL-HLS request already timed out so retry immediately
         this.warn(

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -72,6 +72,7 @@ export default class ErrorController implements NetworkComponentAPI {
     const hls = this.hls;
     hls.on(Events.ERROR, this.onError, this);
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
+    hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
   }
 
   private unregisterListeners() {
@@ -82,6 +83,7 @@ export default class ErrorController implements NetworkComponentAPI {
     hls.off(Events.ERROR, this.onError, this);
     hls.off(Events.ERROR, this.onErrorOut, this);
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
+    hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
   }
 
   destroy() {
@@ -106,6 +108,10 @@ export default class ErrorController implements NetworkComponentAPI {
   private onManifestLoading() {
     this.playlistError = 0;
     this.penalizedRenditions = {};
+  }
+
+  private onLevelUpdated() {
+    this.playlistError = 0;
   }
 
   private onError(event: Events.ERROR, data: ErrorData) {
@@ -371,6 +377,7 @@ export default class ErrorController implements NetworkComponentAPI {
         }
         if (nextLevel > -1 && hls.loadLevel !== nextLevel) {
           data.levelRetry = true;
+          this.playlistError = 0;
           return {
             action: NetworkErrorAction.SendAlternateToPenaltyBox,
             flags: ErrorActionFlags.None,


### PR DESCRIPTION
### This PR will...
- Reset playlist loading error count when handling error with level switch and on level updated
- Do not mark errors as resolved by playlist controller if retries are maxed out 
- Use buffered helper in audio-stream-controller to prevent exceptions when source buffer is detached because of error

### Why is this Pull Request needed?
Playlist loading errors must be fatal after all levels and retries exhausted.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5488

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
