### PR TITLE
Fix Multivariant Playlist and Key XHR loader retries

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1530,6 +1530,10 @@ export default class BaseStreamController
           `${data.details} reached or exceeded max retry (${retryCount})`
         );
       }
+    } else if (
+      errorAction?.action === NetworkErrorAction.SendAlternateToPenaltyBox
+    ) {
+      this.state = State.WAITING_LEVEL;
     } else {
       this.state = State.ERROR;
     }

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -86,6 +86,7 @@ class XhrLoader implements Loader<LoaderContext> {
     const stats = this.stats;
     stats.loading.first = 0;
     stats.loaded = 0;
+    stats.aborted = false;
     const xhrSetup = this.xhrSetup;
 
     if (xhrSetup) {


### PR DESCRIPTION
### This PR will...
Fix Multivariant Playlist and Key XHR loader retries.

### Why is this Pull Request needed?

**XHR Loader Issue:**
Loader was marking its state as aborted when timeouts execute while xhr.readystate is low. This was not reset on internal retries so on subsequent completes (retries), the loader exited, treating the retry request as aborted.

**Base Stream Controller Frag/Key Load Error Handler Issue:**
The stream controller state was set to ERROR On Frag/Key errors without a retry configuration. This caused the stream controller to stall after a `SendAlternateToPenaltyBox` (level switch) error action.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5588

### Checklist

- [x] changes have been done against master branch, and PR does not conflict