### PR TITLE
Adjust parsed TS AVC samples when start PTS overlaps with last DTS

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -489,7 +489,7 @@ export default class MP4Remuxer implements Remuxer {
             )} ms (${delta}dts) overlapping between fragments detected`
           );
         }
-        if (!foundOverlap || nextAvcDts > inputSamples[0].pts) {
+        if (!foundOverlap || nextAvcDts >= inputSamples[0].pts) {
           firstDTS = nextAvcDts;
           const firstPTS = inputSamples[0].pts - delta;
           inputSamples[0].dts = firstDTS;


### PR DESCRIPTION
### This PR will...
Adjust parsed TS AVC samples when start PTS overlaps with last DTS

### Why is this Pull Request needed?
Resolves user reported buffer gaps in Chrome for TS streams produced from Cloudflare with overlapping video samples between the first and second segment (#5477).

### Are there any points in the code the reviewer needs to double check?
Older releases of the player made this adjustment, but the change was dialed back in 1.2.5. This change makes a slight adjustment to allow the timestamp adjustment that works for the samples provided in #5477.

### Resolves issues:
Resolves #5477

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
