### PR TITLE
Improve buffer-controller logging

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -534,9 +534,13 @@ export class BufferController implements ComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
+    protected error: (msg: any, obj?: any) => void;
+    // (undocumented)
     flushBackBuffer(): void;
     // (undocumented)
     hasSourceTypes(): boolean;
+    // (undocumented)
+    protected log: (msg: any) => void;
     // (undocumented)
     media: HTMLMediaElement | null;
     // (undocumented)
@@ -575,6 +579,8 @@ export class BufferController implements ComponentAPI {
     protected unregisterListeners(): void;
     // (undocumented)
     updateSeekableRange(levelDetails: any): void;
+    // (undocumented)
+    protected warn: (msg: any, obj?: any) => void;
 }
 
 // Warning: (ae-missing-release-tag) "BufferControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)


### PR DESCRIPTION
### This PR will...
Improve buffer-controller logging

### Why is this Pull Request needed?
Log seekable range start and end when using `liveDurationInfinity` to help with debugging live stream catchup and stalls. Also optimizes log statements by binding module name to the start of each statement instead of repeating it.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #5536