### PR TITLE
fix(latency-controller): only sync live stream

### DIFF
--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -206,7 +206,11 @@ export default class LatencyController implements ComponentAPI {
 
     // Adapt playbackRate to meet target latency in low-latency mode
     const { lowLatencyMode, maxLiveSyncPlaybackRate } = this.config;
-    if (!lowLatencyMode || maxLiveSyncPlaybackRate === 1) {
+    if (
+      !lowLatencyMode ||
+      maxLiveSyncPlaybackRate === 1 ||
+      !levelDetails.live
+    ) {
       return;
     }
     const targetLatency = this.targetLatency;
@@ -222,8 +226,8 @@ export default class LatencyController implements ComponentAPI {
       targetLatency + levelDetails.targetduration
     );
     const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
+
     if (
-      levelDetails.live &&
       inLiveRange &&
       distanceFromTarget > 0.05 &&
       this.forwardBufferLength > 1


### PR DESCRIPTION
### This PR will...
`maxLiveSyncPlaybackRate` should only work for live stream.

I'm using same config (`{ maxLiveSyncPlaybackRate: 1.2 }`) to play normal playback and live stream.
When playing playback, we hope users can change playback rate as needed. However, things work not quiet well.

**When user changes playback rate to 2, the player will reset to 1 quickly.**

![image](https://github.com/video-dev/hls.js/assets/17154608/0ac8e6e8-9dc2-455c-9efe-499c33b7a6a4)

To figure out what happen, I have debugged the `latency-controller.ts` file.
It seems that we want to listen 'timeupdate' event when receive **MEDIA_ATTACHED**(https://github.com/video-dev/hls.js/blob/master/src/controller/latency-controller.ts#L153), and remove 'timeupdate' event when receive **LEVEL_UPDATED**(https://github.com/video-dev/hls.js/blob/master/src/controller/latency-controller.ts#L177).

Since the **MEDIA_ATTACHED** is triggered by [_onMediaSourceOpen](https://github.com/video-dev/hls.js/blob/master/src/controller/buffer-controller.ts#L796) fired by `sourceopen` event, the order between **MEDIA_ATTACHED** and **LEVEL_UPDATED** cannot be guaranteed.

When **LEVEL_UPDATED** triggered before **MEDIA_ATTACHED**, the latency tracer (mouted by 'timeupdate') will never get a chance to stop, making user unable to change playback rate.

### Why is this Pull Request needed?

To make sure `maxLiveSyncPlaybackRate` config only work for live stream.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
