### PR TITLE
Allow the odd empty segment to be skipped like a gap segment

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1708,8 +1708,15 @@ export default class BaseStreamController
       level.fragmentError = 0;
     } else if (this.transmuxer?.error === null) {
       const error = new Error(
-        `Found no media in fragment ${frag.sn} of level ${level.id} resetting transmuxer to fallback to playlist timing`
+        `Found no media in fragment ${frag.sn} of level ${frag.level} resetting transmuxer to fallback to playlist timing`
       );
+      if (level.fragmentError === 0) {
+        // Mark and track the odd empty segment as a gap to avoid reloading
+        level.fragmentError++;
+        frag.gap = true;
+        this.fragmentTracker.removeFragment(frag);
+        this.fragmentTracker.fragBuffered(frag, true);
+      }
       this.warn(error.message);
       this.hls.trigger(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -128,8 +128,17 @@ export default class ErrorController implements NetworkComponentAPI {
       case ErrorDetails.KEY_LOAD_TIMEOUT:
         data.errorAction = this.getFragRetryOrSwitchAction(data);
         return;
-      case ErrorDetails.FRAG_GAP:
       case ErrorDetails.FRAG_PARSING_ERROR:
+        // ignore empty segment errors marked as gap
+        if (data.frag?.gap) {
+          data.errorAction = {
+            action: NetworkErrorAction.DoNothing,
+            flags: ErrorActionFlags.None,
+          };
+          return;
+        }
+      // falls through
+      case ErrorDetails.FRAG_GAP:
       case ErrorDetails.FRAG_DECRYPT_ERROR: {
         // Switch level if possible, otherwise allow retry count to reach max error retries
         data.errorAction = this.getFragRetryOrSwitchAction(data);

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -179,13 +179,13 @@ export class FragmentTracker implements ComponentAPI {
   public detectPartialFragments(data: FragBufferedData) {
     const timeRanges = this.timeRanges;
     const { frag, part } = data;
-    if (!timeRanges || frag.sn === 'initSegment' || frag.gap) {
+    if (!timeRanges || frag.sn === 'initSegment') {
       return;
     }
 
     const fragKey = getFragmentKey(frag);
     const fragmentEntity = this.fragments[fragKey];
-    if (!fragmentEntity) {
+    if (!fragmentEntity || (fragmentEntity.buffered && frag.gap)) {
       return;
     }
     const isFragHint = !frag.relurl;

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -179,7 +179,7 @@ export class FragmentTracker implements ComponentAPI {
   public detectPartialFragments(data: FragBufferedData) {
     const timeRanges = this.timeRanges;
     const { frag, part } = data;
-    if (!timeRanges || frag.sn === 'initSegment') {
+    if (!timeRanges || frag.sn === 'initSegment' || frag.gap) {
       return;
     }
 


### PR DESCRIPTION
### This PR will...
Treat the odd empty segment FRAG_PARSING_ERROR as a gap. The stream controller will advance to the next segment without loop loading. If subsequent errors occur, a level switch will be attempted, up to `maxRetry` count.

### Why is this Pull Request needed?
Fixes regression of #4799 in v1.3 and v1.4 that introduced loop loading, and fatal errors after parsing errors accumulated beyond `maxRetry` count.

### Are there any points in the code the reviewer needs to double check?

Some care was taken not to regress frag parsing error handling and gap jumping:
- #5011 CC @mattzucker
- #2940 CC @mtoczko

For the sample streams provided in #5674 the empty segments are not needed and once the following segments are appended there are not gaps. The player does not recognize this to the case, and proceeds naively. In most cases we would want to switch variants when an error like this occurs to find an alternative, but in this case all variants are empty at the same playlist position. For that reason, this fix works well for that case, by avoiding switching. The problem is this may not work as well in cases where a better alternative would be found by switching down. In those cases, the down switch would not be made unless two consecutive errors occur.

### Resolves issues:
Resolves #5674

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
