### PR TITLE
Lazy init CEA608 parsers

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -60,8 +60,8 @@ export class TimelineController implements ComponentAPI {
   private unparsedVttFrags: Array<FragLoadedData | FragDecryptedData> = [];
   private captionsTracks: Record<string, TextTrack> = {};
   private nonNativeCaptionsTracks: Record<string, NonNativeCaptionsTrack> = {};
-  private cea608Parser1!: Cea608Parser;
-  private cea608Parser2!: Cea608Parser;
+  private cea608Parser1?: Cea608Parser;
+  private cea608Parser2?: Cea608Parser;
   private lastCc: number = -1; // Last video (CEA-608) fragment CC
   private lastSn: number = -1; // Last video (CEA-608) fragment MSN
   private lastPartIndex: number = -1; // Last video (CEA-608) fragment Part Index
@@ -98,15 +98,6 @@ export class TimelineController implements ComponentAPI {
       },
     };
 
-    if (this.config.enableCEA708Captions) {
-      const channel1 = new OutputFilter(this, 'textTrack1');
-      const channel2 = new OutputFilter(this, 'textTrack2');
-      const channel3 = new OutputFilter(this, 'textTrack3');
-      const channel4 = new OutputFilter(this, 'textTrack4');
-      this.cea608Parser1 = new Cea608Parser(1, channel1, channel2);
-      this.cea608Parser2 = new Cea608Parser(3, channel3, channel4);
-    }
-
     hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
@@ -137,6 +128,17 @@ export class TimelineController implements ComponentAPI {
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
     // @ts-ignore
     this.hls = this.config = this.cea608Parser1 = this.cea608Parser2 = null;
+  }
+
+  private lazyInit608() {
+    if (this.config.enableCEA708Captions) {
+      const channel1 = new OutputFilter(this, 'textTrack1');
+      const channel2 = new OutputFilter(this, 'textTrack2');
+      const channel3 = new OutputFilter(this, 'textTrack3');
+      const channel4 = new OutputFilter(this, 'textTrack4');
+      this.cea608Parser1 = new Cea608Parser(1, channel1, channel2);
+      this.cea608Parser2 = new Cea608Parser(3, channel3, channel4);
+    }
   }
 
   public addCues(
@@ -655,16 +657,19 @@ export class TimelineController implements ComponentAPI {
     event: Events.FRAG_PARSING_USERDATA,
     data: FragParsingUserdataData
   ) {
-    const { cea608Parser1, cea608Parser2 } = this;
-    if (!this.enabled || !(cea608Parser1 && cea608Parser2)) {
+    if (!this.enabled) {
       return;
     }
-
     const { frag, samples } = data;
     if (
       frag.type === PlaylistLevelType.MAIN &&
       this.closedCaptionsForLevel(frag) === 'NONE'
     ) {
+      return;
+    }
+    this.lazyInit608();
+    const { cea608Parser1, cea608Parser2 } = this;
+    if (!cea608Parser1 || !cea608Parser2) {
       return;
     }
     // If the event contains captions (found in the bytes property), push all bytes into the parser immediately


### PR DESCRIPTION
### This PR will...
Push back the initialization of 608 parsers until `FRAG_PARSING_USERDATA`.

### Why is this Pull Request needed?
Improved script eval and player setup setup performance. This can improve page load and time to request initial HLS Playlist.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
