### PR TITLE
Reset loading start on worker setup error

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1493,10 +1493,7 @@ export default class BaseStreamController
       action === NetworkErrorAction.RetryRequest &&
       retryConfig
     ) {
-      if (!this.loadedmetadata) {
-        this.startFragRequested = false;
-        this.nextLoadPosition = this.startPosition;
-      }
+      this.resetStartWhenNotLoaded(this.levelLastLoaded ?? frag.level);
       const delay = getRetryDelay(retryConfig, retryCount);
       this.warn(
         `Fragment ${frag.sn} of ${filterType} ${frag.level} errored with ${
@@ -1633,7 +1630,7 @@ export default class BaseStreamController
       `The loading context changed while buffering fragment ${chunkMeta.sn} of level ${chunkMeta.level}. This chunk will not be buffered.`
     );
     this.removeUnbufferedFrags();
-    this.resetStartWhenNotLoaded(chunkMeta.level);
+    this.resetStartWhenNotLoaded(this.levelLastLoaded ?? chunkMeta.level);
     this.resetLoadingState();
   }
 
@@ -1731,7 +1728,11 @@ export default class BaseStreamController
 
   protected recoverWorkerError(data: ErrorData) {
     if (data.event === 'demuxerWorker') {
+      this.fragmentTracker.removeAllFragments();
       this.resetTransmuxer();
+      this.resetStartWhenNotLoaded(
+        this.levelLastLoaded ?? this.fragCurrent?.level ?? 0
+      );
       this.resetLoadingState();
     }
   }


### PR DESCRIPTION
### This PR will...
Fixes #5617

### Why is this Pull Request needed?
When worker setup errors, stream-controller `nextLoadPosition` is not reset, leading to the player skipping any segments loaded while attempting worker setup. This leads to initial segment appends being performed out of order, after the skipped segments are reloaded, which can produce gaps.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5617
