### PR TITLE
Never back-track on first fragment to avoid loop loading

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1111,6 +1111,7 @@ export default class StreamController
     }
 
     // Avoid buffering if backtracking this fragment
+    const notFirstFragment = frag.sn !== details?.startSN;
     if (video && remuxResult.independent !== false) {
       if (details) {
         const { startPTS, endPTS, startDTS, endDTS } = video;
@@ -1135,7 +1136,10 @@ export default class StreamController
             const startTime = video.firstKeyFramePTS
               ? video.firstKeyFramePTS
               : startPTS;
-            if (targetBufferTime < startTime - this.config.maxBufferHole) {
+            if (
+              notFirstFragment &&
+              targetBufferTime < startTime - this.config.maxBufferHole
+            ) {
               this.backtrack(frag);
               return;
             }
@@ -1162,7 +1166,7 @@ export default class StreamController
         }
         this.bufferFragmentData(video, frag, part, chunkMeta);
       }
-    } else if (remuxResult.independent === false) {
+    } else if (notFirstFragment && remuxResult.independent === false) {
       this.backtrack(frag);
       return;
     }


### PR DESCRIPTION
### This PR will...
Skip backtracking on first segment.

### Why is this Pull Request needed?
Calling `this.backtrack` on first segment can cause loop loading because the loaded media is rejected in favor of loading an earlier segment in hopes of finding an IDR frame that begins before the playhead position.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5609