### PR TITLE
Custom shouldRetry in retryConfig

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2917,6 +2917,7 @@ export type RetryConfig = {
     retryDelayMs: number;
     maxRetryDelayMs: number;
     backoff?: 'exponential' | 'linear';
+    shouldRetry?: (retryConfig: RetryConfig | null | undefined, retryCount: number, isTimeout: boolean, httpStatus: number | undefined, retry: boolean) => boolean;
 };
 
 // Warning: (ae-missing-release-tag) "SourceBufferName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,6 +64,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
       - [`retryDelayMs: number`](#retrydelayms-number)
       - [`maxRetryDelayMs: number`](#maxretrydelayms-number)
       - [`backoff?: 'exponential' | 'linear'`](#backoff-exponential--linear)
+      - [`shouldRetry`](#shouldretry)
   - [`startFragPrefetch`](#startfragprefetch)
   - [`testBandwidth`](#testbandwidth)
   - [`progressive`](#progressive)
@@ -869,6 +870,12 @@ Maximum delay between retries in milliseconds. With each retry, the delay is inc
 ##### `backoff?: 'exponential' | 'linear'`
 
 Used to determine retry backoff duration: Retry delay = 2^retryCount \* retryDelayMs (exponential).
+
+##### `shouldRetry`
+
+(default: internal shouldRetry function, type: `(retryConfig: RetryConfig | null | undefined, retryCount: number, isTimeout: boolean, httpStatus: number | undefined,retry: boolean) => boolean`)
+
+Override default shouldRetry check
 
 ### `startFragPrefetch`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -189,6 +189,13 @@ export type RetryConfig = {
   retryDelayMs: number; // Retry delay = 2^retryCount * retryDelayMs (exponential) or retryCount * retryDelayMs (linear)
   maxRetryDelayMs: number; // Maximum delay between retries
   backoff?: 'exponential' | 'linear'; // used to determine retry backoff duration (see retryDelayMs)
+  shouldRetry?: (
+    retryConfig: RetryConfig | null | undefined,
+    retryCount: number,
+    isTimeout: boolean,
+    httpStatus: number | undefined,
+    retry: boolean
+  ) => boolean;
 };
 
 export type StreamControllerConfig = {

--- a/src/utils/error-helper.ts
+++ b/src/utils/error-helper.ts
@@ -52,11 +52,21 @@ export function shouldRetry(
   isTimeout: boolean,
   httpStatus?: number | undefined
 ): retryConfig is RetryConfig & boolean {
-  return (
-    !!retryConfig &&
+  if (!retryConfig) {
+    return false;
+  }
+  const retry =
     retryCount < retryConfig.maxNumRetry &&
-    (retryForHttpStatus(httpStatus) || !!isTimeout)
-  );
+    (retryForHttpStatus(httpStatus) || !!isTimeout);
+  return retryConfig.shouldRetry
+    ? retryConfig.shouldRetry(
+        retryConfig,
+        retryCount,
+        isTimeout,
+        httpStatus,
+        retry
+      )
+    : retry;
 }
 
 export function retryForHttpStatus(httpStatus: number | undefined) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -38,6 +38,7 @@ import './unit/loader/playlist-loader';
 import './unit/utils/attr-list';
 import './unit/utils/binary-search';
 import './unit/utils/buffer-helper';
+import './unit/utils/error-helper';
 import './unit/utils/discontinuities';
 import './unit/utils/exp-golomb';
 import './unit/utils/output-filter';

--- a/tests/unit/utils/error-helper.js
+++ b/tests/unit/utils/error-helper.js
@@ -1,0 +1,33 @@
+import { shouldRetry } from '../../../src/utils/error-helper';
+
+describe('ErrorHelper', function () {
+  it('shouldRetry', function () {
+    const retryConfig = {
+      maxNumRetry: 3,
+    };
+    expect(shouldRetry(retryConfig, 3, false, '502')).to.be.false;
+    expect(shouldRetry(null, 3, false, '502')).to.be.false;
+    expect(shouldRetry(retryConfig, 2, false, '502')).to.be.true;
+    expect(shouldRetry(retryConfig, 2, false, '404')).to.be.false;
+
+    retryConfig.shouldRetry = (
+      _retryConfig,
+      _retryCount,
+      _isTimeout,
+      httpStatus,
+      retry
+    ) => {
+      if (!retry && httpStatus === '404') {
+        return true;
+      }
+
+      return false;
+    };
+    expect(shouldRetry(retryConfig, 5, false, '404', false)).to.be.true;
+
+    retryConfig.shouldRetry = (retryConfig, retryCount) => {
+      return retryConfig.maxNumRetry <= retryCount;
+    };
+    expect(shouldRetry(retryConfig, 2, false, '502', true)).to.be.false;
+  });
+});


### PR DESCRIPTION
### This PR will...
Adds the ability to set a custom function `shouldRetry` via `retryConfig`, which overrides default

### Why is this Pull Request needed?
Was recommended to add this improvement in #5647 in cases when user need to have possibility to override default `shouldRetry`

### Resolves issues:
#5647 
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
