### PR TITLE
Resume fragment loading after level switch follows level error

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -180,6 +180,9 @@ export default class StreamController
           }
           this.state = State.IDLE;
           break;
+        } else if (this.hls.nextLoadLevel !== this.level) {
+          this.state = State.IDLE;
+          break;
         }
         break;
       }


### PR DESCRIPTION
### This PR will...
Resume fragment loading after level switch follows level error

### Why is this Pull Request needed?
The stream-controller gets stuck in WAITING_LEVEL state waiting for the first level that failed to load. The stream-controller's idle tick needs to run to update its level property to match `hls.nextLoadLevel` so that it will attempt to fetch segments from the current level if available or go back to WAITING_LEVEL for the active level that has yet to load.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5498
