### PR TITLE
Base initial bandwidth estimate on first level bitrate

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -22,7 +22,7 @@ export interface AbrComponentAPI extends ComponentAPI {
 export class AbrController implements AbrComponentAPI {
     constructor(hls: Hls);
     // (undocumented)
-    readonly bwEstimator: EwmaBandWidthEstimator;
+    bwEstimator: EwmaBandWidthEstimator;
     // (undocumented)
     clearTimer(): void;
     // (undocumented)
@@ -45,6 +45,8 @@ export class AbrController implements AbrComponentAPI {
     // (undocumented)
     protected registerListeners(): void;
     // (undocumented)
+    resetEstimator(abrEwmaDefaultEstimate?: number): void;
+    // (undocumented)
     protected unregisterListeners(): void;
 }
 
@@ -57,6 +59,7 @@ export type ABRControllerConfig = {
     abrEwmaFastVoD: number;
     abrEwmaSlowVoD: number;
     abrEwmaDefaultEstimate: number;
+    abrEwmaDefaultEstimateMax: number;
     abrBandWidthFactor: number;
     abrBandWidthUpFactor: number;
     abrMaxWithRealBitrate: boolean;
@@ -1523,6 +1526,7 @@ class Hls implements HlsEventEmitter {
     set autoLevelCapping(newLevel: number);
     get autoLevelEnabled(): boolean;
     get bandwidthEstimate(): number;
+    set bandwidthEstimate(abrEwmaDefaultEstimate: number);
     get capLevelToPlayerSize(): boolean;
     // Warning: (ae-setter-with-docs) The doc comment for the property "capLevelToPlayerSize" must appear on the getter, not the setter.
     set capLevelToPlayerSize(shouldStartCapping: boolean);
@@ -1981,6 +1985,8 @@ export class Level {
     get audioGroupId(): string | undefined;
     // (undocumented)
     audioGroupIds?: (string | undefined)[];
+    // (undocumented)
+    get averageBitrate(): number;
     // (undocumented)
     readonly bitrate: number;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -104,6 +104,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`abrEwmaFastVoD`](#abrewmafastvod)
   - [`abrEwmaSlowVoD`](#abrewmaslowvod)
   - [`abrEwmaDefaultEstimate`](#abrewmadefaultestimate)
+  - [`abrEwmaDefaultEstimateMax`](#abrewmadefaultestimatemax)
   - [`abrBandWidthFactor`](#abrbandwidthfactor)
   - [`abrBandWidthUpFactor`](#abrbandwidthupfactor)
   - [`abrMaxWithRealBitrate`](#abrmaxwithrealbitrate)
@@ -410,6 +411,7 @@ var config = {
   abrEwmaFastVoD: 3.0,
   abrEwmaSlowVoD: 9.0,
   abrEwmaDefaultEstimate: 500000,
+  abrEwmaDefaultEstimateMax: 5000000,
   abrBandWidthFactor: 0.95,
   abrBandWidthUpFactor: 0.7,
   abrMaxWithRealBitrate: false,
@@ -1342,6 +1344,12 @@ parameter should be a float greater than [abrEwmaFastVoD](#abrewmafastvod)
 
 Default bandwidth estimate in bits/s prior to collecting fragment bandwidth samples.
 
+### `abrEwmaDefaultEstimateMax`
+
+(default: `5000000`)
+
+Limits value of updated bandwidth estimate taken from first variant found in multivariant playlist on start.
+
 ### `abrBandWidthFactor`
 
 (default: `0.95`)
@@ -1621,6 +1629,8 @@ Default value is set via [`capLevelToPlayerSize`](#capleveltoplayersize) in conf
 ### `hls.bandwidthEstimate`
 
 get: Returns the current bandwidth estimate in bits/s, if available. Otherwise, `NaN` is returned.
+
+set: Reset `EwmaBandWidthEstimator` using the value set as the new default estimate. This will update the value of `config.abrEwmaDefaultEstimate`.
 
 ### `hls.removeLevel(levelIndex, urlId)`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export type ABRControllerConfig = {
    * Default bandwidth estimate in bits/s prior to collecting fragment bandwidth samples
    */
   abrEwmaDefaultEstimate: number;
+  abrEwmaDefaultEstimateMax: number;
   abrBandWidthFactor: number;
   abrBandWidthUpFactor: number;
   abrMaxWithRealBitrate: boolean;
@@ -361,6 +362,7 @@ export const hlsDefaultConfig: HlsConfig = {
   abrEwmaFastVoD: 3, // used by abr-controller
   abrEwmaSlowVoD: 9, // used by abr-controller
   abrEwmaDefaultEstimate: 5e5, // 500 kbps  // used by abr-controller
+  abrEwmaDefaultEstimateMax: 5e6, // 5 mbps
   abrBandWidthFactor: 0.95, // used by abr-controller
   abrBandWidthUpFactor: 0.7, // used by abr-controller
   abrMaxWithRealBitrate: false, // used by abr-controller

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -1,7 +1,6 @@
 import { Events } from '../events';
-import { Level } from '../types/level';
+import { Level, addGroupId } from '../types/level';
 import { AttrList } from '../utils/attr-list';
-import { addGroupId } from './level-controller';
 import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
 import { logger } from '../utils/logger';
 import type Hls from '../hls';

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -611,6 +611,10 @@ export default class Hls implements HlsEventEmitter {
     return bwEstimator.getEstimate();
   }
 
+  set bandwidthEstimate(abrEwmaDefaultEstimate: number) {
+    this.abrController.resetEstimator(abrEwmaDefaultEstimate);
+  }
+
   /**
    * get time to first byte estimate
    * @type {number}

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -152,8 +152,8 @@ export default class M3U8Parser {
         const level: LevelParsed = {
           attrs,
           bitrate:
-            attrs.decimalInteger('AVERAGE-BANDWIDTH') ||
-            attrs.decimalInteger('BANDWIDTH'),
+            attrs.decimalInteger('BANDWIDTH') ||
+            attrs.decimalInteger('AVERAGE-BANDWIDTH'),
           name: attrs.NAME,
           url: M3U8Parser.resolve(uri, baseurl),
         };

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -105,6 +105,7 @@ export class Level {
   public textGroupIds?: (string | undefined)[];
   public url: string[];
   private _urlId: number = 0;
+  private _avgBitrate: number = 0;
 
   constructor(data: LevelParsed) {
     this.url = [data.url];
@@ -117,6 +118,7 @@ export class Level {
     this.name = data.name;
     this.width = data.width || 0;
     this.height = data.height || 0;
+    this._avgBitrate = this.attrs.decimalInteger('AVERAGE-BANDWIDTH');
     this.audioCodec = data.audioCodec;
     this.videoCodec = data.videoCodec;
     this.unknownCodecs = data.unknownCodecs;
@@ -128,6 +130,10 @@ export class Level {
 
   get maxBitrate(): number {
     return Math.max(this.realBitrate, this.bitrate);
+  }
+
+  get averageBitrate(): number {
+    return this._avgBitrate || this.realBitrate || this.bitrate;
   }
 
   get attrs(): LevelAttributes {
@@ -167,5 +173,26 @@ export class Level {
   addFallback(data: LevelParsed) {
     this.url.push(data.url);
     this._attrs.push(data.attrs);
+  }
+}
+
+export function addGroupId(
+  level: Level,
+  type: string,
+  id: string | undefined
+): void {
+  if (!id) {
+    return;
+  }
+  if (type === 'audio') {
+    if (!level.audioGroupIds) {
+      level.audioGroupIds = [];
+    }
+    level.audioGroupIds[level.url.length - 1] = id;
+  } else if (type === 'text') {
+    if (!level.textGroupIds) {
+      level.textGroupIds = [];
+    }
+    level.textGroupIds[level.url.length - 1] = id;
   }
 }

--- a/tests/unit/controller/abr-controller.ts
+++ b/tests/unit/controller/abr-controller.ts
@@ -2,10 +2,25 @@ import AbrController from '../../../src/controller/abr-controller';
 import EwmaBandWidthEstimator from '../../../src/utils/ewma-bandwidth-estimator';
 import Hls from '../../../src/hls';
 
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
 describe('AbrController', function () {
+  it('can be reset with new BWE', function () {
+    const hls = new Hls({ maxStarvationDelay: 4 });
+    const abrController = new AbrController(hls);
+    abrController.bwEstimator = new EwmaBandWidthEstimator(15, 4, 5e5, 100);
+    expect(abrController.bwEstimator.getEstimate()).to.equal(5e5);
+    abrController.resetEstimator(5e6);
+    expect(abrController.bwEstimator.getEstimate()).to.equal(5e6);
+  });
+
   it('should return correct next auto level', function () {
     const hls = new Hls({ maxStarvationDelay: 4 });
-    hls.levelController._levels = [
+    (hls as any).levelController._levels = [
       {
         bitrate: 105000,
         name: '144',
@@ -38,7 +53,7 @@ describe('AbrController', function () {
       },
     ];
     const abrController = new AbrController(hls);
-    abrController.bwEstimator = new EwmaBandWidthEstimator(hls, 15, 4, 5e5);
+    abrController.bwEstimator = new EwmaBandWidthEstimator(15, 4, 5e5, 100);
     expect(abrController.nextAutoLevel).to.equal(0);
   });
 });

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -7,6 +7,7 @@ import { Fragment } from '../../../src/loader/fragment';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import KeyLoader from '../../../src/loader/key-loader';
 import { SubtitleStreamController } from '../../../src/controller/subtitle-stream-controller';
+import { AttrList } from '../../../src/utils/attr-list';
 
 const mediaMock = {
   currentTime: 0,
@@ -18,11 +19,11 @@ const tracksMock = [
   {
     id: 0,
     details: { url: '', fragments: [] },
-    attrs: {},
+    attrs: new AttrList(),
   },
   {
     id: 1,
-    attrs: {},
+    attrs: new AttrList(),
   },
 ];
 


### PR DESCRIPTION
### This PR will...
Set default bandwidth estimate based on first variant in multivariant playlist
- Adds setter for `hls.bandwidthEstimate` which resets the bandwidth estimator using the input value as the new default estimate.
- Adds `config.abrEwmaDefaultEstimateMax` option which limits how high default value can be adjusted to.

- `Level.bitrate` returns peak bitrate value (BANDWIDTH attribute) by default
- Adds `averageBitrate` getter to `Level`

### Why is this Pull Request needed?
This is the first of several changes that will allow selection and playback of preferred codecs on start.

### Are there any points in the code the reviewer needs to double check?

This change does not change default initial quality selection. It should however provide a faster BWE ramp up, and more stable start.

### Resolves issues:
Resolves #2754

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
