### PR TITLE
Use input timescale when remuxing inband captions

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -1125,7 +1125,7 @@ export function flushTextTrackUserdataCueSamples(
     // using this._initPTS and this._initDTS to calculate relative time
     sample.pts =
       normalizePts(
-        sample.pts - (initPTS.baseTime * 90000) / initPTS.timescale,
+        sample.pts - (initPTS.baseTime * inputTimeScale) / initPTS.timescale,
         timeOffset * inputTimeScale
       ) / inputTimeScale;
   }

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -29,13 +29,19 @@ export function addCueToTrack(track: TextTrack, cue: VTTCue) {
       }
     } catch (err) {
       logger.debug(`[texttrack-utils]: ${err}`);
-      const textTrackCue = new (self.TextTrackCue as any)(
-        cue.startTime,
-        cue.endTime,
-        cue.text
-      );
-      textTrackCue.id = cue.id;
-      track.addCue(textTrackCue);
+      try {
+        const textTrackCue = new (self.TextTrackCue as any)(
+          cue.startTime,
+          cue.endTime,
+          cue.text
+        );
+        textTrackCue.id = cue.id;
+        track.addCue(textTrackCue);
+      } catch (err2) {
+        logger.debug(
+          `[texttrack-utils]: Legacy TextTrackCue fallback failed: ${err2}`
+        );
+      }
     }
   }
   if (mode === 'disabled') {


### PR DESCRIPTION
### This PR will...
- Use input timescale when remuxing inband captions
- Catch exceptions attempting to create TextTrackCue instances and adding them to TextTracks

### Why is this Pull Request needed?
The start time of 608 captions was not being remuxed from mp4 segments correctly. Negative start times resulted in `addCueToTrack` throwing, and then the fallback also threw because the constructor for `TextTrackCue` has changed in latest Safari (document fragments in cues is not to be supported until a later date).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5669

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
