### PR TITLE
Fix capLevelToPlayerSize after hiding player and maintain stable selection when aspect ratio changes

### DIFF
--- a/src/controller/cap-level-controller.ts
+++ b/src/controller/cap-level-controller.ts
@@ -124,7 +124,11 @@ class CapLevelController implements ComponentAPI {
   }
 
   detectPlayerSize() {
-    if (this.media && this.mediaHeight > 0 && this.mediaWidth > 0) {
+    if (this.media) {
+      if (this.mediaHeight <= 0 || this.mediaWidth <= 0) {
+        this.clientRect = null;
+        return;
+      }
       const levels = this.hls.levels;
       if (levels.length) {
         const hls = this.hls;


### PR DESCRIPTION
### This PR will...
- Continue to poll player size when not displayed with `capLevelToPlayerSize`
  - Fixes #5611
- Prevent changes in aspect-ratio from causing capping to toggle back and forth

### Why is this Pull Request needed?

Makes cap-level-controller continue to detect player size changes after it has been hidden and shown again.

Also prevents `autoLevelCapping` from bouncing back and forth when aspect ratio changes slightly between renditions because of rounded height values. To repro set player size to 426px with first BBB test stream.

### Are there any points in the code the reviewer needs to double check?

The first issue (#5611) can be worked around by toggling capping after displaying the media element again:
```
hls.capLevelToPlayerSize = false;
hls.capLevelToPlayerSize = true;
```

This could be done at any time the size/layout of the media element is changed to perform a timely update of `autoLevelCapping` on `requestAnimationFrame`.

If you are already using HLS.js in a player that reads/writes page layout and controls the media element and observes its dimensions, then it is recommended to not use  cap-level-controller. Instead batch the work of reading player width and height with existing checks in your player, and set `hls.maxAutoLevel` externally.

### Resolves issues:
Fixes #5611

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
