### PR TITLE
Fix Safari decode errors with DTS not increasing when PTS decreases

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -516,6 +516,7 @@ export default class MP4Remuxer implements Remuxer {
 
     let nbNalu = 0;
     let naluLen = 0;
+    let dtsStep = firstDTS;
     for (let i = 0; i < nbSamples; i++) {
       // compute total/avc sample length and nb of NAL units
       const sample = inputSamples[i];
@@ -531,7 +532,7 @@ export default class MP4Remuxer implements Remuxer {
       sample.length = sampleLen;
 
       // ensure sample monotonic DTS
-      sample.dts = Math.max(sample.dts, firstDTS);
+      sample.dts = sample.dts < dtsStep ? dtsStep++ : sample.dts;
 
       minPTS = Math.min(sample.pts, minPTS);
       maxPTS = Math.max(sample.pts, maxPTS);


### PR DESCRIPTION
### This PR will...
Increase m2ts->fmp4 remuxed sample dts to prevent decode artifacts and errors in Safari. 

### Why is this Pull Request needed?
Samples with negative DTS after aligning on PTS can cause decode artifacts and errors when hls.js sets those initial samples' DTS to 0.

### Are there any points in the code the reviewer needs to double check?
It's not ideal that hls.js has to modify the decode timeline in order to align the media presentation to 0. This is done to remove large video starting gaps that result from MSE implementations not accounting for or reflecting composition time in the media elements timeline.

In the future, HLS.js could improve by setting SourceBuffer `timestampOffset` before appending, without shifting sample timestamps. That would be a much more involved change as it could impact fragment timing properties and append positions across browsers, so for these reasons this intermediate fix is being made instead.

### Resolves issues:
- Resolves #5709
- Resolves #5526

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
