### PR TITLE
Initial selection and level filtering based on preferred codecs and MediaCapabilities

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     __USE_CONTENT_STEERING__: true,
     __USE_VARIABLE_SUBSTITUTION__: true,
     __USE_M2TS_ADVANCED_CODECS__: true,
+    __USE_MEDIA_CAPABILITIES__: true,
   },
   // see https://github.com/standard/eslint-config-standard
   // 'prettier' (https://github.com/prettier/eslint-config-prettier) must be last

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2031,6 +2031,8 @@ export class Level {
     // (undocumented)
     realBitrate: number;
     // (undocumented)
+    get score(): number;
+    // (undocumented)
     get textGroupId(): string | undefined;
     // (undocumented)
     textGroupIds?: (string | undefined)[];

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -28,10 +28,16 @@ export class AbrController implements AbrComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
+    get firstAutoLevel(): number;
+    // (undocumented)
+    get forcedAutoLevel(): number;
+    // (undocumented)
     protected hls: Hls;
     // (undocumented)
     get nextAutoLevel(): number;
     set nextAutoLevel(nextLevel: number);
+    // (undocumented)
+    protected onError(event: Events.ERROR, data: ErrorData): void;
     // (undocumented)
     protected onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData): void;
     // (undocumented)
@@ -42,6 +48,8 @@ export class AbrController implements AbrComponentAPI {
     protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData): void;
     // (undocumented)
     protected onLevelSwitching(event: Events.LEVEL_SWITCHING, data: LevelSwitchingData): void;
+    // (undocumented)
+    protected onManifestLoading(event: Events.MANIFEST_LOADING, data: ManifestLoadingData): void;
     // (undocumented)
     protected registerListeners(): void;
     // (undocumented)
@@ -156,6 +164,8 @@ export class AudioStreamController extends BaseStreamController implements Netwo
 // @public (undocumented)
 export class AudioTrackController extends BasePlaylistController {
     constructor(hls: Hls);
+    // (undocumented)
+    get allAudioTracks(): MediaPlaylist[];
     // (undocumented)
     get audioTrack(): number;
     set audioTrack(newId: number);
@@ -1505,19 +1515,17 @@ export interface FragParsingUserdataData {
     samples: UserdataSample[];
 }
 
+// Warning: (ae-forgotten-export) The symbol "HdcpLevels" needs to be exported by the entry point hls.d.ts
 // Warning: (ae-missing-release-tag) "HdcpLevel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type HdcpLevel = (typeof HdcpLevels)[number];
 
-// Warning: (ae-missing-release-tag) "HdcpLevels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const HdcpLevels: readonly ["NONE", "TYPE-0", "TYPE-1", null];
-
 // @public
 class Hls implements HlsEventEmitter {
     constructor(userConfig?: Partial<HlsConfig>);
+    get allAudioTracks(): Array<MediaPlaylist>;
+    get allSubtitleTracks(): Array<MediaPlaylist>;
     attachMedia(media: HTMLMediaElement): void;
     get audioTrack(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "audioTrack" must appear on the getter, not the setter.
@@ -1552,6 +1560,8 @@ class Hls implements HlsEventEmitter {
     static get ErrorTypes(): typeof ErrorTypes;
     // (undocumented)
     static get Events(): typeof Events;
+    // (undocumented)
+    get firstAutoLevel(): number;
     get firstLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "firstLevel" must appear on the getter, not the setter.
     set firstLevel(newLevel: number);
@@ -1992,11 +2002,15 @@ export class Level {
     // (undocumented)
     readonly bitrate: number;
     // (undocumented)
+    get codecs(): string;
+    // (undocumented)
     readonly codecSet: string;
     // (undocumented)
     details?: LevelDetails;
     // (undocumented)
     fragmentError: number;
+    // (undocumented)
+    readonly frameRate: number;
     // (undocumented)
     readonly height: number;
     // (undocumented)
@@ -2031,6 +2045,10 @@ export class Level {
     set urlId(value: number);
     // (undocumented)
     readonly videoCodec: string | undefined;
+    // Warning: (ae-forgotten-export) The symbol "VideoRange" needs to be exported by the entry point hls.d.ts
+    //
+    // (undocumented)
+    get videoRange(): VideoRange;
     // (undocumented)
     readonly width: number;
 }
@@ -2056,7 +2074,7 @@ export interface LevelAttributes extends AttrList {
     // (undocumented)
     'SUPPLEMENTAL-CODECS'?: string;
     // (undocumented)
-    'VIDEO-RANGE'?: 'SDR' | 'HLG' | 'PQ';
+    'VIDEO-RANGE'?: VideoRange;
     // (undocumented)
     AUDIO?: string;
     // (undocumented)
@@ -3036,6 +3054,8 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
 // @public (undocumented)
 export class SubtitleTrackController extends BasePlaylistController {
     constructor(hls: Hls);
+    // (undocumented)
+    get allSubtitleTracks(): MediaPlaylist[];
     // (undocumented)
     destroy(): void;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1672,6 +1672,7 @@ export type HlsConfig = {
     cmcd?: CMCDControllerConfig;
     cmcdController?: typeof CMCDController;
     contentSteeringController?: typeof ContentSteeringController;
+    useMediaCapabilities: boolean;
     abrController: typeof AbrController;
     bufferController: typeof BufferController;
     capLevelController: typeof CapLevelController;
@@ -2032,6 +2033,10 @@ export class Level {
     realBitrate: number;
     // (undocumented)
     get score(): number;
+    // (undocumented)
+    supportedPromise?: Promise<MediaDecodingInfo>;
+    // (undocumented)
+    supportedResult?: MediaDecodingInfo;
     // (undocumented)
     get textGroupId(): string | undefined;
     // (undocumented)
@@ -2671,6 +2676,16 @@ export interface MediaAttributes extends AttrList {
     // (undocumented)
     URI?: string;
 }
+
+// Warning: (ae-missing-release-tag) "MediaDecodingInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MediaDecodingInfo = {
+    supported: boolean;
+    configurations: readonly MediaDecodingConfiguration[];
+    decodingInfoResults: readonly MediaCapabilitiesDecodingInfo[];
+    error?: Error;
+};
 
 // Warning: (ae-missing-release-tag) "MediaKeyFunc" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/build-config.js
+++ b/build-config.js
@@ -43,6 +43,8 @@ const addVariableSubstitutionSupport =
   !!env.VARIABLE_SUBSTITUTION || !!env.USE_VARIABLE_SUBSTITUTION;
 const addM2TSAdvancedCodecSupport =
   !!env.M2TS_ADVANCED_CODECS || !!env.USE_M2TS_ADVANCED_CODECS;
+const addMediaCapabilitiesSupport =
+  !!env.MEDIA_CAPABILITIES || !!env.USE_MEDIA_CAPABILITIES;
 
 const shouldBundleWorker = (format) => format !== FORMAT.esm;
 
@@ -66,6 +68,9 @@ const buildConstants = (type, additional = {}) => ({
     ),
     __USE_M2TS_ADVANCED_CODECS__: JSON.stringify(
       type === BUILD_TYPE.full || addM2TSAdvancedCodecSupport
+    ),
+    __USE_MEDIA_CAPABILITIES__: JSON.stringify(
+      type === BUILD_TYPE.full || addMediaCapabilitiesSupport
     ),
 
     ...additional,
@@ -222,6 +227,13 @@ function getAliasesForLightDist() {
     aliases = {
       ...aliases,
       './ac3-demuxer': '../empty.js',
+    };
+  }
+
+  if (!addMediaCapabilitiesSupport) {
+    aliases = {
+      ...aliases,
+      '../utils/mediacapabilities-helper': '../empty.js',
     };
   }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -129,6 +129,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`hls.loadLevel`](#hlsloadlevel)
   - [`hls.nextLoadLevel`](#hlsnextloadlevel)
   - [`hls.firstLevel`](#hlsfirstlevel)
+  - [`hls.firstAutoLevel`](#hlsfirstautolevel)
   - [`hls.startLevel`](#hlsstartlevel)
   - [`hls.autoLevelEnabled`](#hlsautolevelenabled)
   - [`hls.autoLevelCapping`](#hlsautolevelcapping)
@@ -1593,7 +1594,11 @@ Set to `-1` for automatic level selection.
 
 ### `hls.firstLevel`
 
-- get: First level index (index of first level appearing in Manifest. it is usually defined as start level hint for player).
+- get: First level index (index of the first Variant appearing in the Multivariant Playlist).
+
+### `hls.firstAutoLevel`
+
+- get: Return quality level that will be used to load the first fragment when not overridden by `startLevel`.
 
 ### `hls.startLevel`
 
@@ -2020,12 +2025,35 @@ See sample `Level` object below:
 
 ```js
 {
-  url: [ 'http://levelURL.com', 'http://levelURLfailover.com' ],
-  bitrate: 246440,
-  name: "240",
-  codecs: "mp4a.40.5,avc1.42000d",
-  width: 320,
-  height: 136,
+  audioCodec: "mp4a.40.2"
+  audioGroupIds: <string[]> | undefined,
+  bitrate: 3000000,
+  codecSet: "avc1,mp4a",
+  details: <LevelDetails> | undefined
+  fragmentError: 0,
+  frameRate: 30,
+  height: 720,
+  loadError: 0
+  name: "720p",
+  realBitrate: 0,
+  supportedPromise: undefined,
+  supportedResult: {supported: true, configurations: <MediaDecodingConfiguration[]>, decodingInfoResults: <MediaCapabilitiesDecodingInfo[]>}
+  textGroupIds: <string[]> | undefined,
+  unknownCodecs: [],
+  url: [ "http://levelURL.com", "http://levelURLfailover.com" ],
+  videoCodec: "avc1.66.30",
+  width: 1280,
+  attrs: <AttrList>,
+  audioGroupId: undefined,
+  averageBitrate: 2962000,
+  codecs: "avc1.66.30,mp4a.40.2",
+  maxBitrate: 3000000,
+  pathwayId: ".",
+  score: 0,
+  textGroupId: "subs",
+  uri: "http://levelURL.com",
+  urlId: 0,
+  videoRange: "SDR"
 }
 ```
 
@@ -2075,6 +2103,7 @@ See sample object below:
 {
   duration: 10,
   level: 3,
+  cc: 0
   sn: 35,
   start: 30,
   url: 'http://fragURL.com'

--- a/src/config.ts
+++ b/src/config.ts
@@ -270,6 +270,9 @@ export type HlsConfig = {
   // Content Steering
   contentSteeringController?: typeof ContentSteeringController;
 
+  // MediaCapabilies API for level, track, and switch filtering
+  useMediaCapabilities: boolean;
+
   abrController: typeof AbrController;
   bufferController: typeof BufferController;
   capLevelController: typeof CapLevelController;
@@ -383,6 +386,7 @@ export const hlsDefaultConfig: HlsConfig = {
   enableDateRangeMetadataCues: true,
   enableEmsgMetadataCues: true,
   enableID3MetadataCues: true,
+  useMediaCapabilities: true,
 
   certLoadPolicy: {
     default: defaultLoadPolicy,

--- a/src/config.ts
+++ b/src/config.ts
@@ -386,7 +386,7 @@ export const hlsDefaultConfig: HlsConfig = {
   enableDateRangeMetadataCues: true,
   enableEmsgMetadataCues: true,
   enableID3MetadataCues: true,
-  useMediaCapabilities: true,
+  useMediaCapabilities: __USE_MEDIA_CAPABILITIES__,
 
   certLoadPolicy: {
     default: defaultLoadPolicy,

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -656,6 +656,7 @@ class AbrController implements AbrComponentAPI {
         continue;
       }
       if (
+        __USE_MEDIA_CAPABILITIES__ &&
         this.hls.config.useMediaCapabilities &&
         !levelInfo.supportedResult &&
         !levelInfo.supportedPromise

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -206,11 +206,12 @@ class AbrController implements AbrComponentAPI {
     const stats: LoaderStats = part ? part.stats : frag.stats;
     const duration = part ? part.duration : frag.duration;
     const timeLoading = now - stats.loading.start;
+    const minAutoLevel = hls.minAutoLevel;
     // If frag loading is aborted, complete, or from lowest level, stop timer and return
     if (
       stats.aborted ||
       (stats.loaded && stats.loaded === stats.total) ||
-      frag.level === 0
+      frag.level <= minAutoLevel
     ) {
       this.clearTimer();
       // reset forced auto level value so that next level will be selected
@@ -255,12 +256,12 @@ class AbrController implements AbrComponentAPI {
       : -1;
     const loadedFirstByte = stats.loaded && ttfb > -1;
     const bwEstimate: number = this.getBwEstimate();
-    const { levels, minAutoLevel } = hls;
+    const levels = hls.levels;
     const level = levels[frag.level];
     const expectedLen =
       stats.total ||
       Math.max(stats.loaded, Math.round((duration * level.maxBitrate) / 8));
-    let timeStreaming = timeLoading - ttfb;
+    let timeStreaming = loadedFirstByte ? timeLoading - ttfb : timeLoading;
     if (timeStreaming < 1 && loadedFirstByte) {
       timeStreaming = Math.min(timeLoading, (stats.loaded * 8) / bwEstimate);
     }

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -679,7 +679,13 @@ class AbrController implements AbrComponentAPI {
           );
           levelInfo.supportedPromise.then((decodingInfo) => {
             levelInfo.supportedResult = decodingInfo;
-            if (!decodingInfo.supported) {
+            if (decodingInfo.error) {
+              logger.warn(
+                `[abr] MediaCapabilities decodingInfo error: "${
+                  decodingInfo.error
+                }" for level ${i} ${JSON.stringify(decodingInfo)}`
+              );
+            } else if (!decodingInfo.supported) {
               logger.warn(
                 `[abr] Removing unsupported level ${i} after MediaCapabilities decodingInfo check failed ${JSON.stringify(
                   decodingInfo

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -1,9 +1,12 @@
 import EwmaBandWidthEstimator from '../utils/ewma-bandwidth-estimator';
 import { Events } from '../events';
+import { ErrorDetails } from '../errors';
 import { PlaylistLevelType } from '../types/loader';
+import { codecsSetSelectionPreferenceValue } from '../utils/codecs';
 import { logger } from '../utils/logger';
 import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
+import type { Level, VideoRange } from '../types/level';
 import type { LoaderStats } from '../types/loader';
 import type Hls from '../hls';
 import type {
@@ -12,14 +15,40 @@ import type {
   FragBufferedData,
   LevelLoadedData,
   LevelSwitchingData,
+  ManifestLoadingData,
+  ErrorData,
 } from '../types/events';
 import type { AbrComponentAPI } from '../types/component-api';
+
+type CodecSetTier = {
+  minBitrate: number;
+  minHeight: number;
+  minFramerate: number;
+  videoRanges: Record<string, number>;
+  channels: Record<string, number>;
+  hasDefaultAudio: boolean;
+  fragmentError: number;
+};
+
+type AudioTrackGroup = {
+  channels: Record<string, number>;
+  hasDefault: boolean;
+  hasAutoSelect: boolean;
+};
+type StartParameters = {
+  codecSet: string | undefined;
+  videoRange: VideoRange | undefined;
+  minFramerate: number;
+  minBitrate: number;
+};
 
 class AbrController implements AbrComponentAPI {
   protected hls: Hls;
   private lastLevelLoadSec: number = 0;
-  private lastLoadedFragLevel: number = 0;
+  private lastLoadedFragLevel: number = -1;
   private _nextAutoLevel: number = -1;
+  private nextAutoLevelKey: string = '';
+  private codecTiers: Record<string, CodecSetTier> | null = null;
   private timer: number = -1;
   private onCheck: Function = this._abandonRulesCheck.bind(this);
   private fragCurrent: Fragment | null = null;
@@ -52,20 +81,29 @@ class AbrController implements AbrComponentAPI {
 
   protected registerListeners() {
     const { hls } = this;
+    hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.FRAG_LOADING, this.onFragLoading, this);
     hls.on(Events.FRAG_LOADED, this.onFragLoaded, this);
     hls.on(Events.FRAG_BUFFERED, this.onFragBuffered, this);
     hls.on(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     hls.on(Events.LEVEL_LOADED, this.onLevelLoaded, this);
+    hls.on(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
+    hls.on(Events.ERROR, this.onError, this);
   }
 
   protected unregisterListeners() {
     const { hls } = this;
+    if (!hls) {
+      return;
+    }
+    hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.FRAG_LOADING, this.onFragLoading, this);
     hls.off(Events.FRAG_LOADED, this.onFragLoaded, this);
     hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
     hls.off(Events.LEVEL_SWITCHING, this.onLevelSwitching, this);
     hls.off(Events.LEVEL_LOADED, this.onLevelLoaded, this);
+    hls.off(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
+    hls.off(Events.ERROR, this.onError, this);
   }
 
   public destroy() {
@@ -76,13 +114,35 @@ class AbrController implements AbrComponentAPI {
     this.fragCurrent = this.partCurrent = null;
   }
 
+  protected onManifestLoading(
+    event: Events.MANIFEST_LOADING,
+    data: ManifestLoadingData
+  ) {
+    this.lastLoadedFragLevel = -1;
+    this.lastLevelLoadSec = 0;
+    this.fragCurrent = this.partCurrent = null;
+    this.onLevelsUpdated();
+    this.clearTimer();
+  }
+
+  private onLevelsUpdated() {
+    if (this.lastLoadedFragLevel > -1 && this.fragCurrent) {
+      this.lastLoadedFragLevel = this.fragCurrent.level;
+    }
+    this._nextAutoLevel = -1;
+    this.nextAutoLevelKey = '';
+    this.codecTiers = null;
+  }
+
   protected onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {
     const frag = data.frag;
     if (this.ignoreFragment(frag)) {
       return;
     }
-    this.fragCurrent = frag;
-    this.partCurrent = data.part ?? null;
+    if (!frag.bitrateTest) {
+      this.fragCurrent = frag;
+      this.partCurrent = data.part ?? null;
+    }
     this.clearTimer();
     this.timer = self.setInterval(this.onCheck, 100);
   }
@@ -92,6 +152,18 @@ class AbrController implements AbrComponentAPI {
     data: LevelSwitchingData
   ): void {
     this.clearTimer();
+  }
+
+  protected onError(event: Events.ERROR, data: ErrorData) {
+    if (data.fatal) {
+      return;
+    }
+    switch (data.details) {
+      case ErrorDetails.BUFFER_ADD_CODEC_ERROR:
+      case ErrorDetails.BUFFER_APPEND_ERROR:
+        // Reset last loaded level so that a new selection can be made after calling recoverMediaError
+        this.lastLoadedFragLevel = -1;
+    }
   }
 
   private getTimeToLoadFrag(
@@ -107,10 +179,10 @@ class AbrController implements AbrComponentAPI {
 
   protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
     const config = this.hls.config;
-    const { total, bwEstimate } = data.stats;
-    // Total is the bytelength and bwEstimate in bits/sec
-    if (Number.isFinite(total) && Number.isFinite(bwEstimate)) {
-      this.lastLevelLoadSec = (8 * total) / bwEstimate;
+    const { loading } = data.stats;
+    const timeLoadingMs = loading.end - loading.start;
+    if (Number.isFinite(timeLoadingMs)) {
+      this.lastLevelLoadSec = timeLoadingMs / 1000;
     }
     if (data.details.live) {
       this.bwEstimator.update(config.abrEwmaSlowLive, config.abrEwmaFastLive);
@@ -261,9 +333,7 @@ class AbrController implements AbrComponentAPI {
       Current BW estimate: ${
         Number.isFinite(bwEstimate) ? (bwEstimate / 1024).toFixed(3) : 'Unknown'
       } Kb/s
-      New BW estimate: ${(this.bwEstimator.getEstimate() / 1024).toFixed(
-        3
-      )} Kb/s
+      New BW estimate: ${(this.getBwEstimate() / 1024).toFixed(3)} Kb/s
       Aborting and switching to level ${nextLoadLevel}`);
     if (frag.loader) {
       this.fragCurrent = this.partCurrent = null;
@@ -285,8 +355,6 @@ class AbrController implements AbrComponentAPI {
     }
     // stop monitoring bw once frag loaded
     this.clearTimer();
-    // store level id after successful fragment load
-    this.lastLoadedFragLevel = frag.level;
     // reset forced auto level value so that next level will be selected
     this._nextAutoLevel = -1;
 
@@ -310,6 +378,9 @@ class AbrController implements AbrComponentAPI {
       };
       this.onFragBuffered(Events.FRAG_BUFFERED, fragBufferedData);
       frag.bitrateTest = false;
+    } else {
+      // store level id after successful fragment load for playback
+      this.lastLoadedFragLevel = frag.level;
     }
   }
 
@@ -351,26 +422,70 @@ class AbrController implements AbrComponentAPI {
   }
 
   public clearTimer() {
-    self.clearInterval(this.timer);
+    if (this.timer > -1) {
+      self.clearInterval(this.timer);
+      this.timer = -1;
+    }
+  }
+
+  get firstAutoLevel(): number {
+    const { maxAutoLevel, minAutoLevel } = this.hls;
+    const maxStartDelay = this.hls.config.maxStarvationDelay;
+    const abrAutoLevel = this.findBestLevel(
+      this.getBwEstimate(),
+      minAutoLevel,
+      maxAutoLevel,
+      0,
+      maxStartDelay,
+      1,
+      1
+    );
+    if (abrAutoLevel > -1) {
+      return abrAutoLevel;
+    }
+    const firstLevel = this.hls.firstLevel;
+    const clamped = Math.min(Math.max(firstLevel, minAutoLevel), maxAutoLevel);
+    logger.warn(
+      `[abr] Could not find best starting auto level. Defaulting to first in playlist ${firstLevel} clamped to ${clamped}`
+    );
+    return clamped;
+  }
+
+  get forcedAutoLevel(): number {
+    if (this.nextAutoLevelKey) {
+      return -1;
+    }
+    return this._nextAutoLevel;
   }
 
   // return next auto level
   get nextAutoLevel(): number {
     const forcedAutoLevel = this._nextAutoLevel;
     const bwEstimator = this.bwEstimator;
+    const useEstimate = bwEstimator.canEstimate();
+    const loadedFirstFrag = this.lastLoadedFragLevel > -1;
     // in case next auto level has been forced, and bw not available or not reliable, return forced value
-    if (forcedAutoLevel !== -1 && !bwEstimator.canEstimate()) {
+    if (
+      forcedAutoLevel !== -1 &&
+      (!useEstimate ||
+        !loadedFirstFrag ||
+        this.nextAutoLevelKey === this.getAutoLevelKey())
+    ) {
       return forcedAutoLevel;
     }
 
     // compute next level using ABR logic
-    let nextABRAutoLevel = this.getNextABRAutoLevel();
+    let nextABRAutoLevel =
+      useEstimate && loadedFirstFrag
+        ? this.getNextABRAutoLevel()
+        : this.firstAutoLevel;
+
     // use forced auto level when ABR selected level has errored
     if (forcedAutoLevel !== -1) {
       const levels = this.hls.levels;
       if (
         levels.length > Math.max(forcedAutoLevel, nextABRAutoLevel) &&
-        levels[forcedAutoLevel].loadError <= levels[nextABRAutoLevel].loadError
+        levels[forcedAutoLevel].loadError < levels[nextABRAutoLevel].loadError
       ) {
         return forcedAutoLevel;
       }
@@ -380,7 +495,15 @@ class AbrController implements AbrComponentAPI {
       nextABRAutoLevel = Math.min(forcedAutoLevel, nextABRAutoLevel);
     }
 
+    // save result until state has changed
+    this._nextAutoLevel = nextABRAutoLevel;
+    this.nextAutoLevelKey = this.getAutoLevelKey();
+
     return nextABRAutoLevel;
+  }
+
+  private getAutoLevelKey(): string {
+    return `${this.getBwEstimate()}_${this.hls.mainForwardBufferInfo?.len}`;
   }
 
   private getNextABRAutoLevel(): number {
@@ -402,30 +525,28 @@ class AbrController implements AbrComponentAPI {
     const bufferStarvationDelay =
       (bufferInfo ? bufferInfo.len : 0) / playbackRate;
 
+    let bwFactor = config.abrBandWidthFactor;
+    let bwUpFactor = config.abrBandWidthUpFactor;
+
     // First, look to see if we can find a level matching with our avg bandwidth AND that could also guarantee no rebuffering at all
-    let bestLevel = this.findBestLevel(
-      avgbw,
-      minAutoLevel,
-      maxAutoLevel,
-      bufferStarvationDelay,
-      config.abrBandWidthFactor,
-      config.abrBandWidthUpFactor
-    );
-    if (bestLevel >= 0) {
-      return bestLevel;
+    if (bufferStarvationDelay) {
+      const bestLevel = this.findBestLevel(
+        avgbw,
+        minAutoLevel,
+        maxAutoLevel,
+        bufferStarvationDelay,
+        0,
+        bwFactor,
+        bwUpFactor
+      );
+      if (bestLevel >= 0) {
+        return bestLevel;
+      }
     }
-    logger.trace(
-      `[abr] ${
-        bufferStarvationDelay ? 'rebuffering expected' : 'buffer is empty'
-      }, finding optimal quality level`
-    );
-    // not possible to get rid of rebuffering ... let's try to find level that will guarantee less than maxStarvationDelay of rebuffering
-    // if no matching level found, logic will return 0
+    // not possible to get rid of rebuffering... try to find level that will guarantee less than maxStarvationDelay of rebuffering
     let maxStarvationDelay = currentFragDuration
       ? Math.min(currentFragDuration, config.maxStarvationDelay)
       : config.maxStarvationDelay;
-    let bwFactor = config.abrBandWidthFactor;
-    let bwUpFactor = config.abrBandWidthUpFactor;
 
     if (!bufferStarvationDelay) {
       // in case buffer is empty, let's check if previous fragment was loaded to perform a bitrate test
@@ -440,7 +561,7 @@ class AbrController implements AbrComponentAPI {
           ? Math.min(currentFragDuration, config.maxLoadingDelay)
           : config.maxLoadingDelay;
         maxStarvationDelay = maxLoadingDelay - bitrateTestDelay;
-        logger.trace(
+        logger.info(
           `[abr] bitrate test took ${Math.round(
             1000 * bitrateTestDelay
           )}ms, set first fragment max fetchDuration to ${Math.round(
@@ -451,19 +572,35 @@ class AbrController implements AbrComponentAPI {
         bwFactor = bwUpFactor = 1;
       }
     }
-    bestLevel = this.findBestLevel(
+    const bestLevel = this.findBestLevel(
       avgbw,
       minAutoLevel,
       maxAutoLevel,
-      bufferStarvationDelay + maxStarvationDelay,
+      bufferStarvationDelay,
+      maxStarvationDelay,
       bwFactor,
       bwUpFactor
     );
-    return Math.max(bestLevel, 0);
+    logger.info(
+      `[abr] ${
+        bufferStarvationDelay ? 'rebuffering expected' : 'buffer is empty'
+      }, optimal quality level ${bestLevel}`
+    );
+    if (bestLevel > -1) {
+      return bestLevel;
+    }
+    // If no matching level found, see if min auto level would be a better option
+    const minLevel = hls.levels[minAutoLevel];
+    const autoLevel = hls.levels[hls.loadLevel];
+    if (minLevel?.bitrate < autoLevel?.bitrate) {
+      return minAutoLevel;
+    }
+    // or if bitrate is not lower, continue to use loadLevel
+    return hls.loadLevel;
   }
 
   private getBwEstimate(): number {
-    return this.bwEstimator
+    return this.bwEstimator.canEstimate()
       ? this.bwEstimator.getEstimate()
       : this.hls.config.abrEwmaDefaultEstimate;
   }
@@ -472,19 +609,39 @@ class AbrController implements AbrComponentAPI {
     currentBw: number,
     minAutoLevel: number,
     maxAutoLevel: number,
-    maxFetchDuration: number,
+    bufferStarvationDelay: number,
+    maxStarvationDelay: number,
     bwFactor: number,
     bwUpFactor: number
   ): number {
-    const {
-      fragCurrent,
-      partCurrent,
-      lastLoadedFragLevel: currentLevel,
-    } = this;
-    const { levels } = this.hls;
-    const level = levels[currentLevel];
+    const maxFetchDuration: number = bufferStarvationDelay + maxStarvationDelay;
+    const lastLoadedFragLevel = this.lastLoadedFragLevel;
+    const selectionBaseLevel =
+      lastLoadedFragLevel === -1 ? this.hls.firstLevel : lastLoadedFragLevel;
+    const { fragCurrent, partCurrent } = this;
+    const { levels, loadLevel } = this.hls;
+    const level: Level | undefined = levels[selectionBaseLevel];
     const live = !!level?.details?.live;
-    const currentCodecSet = level?.codecSet;
+    const firstSelection = loadLevel === -1 || lastLoadedFragLevel === -1;
+    let currentCodecSet: string | undefined;
+    let currentVideoRange: VideoRange | undefined = 'SDR';
+    let currentFrameRate = level?.frameRate || 0;
+    if (firstSelection) {
+      const { codecSet, videoRange, minFramerate, minBitrate } =
+        this.getStartCodecTier(
+          currentVideoRange,
+          currentBw,
+          minAutoLevel,
+          maxAutoLevel
+        );
+      currentCodecSet = codecSet;
+      currentVideoRange = videoRange;
+      currentFrameRate = minFramerate;
+      currentBw = Math.max(currentBw, minBitrate);
+    } else {
+      currentCodecSet = level?.codecSet;
+      currentVideoRange = level?.videoRange;
+    }
 
     const currentFragDuration = partCurrent
       ? partCurrent.duration
@@ -493,25 +650,26 @@ class AbrController implements AbrComponentAPI {
       : 0;
 
     const ttfbEstimateSec = this.bwEstimator.getEstimateTTFB() / 1000;
-    let levelSkippedMin = minAutoLevel;
-    let levelSkippedMax = -1;
+    const levelsSkipped: number[] = [];
     for (let i = maxAutoLevel; i >= minAutoLevel; i--) {
       const levelInfo = levels[i];
+      const upSwitch = i > selectionBaseLevel;
 
+      // skip candidates which change codec-family or video-range,
+      // and which decrease or increase frame-rate for up and down-switch respectfully
       if (
         !levelInfo ||
-        (currentCodecSet && levelInfo.codecSet !== currentCodecSet)
+        (currentCodecSet && levelInfo.codecSet !== currentCodecSet) ||
+        (currentVideoRange && levelInfo.videoRange !== currentVideoRange) ||
+        (upSwitch && levelInfo.frameRate < currentFrameRate) ||
+        (!upSwitch &&
+          currentFrameRate &&
+          levelInfo.frameRate > currentFrameRate)
       ) {
         if (levelInfo) {
-          levelSkippedMin = Math.min(i, levelSkippedMin);
-          levelSkippedMax = Math.max(i, levelSkippedMax);
+          levelsSkipped.push(i);
         }
         continue;
-      }
-      if (levelSkippedMax !== -1) {
-        logger.trace(
-          `[abr] Skipped level(s) ${levelSkippedMin}-${levelSkippedMax} with CODECS:"${levels[levelSkippedMax].attrs.CODECS}"; not compatible with "${level.attrs.CODECS}"`
-        );
       }
 
       const levelDetails = levelInfo.details;
@@ -527,13 +685,19 @@ class AbrController implements AbrComponentAPI {
       // consider only 80% of the available bandwidth, but if we are switching up,
       // be even more conservative (70%) to avoid overestimating and immediately
       // switching back.
-      if (i <= currentLevel) {
+      if (!upSwitch) {
         adjustedbw = bwFactor * currentBw;
       } else {
         adjustedbw = bwUpFactor * currentBw;
       }
 
-      const bitrate: number = levels[i].maxBitrate;
+      // Use average bitrate when starvation delay (buffer length) is gt or eq two segment durations and rebuffering is not expected (maxStarvationDelay > 0)
+      const bitrate: number =
+        currentFragDuration &&
+        bufferStarvationDelay >= currentFragDuration * 2 &&
+        maxStarvationDelay === 0
+          ? levels[i].averageBitrate
+          : levels[i].maxBitrate;
       const fetchDuration: number = this.getTimeToLoadFrag(
         ttfbEstimateSec,
         adjustedbw,
@@ -541,26 +705,48 @@ class AbrController implements AbrComponentAPI {
         levelDetails === undefined
       );
 
-      logger.trace(
-        `[abr] level:${i} adjustedbw-bitrate:${Math.round(
-          adjustedbw - bitrate
-        )} avgDuration:${avgDuration.toFixed(
-          1
-        )} maxFetchDuration:${maxFetchDuration.toFixed(
-          1
-        )} fetchDuration:${fetchDuration.toFixed(1)}`
-      );
-      // if adjusted bw is greater than level bitrate AND
-      if (
-        adjustedbw > bitrate &&
+      const canSwitchWithinTolerance =
+        // if adjusted bw is greater than level bitrate AND
+        adjustedbw >= bitrate &&
+        // no level change, or new level has no error history
+        (i === lastLoadedFragLevel ||
+          (levelInfo.loadError === 0 && levelInfo.fragmentError === 0)) &&
         // fragment fetchDuration unknown OR live stream OR fragment fetchDuration less than max allowed fetch duration, then this level matches
         // we don't account for max Fetch Duration for live streams, this is to avoid switching down when near the edge of live sliding window ...
         // special case to support startLevel = -1 (bitrateTest) on live streams : in that case we should not exit loop so that findBestLevel will return -1
         (fetchDuration <= ttfbEstimateSec ||
           !Number.isFinite(fetchDuration) ||
           (live && !this.bitrateTestDelay) ||
-          fetchDuration < maxFetchDuration)
-      ) {
+          fetchDuration < maxFetchDuration);
+      if (canSwitchWithinTolerance) {
+        if (i !== loadLevel) {
+          if (levelsSkipped.length) {
+            logger.trace(
+              `[abr] Skipped level(s) ${levelsSkipped.join(
+                ','
+              )} of ${maxAutoLevel} max with CODECS and VIDEO-RANGE:"${
+                levels[levelsSkipped[0]].codecs
+              }" ${levels[levelsSkipped[0]].videoRange}; not compatible with "${
+                level.codecs
+              }" ${currentVideoRange}`
+            );
+          }
+          logger.info(
+            `[abr] switch candidate:${selectionBaseLevel}->${i} adjustedbw(${Math.round(
+              adjustedbw
+            )})-bitrate=${Math.round(
+              adjustedbw - bitrate
+            )} ttfb:${ttfbEstimateSec.toFixed(
+              1
+            )} avgDuration:${avgDuration.toFixed(
+              1
+            )} maxFetchDuration:${maxFetchDuration.toFixed(
+              1
+            )} fetchDuration:${fetchDuration.toFixed(
+              1
+            )} firstSelection:${firstSelection} codecSet:${currentCodecSet} videoRange:${currentVideoRange} hls.loadLevel:${loadLevel}`
+          );
+        }
         // as we are looping from highest to lowest, this will return the best achievable quality level
         return i;
       }
@@ -569,8 +755,163 @@ class AbrController implements AbrComponentAPI {
     return -1;
   }
 
+  private getStartCodecTier(
+    videoRange: VideoRange | undefined,
+    currentBw: number,
+    minAutoLevel: number,
+    maxAutoLevel: number
+  ): StartParameters {
+    const codecTiers = this.getCodecTiers(minAutoLevel, maxAutoLevel);
+    const codecSets = Object.keys(codecTiers);
+    // Use first level set to determine stereo, and minimum resolution and framerate
+    let hasStereo = true;
+    let hasCurrentVideoRange = false;
+    let minHeight = Infinity;
+    let minFramerate = Infinity;
+    let minBitrate = Infinity;
+    for (let i = codecSets.length; i--; ) {
+      const tier = codecTiers[codecSets[i]];
+      hasStereo = tier.channels[2] > 0;
+      minHeight = Math.min(minHeight, tier.minHeight);
+      minFramerate = Math.min(minFramerate, tier.minFramerate);
+      minBitrate = Math.min(minBitrate, tier.minBitrate);
+      if (videoRange) {
+        hasCurrentVideoRange ||= tier.videoRanges[videoRange] > 0;
+      }
+    }
+    minHeight = Number.isFinite(minHeight) ? minHeight : 0;
+    minFramerate = Number.isFinite(minFramerate) ? minFramerate : 0;
+    const maxHeight = Math.max(1080, minHeight);
+    const maxFramerate = Math.max(30, minFramerate);
+    minBitrate = Number.isFinite(minBitrate) ? minBitrate : currentBw;
+    currentBw = Math.max(minBitrate, currentBw);
+    // If there are no SDR variants, set currentVideoRange to undefined
+    if (!hasCurrentVideoRange) {
+      videoRange = undefined;
+    }
+    const codecSet = codecSets.reduce(
+      (selected: string | undefined, candidate: string) => {
+        // Remove candiates which do not meet bitrate, default audio, stereo, 1080p or lower, 30fps or lower, or SDR if present
+        const candidateTier = codecTiers[candidate];
+        if (
+          candidate === selected ||
+          candidateTier.minBitrate > currentBw ||
+          !candidateTier.hasDefaultAudio ||
+          (hasStereo && candidateTier.channels['2'] === 0) ||
+          candidateTier.minHeight > maxHeight ||
+          candidateTier.minFramerate > maxFramerate ||
+          (videoRange && candidateTier.videoRanges[videoRange] === 0)
+        ) {
+          return selected;
+        }
+        // Remove candiates with less preferred codecs or more errors
+        if (
+          selected &&
+          (codecsSetSelectionPreferenceValue(candidate) >=
+            codecsSetSelectionPreferenceValue(selected) ||
+            candidateTier.fragmentError > codecTiers[selected].fragmentError)
+        ) {
+          return selected;
+        }
+        return candidate;
+      },
+      undefined
+    );
+    return {
+      codecSet,
+      videoRange,
+      minFramerate,
+      minBitrate,
+    };
+  }
+
+  private getCodecTiers(
+    minAutoLevel: number,
+    maxAutoLevel: number
+  ): Record<string, CodecSetTier> {
+    let codecTiers = this.codecTiers;
+    if (codecTiers === null) {
+      let hasDefaultAudio = false;
+      let hasAutoSelectAudio = false;
+      const audioTracksByGroup = this.hls.allAudioTracks.reduce(
+        (trackGroups: Record<string, AudioTrackGroup>, track) => {
+          let trackGroup = trackGroups[track.groupId];
+          if (!trackGroup) {
+            trackGroup = trackGroups[track.groupId] = {
+              channels: { 2: 0 },
+              hasDefault: false,
+              hasAutoSelect: false,
+            };
+          }
+          trackGroup.channels[track.attrs.CHANNELS || 2] =
+            (trackGroup.channels[track.attrs.CHANNELS || 2] || 0) + 1;
+          trackGroup.hasDefault = trackGroup.hasDefault || track.default;
+          trackGroup.hasAutoSelect =
+            trackGroup.hasAutoSelect || track.autoselect;
+          if (trackGroup.hasDefault) {
+            hasDefaultAudio = true;
+          }
+          if (trackGroup.hasAutoSelect) {
+            hasAutoSelectAudio = true;
+          }
+          return trackGroups;
+        },
+        {}
+      );
+
+      codecTiers = this.codecTiers = this.hls.levels
+        .slice(minAutoLevel, maxAutoLevel + 1)
+        .reduce((tiers: Record<string, CodecSetTier>, level) => {
+          if (!level.codecSet) {
+            return tiers;
+          }
+          const audioGroup = level.audioGroupId
+            ? audioTracksByGroup[level.audioGroupId]
+            : null;
+          let tier = tiers[level.codecSet];
+          if (!tier) {
+            tiers[level.codecSet] = tier = {
+              minBitrate: Infinity,
+              minHeight: Infinity,
+              minFramerate: Infinity,
+              videoRanges: { SDR: 0 },
+              channels: { 2: 0 },
+              hasDefaultAudio: !audioGroup,
+              fragmentError: 0,
+            };
+          }
+          tier.minBitrate = Math.min(tier.minBitrate, level.bitrate);
+          const lesserWidthOrHeight = Math.min(level.height, level.width);
+          tier.minHeight = Math.min(tier.minHeight, lesserWidthOrHeight);
+          tier.minFramerate = Math.min(tier.minFramerate, level.frameRate);
+          tier.fragmentError += level.fragmentError;
+          tier.videoRanges[level.videoRange] =
+            (tier.videoRanges[level.videoRange] || 0) + 1;
+          if (audioGroup) {
+            // Default audio is any group with DEFAULT=YES, or if missing then any group with AUTOSELECT=YES, or all variants
+            tier.hasDefaultAudio =
+              tier.hasDefaultAudio || hasDefaultAudio
+                ? audioGroup.hasDefault
+                : audioGroup.hasAutoSelect ||
+                  (!hasDefaultAudio && !hasAutoSelectAudio);
+            Object.keys(audioGroup.channels).forEach((channels) => {
+              tier.channels[channels] =
+                (tier.channels[channels] || 0) + audioGroup.channels[channels];
+            });
+          }
+
+          return tiers;
+        }, {});
+    }
+    return codecTiers;
+  }
+
   set nextAutoLevel(nextLevel: number) {
-    this._nextAutoLevel = nextLevel;
+    const value = Math.max(this.hls.minAutoLevel, nextLevel);
+    if (this._nextAutoLevel != value) {
+      this.nextAutoLevelKey = '';
+      this._nextAutoLevel = value;
+    }
   }
 }
 

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -938,8 +938,8 @@ class AudioStreamController
       media &&
       bufferedAttributes &&
       (bufferedAttributes.CHANNELS !== switchAttributes.CHANNELS ||
-        bufferedAttributes.NAME !== switchAttributes.NAME ||
-        bufferedAttributes.LANGUAGE !== switchAttributes.LANGUAGE)
+        bufferedTrack.name !== switchingTrack.name ||
+        bufferedTrack.lang !== switchingTrack.lang)
     ) {
       this.log('Switching audio track : flushing all audio');
       super.flushMainBuffer(0, Number.POSITIVE_INFINITY, 'audio');

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -162,6 +162,10 @@ class AudioTrackController extends BasePlaylistController {
     }
   }
 
+  get allAudioTracks(): MediaPlaylist[] {
+    return this.tracks;
+  }
+
   get audioTracks(): MediaPlaylist[] {
     return this.tracksInGroup;
   }

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -1,7 +1,7 @@
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
 import { getSkipValue, HlsSkip, HlsUrlParameters, Level } from '../types/level';
-import { computeReloadInterval, mergeDetails } from './level-helper';
+import { computeReloadInterval, mergeDetails } from '../utils/level-helper';
 import { ErrorData } from '../types/events';
 import { getRetryDelay, isTimeoutError } from '../utils/error-helper';
 import { NetworkErrorAction } from './error-controller';

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -17,7 +17,7 @@ import {
   getFragmentWithSN,
   getPartWith,
   updateFragPTSDTS,
-} from './level-helper';
+} from '../utils/level-helper';
 import TransmuxerInterface from '../demux/transmuxer-interface';
 import { Fragment, Part } from '../loader/fragment';
 import FragmentLoader, {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -500,26 +500,10 @@ export default class BaseStreamController
                 },
               });
               data.payload = decryptedData;
-
-              return data;
+              return this.completeInitSegmentLoad(data);
             });
         }
-
-        return data;
-      })
-      .then((data: FragLoadedData) => {
-        const { levels } = this;
-        if (!levels) {
-          throw new Error('init load aborted, missing levels');
-        }
-
-        const stats = frag.stats;
-        this.state = State.IDLE;
-        level.fragmentError = 0;
-        frag.data = new Uint8Array(data.payload);
-        stats.parsing.start = stats.buffering.start = self.performance.now();
-        stats.parsing.end = stats.buffering.end = self.performance.now();
-        this.tick();
+        return this.completeInitSegmentLoad(data);
       })
       .catch((reason) => {
         if (this.state === State.STOPPED || this.state === State.ERROR) {
@@ -528,6 +512,19 @@ export default class BaseStreamController
         this.warn(reason);
         this.resetFragmentLoading(frag);
       });
+  }
+
+  private completeInitSegmentLoad(data: FragLoadedData) {
+    const { levels } = this;
+    if (!levels) {
+      throw new Error('init load aborted, missing levels');
+    }
+    const stats = data.frag.stats;
+    this.state = State.IDLE;
+    data.frag.data = new Uint8Array(data.payload);
+    stats.parsing.start = stats.buffering.start = self.performance.now();
+    stats.parsing.end = stats.buffering.end = self.performance.now();
+    this.tick();
   }
 
   protected fragContextChanged(frag: Fragment | null) {
@@ -556,6 +553,23 @@ export default class BaseStreamController
           : '(detached)'
       })`
     );
+    if (frag.sn !== 'initSegment') {
+      if (frag.type !== PlaylistLevelType.SUBTITLE) {
+        const el = frag.elementaryStreams;
+        if (!Object.keys(el).some((type) => !!el[type])) {
+          // empty segment
+          this.state = State.IDLE;
+          return;
+        }
+      }
+      const level = this.levels?.[frag.level];
+      if (level?.fragmentError) {
+        this.log(
+          `Resetting level fragment error count of ${level.fragmentError} on frag buffered`
+        );
+        level.fragmentError = 0;
+      }
+    }
     this.state = State.IDLE;
     if (!media) {
       return;
@@ -1699,9 +1713,7 @@ export default class BaseStreamController
       },
       false
     );
-    if (parsed) {
-      level.fragmentError = 0;
-    } else if (this.transmuxer?.error === null) {
+    if (!parsed && this.transmuxer?.error === null) {
       const error = new Error(
         `Found no media in fragment ${frag.sn} of level ${frag.level} resetting transmuxer to fallback to playlist timing`
       );

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -139,6 +139,11 @@ export default class BufferController implements ComponentAPI {
       video: [],
       audiovideo: [],
     };
+    this.appendErrors = {
+      audio: 0,
+      video: 0,
+      audiovideo: 0,
+    };
     this.lastMpegAudioChunk = null;
   }
 
@@ -410,6 +415,12 @@ export default class BufferController implements ComponentAPI {
           timeRanges[type] = BufferHelper.getBuffered(sourceBuffer[type]);
         }
         this.appendErrors[type] = 0;
+        if (type === 'audio' || type === 'video') {
+          this.appendErrors.audiovideo = 0;
+        } else {
+          this.appendErrors.audio = 0;
+          this.appendErrors.video = 0;
+        }
         this.hls.trigger(Events.BUFFER_APPENDED, {
           type,
           frag,
@@ -447,7 +458,7 @@ export default class BufferController implements ComponentAPI {
           this.warn(
             `Failed ${appendErrorCount}/${hls.config.appendErrorMaxRetry} times to append segment in "${type}" sourceBuffer`
           );
-          if (appendErrorCount > hls.config.appendErrorMaxRetry) {
+          if (appendErrorCount >= hls.config.appendErrorMaxRetry) {
             event.fatal = true;
           }
         }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -2,7 +2,10 @@ import { Events } from '../events';
 import { logger } from '../utils/logger';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { BufferHelper } from '../utils/buffer-helper';
-import { getCodecCompatibleName } from '../utils/codecs';
+import {
+  getCodecCompatibleName,
+  pickMostCompleteCodecName,
+} from '../utils/codecs';
 import { getMediaSource } from '../utils/mediasource-helper';
 import { ElementaryStreamTypes } from '../loader/fragment';
 import type { TrackSet } from '../types/track';
@@ -276,22 +279,26 @@ export default class BufferController implements ComponentAPI {
         if (track && typeof track.buffer.changeType === 'function') {
           const { id, codec, levelCodec, container, metadata } =
             data[trackName];
-          const currentCodec = (track.levelCodec || track.codec).replace(
+          const currentCodedFull = pickMostCompleteCodecName(
+            track.codec,
+            track.levelCodec
+          );
+          const currentCodec = currentCodedFull.replace(
             VIDEO_CODEC_PROFILE_REPLACE,
             '$1'
           );
-          const nextCodec = (levelCodec || codec).replace(
+          let trackCodec = pickMostCompleteCodecName(codec, levelCodec);
+          const nextCodec = trackCodec.replace(
             VIDEO_CODEC_PROFILE_REPLACE,
             '$1'
           );
           if (currentCodec !== nextCodec) {
-            let trackCodec = levelCodec || codec;
             if (trackName.slice(0, 5) === 'audio') {
               trackCodec = getCodecCompatibleName(trackCodec);
             }
             const mimeType = `${container};codecs=${trackCodec}`;
             this.appendChangeType(trackName, mimeType);
-            this.log(`switching codec ${currentCodec} to ${nextCodec}`);
+            this.log(`switching codec ${currentCodedFull} to ${trackCodec}`);
             this.tracks[trackName] = {
               buffer: track.buffer,
               codec,

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -1,5 +1,6 @@
 import { Events } from '../events';
 import { Level, addGroupId } from '../types/level';
+import { reassignFragmentLevelIndexes } from './level-helper';
 import { AttrList } from '../utils/attr-list';
 import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
 import { logger } from '../utils/logger';
@@ -249,6 +250,7 @@ export default class ContentSteeringController implements NetworkComponentAPI {
       if (levels.length > 0) {
         this.log(`Setting Pathway to "${pathwayId}"`);
         this.pathwayId = pathwayId;
+        reassignFragmentLevelIndexes(levels);
         this.hls.trigger(Events.LEVELS_UPDATED, { levels });
         // Set LevelController's level to trigger LEVEL_SWITCHING which loads playlist if needed
         const levelAfterChange = this.hls.levels[selectedIndex];

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -1,6 +1,6 @@
 import { Events } from '../events';
 import { Level, addGroupId } from '../types/level';
-import { reassignFragmentLevelIndexes } from './level-helper';
+import { reassignFragmentLevelIndexes } from '../utils/level-helper';
 import { AttrList } from '../utils/attr-list';
 import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
 import { logger } from '../utils/logger';

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -857,7 +857,7 @@ class EMEController implements ComponentAPI {
     if (!url) {
       return Promise.resolve();
     }
-    this.log(`Fetching serverCertificate for "${keySystem}"`);
+    this.log(`Fetching server certificate for "${keySystem}"`);
     return new Promise((resolve, reject) => {
       const loaderContext: LoaderContext = {
         responseType: 'arraybuffer',

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -214,6 +214,8 @@ export default class ErrorController implements NetworkComponentAPI {
               flags: ErrorActionFlags.MoveAllAlternatesMatchingHDCP,
               hdcpLevel: restrictedHdcpLevel,
             };
+          } else {
+            this.keySystemError(data);
           }
         }
         return;
@@ -240,12 +242,15 @@ export default class ErrorController implements NetworkComponentAPI {
     }
 
     if (data.type === ErrorTypes.KEY_SYSTEM_ERROR) {
-      const levelIndex = this.getVariantLevelIndex(data.frag);
-      // Do not retry level. Escalate to fatal if switching levels fails.
-      data.levelRetry = false;
-      data.errorAction = this.getLevelSwitchAction(data, levelIndex);
-      return;
+      this.keySystemError(data);
     }
+  }
+
+  private keySystemError(data: ErrorData) {
+    const levelIndex = this.getVariantLevelIndex(data.frag);
+    // Do not retry level. Escalate to fatal if switching levels fails.
+    data.levelRetry = false;
+    data.errorAction = this.getLevelSwitchAction(data, levelIndex);
   }
 
   private getPlaylistRetryOrSwitchAction(

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -196,7 +196,7 @@ export default class LevelController extends BasePlaylistController {
     if ((resolutionFound || videoCodecFound) && audioCodecFound) {
       levels = levels.filter(
         ({ videoCodec, videoRange, width, height }) =>
-          !!videoCodec || !!(width && height) || !isVideoRange(videoRange)
+          (!!videoCodec || !!(width && height)) && isVideoRange(videoRange)
       );
     }
 

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -29,7 +29,7 @@ import {
 import BasePlaylistController from './base-playlist-controller';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import ContentSteeringController from './content-steering-controller';
-import { reassignFragmentLevelIndexes } from './level-helper';
+import { reassignFragmentLevelIndexes } from '../utils/level-helper';
 import { hlsDefaultConfig } from '../config';
 import type Hls from '../hls';
 import type { HlsUrlParameters, LevelParsed } from '../types/level';

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -273,12 +273,6 @@ export default class LevelController extends BasePlaylistController {
       if (a.bitrate !== b.bitrate) {
         return a.bitrate - b.bitrate;
       }
-      if (a.attrs.SCORE !== b.attrs.SCORE) {
-        return (
-          a.attrs.decimalFloatingPoint('SCORE') -
-          b.attrs.decimalFloatingPoint('SCORE')
-        );
-      }
       return 0;
     });
 

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -7,22 +7,29 @@ import {
   ManifestParsedData,
   LevelLoadedData,
   TrackSwitchedData,
-  FragLoadedData,
   ErrorData,
   LevelSwitchingData,
   LevelsUpdatedData,
   ManifestLoadingData,
+  FragBufferedData,
 } from '../types/events';
-import { Level, addGroupId } from '../types/level';
+import {
+  Level,
+  VideoRangeValues,
+  addGroupId,
+  isVideoRange,
+} from '../types/level';
 import { Events } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import {
-  getCodecCompatibleName,
   areCodecsMediaSourceSupported,
+  codecsSetSelectionPreferenceValue,
+  getCodecCompatibleName,
 } from '../utils/codecs';
 import BasePlaylistController from './base-playlist-controller';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import ContentSteeringController from './content-steering-controller';
+import { reassignFragmentLevelIndexes } from './level-helper';
 import { hlsDefaultConfig } from '../config';
 import type Hls from '../hls';
 import type { HlsUrlParameters, LevelParsed } from '../types/level';
@@ -57,7 +64,7 @@ export default class LevelController extends BasePlaylistController {
     hls.on(Events.LEVEL_LOADED, this.onLevelLoaded, this);
     hls.on(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.on(Events.AUDIO_TRACK_SWITCHED, this.onAudioTrackSwitched, this);
-    hls.on(Events.FRAG_LOADED, this.onFragLoaded, this);
+    hls.on(Events.FRAG_BUFFERED, this.onFragBuffered, this);
     hls.on(Events.ERROR, this.onError, this);
   }
 
@@ -68,7 +75,7 @@ export default class LevelController extends BasePlaylistController {
     hls.off(Events.LEVEL_LOADED, this.onLevelLoaded, this);
     hls.off(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.off(Events.AUDIO_TRACK_SWITCHED, this.onAudioTrackSwitched, this);
-    hls.off(Events.FRAG_LOADED, this.onFragLoaded, this);
+    hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
     hls.off(Events.ERROR, this.onError, this);
   }
 
@@ -185,10 +192,11 @@ export default class LevelController extends BasePlaylistController {
       }
     );
 
-    // remove audio-only level if we also have levels with video codecs or RESOLUTION signalled
+    // remove audio-only and invalid video-range levels if we also have levels with video codecs or RESOLUTION signalled
     if ((resolutionFound || videoCodecFound) && audioCodecFound) {
       levels = levels.filter(
-        ({ videoCodec, width, height }) => !!videoCodec || !!(width && height)
+        ({ videoCodec, videoRange, width, height }) =>
+          !!videoCodec || !!(width && height) || !isVideoRange(videoRange)
       );
     }
 
@@ -198,7 +206,9 @@ export default class LevelController extends BasePlaylistController {
         if (this.hls) {
           if (unfilteredLevels.length) {
             this.warn(
-              `One or more CODECS in variant not supported: "${unfilteredLevels[0].attrs.CODECS}"`
+              `One or more CODECS in variant not supported: ${JSON.stringify(
+                unfilteredLevels[0].attrs
+              )}`
             );
           }
           const error = new Error(
@@ -240,23 +250,34 @@ export default class LevelController extends BasePlaylistController {
           ? 1
           : -1;
       }
+      // sort on height before bitrate for cap-level-controller
+      if (resolutionFound && a.height !== b.height) {
+        return a.height - b.height;
+      }
+      if (a.frameRate !== b.frameRate) {
+        return a.frameRate - b.frameRate;
+      }
+      if (a.codecSet !== b.codecSet) {
+        const valueA = codecsSetSelectionPreferenceValue(a.codecSet);
+        const valueB = codecsSetSelectionPreferenceValue(b.codecSet);
+        if (valueA !== valueB) {
+          return valueB - valueA;
+        }
+      }
+      if (a.videoRange !== b.videoRange) {
+        return (
+          VideoRangeValues.indexOf(a.videoRange) -
+          VideoRangeValues.indexOf(b.videoRange)
+        );
+      }
       if (a.bitrate !== b.bitrate) {
         return a.bitrate - b.bitrate;
-      }
-      if (a.attrs['FRAME-RATE'] !== b.attrs['FRAME-RATE']) {
-        return (
-          a.attrs.decimalFloatingPoint('FRAME-RATE') -
-          b.attrs.decimalFloatingPoint('FRAME-RATE')
-        );
       }
       if (a.attrs.SCORE !== b.attrs.SCORE) {
         return (
           a.attrs.decimalFloatingPoint('SCORE') -
           b.attrs.decimalFloatingPoint('SCORE')
         );
-      }
-      if (resolutionFound && a.height !== b.height) {
-        return a.height - b.height;
       }
       return 0;
     });
@@ -378,7 +399,11 @@ export default class LevelController extends BasePlaylistController {
     }
 
     this.log(
-      `Switching to level ${newLevel}${
+      `Switching to level ${newLevel} (${
+        level.height ? level.height + 'p ' : ''
+      }${level.videoRange ? level.videoRange + ' ' : ''}${
+        level.codecSet ? level.codecSet + ' ' : ''
+      }@${level.bitrate})${
         pathwayId ? ' with Pathway ' + pathwayId : ''
       } from level ${lastLevelIndex}${
         lastPathwayId ? ' with Pathway ' + lastPathwayId : ''
@@ -431,22 +456,19 @@ export default class LevelController extends BasePlaylistController {
     this._firstLevel = newLevel;
   }
 
-  get startLevel() {
-    // hls.startLevel takes precedence over config.startLevel
-    // if none of these values are defined, fallback on this._firstLevel (first quality level appearing in variant manifest)
+  get startLevel(): number {
+    // Setting hls.startLevel (this._startLevel) overrides config.startLevel
     if (this._startLevel === undefined) {
       const configStartLevel = this.hls.config.startLevel;
       if (configStartLevel !== undefined) {
         return configStartLevel;
-      } else {
-        return this._firstLevel;
       }
-    } else {
-      return this._startLevel;
+      return this.hls.firstAutoLevel;
     }
+    return this._startLevel;
   }
 
-  set startLevel(newLevel) {
+  set startLevel(newLevel: number) {
     this._startLevel = newLevel;
   }
 
@@ -464,10 +486,20 @@ export default class LevelController extends BasePlaylistController {
   }
 
   // reset errors on the successful load of a fragment
-  protected onFragLoaded(event: Events.FRAG_LOADED, { frag }: FragLoadedData) {
+  protected onFragBuffered(
+    event: Events.FRAG_BUFFERED,
+    { frag }: FragBufferedData
+  ) {
     if (frag !== undefined && frag.type === PlaylistLevelType.MAIN) {
+      const el = frag.elementaryStreams;
+      if (!Object.keys(el).some((type) => !!el[type])) {
+        return;
+      }
       const level = this._levels[frag.level];
-      if (level !== undefined) {
+      if (level?.loadError) {
+        this.log(
+          `Resetting level error count of ${level.loadError} on frag buffered`
+        );
         level.loadError = 0;
       }
     }
@@ -613,9 +645,20 @@ export default class LevelController extends BasePlaylistController {
       if (this.steering) {
         this.steering.removeLevel(level);
       }
+      if (level === this.currentLevel) {
+        this.currentLevel = null;
+        this.currentLevelIndex = -1;
+        if (level.details) {
+          level.details.fragments.forEach((f) => (f.level = -1));
+        }
+      }
       return false;
     });
-
+    reassignFragmentLevelIndexes(levels);
+    this._levels = levels;
+    if (this.currentLevelIndex > -1 && this.currentLevel?.details) {
+      this.currentLevelIndex = this.currentLevel.details.fragments[0].level;
+    }
     this.hls.trigger(Events.LEVELS_UPDATED, { levels });
   }
 
@@ -623,14 +666,6 @@ export default class LevelController extends BasePlaylistController {
     event: Events.LEVELS_UPDATED,
     { levels }: LevelsUpdatedData
   ) {
-    levels.forEach((level, index) => {
-      const { details } = level;
-      if (details?.fragments) {
-        details.fragments.forEach((fragment) => {
-          fragment.level = index;
-        });
-      }
-    });
     this._levels = levels;
   }
 }

--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -482,3 +482,14 @@ export function findPart(
   }
   return null;
 }
+
+export function reassignFragmentLevelIndexes(levels: Level[]) {
+  levels.forEach((level, index) => {
+    const { details } = level;
+    if (details?.fragments) {
+      details.fragments.forEach((fragment) => {
+        fragment.level = index;
+      });
+    }
+  });
+}

--- a/src/controller/rendition-helper.ts
+++ b/src/controller/rendition-helper.ts
@@ -1,0 +1,225 @@
+import { codecsSetSelectionPreferenceValue } from '../utils/codecs';
+import { logger } from '../utils/logger';
+import type { Level, VideoRange } from '../types/level';
+import type { MediaPlaylist } from '../types/media-playlist';
+
+export type CodecSetTier = {
+  minBitrate: number;
+  minHeight: number;
+  minFramerate: number;
+  maxScore: number;
+  videoRanges: Record<string, number>;
+  channels: Record<string, number>;
+  hasDefaultAudio: boolean;
+  fragmentError: number;
+};
+
+type AudioTrackGroup = {
+  channels: Record<string, number>;
+  hasDefault: boolean;
+  hasAutoSelect: boolean;
+};
+type StartParameters = {
+  codecSet: string | undefined;
+  videoRange: VideoRange | undefined;
+  minFramerate: number;
+  minBitrate: number;
+};
+
+export function getStartCodecTier(
+  codecTiers: Record<string, CodecSetTier>,
+  videoRange: VideoRange | undefined,
+  currentBw: number
+): StartParameters {
+  const codecSets = Object.keys(codecTiers);
+  // Use first level set to determine stereo, and minimum resolution and framerate
+  let hasStereo = true;
+  let hasCurrentVideoRange = false;
+  let minHeight = Infinity;
+  let minFramerate = Infinity;
+  let minBitrate = Infinity;
+  let selectedScore = 0;
+  for (let i = codecSets.length; i--; ) {
+    const tier = codecTiers[codecSets[i]];
+    hasStereo = tier.channels[2] > 0;
+    minHeight = Math.min(minHeight, tier.minHeight);
+    minFramerate = Math.min(minFramerate, tier.minFramerate);
+    minBitrate = Math.min(minBitrate, tier.minBitrate);
+    if (videoRange) {
+      hasCurrentVideoRange ||= tier.videoRanges[videoRange] > 0;
+    }
+  }
+  minHeight = Number.isFinite(minHeight) ? minHeight : 0;
+  minFramerate = Number.isFinite(minFramerate) ? minFramerate : 0;
+  const maxHeight = Math.max(1080, minHeight);
+  const maxFramerate = Math.max(30, minFramerate);
+  minBitrate = Number.isFinite(minBitrate) ? minBitrate : currentBw;
+  currentBw = Math.max(minBitrate, currentBw);
+  // If there are no SDR variants, set currentVideoRange to undefined
+  if (!hasCurrentVideoRange) {
+    videoRange = undefined;
+  }
+  const codecSet = codecSets.reduce(
+    (selected: string | undefined, candidate: string) => {
+      // Remove candiates which do not meet bitrate, default audio, stereo, 1080p or lower, 30fps or lower, or SDR if present
+      const candidateTier = codecTiers[candidate];
+      if (candidate === selected) {
+        return selected;
+      }
+      if (candidateTier.minBitrate > currentBw) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `min bitrate of ${candidateTier.minBitrate} > current estimate of ${currentBw}`
+        );
+        return selected;
+      }
+      if (!candidateTier.hasDefaultAudio) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `no renditions with default or auto-select sound found`
+        );
+        return selected;
+      }
+      if (hasStereo && candidateTier.channels['2'] === 0) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `no renditions with stereo sound found`
+        );
+        return selected;
+      }
+      if (candidateTier.minHeight > maxHeight) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `min resolution of ${candidateTier.minHeight} > maximum of ${maxHeight}`
+        );
+        return selected;
+      }
+      if (candidateTier.minFramerate > maxFramerate) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `min framerate of ${candidateTier.minFramerate} > maximum of ${maxFramerate}`
+        );
+        return selected;
+      }
+      if (videoRange && candidateTier.videoRanges[videoRange] === 0) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `no variants with VIDEO-RANGE of ${videoRange} found`
+        );
+        return selected;
+      }
+      if (candidateTier.maxScore < selectedScore) {
+        logStartCodecCandidateIgnored(
+          candidate,
+          `max score of ${candidateTier.maxScore} < selected max of ${selectedScore}`
+        );
+        return selected;
+      }
+      // Remove candiates with less preferred codecs or more errors
+      if (
+        selected &&
+        (codecsSetSelectionPreferenceValue(candidate) >=
+          codecsSetSelectionPreferenceValue(selected) ||
+          candidateTier.fragmentError > codecTiers[selected].fragmentError)
+      ) {
+        return selected;
+      }
+      selectedScore = candidateTier.maxScore;
+      return candidate;
+    },
+    undefined
+  );
+  return {
+    codecSet,
+    videoRange,
+    minFramerate,
+    minBitrate,
+  };
+}
+
+export function getCodecTiers(
+  levels: Level[],
+  allAudioTracks: MediaPlaylist[],
+  minAutoLevel: number,
+  maxAutoLevel: number
+): Record<string, CodecSetTier> {
+  let hasDefaultAudio = false;
+  let hasAutoSelectAudio = false;
+  const audioTracksByGroup = allAudioTracks.reduce(
+    (trackGroups: Record<string, AudioTrackGroup>, track) => {
+      let trackGroup = trackGroups[track.groupId];
+      if (!trackGroup) {
+        trackGroup = trackGroups[track.groupId] = {
+          channels: { 2: 0 },
+          hasDefault: false,
+          hasAutoSelect: false,
+        };
+      }
+      const channels = track.attrs.CHANNELS;
+      trackGroup.channels[channels || 2] =
+        (trackGroup.channels[channels || 2] || 0) + 1;
+      trackGroup.hasDefault = trackGroup.hasDefault || track.default;
+      trackGroup.hasAutoSelect = trackGroup.hasAutoSelect || track.autoselect;
+      if (trackGroup.hasDefault) {
+        hasDefaultAudio = true;
+      }
+      if (trackGroup.hasAutoSelect) {
+        hasAutoSelectAudio = true;
+      }
+      return trackGroups;
+    },
+    {}
+  );
+
+  return levels
+    .slice(minAutoLevel, maxAutoLevel + 1)
+    .reduce((tiers: Record<string, CodecSetTier>, level) => {
+      if (!level.codecSet) {
+        return tiers;
+      }
+      const audioGroup = level.audioGroupId
+        ? audioTracksByGroup[level.audioGroupId]
+        : null;
+      let tier = tiers[level.codecSet];
+      if (!tier) {
+        tiers[level.codecSet] = tier = {
+          minBitrate: Infinity,
+          minHeight: Infinity,
+          minFramerate: Infinity,
+          maxScore: 0,
+          videoRanges: { SDR: 0 },
+          channels: { 2: 0 },
+          hasDefaultAudio: !audioGroup,
+          fragmentError: 0,
+        };
+      }
+      tier.minBitrate = Math.min(tier.minBitrate, level.bitrate);
+      const lesserWidthOrHeight = Math.min(level.height, level.width);
+      tier.minHeight = Math.min(tier.minHeight, lesserWidthOrHeight);
+      tier.minFramerate = Math.min(tier.minFramerate, level.frameRate);
+      tier.maxScore = Math.max(tier.maxScore, level.score);
+      tier.fragmentError += level.fragmentError;
+      tier.videoRanges[level.videoRange] =
+        (tier.videoRanges[level.videoRange] || 0) + 1;
+      if (audioGroup) {
+        // Default audio is any group with DEFAULT=YES, or if missing then any group with AUTOSELECT=YES, or all variants
+        tier.hasDefaultAudio =
+          tier.hasDefaultAudio || hasDefaultAudio
+            ? audioGroup.hasDefault
+            : audioGroup.hasAutoSelect ||
+              (!hasDefaultAudio && !hasAutoSelectAudio);
+        Object.keys(audioGroup.channels).forEach((channels) => {
+          tier.channels[channels] =
+            (tier.channels[channels] || 0) + audioGroup.channels[channels];
+        });
+      }
+
+      return tiers;
+    }, {});
+}
+
+function logStartCodecCandidateIgnored(codeSet: string, reason: string) {
+  logger.log(
+    `[abr] start candidates with "${codeSet}" ignored because ${reason}`
+  );
+}

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -135,7 +135,7 @@ export default class StreamController
             startLevel = 0;
             this.bitrateTest = true;
           } else {
-            startLevel = hls.nextAutoLevel;
+            startLevel = hls.firstAutoLevel;
           }
         }
         // set new level to playlist loader : this will trigger start level load
@@ -978,6 +978,9 @@ export default class StreamController
     event: Events.LEVELS_UPDATED,
     data: LevelsUpdatedData
   ) {
+    if (this.level > -1 && this.fragCurrent) {
+      this.level = this.fragCurrent.level;
+    }
     this.levels = data.levels;
   }
 
@@ -1306,11 +1309,7 @@ export default class StreamController
     }
     if (audiovideo) {
       this.log(
-        `Init audiovideo buffer, container:${
-          audiovideo.container
-        }, codecs[level/parsed]=[${currentLevel.attrs.CODECS || ''}/${
-          audiovideo.codec
-        }]`
+        `Init audiovideo buffer, container:${audiovideo.container}, codecs[level/parsed]=[${currentLevel.codecs}/${audiovideo.codec}]`
       );
     }
     this.hls.trigger(Events.BUFFER_CODECS, tracks);

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -160,6 +160,7 @@ export class SubtitleStreamController
       buffered.push(timeRange);
     }
     this.fragmentTracker.fragBuffered(frag);
+    this.fragBufferedComplete(frag, null);
   }
 
   onBufferFlushing(event: Events.BUFFER_FLUSHING, data: BufferFlushingData) {

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -2,7 +2,7 @@ import { Events } from '../events';
 import { Bufferable, BufferHelper } from '../utils/buffer-helper';
 import { findFragmentByPTS } from './fragment-finders';
 import { alignMediaPlaylistByPDT } from '../utils/discontinuities';
-import { addSliding } from './level-helper';
+import { addSliding } from '../utils/level-helper';
 import { FragmentState } from './fragment-tracker';
 import BaseStreamController, { State } from './base-stream-controller';
 import { PlaylistLevelType } from '../types/loader';

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -255,6 +255,10 @@ class SubtitleTrackController extends BasePlaylistController {
     }
   }
 
+  get allSubtitleTracks(): MediaPlaylist[] {
+    return this.tracks;
+  }
+
   /** get alternate subtitle tracks list from playlist **/
   get subtitleTracks(): MediaPlaylist[] {
     return this.tracksInGroup;

--- a/src/define-plugin.d.ts
+++ b/src/define-plugin.d.ts
@@ -8,6 +8,7 @@ declare const __USE_CMCD__: boolean;
 declare const __USE_CONTENT_STEERING__: boolean;
 declare const __USE_VARIABLE_SUBSTITUTION__: boolean;
 declare const __USE_M2TS_ADVANCED_CODECS__: boolean;
+declare const __USE_MEDIA_CAPABILITIES__: boolean;
 
 // __IN_WORKER__ is provided from a closure call around the final UMD bundle.
 declare const __IN_WORKER__: boolean;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -12,7 +12,7 @@ import { enableStreamingMode, hlsDefaultConfig, mergeConfig } from './config';
 import { EventEmitter } from 'eventemitter3';
 import { Events } from './events';
 import { ErrorTypes, ErrorDetails } from './errors';
-import { HdcpLevels } from './types/level';
+import { isHdcpLevel, type HdcpLevel, type Level } from './types/level';
 import type { HlsEventEmitter, HlsListeners } from './events';
 import type AudioTrackController from './controller/audio-track-controller';
 import type AbrController from './controller/abr-controller';
@@ -24,7 +24,6 @@ import type SubtitleTrackController from './controller/subtitle-track-controller
 import type { ComponentAPI, NetworkComponentAPI } from './types/component-api';
 import type { MediaPlaylist } from './types/media-playlist';
 import type { HlsConfig } from './config';
-import type { HdcpLevel, Level } from './types/level';
 import type { BufferInfo } from './utils/buffer-helper';
 import type AudioStreamController from './controller/audio-stream-controller';
 import type BasePlaylistController from './controller/base-playlist-controller';
@@ -541,13 +540,17 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
-   * Return start level (level of first fragment that will be played back)
-   * if not overrided by user, first level appearing in manifest will be used as start level
-   * if -1 : automatic start level selection, playback will start from level matching download bandwidth
-   * (determined from download of first segment)
+   * Return the desired start level for the first fragment that will be loaded.
+   * The default value of -1 indicates automatic start level selection.
+   * Setting hls.nextAutoLevel without setting a startLevel will result in
+   * the nextAutoLevel value being used for one fragment load.
    */
   get startLevel(): number {
-    return this.levelController.startLevel;
+    const startLevel = this.levelController.startLevel;
+    if (startLevel === -1 && this.abrController.forcedAutoLevel > -1) {
+      return this.abrController.forcedAutoLevel;
+    }
+    return startLevel;
   }
 
   /**
@@ -642,7 +645,7 @@ export default class Hls implements HlsEventEmitter {
   }
 
   set maxHdcpLevel(value: HdcpLevel) {
-    if (HdcpLevels.indexOf(value) > -1) {
+    if (isHdcpLevel(value)) {
       this._maxHdcpLevel = value;
     }
   }
@@ -706,15 +709,15 @@ export default class Hls implements HlsEventEmitter {
     return maxAutoLevel;
   }
 
+  get firstAutoLevel(): number {
+    return this.abrController.firstAutoLevel;
+  }
+
   /**
    * next automatically selected quality level
    */
   get nextAutoLevel(): number {
-    // ensure next auto level is between  min and max auto level
-    return Math.min(
-      Math.max(this.abrController.nextAutoLevel, this.minAutoLevel),
-      this.maxAutoLevel
-    );
+    return this.abrController.nextAutoLevel;
   }
 
   /**
@@ -725,7 +728,7 @@ export default class Hls implements HlsEventEmitter {
    * this value will be resetted to -1 by ABR controller.
    */
   set nextAutoLevel(nextLevel: number) {
-    this.abrController.nextAutoLevel = Math.max(this.minAutoLevel, nextLevel);
+    this.abrController.nextAutoLevel = nextLevel;
   }
 
   /**
@@ -737,6 +740,14 @@ export default class Hls implements HlsEventEmitter {
 
   public get mainForwardBufferInfo(): BufferInfo | null {
     return this.streamController.getMainFwdBufferInfo();
+  }
+
+  /**
+   * Get the complete list of audio tracks across all media groups
+   */
+  get allAudioTracks(): Array<MediaPlaylist> {
+    const audioTrackController = this.audioTrackController;
+    return audioTrackController ? audioTrackController.allAudioTracks : [];
   }
 
   /**
@@ -763,6 +774,16 @@ export default class Hls implements HlsEventEmitter {
     if (audioTrackController) {
       audioTrackController.audioTrack = audioTrackId;
     }
+  }
+
+  /**
+   * get the complete list of subtitle tracks across all media groups
+   */
+  get allSubtitleTracks(): Array<MediaPlaylist> {
+    const subtitleTrackController = this.subtitleTrackController;
+    return subtitleTrackController
+      ? subtitleTrackController.allSubtitleTracks
+      : [];
   }
 
   /**
@@ -888,7 +909,6 @@ export type {
   HlsEventEmitter,
   HlsConfig,
   BufferInfo,
-  HdcpLevels,
   HdcpLevel,
   AbrController,
   AudioStreamController,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -447,7 +447,7 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
-   * @returns an array of levels (variants) sorted by HDCP-LEVEL, BANDWIDTH, SCORE, and RESOLUTION (height)
+   * @returns an array of levels (variants) sorted by HDCP-LEVEL, RESOLUTION (height), FRAME-RATE, CODECS, VIDEO-RANGE, and BANDWIDTH
    */
   get levels(): Level[] {
     const levels = this.levelController.levels;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -986,6 +986,7 @@ export type {
   LevelParsed,
   VariableMap,
 } from './types/level';
+export type { MediaDecodingInfo } from './utils/mediacapabilities-helper';
 export type {
   PlaylistLevelType,
   HlsChunkPerformanceTiming,

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -281,8 +281,11 @@ function getParsedTrackCodec(
     if (parsedCodec === 'fLaC' || parsedCodec === 'Opus') {
       return getCodecCompatibleName(parsedCodec);
     }
-    logger.warn(`Unhandled audio codec "${parsedCodec}" or audio object type`);
-    return 'mp4a.40.5';
+    const result = 'mp4a.40.5';
+    logger.info(
+      `Parsed audio codec "${parsedCodec}" or audio object type not handled. Using "${result}"`
+    );
+    return result;
   }
   // Provide defaults based on codec type
   // This allows for some playback of some fmp4 playlists without CODECS defined in manifest

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -43,7 +43,7 @@ export function isHdcpLevel(value: any): value is HdcpLevel {
   return HdcpLevels.indexOf(value) > -1;
 }
 
-export const VideoRangeValues = ['SDR', 'PQ', 'HLG'] as const;
+export const VideoRangeValues = ['SDR', 'HLG', 'PQ'] as const;
 export type VideoRange = (typeof VideoRangeValues)[number];
 
 export function isVideoRange(value: any): value is VideoRange {

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -165,6 +165,10 @@ export class Level {
     return this.attrs['VIDEO-RANGE'] || 'SDR';
   }
 
+  get score(): number {
+    return this.attrs.optionalFloat('SCORE', 0);
+  }
+
   get uri(): string {
     return this.url[this._urlId] || '';
   }

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -1,5 +1,6 @@
-import { LevelDetails } from '../loader/level-details';
-import { AttrList } from '../utils/attr-list';
+import type { LevelDetails } from '../loader/level-details';
+import type { AttrList } from '../utils/attr-list';
+import type { MediaDecodingInfo } from '../utils/mediacapabilities-helper';
 
 export interface LevelParsed {
   attrs: LevelAttributes;
@@ -43,7 +44,7 @@ export function isHdcpLevel(value: any): value is HdcpLevel {
   return HdcpLevels.indexOf(value) > -1;
 }
 
-export const VideoRangeValues = ['SDR', 'HLG', 'PQ'] as const;
+export const VideoRangeValues = ['SDR', 'PQ', 'HLG'] as const;
 export type VideoRange = (typeof VideoRangeValues)[number];
 
 export function isVideoRange(value: any): value is VideoRange {
@@ -116,6 +117,8 @@ export class Level {
   public realBitrate: number = 0;
   public textGroupIds?: (string | undefined)[];
   public url: string[];
+  public supportedPromise?: Promise<MediaDecodingInfo>;
+  public supportedResult?: MediaDecodingInfo;
   private _urlId: number = 0;
   private _avgBitrate: number = 0;
 

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -153,3 +153,15 @@ export function getCodecCompatibleName(codec: string): string {
     getCodecCompatibleNameLower(m.toLowerCase() as LowerCaseCodecType)
   );
 }
+
+export function pickMostCompleteCodecName(
+  parsedCodec: string,
+  levelCodec: string
+): string {
+  // Parsing of mp4a codecs strings in mp4-tools from media is incomplete as of d8c6c7a
+  // so use level codec is parsed codec is unavailable or incomplete
+  if (parsedCodec && parsedCodec !== 'mp4a') {
+    return parsedCodec;
+  }
+  return levelCodec;
+}

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -96,7 +96,11 @@ export function areCodecsMediaSourceSupported(
 }
 
 function isCodecMediaSourceSupported(codec: string, type: CodecType): boolean {
-  return MediaSource?.isTypeSupported(`${type}/mp4;codecs="${codec}"`) ?? false;
+  return MediaSource?.isTypeSupported(mimeTypeForCodec(codec, type)) ?? false;
+}
+
+export function mimeTypeForCodec(codec: string, type: CodecType): string {
+  return `${type}/mp4;codecs="${codec}"`;
 }
 
 export function codecsSetSelectionPreferenceValue(codecSet: string): number {

--- a/src/utils/discontinuities.ts
+++ b/src/utils/discontinuities.ts
@@ -1,5 +1,5 @@
 import { logger } from './logger';
-import { adjustSliding } from '../controller/level-helper';
+import { adjustSliding } from './level-helper';
 
 import type { Fragment } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -2,7 +2,7 @@
  * Provides methods dealing with playlist sliding and drift
  */
 
-import { logger } from '../utils/logger';
+import { logger } from './logger';
 import { Fragment, Part } from '../loader/fragment';
 import { LevelDetails } from '../loader/level-details';
 import type { Level } from '../types/level';

--- a/src/utils/mediacapabilities-helper.ts
+++ b/src/utils/mediacapabilities-helper.ts
@@ -1,0 +1,119 @@
+import { mimeTypeForCodec } from './codecs';
+import type { Level, VideoRange } from '../types/level';
+
+export type MediaDecodingInfo = {
+  supported: boolean;
+  configurations: readonly MediaDecodingConfiguration[];
+  decodingInfoResults: readonly MediaCapabilitiesDecodingInfo[];
+  error?: Error;
+};
+
+type BaseVideoConfiguration = Omit<VideoConfiguration, 'contentType'>;
+
+export const SUPPORTED_INFO_DEFAULT: MediaDecodingInfo = {
+  supported: true,
+  configurations: [] as MediaDecodingConfiguration[],
+  decodingInfoResults: [
+    {
+      supported: true,
+      powerEfficient: true,
+      smooth: true,
+    },
+  ],
+} as const;
+
+export const SUPPORTED_INFO_CACHE: Record<
+  string,
+  Promise<MediaDecodingInfo>
+> = {};
+
+export function requiresMediaCapabilitiesDecodingInfo(
+  level: Level,
+  mediaCapabilities: MediaCapabilities | undefined,
+  currentVideoRange: VideoRange | undefined,
+  currentFrameRate: number,
+  currentBw: number
+): boolean {
+  // Only test support when configuration is exceeds minimum options
+  return (
+    typeof mediaCapabilities?.decodingInfo == 'function' &&
+    level.videoCodec !== undefined &&
+    ((level.width > 1920 && level.height > 1088) ||
+      (level.height > 1920 && level.width > 1088) ||
+      level.frameRate > Math.max(currentFrameRate, 30) ||
+      (level.videoRange !== 'SDR' && level.videoRange !== currentVideoRange) ||
+      level.bitrate > Math.max(currentBw, 8e6))
+  );
+}
+
+export function getMediaDecodingInfoPromise(
+  level: Level,
+  mediaCapabilities: MediaCapabilities
+): Promise<MediaDecodingInfo> {
+  const videoCodecs = level.videoCodec;
+  if (!videoCodecs) {
+    return Promise.resolve(SUPPORTED_INFO_DEFAULT);
+  }
+
+  const baseVideoConfiguration: BaseVideoConfiguration = {
+    width: level.width,
+    height: level.height,
+    bitrate: Math.ceil(Math.max(level.bitrate * 0.9, level.averageBitrate)),
+    framerate: level.frameRate,
+  };
+
+  const videoRange = level.videoRange;
+  if (videoRange !== 'SDR') {
+    baseVideoConfiguration.transferFunction =
+      videoRange.toLowerCase() as TransferFunction;
+  }
+
+  // Cache MediaCapabilities promises
+  const decodingInfoKey = getMediaDecodingInfoKey(
+    baseVideoConfiguration,
+    videoCodecs
+  );
+  let supportedPromise = SUPPORTED_INFO_CACHE[decodingInfoKey];
+  if (supportedPromise) {
+    return supportedPromise;
+  }
+
+  const configurations: MediaDecodingConfiguration[] = videoCodecs
+    .split(',')
+    .map((codec) => ({
+      type: 'media-source',
+      video: {
+        ...baseVideoConfiguration,
+        contentType: mimeTypeForCodec(codec, 'video'),
+      },
+    }));
+
+  supportedPromise = SUPPORTED_INFO_CACHE[decodingInfoKey] = Promise.all(
+    configurations.map((configuration) =>
+      mediaCapabilities.decodingInfo(configuration)
+    )
+  )
+    .then((decodingInfoResults) => ({
+      supported: !decodingInfoResults.some((info) => !info.supported),
+      configurations,
+      decodingInfoResults,
+    }))
+    .catch((error) => ({
+      supported: false,
+      configurations,
+      decodingInfoResults: [] as MediaCapabilitiesDecodingInfo[],
+      error,
+    }));
+  return supportedPromise;
+}
+
+function getMediaDecodingInfoKey(
+  video: BaseVideoConfiguration,
+  videoCodecs: string
+): string {
+  return `r${video.height}x${video.width}b${Math.ceil(
+    video.bitrate / 1e5
+  )}f${Math.ceil(video.framerate)}${
+    video.transferFunction || 'sd'
+  }_${videoCodecs}`;
+}

--- a/src/utils/mediacapabilities-helper.ts
+++ b/src/utils/mediacapabilities-helper.ts
@@ -69,7 +69,8 @@ export function getMediaDecodingInfoPromise(
     width: level.width,
     height: level.height,
     bitrate: Math.ceil(Math.max(level.bitrate * 0.9, level.averageBitrate)),
-    framerate: level.frameRate,
+    // Assume a framerate of 30fps since MediaCapabilities will not accept Level default of 0.
+    framerate: level.frameRate || 30,
   };
 
   const videoRange = level.videoRange;

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -144,9 +144,8 @@ function createMediaKeySystemConfigurations(
 ): MediaKeySystemConfiguration[] {
   const baseConfig: MediaKeySystemConfiguration = {
     initDataTypes: initDataTypes,
-    persistentState: drmSystemOptions.persistentState || 'not-allowed',
-    distinctiveIdentifier:
-      drmSystemOptions.distinctiveIdentifier || 'not-allowed',
+    persistentState: drmSystemOptions.persistentState || 'optional',
+    distinctiveIdentifier: drmSystemOptions.distinctiveIdentifier || 'optional',
     sessionTypes: drmSystemOptions.sessionTypes || [
       drmSystemOptions.sessionType || 'temporary',
     ],

--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -1,5 +1,5 @@
-import { codecsSetSelectionPreferenceValue } from '../utils/codecs';
-import { logger } from '../utils/logger';
+import { codecsSetSelectionPreferenceValue } from './codecs';
+import { logger } from './logger';
 import type { Level, VideoRange } from '../types/level';
 import type { MediaPlaylist } from '../types/media-playlist';
 
@@ -137,6 +137,12 @@ export function getStartCodecTier(
   };
 }
 
+function logStartCodecCandidateIgnored(codeSet: string, reason: string) {
+  logger.log(
+    `[abr] start candidates with "${codeSet}" ignored because ${reason}`
+  );
+}
+
 export function getCodecTiers(
   levels: Level[],
   allAudioTracks: MediaPlaylist[],
@@ -155,9 +161,9 @@ export function getCodecTiers(
           hasAutoSelect: false,
         };
       }
-      const channels = track.attrs.CHANNELS;
-      trackGroup.channels[channels || 2] =
-        (trackGroup.channels[channels || 2] || 0) + 1;
+      const channelsKey = track.attrs.CHANNELS || '2';
+      trackGroup.channels[channelsKey] =
+        (trackGroup.channels[channelsKey] || 0) + 1;
       trackGroup.hasDefault = trackGroup.hasDefault || track.default;
       trackGroup.hasAutoSelect = trackGroup.hasAutoSelect || track.autoselect;
       if (trackGroup.hasDefault) {
@@ -188,7 +194,7 @@ export function getCodecTiers(
           minFramerate: Infinity,
           maxScore: 0,
           videoRanges: { SDR: 0 },
-          channels: { 2: 0 },
+          channels: { '2': 0 },
           hasDefaultAudio: !audioGroup,
           fragmentError: 0,
         };
@@ -216,10 +222,4 @@ export function getCodecTiers(
 
       return tiers;
     }, {});
-}
-
-function logStartCodecCandidateIgnored(codeSet: string, reason: string) {
-  logger.log(
-    `[abr] start candidates with "${codeSet}" ignored because ${reason}`
-  );
 }

--- a/tests/unit/controller/abr-controller.ts
+++ b/tests/unit/controller/abr-controller.ts
@@ -1,59 +1,342 @@
 import AbrController from '../../../src/controller/abr-controller';
-import EwmaBandWidthEstimator from '../../../src/utils/ewma-bandwidth-estimator';
+import { Level, LevelParsed } from '../../../src/types/level';
+import { LevelDetails } from '../../../src/loader/level-details';
+import { Fragment } from '../../../src/loader/fragment';
+import { LoadStats } from '../../../src/loader/load-stats';
+import { AttrList } from '../../../src/utils/attr-list';
+import { PlaylistLevelType } from '../../../src/types/loader';
+import { Events, HlsListeners } from '../../../src/events';
 import Hls from '../../../src/hls';
 
+import sinon from 'sinon';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 const expect = chai.expect;
 
+function levelDetailsWithDuration(duration: number) {
+  const details = new LevelDetails('');
+  details.totalduration = duration;
+  const frag = new Fragment(PlaylistLevelType.MAIN, '');
+  frag.url = 'foo';
+  details.fragments.push();
+  return details;
+}
+
 describe('AbrController', function () {
-  it('can be reset with new BWE', function () {
-    const hls = new Hls({ maxStarvationDelay: 4 });
-    const abrController = new AbrController(hls);
-    abrController.bwEstimator = new EwmaBandWidthEstimator(15, 4, 5e5, 100);
-    expect(abrController.bwEstimator.getEstimate()).to.equal(5e5);
-    abrController.resetEstimator(5e6);
-    expect(abrController.bwEstimator.getEstimate()).to.equal(5e6);
+  const sandbox = sinon.createSandbox();
+
+  let hls: Hls;
+  let abrController: AbrController;
+
+  beforeEach(function () {
+    hls = new Hls({
+      maxStarvationDelay: 4,
+      // debug: true
+    });
+    abrController = (hls as any).abrController;
   });
 
-  it('should return correct next auto level', function () {
-    const hls = new Hls({ maxStarvationDelay: 4 });
-    (hls as any).levelController._levels = [
-      {
-        bitrate: 105000,
-        name: '144',
-        details: { totalduration: 4, fragments: [{}] },
-      },
-      {
-        bitrate: 246440,
-        name: '240',
-        details: { totalduration: 10, fragments: [{}] },
-      },
-      {
-        bitrate: 460560,
-        name: '380',
-        details: { totalduration: 10, fragments: [{}] },
-      },
-      {
-        bitrate: 836280,
-        name: '480',
-        details: { totalduration: 10, fragments: [{}] },
-      },
-      {
-        bitrate: 2149280,
-        name: '720',
-        details: { totalduration: 10, fragments: [{}] },
-      },
-      {
-        bitrate: 6221600,
-        name: '1080',
-        details: { totalduration: 10, fragments: [{}] },
-      },
-    ];
-    const abrController = new AbrController(hls);
-    abrController.bwEstimator = new EwmaBandWidthEstimator(15, 4, 5e5, 100);
-    expect(abrController.nextAutoLevel).to.equal(0);
+  afterEach(function () {
+    sandbox.restore();
+    hls.destroy();
+  });
+
+  describe('resetEstimator', function () {
+    it('estimate can be reset with new value', function () {
+      const { abrEwmaDefaultEstimate } = hls.config;
+      expect(abrController.bwEstimator.getEstimate()).to.equal(
+        abrEwmaDefaultEstimate
+      );
+      const updatedEstimate = 5e6 + 1;
+      abrController.resetEstimator(updatedEstimate);
+      expect(abrController.bwEstimator.getEstimate()).to.equal(updatedEstimate);
+    });
+  });
+
+  describe('firstAutoLevel getter', function () {
+    it('returns starting level index matching estimate', function () {
+      (hls as any).levelController._levels = getSimpleLevels();
+      const bwe = abrController.bwEstimator.getEstimate();
+      expect(bwe).to.equal(5e5);
+      const firstAutoLevel = abrController.firstAutoLevel;
+      const level = hls.levels[firstAutoLevel];
+      expect(level.bitrate).to.be.lessThanOrEqual(bwe);
+      expect(firstAutoLevel).to.equal(2);
+    });
+
+    it('returns starting level with preferred codecs within estimate', function () {
+      (hls as any).levelController._levels = getMultiCodecLevels();
+      const bwe = abrController.bwEstimator.getEstimate();
+      expect(bwe).to.equal(5e5);
+      const firstAutoLevel = abrController.firstAutoLevel;
+      const level = hls.levels[firstAutoLevel];
+      expect(level.codecSet).to.equal('hevc,mp4a');
+      expect(level.bitrate).to.be.lessThanOrEqual(bwe);
+      expect(firstAutoLevel).to.equal(3);
+    });
+
+    it('returns starting level between minAutoLevel and maxAutoLevel', function () {
+      (hls as any).levelController._levels = getSimpleLevels();
+      expect(hls.minAutoLevel).to.equal(0);
+      expect(hls.maxAutoLevel).to.equal(hls.levels.length - 1);
+
+      hls.firstLevel = 4;
+      abrController.resetEstimator(hls.levels[hls.firstLevel].bitrate);
+      expect(abrController.firstAutoLevel).to.equal(
+        4,
+        'firstAutoLevel exact match'
+      );
+
+      hls.autoLevelCapping = 3;
+      hls.config.minAutoBitrate = 460560;
+      expect(hls.minAutoLevel).to.equal(2);
+      expect(hls.maxAutoLevel).to.equal(3);
+      expect(abrController.firstAutoLevel).to.equal(
+        3,
+        'firstAutoLevel capped to 3'
+      );
+
+      hls.autoLevelCapping = 0;
+      hls.config.minAutoBitrate = 0;
+      expect(hls.minAutoLevel).to.equal(0);
+      expect(hls.maxAutoLevel).to.equal(0);
+      expect(abrController.firstAutoLevel).to.equal(
+        0,
+        'firstAutoLevel capped to 0'
+      );
+    });
+
+    it('returns hls.firstLevel when match cannot be found', function () {
+      (hls as any).levelController._levels = getSimpleLevels();
+      expect(hls.minAutoLevel).to.equal(0);
+      expect(hls.maxAutoLevel).to.equal(hls.levels.length - 1);
+      expect(hls.firstLevel).to.equal(0);
+
+      hls.firstLevel = 3;
+      abrController.resetEstimator(hls.levels[hls.firstLevel].bitrate);
+      expect(hls.firstLevel).to.equal(3);
+      expect(abrController.firstAutoLevel).to.equal(3);
+
+      abrController.resetEstimator(999999999);
+      expect(abrController.firstAutoLevel).to.equal(5);
+
+      abrController.resetEstimator(1);
+      expect(abrController.firstAutoLevel).to.equal(3);
+    });
+  });
+
+  describe('nextAutoLevel getter', function () {
+    it('returns higher level index with sufficient buffer', function () {
+      setForwardBufferlength(sandbox, hls, 8);
+      (hls as any).levelController._levels = getSimpleLevels();
+      const requiredBitrateForLevel2 = 460560 / 0.7 + 1;
+      loadAndBufferFragment(
+        abrController,
+        0,
+        requiredBitrateForLevel2 / 8,
+        1000
+      );
+      expect(abrController.nextAutoLevel).to.equal(2);
+    });
+  });
+
+  describe('nextAutoLevel setter and forcedAutoLevel getter', function () {
+    it('forcedAutoLevel returns value set by nextAutoLevel setter until nextAutoLevel can use estimate and find a candidate', function () {
+      (hls as any).levelController._levels = getSimpleLevels();
+      expect(abrController.forcedAutoLevel).to.equal(-1);
+      expect(abrController.nextAutoLevel).to.equal(2);
+
+      abrController.nextAutoLevel = 1;
+      expect(abrController.forcedAutoLevel).to.equal(1);
+      expect(abrController.nextAutoLevel).to.equal(1);
+
+      loadAndBufferFragment(abrController, 0, 5e6, 1000);
+      expect(abrController.forcedAutoLevel).to.equal(-1);
+      expect(abrController.nextAutoLevel).to.equal(5);
+    });
   });
 });
+
+function loadAndBufferFragment(
+  abrController: AbrController,
+  levelIndex: number,
+  sizeInBytes: number,
+  timeToLoad: number,
+  timeToFirstByte: number = 0,
+  timeToParse: number = 0
+) {
+  const frag = new Fragment(PlaylistLevelType.MAIN, '');
+  frag.level = levelIndex;
+  frag.stats = new LoadStats();
+  frag.stats.loaded = sizeInBytes;
+  frag.stats.loading = {
+    first: 0,
+    start: timeToFirstByte,
+    end: timeToLoad + timeToFirstByte,
+  };
+  frag.stats.parsing = {
+    start: frag.stats.loading.end,
+    end: frag.stats.loading.end + timeToParse,
+  };
+  ((abrController as any).onFragLoaded as HlsListeners[Events.FRAG_LOADED])(
+    Events.FRAG_LOADED,
+    {
+      frag,
+      part: null,
+      payload: new ArrayBuffer(0),
+      networkDetails: null,
+    }
+  );
+  ((abrController as any).onFragBuffered as HlsListeners[Events.FRAG_BUFFERED])(
+    Events.FRAG_BUFFERED,
+    {
+      frag,
+      part: null,
+      stats: frag.stats,
+      id: 'video',
+    }
+  );
+}
+
+function setForwardBufferlength(
+  sandbox: sinon.SinonSandbox,
+  hls: Hls,
+  length: number
+) {
+  sandbox
+    .stub((hls as any).streamController, 'getMainFwdBufferInfo')
+    .returns({ len: length, start: 0, end: length, nextStart: undefined });
+}
+
+function getSimpleLevels(): Level[] {
+  const parsedLevels: LevelParsed[] = [
+    {
+      bitrate: 105000,
+      name: '144',
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+    },
+    {
+      bitrate: 246440,
+      name: '240',
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+    },
+    {
+      bitrate: 460560,
+      name: '380',
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+    },
+    {
+      bitrate: 836280,
+      name: '480',
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+    },
+    {
+      bitrate: 2149280,
+      name: '720',
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+    },
+    {
+      bitrate: 6221600,
+      name: '1080',
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+    },
+  ];
+  return parsedLevels.map((parsedLevel) => new Level(parsedLevel));
+}
+
+function getMultiCodecLevels(): Level[] {
+  const parsedLevels: LevelParsed[] = [
+    {
+      bitrate: 336280,
+      name: '480',
+      width: 852,
+      height: 480,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'avc1',
+      audioCodec: 'mp4a',
+    },
+    {
+      bitrate: 300000,
+      name: '480',
+      width: 852,
+      height: 480,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'hevc',
+      audioCodec: 'mp4a',
+    },
+    {
+      bitrate: 414928,
+      name: '720',
+      width: 1280,
+      height: 720,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'avc1',
+      audioCodec: 'mp4a',
+    },
+    {
+      bitrate: 480928,
+      name: '720',
+      width: 1280,
+      height: 720,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'hevc',
+      audioCodec: 'mp4a',
+    },
+    {
+      bitrate: 480000,
+      name: '1080',
+      width: 1920,
+      height: 1080,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'avc1',
+      audioCodec: 'mp4a',
+    },
+    {
+      bitrate: 522160,
+      name: '1080',
+      width: 1920,
+      height: 1080,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'avc1',
+      audioCodec: 'mp4a',
+    },
+    {
+      bitrate: 500060,
+      name: '1080',
+      width: 1920,
+      height: 1080,
+      details: levelDetailsWithDuration(10),
+      attrs: new AttrList({}),
+      url: '',
+      videoCodec: 'hevc',
+      audioCodec: 'mp4a',
+    },
+  ];
+  return parsedLevels.map((parsedLevel) => new Level(parsedLevel));
+}

--- a/tests/unit/controller/cap-level-controller.js
+++ b/tests/unit/controller/cap-level-controller.js
@@ -79,6 +79,7 @@ describe('CapLevelController', function () {
     let hls;
     let media;
     let capLevelController;
+
     beforeEach(function () {
       const fixture = document.createElement('div');
       fixture.id = 'test-fixture';
@@ -86,7 +87,7 @@ describe('CapLevelController', function () {
 
       hls = new Hls({ capLevelToPlayerSize: true });
       media = document.createElement('video');
-      capLevelController = new CapLevelController(hls);
+      capLevelController = hls.capLevelController;
       capLevelController.onMediaAttaching(Events.MEDIA_ATTACHING, {
         media,
       });
@@ -100,6 +101,7 @@ describe('CapLevelController', function () {
         media.parentNode.removeChild(media);
       }
       document.body.removeChild(document.querySelector('#test-fixture'));
+      hls.destroy();
     });
 
     it('gets 0 for width and height when the media element is not in the DOM', function () {
@@ -135,7 +137,7 @@ describe('CapLevelController', function () {
 
     it('gets valid width and height when the media element is attached after onManifestParsed', function () {
       hls = new Hls({ capLevelToPlayerSize: true });
-      capLevelController = new CapLevelController(hls);
+      capLevelController = hls.capLevelController;
       capLevelController.onManifestParsed(Events.MANIFEST_PARSED, {
         levels,
       });
@@ -165,15 +167,17 @@ describe('CapLevelController', function () {
   describe('initialization', function () {
     let hls;
     let capLevelController;
-    let firstLevelSpy;
     let startCappingSpy;
     let stopCappingSpy;
     beforeEach(function () {
       hls = new Hls({ capLevelToPlayerSize: true });
-      firstLevelSpy = sinon.spy(hls, 'firstLevel', ['set']);
-      capLevelController = new CapLevelController(hls);
+      capLevelController = hls.capLevelController;
       startCappingSpy = sinon.spy(capLevelController, 'startCapping');
       stopCappingSpy = sinon.spy(capLevelController, 'stopCapping');
+    });
+
+    this.afterEach(function () {
+      hls.destroy();
     });
 
     describe('start and stop', function () {
@@ -185,8 +189,7 @@ describe('CapLevelController', function () {
         capLevelController.startCapping();
 
         expect(capLevelController.timer).to.exist;
-        expect(firstLevelSpy.set.calledOnce).to.be.true;
-        expect(detectPlayerSizeSpy.calledOnce).to.be.true;
+        expect(detectPlayerSizeSpy.callCount).to.equal(1);
       });
 
       it('stops the capping timer and resets capping', function () {
@@ -209,8 +212,6 @@ describe('CapLevelController', function () {
       expect(capLevelController.autoLevelCapping).to.equal(
         Number.POSITIVE_INFINITY
       );
-
-      expect(firstLevelSpy.set.notCalled).to.be.true;
     });
 
     it('starts capping on BUFFER_CODECS only if video is found', function () {

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -30,6 +30,7 @@ describe('ErrorController Integration Tests', function () {
       // debug: true,
       startFragPrefetch: true,
       enableWorker: false,
+      testBandwidth: false,
     });
     sinon.spy(hls, 'stopLoad');
     sinon.spy(hls, 'trigger');
@@ -364,7 +365,7 @@ describe('ErrorController Integration Tests', function () {
         expect(data.details).to.equal(ErrorDetails.LEVEL_LOAD_ERROR);
         expect(data.fatal).to.equal(false, 'Error should not be fatal');
         expect(data.error.message).to.equal(
-          'A network error (status 400) occurred while loading level: 1 id: 0',
+          'A network error (status 400) occurred while loading level: 2 id: 0',
           data.error.message
         );
         hls.stopLoad.should.have.been.calledOnce;
@@ -390,7 +391,7 @@ describe('ErrorController Integration Tests', function () {
         expect(data.details).to.equal(ErrorDetails.LEVEL_LOAD_TIMEOUT);
         expect(data.fatal).to.equal(false, 'Error should not be fatal');
         expect(data.error.message).to.equal(
-          'A network timeout occurred while loading level: 1 id: 0',
+          'A network timeout occurred while loading level: 2 id: 0',
           data.error.message
         );
         server.respond();

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -160,6 +160,7 @@ describe('LevelController', function () {
       audioGroupIds: undefined,
       bitrate: 246440,
       codecSet: '',
+      frameRate: 0,
       details: undefined,
       fragmentError: 0,
       height: 0,

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -160,6 +160,8 @@ describe('LevelController', function () {
       audioGroupIds: undefined,
       bitrate: 246440,
       codecSet: '',
+      supportedPromise: undefined,
+      supportedResult: undefined,
       frameRate: 0,
       details: undefined,
       fragmentError: 0,
@@ -293,10 +295,10 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         'http://foo.example.com/sdr/prog_index.m3u8'
       );
       expect(levels[2].uri).to.equal(
-        'http://foo.example.com/hlg/prog_index.m3u8'
+        'http://foo.example.com/pq/prog_index.m3u8'
       );
       expect(levels[3].uri).to.equal(
-        'http://foo.example.com/pq/prog_index.m3u8'
+        'http://foo.example.com/hlg/prog_index.m3u8'
       );
     });
   });

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -4,7 +4,7 @@ import {
   mapFragmentIntersection,
   mapPartIntersection,
   mergeDetails,
-} from '../../../src/controller/level-helper';
+} from '../../../src/utils/level-helper';
 import { LevelDetails } from '../../../src/loader/level-details';
 import { Fragment, Part } from '../../../src/loader/fragment';
 import { PlaylistLevelType } from '../../../src/types/loader';

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -470,6 +470,12 @@ describe('StreamController', function () {
       firstFrag.start = 0;
       firstFrag.sn = 1;
       firstFrag.cc = 0;
+      firstFrag.elementaryStreams.video = {
+        startDTS: 0,
+        startPTS: 0,
+        endDTS: 5,
+        endPTS: 5,
+      };
       // @ts-ignore
       const seekStub = sandbox.stub(streamController, 'seekToStartPos');
       streamController['loadedmetadata'] = false;
@@ -515,20 +521,28 @@ describe('StreamController', function () {
 
     describe('startLoad', function () {
       beforeEach(function () {
-        streamController['levels'] = [
-          new Level({
-            name: '',
-            url: '',
-            attrs,
-            bitrate: 500000,
-          }),
-          new Level({
-            name: '',
-            url: '',
-            attrs,
-            bitrate: 250000,
-          }),
-        ];
+        hls.trigger(Events.LEVELS_UPDATED, {
+          levels: [
+            new Level({
+              name: '',
+              url: '',
+              attrs,
+              bitrate: 500000,
+            }),
+            new Level({
+              name: '',
+              url: '',
+              attrs,
+              bitrate: 250000,
+            }),
+            new Level({
+              name: '',
+              url: '',
+              attrs,
+              bitrate: 750000,
+            }),
+          ],
+        });
         streamController['media'] = null;
       });
       it('should not start when controller does not have level data', function () {
@@ -582,24 +596,26 @@ describe('StreamController', function () {
       it('should not signal a bandwidth test if config.testBandwidth is false', function () {
         streamController['startFragRequested'] = false;
         hls.startLevel = -1;
-        hls.nextAutoLevel = 3;
+        hls.nextAutoLevel = 2;
         hls.config.testBandwidth = false;
 
         streamController.startLoad(-1);
-        expect(streamController['level']).to.equal(hls.nextAutoLevel);
+        expect(streamController['level']).to.equal(2);
         expect(streamController['bitrateTest']).to.be.false;
       });
 
       it('should not signal a bandwidth test with only one level', function () {
         streamController['startFragRequested'] = false;
-        streamController['levels'] = [
-          new Level({
-            name: '',
-            url: '',
-            attrs,
-            bitrate: 250000,
-          }),
-        ];
+        hls.trigger(Events.LEVELS_UPDATED, {
+          levels: [
+            new Level({
+              name: '',
+              url: '',
+              attrs,
+              bitrate: 250000,
+            }),
+          ],
+        });
         hls.startLevel = -1;
 
         streamController.startLoad(-1);

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -5,9 +5,9 @@ import { Events } from '../../../src/events';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 import { Fragment } from '../../../src/loader/fragment';
 import { PlaylistLevelType } from '../../../src/types/loader';
+import { AttrList } from '../../../src/utils/attr-list';
 import KeyLoader from '../../../src/loader/key-loader';
 import { SubtitleStreamController } from '../../../src/controller/subtitle-stream-controller';
-import { AttrList } from '../../../src/utils/attr-list';
 
 const mediaMock = {
   currentTime: 0,


### PR DESCRIPTION
### This PR will...

#### Make initial variant selection based on preferred codec rather than the first variant in the multivariant playlist

- `hls.firstAutoLevel` is used to evaluate first level based on available codecs, resolution, framerate, default or autoselect audio options, audio channels, video-range, and score, not exceeding 1080p*, 30fps*, SDR, or stereo when possible.
_\* Resolution and frame-rate of first auto level may exceed 1080p/30fps when initial bandwidth estimate allows and `capLevelToPlayerSize` is not enabled._

#### MediaCapabilities support
- Run `mediaCapabilities.decodingInfo` checks for UHD, HFR, and HDR variants, as well as multi-channel-audio renditions
  - Auto adaptations will not occur on variants running tests until they have passed
  - Failed checks will result in the level being removed

MediaCapabilities checks will be added to another PR to prevent switching up to UHD and HFR variants on constrained devices.

#### API enhancements

- Adds `hls.firstAutoLevel` getter, used internally to get the starting level index.
- `hls.levels` are sorted on height, frame rate, preferred codec, and video-range to infer order by quality. Height-first sorting allows cap-level-lontroller to set a max quality index at the maximum allowed resolution.
- Adds methods to get all audio tracks and all subtitle tracks: `hls.allAudioTracks()` and  `hls.allSubtitleTracks()`.
- In #5649 `abrEwmaDefaultEstimateMax` was added. HLS.js will no longer start on the first variant (`hls.firstLevel`), or any variant of a preferred codec, if its BANDWIDTH exceeds this value.

#### Changes to Level parsing
- `Level.bitrate` uses variant BANDWIDTH (required peak bitrate) before falling back to optional AVERAGE-BANDWIDTH.
- `Level.averageBitrate` returns parsed AVERAGE-BANDWIDTH. Falls back to runtime average `Level.realBitrate` (which is only set when `config.abrMaxWithRealBitrate` is enabled) and finally `Level.bitrate` (BANDWIDTH).
- Added `Level.frameRate` returns parsed FRAME-RATE number or 0.
- Added `Level.codecs` returns parsed CODECS or emptry string.
- Added `Level.score` returns parsed SCORE number or 0.

####  Performance Improvements
- Reduced the number of times nextAutoLevel is evaluated.

#### Error handling improvements
- Switch back to auto mode when erroring in manual mode.
- Find alternate on `BUFFER_APPEND_ERROR` and `BUFFER_ADD_CODEC_ERROR` errors.
- Do not switch to playlists that have errored or failed to append media.
- Only reset `level|track.fragmentError` count on successful append.
- Reset append error count on successful appends for mixed muxed/unmuxed error handling

### Why is this Pull Request needed?
HLS.js is expected to select more efficient codecs from the start of playback.

### Are there any points in the code the reviewer needs to double check?

Switching from SDR to HDR, stereo to multi-channel audio, or from one codec family to another, requires a manual level change. Options to auto-select or prefer these configurations may be added in the future. Auto codec switching _may_ be added after implementing MediaCapabilities `MediaCapabilitiesDecodingInfo.transition` if it proves to be well supported and implemented.

Additional MediaCapabilities options, like blocking and filtering levels before start (MANIFEST_PARSED), or choosing which variants to run checks on and what to do with supported results that are not smooth or power efficient will be considered upon request. Currently, all checks are performed after startup, and do not prevent manual selection of variants (levels) and renditions (audio tracks).

### Resolves issues:
- Resolves #4958 (unsupported container-less EC-3 fails over to AC-3)
- Resolves #5162 (by selecting FLAC)
- Resolves #5661
- Resolves #5664

Related issues (may not resolve but should improve)
- Related to #5378


### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
