### PR TITLE
Keep level switch error actions within player constraints

### DIFF
--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -330,14 +330,16 @@ export default class ErrorController implements NetworkComponentAPI {
       if (hls.autoLevelEnabled) {
         // Search for next level to retry
         let nextLevel = -1;
-        const levels = hls.levels;
+        const { levels, loadLevel, minAutoLevel, maxAutoLevel } = hls;
         const fragErrorType = data.frag?.type;
         const { type: playlistErrorType, groupId: playlistErrorGroupId } =
           data.context ?? {};
         for (let i = levels.length; i--; ) {
-          const candidate = (i + hls.loadLevel) % levels.length;
+          const candidate = (i + loadLevel) % levels.length;
           if (
-            candidate !== hls.loadLevel &&
+            candidate !== loadLevel &&
+            candidate >= minAutoLevel &&
+            candidate <= maxAutoLevel &&
             levels[candidate].loadError === 0
           ) {
             const levelCandidate = levels[candidate];


### PR DESCRIPTION
### This PR will...
Keep level switch error actions within player constraints

### Why is this Pull Request needed?
The player will not switch to suggested level indexes outside the bounds of `hls.minAutoLevel` and `hls.maxAutoLevel`. Working within these constraints is a condition to reaching a fatal error when all viable level loading attempts have failed.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5566