### PR TITLE
Fail MP3 probe if AC3 or EC3 detected

### DIFF
--- a/src/demux/audio/aacdemuxer.ts
+++ b/src/demux/audio/aacdemuxer.ts
@@ -41,7 +41,7 @@ class AACDemuxer extends BaseAudioDemuxer {
   }
 
   // Source for probe info - https://wiki.multimedia.cx/index.php?title=ADTS
-  static probe(data): boolean {
+  static probe(data: Uint8Array | undefined): boolean {
     if (!data) {
       return false;
     }

--- a/src/demux/audio/dolby.ts
+++ b/src/demux/audio/dolby.ts
@@ -1,0 +1,21 @@
+export const getAudioBSID = (data: Uint8Array, offset: number): number => {
+  // check the bsid to confirm ac-3 | ec-3
+  let bsid = 0;
+  let numBits = 5;
+  offset += numBits;
+  const temp = new Uint32Array(1); // unsigned 32 bit for temporary storage
+  const mask = new Uint32Array(1); // unsigned 32 bit mask value
+  const byte = new Uint8Array(1); // unsigned 8 bit for temporary storage
+  while (numBits > 0) {
+    byte[0] = data[offset];
+    // read remaining bits, upto 8 bits at a time
+    const bits = Math.min(numBits, 8);
+    const shift = 8 - bits;
+    mask[0] = (0xff000000 >>> (24 + shift)) << shift;
+    temp[0] = (byte[0] & mask[0]) >> shift;
+    bsid = !bsid ? temp[0] : (bsid << bits) | temp[0];
+    offset += 1;
+    numBits -= bits;
+  }
+  return bsid;
+};

--- a/src/demux/audio/mp3demuxer.ts
+++ b/src/demux/audio/mp3demuxer.ts
@@ -2,7 +2,8 @@
  * MP3 demuxer
  */
 import BaseAudioDemuxer from './base-audio-demuxer';
-import * as ID3 from '../id3';
+import { getID3Data, getTimeStamp } from '../id3';
+import { getAudioBSID } from './dolby';
 import { logger } from '../../utils/logger';
 import * as MpegAudio from './mpegaudio';
 
@@ -29,7 +30,7 @@ class MP3Demuxer extends BaseAudioDemuxer {
     };
   }
 
-  static probe(data): boolean {
+  static probe(data: Uint8Array | undefined): boolean {
     if (!data) {
       return false;
     }
@@ -38,8 +39,20 @@ class MP3Demuxer extends BaseAudioDemuxer {
     // Look for MPEG header | 1111 1111 | 111X XYZX | where X can be either 0 or 1 and Y or Z should be 1
     // Layer bits (position 14 and 15) in header should be always different from 0 (Layer I or Layer II or Layer III)
     // More info http://www.mp3-tech.org/programmer/frame_header.html
-    const id3Data = ID3.getID3Data(data, 0) || [];
-    let offset = id3Data.length;
+    const id3Data = getID3Data(data, 0);
+    let offset = id3Data?.length || 0;
+
+    // Check for ac-3|ec-3 sync bytes and return false if present
+    if (
+      id3Data &&
+      data[offset] === 0x0b &&
+      data[offset + 1] === 0x77 &&
+      getTimeStamp(id3Data) !== undefined &&
+      // check the bsid to confirm ac-3 or ec-3 (not mp3)
+      getAudioBSID(data, offset) <= 16
+    ) {
+      return false;
+    }
 
     for (let length = data.length; offset < length; offset++) {
       if (MpegAudio.probe(data, offset)) {


### PR DESCRIPTION
### This PR will...
Check for AC3 and EC3 before passing MP3 probe. 

### Why is this Pull Request needed?
Unwrapped EC3 in #4958 sample media was passing the MP3 probe test. It doesn't take much to find MP3 sync bytes in a file after all other probed types fail.

This change moves the bsid check into a dolby module and runs in before passing the MP3 probe test regardless of the `__USE_M2TS_ADVANCED_CODECS__` build constant so that HLS.js does not get false positives for MP3 demuxing when scanning ac3 and ec3 files. This allows HLS.js to go down the correct path (`"[transmuxer] Failed to find demuxer by probing fragment data") for unwrapped/unsupported EC3 files, and the same for AC3 files in the light build where the build constant strips support.

### Are there any points in the code the reviewer needs to double check?

BSID for EC3 is 16, for AC3 < 16. While HLS.js does not support unwrapped EC3 or EC3 in TS, if it did the dolby module would serve as a place for shared code between the AC3 and EC3 demuxer modules.

### Resolves issues:
Related to #4958

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
