### PR TITLE
Make loader context nullable and cleanup loader cleanup

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2340,7 +2340,7 @@ export interface Loader<T extends LoaderContext> {
     // (undocumented)
     abort(): void;
     // (undocumented)
-    context: T;
+    context: T | null;
     // (undocumented)
     destroy(): void;
     getCacheAge?: () => number | null;

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -37,7 +37,7 @@ export default class KeyLoader implements ComponentAPI {
     for (const uri in this.keyUriToKeyInfo) {
       const loader = this.keyUriToKeyInfo[uri].loader;
       if (loader) {
-        if (type && type !== loader.context.frag.type) {
+        if (type && type !== loader.context?.frag.type) {
           return;
         }
         loader.abort();

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -160,7 +160,7 @@ export interface Loader<T extends LoaderContext> {
    */
   getCacheAge?: () => number | null;
   getResponseHeader?: (name: string) => string | null;
-  context: T;
+  context: T | null;
   stats: LoaderStats;
 }
 

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -33,10 +33,10 @@ const BYTERANGE = /(\d+)-(\d+)\/(\d+)/;
 class FetchLoader implements Loader<LoaderContext> {
   private fetchSetup: Function;
   private requestTimeout?: number;
-  private request!: Request;
-  private response!: Response;
+  private request: Request | null = null;
+  private response: Response | null = null;
   private controller: AbortController;
-  public context!: LoaderContext;
+  public context: LoaderContext | null = null;
   private config: LoaderConfiguration | null = null;
   private callbacks: LoaderCallbacks<LoaderContext> | null = null;
   public stats: LoaderStats;
@@ -49,13 +49,21 @@ class FetchLoader implements Loader<LoaderContext> {
   }
 
   destroy(): void {
-    this.loader = this.callbacks = null;
+    this.loader =
+      this.callbacks =
+      this.context =
+      this.config =
+      this.request =
+        null;
     this.abortInternal();
+    this.response = null;
+    // @ts-ignore
+    this.fetchSetup = this.controller = this.stats = null;
   }
 
   abortInternal(): void {
     const response = this.response;
-    if (!response?.ok) {
+    if (this.controller && !response?.ok) {
       this.stats.aborted = true;
       this.controller.abort();
     }
@@ -64,7 +72,11 @@ class FetchLoader implements Loader<LoaderContext> {
   abort(): void {
     this.abortInternal();
     if (this.callbacks?.onAbort) {
-      this.callbacks.onAbort(this.stats, this.context, this.response);
+      this.callbacks.onAbort(
+        this.stats,
+        this.context as LoaderContext,
+        this.response
+      );
     }
   }
 
@@ -101,7 +113,7 @@ class FetchLoader implements Loader<LoaderContext> {
     }, config.timeout);
 
     self
-      .fetch(this.request)
+      .fetch(this.request as Request)
       .then((response: Response): Promise<string | ArrayBuffer> => {
         this.response = this.loader = response;
 
@@ -145,7 +157,10 @@ class FetchLoader implements Loader<LoaderContext> {
         return response.text();
       })
       .then((responseData: string | ArrayBuffer) => {
-        const { response } = this;
+        const response = this.response;
+        if (!response) {
+          throw new Error('loader destroyed');
+        }
         self.clearTimeout(this.requestTimeout);
         stats.loading.end = Math.max(
           self.performance.now(),


### PR DESCRIPTION
### This PR will...
Make loader context nullable and cleanup loader cleanup

### Why is this Pull Request needed?
`context` is undefined before `load()` is called. Making it nullable and clearing it on destroy makes it easier to deal with loader usage after the end of its lifecycle.

### Are there any points in the code the reviewer needs to double check?
Do apps currently use these loader properties after loaders are destroyed (`context` or `stats`)? At the very least we should clear `(xhr|fetch)Setup` callbacks on destroy to remove any references hoisted into the scope of these functions.

### Resolves issues:
Followup to #5494