### PR TITLE
Push AUD units to fix decode errors with some TS segments

### DIFF
--- a/src/demux/video/avc-video-parser.ts
+++ b/src/demux/video/avc-video-parser.ts
@@ -176,7 +176,7 @@ class AvcVideoParser extends BaseVideoParser {
           break;
         // AUD
         case 9:
-          push = false;
+          push = true;
           track.audFound = true;
           if (VideoSample) {
             this.pushAccessUnit(VideoSample, track);

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -1137,6 +1137,15 @@ export function flushTextTrackUserdataCueSamples(
   };
 }
 
+type Mp4SampleFlags = {
+  isLeading: 0;
+  isDependedOn: 0;
+  hasRedundancy: 0;
+  degradPrio: 0;
+  dependsOn: 1 | 2;
+  isNonSync: 0 | 1;
+};
+
 class Mp4Sample {
   public size: number;
   public duration: number;
@@ -1152,20 +1161,13 @@ class Mp4Sample {
     this.duration = duration;
     this.size = size;
     this.cts = cts;
-    this.flags = new Mp4SampleFlags(isKeyframe);
-  }
-}
-
-class Mp4SampleFlags {
-  public isLeading: 0 = 0;
-  public isDependedOn: 0 = 0;
-  public hasRedundancy: 0 = 0;
-  public degradPrio: 0 = 0;
-  public dependsOn: 1 | 2 = 1;
-  public isNonSync: 0 | 1 = 1;
-
-  constructor(isKeyframe) {
-    this.dependsOn = isKeyframe ? 2 : 1;
-    this.isNonSync = isKeyframe ? 0 : 1;
+    this.flags = {
+      isLeading: 0,
+      isDependedOn: 0,
+      hasRedundancy: 0,
+      degradPrio: 0,
+      dependsOn: isKeyframe ? 2 : 1,
+      isNonSync: isKeyframe ? 0 : 1,
+    };
   }
 }


### PR DESCRIPTION
### This PR will...
Push AUD units to fix decode errors with some TS segments

### Why is this Pull Request needed?
Found TS playlists that produce a decode error in HLS.js but not in other MSE based players that push AUD units to the data they remux into fmp4.

Example decoding error:

| |
| :------------- |
| Selected VDAVideoDecoder for video decoding, config: codec: h264, profile: h264 baseline, level: not available, alpha_mode: is_opaque, coded size: [640,360], visible rect: [0,0,640,360], natural size: [640,360], has extra data: false, encryption scheme: Unencrypted, rotation: 0°, flipped: 0, color space: {primaries:BT709, transfer:BT709, matrix:BT709, range:LIMITED} |
| VDA Error 4 |
| video decode error! | 
```
Error Group: DecoderStatus
Error Code: 1
Stacktrace: media/gpu/ipc/service/vda_video_decoder.cc:919
```
```
Error Group: PipelineStatus
Error Code: 3
Stacktrace: media/renderers/video_renderer_impl.cc:591
Caused by:
  Error Group:  DecoderStatus
  Error Code: 108
  Stacktrace: media/filters/decoder_stream.cc:192
```

### Are there any points in the code the reviewer needs to double check?

This should not impact the playback of any TS media already supported by HLS.js.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
