### PR TITLE
Filter variants with any unsupported codecs

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -967,6 +967,7 @@ export default class StreamController
           ? this.videoBuffer
           : this.mediaBuffer) || this.media;
       this.afterBufferFlushed(mediaBuffer, type, PlaylistLevelType.MAIN);
+      this.tick();
     }
   }
 

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -809,19 +809,13 @@ function parseStartTimeOffset(startAttributes: string): number | null {
   return null;
 }
 
-function setCodecs(codecs: Array<string>, level: LevelParsed) {
+function setCodecs(codecs: string[], level: LevelParsed) {
   ['video', 'audio', 'text'].forEach((type: CodecType) => {
     const filtered = codecs.filter((codec) => isCodecType(codec, type));
     if (filtered.length) {
-      const preferred = filtered.filter((codec) => {
-        return (
-          codec.lastIndexOf('avc1', 0) === 0 ||
-          codec.lastIndexOf('mp4a', 0) === 0
-        );
-      });
-      level[`${type}Codec`] = preferred.length > 0 ? preferred[0] : filtered[0];
-
-      // remove from list
+      // Comma separated list of all codecs for type
+      level[`${type}Codec`] = filtered.join(',');
+      // Remove known codecs so that only unknownCodecs are left after iterating through each type
       codecs = codecs.filter((codec) => filtered.indexOf(codec) === -1);
     }
   });

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -85,7 +85,16 @@ export function isCodecType(codec: string, type: CodecType): boolean {
   return !!typeCodes && typeCodes[codec.slice(0, 4)] === true;
 }
 
-export function isCodecSupportedInMp4(codec: string, type: CodecType): boolean {
+export function areCodecsMediaSourceSupported(
+  codecs: string,
+  type: CodecType
+): boolean {
+  return !codecs
+    .split(',')
+    .some((codec) => !isCodecMediaSourceSupported(codec, type));
+}
+
+function isCodecMediaSourceSupported(codec: string, type: CodecType): boolean {
   return (
     MediaSource?.isTypeSupported(`${type || 'video'}/mp4;codecs="${codec}"`) ??
     false
@@ -117,7 +126,7 @@ function getCodecCompatibleNameLower(
   }[lowerCaseCodec];
 
   for (let i = 0; i < codecsToCheck.length; i++) {
-    if (isCodecSupportedInMp4(codecsToCheck[i], 'audio')) {
+    if (isCodecMediaSourceSupported(codecsToCheck[i], 'audio')) {
       CODEC_COMPATIBLE_NAMES[lowerCaseCodec] = codecsToCheck[i];
       return codecsToCheck[i];
     }


### PR DESCRIPTION
### This PR will...
Filter variants with multiple audio or video codecs where any of the codecs are unsupported by MSE.

### Why is this Pull Request needed?
All codecs in the CODECS attribute must be supported for a client to select and play a variant.

Multiple video or audio codecs separated by a comma typically indicate codec changes at discontinuities in the stream (common with digital ad insertion). Multiple audio codecs can also indicate a variety of codecs across playlists within the same audio group. However, since the client can not determine which tracks contain which of the codecs, if any of them are unsupported, the client should not use the variant which could require all of them. For this reason using different audio groups for each audio codec is recommended. 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#5378

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
