### PR TITLE
Fix handling of segments at the discontinuities that do not start with a keyframe

### DIFF
--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -69,8 +69,13 @@ export default class FragmentLoader {
         this.loader.destroy();
       }
       if (frag.gap) {
-        reject(createGapLoadError(frag));
-        return;
+        if (frag.tagList.some((tags) => tags[0] === 'GAP')) {
+          reject(createGapLoadError(frag));
+          return;
+        } else {
+          // Reset temporary treatment as GAP tag
+          frag.gap = false;
+        }
       }
       const loader =
         (this.loader =


### PR DESCRIPTION
### This PR will...
- Prevent backtracking on first segment in discontinuity
- Use gap skipping to handle gap jumping prevent loop loading when large gaps are present in segment/disco start
  - Marks bad segments as GAP segments to avoid loop loading
  - Clears the `gap` property if the fragment loader later needs to reload the fragment after the buffer was cleared and the fragment had no 'GAP' tag.

### Why is this Pull Request needed?
Streams with segments at discontinuity sequence starts that are missing keyframes result in large gaps. HLS.js should not loop load when encountering this scenario.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5629

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
