### PR TITLE
Use input timescale when normalizing metadata cue timestamps

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -1077,12 +1077,12 @@ export function flushTextTrackMetadataCueSamples(
     // using this._initPTS and this._initDTS to calculate relative time
     sample.pts =
       normalizePts(
-        sample.pts - (initPTS.baseTime * 90000) / initPTS.timescale,
+        sample.pts - (initPTS.baseTime * inputTimeScale) / initPTS.timescale,
         timeOffset * inputTimeScale
       ) / inputTimeScale;
     sample.dts =
       normalizePts(
-        sample.dts - (initDTS.baseTime * 90000) / initDTS.timescale,
+        sample.dts - (initDTS.baseTime * inputTimeScale) / initDTS.timescale,
         timeOffset * inputTimeScale
       ) / inputTimeScale;
   }


### PR DESCRIPTION
### This PR will...
Use input timescale when normalizing metadata cue timestamps

### Why is this Pull Request needed?
v1.4.0 introduced rational timestamps (basetime, timescale) for initPTS, and with that a regression in emsg metadata cue timestamp normalization.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5504

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
