### PR TITLE
ManagedMediaSource Support

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1608,12 +1608,14 @@ class Hls implements HlsEventEmitter {
     on<E extends keyof HlsListeners, Context = undefined>(event: E, listener: HlsListeners[E], context?: Context): void;
     // (undocumented)
     once<E extends keyof HlsListeners, Context = undefined>(event: E, listener: HlsListeners[E], context?: Context): void;
+    pauseBuffering(): void;
     get playingDate(): Date | null;
     recoverMediaError(): void;
     // (undocumented)
     removeAllListeners<E extends keyof HlsListeners>(event?: E | undefined): void;
     // (undocumented)
     removeLevel(levelIndex: any, urlId?: number): void;
+    resumeBuffering(): void;
     get startLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "startLevel" must appear on the getter, not the setter.
     set startLevel(newLevel: number);
@@ -1656,6 +1658,7 @@ export type HlsConfig = {
     enableSoftwareAES: boolean;
     minAutoBitrate: number;
     ignoreDevicePixelRatio: boolean;
+    preferManagedMediaSource: boolean;
     loader: {
         new (confg: HlsConfig): Loader<LoaderContext>;
     };
@@ -2633,6 +2636,8 @@ export interface ManifestParsedData {
 export interface MediaAttachedData {
     // (undocumented)
     media: HTMLMediaElement;
+    // (undocumented)
+    mediaSource?: MediaSource;
 }
 
 // Warning: (ae-missing-release-tag) "MediaAttachingData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/config.ts
+++ b/src/config.ts
@@ -249,6 +249,7 @@ export type HlsConfig = {
   enableSoftwareAES: boolean;
   minAutoBitrate: number;
   ignoreDevicePixelRatio: boolean;
+  preferManagedMediaSource: boolean;
   loader: { new (confg: HlsConfig): Loader<LoaderContext> };
   fLoader?: FragmentLoaderConstructor;
   pLoader?: PlaylistLoaderConstructor;
@@ -317,6 +318,7 @@ export const hlsDefaultConfig: HlsConfig = {
   capLevelOnFPSDrop: false, // used by fps-controller
   capLevelToPlayerSize: false, // used by cap-level-controller
   ignoreDevicePixelRatio: false, // used by cap-level-controller
+  preferManagedMediaSource: true,
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller
   backBufferLength: Infinity, // used by buffer-controller

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -1216,9 +1216,7 @@ class EMEController implements ComponentAPI {
         )
         .concat(
           media?.setMediaKeys(null).catch((error) => {
-            this.log(
-              `Could not clear media keys: ${error}. media.src: ${media?.src}`,
-            );
+            this.log(`Could not clear media keys: ${error}`);
           }),
         ),
     )
@@ -1229,9 +1227,7 @@ class EMEController implements ComponentAPI {
         }
       })
       .catch((error) => {
-        this.log(
-          `Could not close sessions and clear media keys: ${error}. media.src: ${media?.src}`,
-        );
+        this.log(`Could not close sessions and clear media keys: ${error}`);
       });
   }
 

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -135,7 +135,10 @@ export default class LevelController extends BasePlaylistController {
       }
 
       if (levelParsed.audioCodec) {
-        levelParsed.audioCodec = getCodecCompatibleName(levelParsed.audioCodec);
+        levelParsed.audioCodec = getCodecCompatibleName(
+          levelParsed.audioCodec,
+          this.hls.config.preferManagedMediaSource,
+        );
       }
 
       const {
@@ -171,6 +174,7 @@ export default class LevelController extends BasePlaylistController {
     unfilteredLevels: Level[],
     data: ManifestLoadedData,
   ) {
+    const { preferManagedMediaSource } = this.hls.config;
     let audioTracks: MediaPlaylist[] = [];
     let subtitleTracks: MediaPlaylist[] = [];
 
@@ -186,8 +190,18 @@ export default class LevelController extends BasePlaylistController {
         audioCodecFound ||= !!audioCodec;
         return (
           !unknownCodecs?.length &&
-          (!audioCodec || areCodecsMediaSourceSupported(audioCodec, 'audio')) &&
-          (!videoCodec || areCodecsMediaSourceSupported(videoCodec, 'video'))
+          (!audioCodec ||
+            areCodecsMediaSourceSupported(
+              audioCodec,
+              'audio',
+              preferManagedMediaSource,
+            )) &&
+          (!videoCodec ||
+            areCodecsMediaSourceSupported(
+              videoCodec,
+              'video',
+              preferManagedMediaSource,
+            ))
         );
       },
     );
@@ -231,7 +245,11 @@ export default class LevelController extends BasePlaylistController {
       audioTracks = data.audioTracks.filter(
         (track) =>
           !track.audioCodec ||
-          areCodecsMediaSourceSupported(track.audioCodec, 'audio'),
+          areCodecsMediaSourceSupported(
+            track.audioCodec,
+            'audio',
+            preferManagedMediaSource,
+          ),
       );
       // Assign ids after filtering as array indices by group-id
       assignTrackIdsByGroup(audioTracks);

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -22,8 +22,6 @@ import type { PlaylistLevelType } from '../types/loader';
 import type { TypeSupported } from './tsdemuxer';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
 
-const MediaSource = getMediaSource() || { isTypeSupported: () => false };
-
 export default class TransmuxerInterface {
   public error: Error | null = null;
   private hls: Hls;
@@ -66,6 +64,9 @@ export default class TransmuxerInterface {
     this.observer.on(Events.FRAG_DECRYPTED, forwardMessage);
     this.observer.on(Events.ERROR, forwardMessage);
 
+    const MediaSource = getMediaSource(config.preferManagedMediaSource) || {
+      isTypeSupported: () => false,
+    };
     const m2tsTypeSupported: TypeSupported = {
       mpeg: MediaSource.isTypeSupported('audio/mpeg'),
       mp3: MediaSource.isTypeSupported('audio/mp4; codecs="mp3"'),

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -51,6 +51,7 @@ export default class Hls implements HlsEventEmitter {
 
   private coreComponents: ComponentAPI[];
   private networkControllers: NetworkComponentAPI[];
+  private started: boolean = false;
   private _emitter: HlsEventEmitter = new EventEmitter();
   private _autoLevelCapping: number;
   private _maxHdcpLevel: HdcpLevel = null;
@@ -404,6 +405,7 @@ export default class Hls implements HlsEventEmitter {
    */
   startLoad(startPosition: number = -1) {
     logger.log(`startLoad(${startPosition})`);
+    this.started = true;
     this.networkControllers.forEach((controller) => {
       controller.startLoad(startPosition);
     });
@@ -414,8 +416,34 @@ export default class Hls implements HlsEventEmitter {
    */
   stopLoad() {
     logger.log('stopLoad');
+    this.started = false;
     this.networkControllers.forEach((controller) => {
       controller.stopLoad();
+    });
+  }
+
+  /**
+   * Resumes stream controller segment loading if previously started.
+   */
+  resumeBuffering() {
+    if (this.started) {
+      this.networkControllers.forEach((controller) => {
+        if ('fragmentLoader' in controller) {
+          controller.startLoad(-1);
+        }
+      });
+    }
+  }
+
+  /**
+   * Stops stream controller segment loading without changing 'started' state like stopLoad().
+   * This allows for media buffering to be paused without interupting playlist loading.
+   */
+  pauseBuffering() {
+    this.networkControllers.forEach((controller) => {
+      if ('fragmentLoader' in controller) {
+        controller.stopLoad();
+      }
     });
   }
 

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -279,7 +279,9 @@ function getParsedTrackCodec(
       return parsedCodec;
     }
     if (parsedCodec === 'fLaC' || parsedCodec === 'Opus') {
-      return getCodecCompatibleName(parsedCodec);
+      // Opting not to get `preferManagedMediaSource` from player config for isSupported() check for simplicity
+      const preferManagedMediaSource = false;
+      return getCodecCompatibleName(parsedCodec, preferManagedMediaSource);
     }
     const result = 'mp4a.40.5';
     logger.info(

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -37,6 +37,7 @@ export interface MediaAttachingData {
 
 export interface MediaAttachedData {
   media: HTMLMediaElement;
+  mediaSource?: MediaSource;
 }
 
 export interface BufferCodecsData {

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -77,8 +77,6 @@ const sampleEntryCodesISO = {
   },
 } as const;
 
-const MediaSource = getMediaSource();
-
 export type CodecType = 'audio' | 'video';
 
 export function isCodecType(codec: string, type: CodecType): boolean {
@@ -89,13 +87,22 @@ export function isCodecType(codec: string, type: CodecType): boolean {
 export function areCodecsMediaSourceSupported(
   codecs: string,
   type: CodecType,
+  preferManagedMediaSource = true,
 ): boolean {
   return !codecs
     .split(',')
-    .some((codec) => !isCodecMediaSourceSupported(codec, type));
+    .some(
+      (codec) =>
+        !isCodecMediaSourceSupported(codec, type, preferManagedMediaSource),
+    );
 }
 
-function isCodecMediaSourceSupported(codec: string, type: CodecType): boolean {
+function isCodecMediaSourceSupported(
+  codec: string,
+  type: CodecType,
+  preferManagedMediaSource = true,
+): boolean {
+  const MediaSource = getMediaSource(preferManagedMediaSource);
   return MediaSource?.isTypeSupported(mimeTypeForCodec(codec, type)) ?? false;
 }
 
@@ -124,6 +131,7 @@ type LowerCaseCodecType = 'flac' | 'opus';
 
 function getCodecCompatibleNameLower(
   lowerCaseCodec: LowerCaseCodecType,
+  preferManagedMediaSource = true,
 ): string {
   if (CODEC_COMPATIBLE_NAMES[lowerCaseCodec]) {
     return CODEC_COMPATIBLE_NAMES[lowerCaseCodec]!;
@@ -138,7 +146,13 @@ function getCodecCompatibleNameLower(
   }[lowerCaseCodec];
 
   for (let i = 0; i < codecsToCheck.length; i++) {
-    if (isCodecMediaSourceSupported(codecsToCheck[i], 'audio')) {
+    if (
+      isCodecMediaSourceSupported(
+        codecsToCheck[i],
+        'audio',
+        preferManagedMediaSource,
+      )
+    ) {
       CODEC_COMPATIBLE_NAMES[lowerCaseCodec] = codecsToCheck[i];
       return codecsToCheck[i];
     }
@@ -148,9 +162,15 @@ function getCodecCompatibleNameLower(
 }
 
 const AUDIO_CODEC_REGEXP = /flac|opus/i;
-export function getCodecCompatibleName(codec: string): string {
+export function getCodecCompatibleName(
+  codec: string,
+  preferManagedMediaSource = true,
+): string {
   return codec.replace(AUDIO_CODEC_REGEXP, (m) =>
-    getCodecCompatibleNameLower(m.toLowerCase() as LowerCaseCodecType),
+    getCodecCompatibleNameLower(
+      m.toLowerCase() as LowerCaseCodecType,
+      preferManagedMediaSource,
+    ),
   );
 }
 

--- a/src/utils/mediasource-helper.ts
+++ b/src/utils/mediasource-helper.ts
@@ -2,7 +2,16 @@
  * MediaSource helper
  */
 
-export function getMediaSource(): typeof MediaSource | undefined {
+export function getMediaSource(
+  preferManagedMediaSource = true,
+): typeof MediaSource | undefined {
   if (typeof self === 'undefined') return undefined;
-  return self.MediaSource || ((self as any).WebKitMediaSource as MediaSource);
+  const mms =
+    (preferManagedMediaSource || !self.MediaSource) &&
+    ((self as any).ManagedMediaSource as undefined | typeof MediaSource);
+  return (
+    mms ||
+    self.MediaSource ||
+    ((self as any).WebKitMediaSource as typeof MediaSource)
+  );
 }

--- a/tests/unit/controller/content-steering-controller.ts
+++ b/tests/unit/controller/content-steering-controller.ts
@@ -30,8 +30,6 @@ import { getMediaSource } from '../../../src/utils/mediasource-helper';
 chai.use(sinonChai);
 const expect = chai.expect;
 
-const MediaSource = getMediaSource();
-
 type ConentSteeringControllerTestable = Omit<
   ContentSteeringController,
   | 'enabled'
@@ -67,6 +65,7 @@ describe('ContentSteeringController', function () {
   let contentSteeringController: ConentSteeringControllerTestable;
 
   beforeEach(function () {
+    const MediaSource = getMediaSource();
     hls = new HlsMock({
       loader: MockXhr,
     });

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -32,8 +32,6 @@ import { getMediaSource } from '../../../src/utils/mediasource-helper';
 chai.use(sinonChai);
 const expect = chai.expect;
 
-const MediaSource = getMediaSource();
-
 type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
   onManifestLoaded: (event: string, data: Partial<ManifestLoadedData>) => void;
   onAudioTrackSwitched: (event: string, data: { id: number }) => void;
@@ -86,6 +84,7 @@ describe('LevelController', function () {
   let levelController: LevelControllerTestable;
 
   beforeEach(function () {
+    const MediaSource = getMediaSource();
     hls = new HlsMock({});
     levelController = new LevelController(
       hls as any,


### PR DESCRIPTION
### This PR will...

1. Use ManagedMediaSource (MMS) when available rather than MediaSource for MSE based playback
    - Adds `preferManagedMediaSource` config option which defaults to `true`. Set to `false` to use standard `MediaSource` when available even if MMS is present.
1. Start and stop loading of media segments with MMS "startstreaming" and "endstreaming" events
    - Adds new new player API methods `pauseBuffering()` and `resumeBuffering()`
    (unlike `startLoad()` and `stopLoad()`, these methods do not interrupt Playlist loading)
1. Cap max quality based on MMS quality:
    1. low = ABR selection limited to 1280x720p max
    1. medium = 1920x1080p max
    1. (other) = no limit
1. Use HTMLSourceElements for MediaSource blob URL and set `media.disableRemotePlayback` to `true` to allow ManagedMediaSource to open (users can add additional source elements and allow remote playback as needed).
    - Setting `preferManagedMediaSource` to `false` prevents this behavior

### Why is this Pull Request needed?
Using ManagedMediaSource when available allows the User Agent to manage buffer levels and limit quality based on information not available to the page.

### Are there any points in the code the reviewer needs to double check?

ManagedMediaSource explainer: https://github.com/w3c/media-source/issues/320