### PR TITLE
Bugfix: large subtitle target duration can result in subtitles not loading as needed

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -165,17 +165,7 @@ export class SubtitleStreamController
   onBufferFlushing(event: Events.BUFFER_FLUSHING, data: BufferFlushingData) {
     const { startOffset, endOffset } = data;
     if (startOffset === 0 && endOffset !== Number.POSITIVE_INFINITY) {
-      const { currentTrackId, levels } = this;
-      if (
-        !levels.length ||
-        !levels[currentTrackId] ||
-        !levels[currentTrackId].details
-      ) {
-        return;
-      }
-      const trackDetails = levels[currentTrackId].details as LevelDetails;
-      const targetDuration = trackDetails.targetduration;
-      const endOffsetSubtitles = endOffset - targetDuration;
+      const endOffsetSubtitles = endOffset - 1;
       if (endOffsetSubtitles <= 0) {
         return;
       }
@@ -408,15 +398,11 @@ export class SubtitleStreamController
       if (!levels.length || !track || !track.details) {
         return;
       }
-
-      // Expand range of subs loaded by one target-duration in either direction to make up for misaligned playlists
-      const trackDetails = track.details as LevelDetails;
-      const targetDuration = trackDetails.targetduration;
       const { config } = this;
       const currentTime = this.getLoadPosition();
       const bufferedInfo = BufferHelper.bufferedInfo(
         this.tracksBuffered[this.currentTrackId] || [],
-        currentTime - targetDuration,
+        currentTime,
         config.maxBufferHole
       );
       const { end: targetBufferTime, len: bufferLen } = bufferedInfo;
@@ -425,8 +411,10 @@ export class SubtitleStreamController
         this.media,
         PlaylistLevelType.MAIN
       );
+      const trackDetails = track.details as LevelDetails;
       const maxBufLen =
-        this.getMaxBufferLength(mainBufferInfo?.len) + targetDuration;
+        this.getMaxBufferLength(mainBufferInfo?.len) +
+        trackDetails.levelTargetDuration;
 
       if (bufferLen > maxBufLen) {
         return;
@@ -438,12 +426,14 @@ export class SubtitleStreamController
       let foundFrag: Fragment | null = null;
       const fragPrevious = this.fragPrevious;
       if (targetBufferTime < end) {
-        const { maxFragLookUpTolerance } = config;
+        const tolerance = config.maxFragLookUpTolerance;
+        const lookupTolerance =
+          targetBufferTime > end - tolerance ? 0 : tolerance;
         foundFrag = findFragmentByPTS(
           fragPrevious,
           fragments,
           Math.max(fragments[0].start, targetBufferTime),
-          maxFragLookUpTolerance
+          lookupTolerance
         );
         if (
           !foundFrag &&
@@ -458,8 +448,18 @@ export class SubtitleStreamController
       if (!foundFrag) {
         return;
       }
-
       foundFrag = this.mapToInitFragWhenRequired(foundFrag) as Fragment;
+      if (foundFrag.sn !== 'initSegment') {
+        // Load earlier fragment to make up for misaligned playlists
+        const curSNIdx = foundFrag.sn - trackDetails.startSN;
+        const prevFrag = fragments[curSNIdx - 1];
+        if (
+          prevFrag &&
+          this.fragmentTracker.getState(prevFrag) === FragmentState.NOT_LOADED
+        ) {
+          foundFrag = prevFrag;
+        }
+      }
       if (
         this.fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED
       ) {

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -450,11 +450,12 @@ export class SubtitleStreamController
       }
       foundFrag = this.mapToInitFragWhenRequired(foundFrag) as Fragment;
       if (foundFrag.sn !== 'initSegment') {
-        // Load earlier fragment to make up for misaligned playlists and cues that extend beyond end of segment
+        // Load earlier fragment in same discontinuity to make up for misaligned playlists and cues that extend beyond end of segment
         const curSNIdx = foundFrag.sn - trackDetails.startSN;
         const prevFrag = fragments[curSNIdx - 1];
         if (
           prevFrag &&
+          prevFrag.cc === foundFrag.cc &&
           this.fragmentTracker.getState(prevFrag) === FragmentState.NOT_LOADED
         ) {
           foundFrag = prevFrag;

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -450,7 +450,7 @@ export class SubtitleStreamController
       }
       foundFrag = this.mapToInitFragWhenRequired(foundFrag) as Fragment;
       if (foundFrag.sn !== 'initSegment') {
-        // Load earlier fragment to make up for misaligned playlists
+        // Load earlier fragment to make up for misaligned playlists and cues that extend beyond end of segment
         const curSNIdx = foundFrag.sn - trackDetails.startSN;
         const prevFrag = fragments[curSNIdx - 1];
         if (

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -576,6 +576,9 @@ export class TimelineController implements ComponentAPI {
         }
         // Something went wrong while parsing. Trigger event with success false.
         logger.log(`Failed to parse VTT cue: ${error}`);
+        if (missingInitPTS && maxAvCC > frag.cc) {
+          return;
+        }
         hls.trigger(Events.SUBTITLE_FRAG_PROCESSED, {
           success: false,
           frag: frag,

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -304,7 +304,7 @@ export class TimelineController implements ComponentAPI {
     this.captionsTracks = {};
     this.nonNativeCaptionsTracks = {};
     this.textTracks = [];
-    this.unparsedVttFrags = this.unparsedVttFrags || [];
+    this.unparsedVttFrags = [];
     this.initPTS = [];
     if (this.cea608Parser1 && this.cea608Parser2) {
       this.cea608Parser1.reset();
@@ -477,24 +477,9 @@ export class TimelineController implements ComponentAPI {
     data: FragDecryptedData | FragLoadedData
   ) {
     const { frag, payload } = data;
-    const { initPTS, unparsedVttFrags } = this;
     if (frag.type === PlaylistLevelType.SUBTITLE) {
       // If fragment is subtitle type, parse as WebVTT.
       if (payload.byteLength) {
-        // We need an initial synchronisation PTS. Store fragments as long as none has arrived.
-        if (!initPTS[frag.cc]) {
-          unparsedVttFrags.push(data);
-          if (initPTS.length) {
-            // finish unsuccessfully, otherwise the subtitle-stream-controller could be blocked from loading new frags.
-            this.hls.trigger(Events.SUBTITLE_FRAG_PROCESSED, {
-              success: false,
-              frag,
-              error: new Error('Missing initial subtitle PTS'),
-            });
-          }
-          return;
-        }
-
         const decryptData = frag.decryptdata;
         // fragment after decryption has a stats object
         const decrypted = 'stats' in data;
@@ -516,7 +501,7 @@ export class TimelineController implements ComponentAPI {
           ) {
             this._parseIMSC1(frag, payload);
           } else {
-            this._parseVTTs(frag, payload, vttCCs);
+            this._parseVTTs(data);
           }
         }
       } else {
@@ -553,7 +538,16 @@ export class TimelineController implements ComponentAPI {
     );
   }
 
-  private _parseVTTs(frag: Fragment, payload: ArrayBuffer, vttCCs: any) {
+  private _parseVTTs(data: FragDecryptedData | FragLoadedData) {
+    const { frag, payload } = data;
+    // We need an initial synchronisation PTS. Store fragments as long as none has arrived
+    const { initPTS, unparsedVttFrags } = this;
+    const maxAvCC = initPTS.length - 1;
+    if (!initPTS[frag.cc] && maxAvCC === -1) {
+      unparsedVttFrags.push(data);
+      return;
+    }
+
     const hls = this.hls;
     // Parse the WebVTT file contents.
     const payloadWebVTT = frag.initSegment?.data
@@ -562,7 +556,7 @@ export class TimelineController implements ComponentAPI {
     parseWebVTT(
       payloadWebVTT,
       this.initPTS[frag.cc],
-      vttCCs,
+      this.vttCCs,
       frag.cc,
       frag.start,
       (cues) => {
@@ -573,7 +567,13 @@ export class TimelineController implements ComponentAPI {
         });
       },
       (error) => {
-        this._fallbackToIMSC1(frag, payload);
+        const missingInitPTS =
+          error.message === 'Missing initPTS for VTT MPEGTS';
+        if (missingInitPTS) {
+          unparsedVttFrags.push(data);
+        } else {
+          this._fallbackToIMSC1(frag, payload);
+        }
         // Something went wrong while parsing. Trigger event with success false.
         logger.log(`Failed to parse VTT cue: ${error}`);
         hls.trigger(Events.SUBTITLE_FRAG_PROCESSED, {
@@ -631,10 +631,6 @@ export class TimelineController implements ComponentAPI {
   ) {
     const { frag } = data;
     if (frag.type === PlaylistLevelType.SUBTITLE) {
-      if (!this.initPTS[frag.cc]) {
-        this.unparsedVttFrags.push(data as unknown as FragLoadedData);
-        return;
-      }
       this.onFragLoaded(Events.FRAG_LOADED, data as unknown as FragLoadedData);
     }
   }


### PR DESCRIPTION
### This PR will...
Remove the use of target duration in ensuring subtitle segment N-1 is loaded. Instead, find best match for position, then ensure N-1 is loaded.

Improve handling of MPEGTS VTT syncing. Rather than always require initPTS for the subtitle discontinuity sequence, only require it when parsed subtitles include an MPEGTS map value, log when it's missing, and trigger a non-fatal error only when only AV initPTS from lower sequence numbers have been loaded.

### Why is this Pull Request needed?
Since target duration is an upper bound of playlist segment durations, and subtitle segments can be very long, using target duration to ensure the last subtitle segment is loaded can lead to subtitle loading starting several segments back. Loading can then idle before reaching the playhead as the subtitle-stream-controller tries to match the media forward buffer length.

The previous subtitle segment must always be loaded since it may contain subtitles that end after the end of the segment which still need to be rendered.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
- Fixes #5595

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
