### PR TITLE
Handle mixed sourcebuffer errors

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -524,7 +524,11 @@ export class BufferController implements ComponentAPI {
     // (undocumented)
     protected appendChangeType(type: any, mimeType: any): void;
     // (undocumented)
-    appendError: number;
+    appendErrors: {
+        audio: number;
+        video: number;
+        audiovideo: number;
+    };
     // (undocumented)
     bufferCodecEventsExpected: number;
     // (undocumented)
@@ -977,9 +981,13 @@ export interface ErrorData {
     // (undocumented)
     parent?: PlaylistLevelType;
     // (undocumented)
+    part?: Part | null;
+    // (undocumented)
     reason?: string;
     // (undocumented)
     response?: LoaderResponse;
+    // (undocumented)
+    sourceBufferName?: SourceBufferName;
     // (undocumented)
     stats?: LoaderStats;
     // (undocumented)

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -233,6 +233,7 @@ export interface ErrorData {
   context?: PlaylistLoaderContext;
   event?: keyof HlsListeners | 'demuxerWorker';
   frag?: Fragment;
+  part?: Part | null;
   level?: number | undefined;
   levelRetry?: boolean;
   loader?: Loader<LoaderContext>;
@@ -243,6 +244,7 @@ export interface ErrorData {
   response?: LoaderResponse;
   url?: string;
   parent?: PlaylistLevelType;
+  sourceBufferName?: SourceBufferName;
   /**
    * @deprecated Use ErrorData.error
    */

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -161,6 +161,7 @@ describe('BufferController', function () {
       ).to.have.been.calledWith(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_APPENDING_ERROR,
+        sourceBufferName: triggerSpy.getCall(0).lastArg.sourceBufferName,
         error: triggerSpy.getCall(0).lastArg.error,
         fatal: false,
       });
@@ -251,6 +252,7 @@ describe('BufferController', function () {
       ).to.have.been.calledWith(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_APPEND_ERROR,
+        sourceBufferName: triggerSpy.getCall(0).lastArg.sourceBufferName,
         parent: 'main',
         frag,
         part: undefined,


### PR DESCRIPTION
### This PR will...
Handle mixed SourceBuffer append errors, up to `appendErrorMaxRetry` consecutive errors per SourceBuffer type ('audio', 'video', and 'audiovideo').

### Why is this Pull Request needed?
Allows append errors across SourceBuffers until the limit of consecutive errors is reached for a single type. The error count is reset for a particular type after a successful append. This prevents some sequences of append errors from being escalated to fatal, which may be recoverable. This also helps to deal with or identify append errors caused by unsupported mixed segment types, such as unmuxed and muxed 'video' and  'audiovideo' segments (#5369). 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #5369, #1510

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
