### PR TITLE
Do not jump start gaps when paused

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -135,7 +135,9 @@ export default class GapController {
         : MAX_START_GAP_JUMP;
       const partialOrGap = this.fragmentTracker.getPartialFragment(currentTime);
       if (startJump > 0 && (startJump <= maxStartGapJump || partialOrGap)) {
-        this._trySkipBufferHole(partialOrGap);
+        if (!media.paused) {
+          this._trySkipBufferHole(partialOrGap);
+        }
         return;
       }
     }


### PR DESCRIPTION
### This PR will...
Prevent gap-controller from jumping start gaps when paused

### Why is this Pull Request needed?
So that small backward seeks can be performed along segment boundaries whose buffered content does not match playlist times can be performed without seeking forward to buffered start.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #5499

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
