### PR TITLE
use explicit check instead of implicit checking the part for truthy as to…

### DIFF
--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -240,7 +240,7 @@ class PlaylistLoader implements NetworkComponentAPI {
 
     // Override level/track timeout for LL-HLS requests
     // (the default of 10000ms is counter productive to blocking playlist reload requests)
-    if (context.deliveryDirectives?.part) {
+    if (context.deliveryDirectives?.part !== null) {
       let levelDetails: LevelDetails | undefined;
       if (
         context.type === PlaylistContextType.LEVEL &&

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -240,7 +240,7 @@ class PlaylistLoader implements NetworkComponentAPI {
 
     // Override level/track timeout for LL-HLS requests
     // (the default of 10000ms is counter productive to blocking playlist reload requests)
-    if (context.deliveryDirectives?.part !== null) {
+    if (Number.isFinite(context.deliveryDirectives?.part)) {
       let levelDetails: LevelDetails | undefined;
       if (
         context.type === PlaylistContextType.LEVEL &&


### PR DESCRIPTION
… not skip part 0

### This PR will...
fix the part check conditional for the logic that overrides the level/track timeouts for LL-HLS blocking playlist reload request
### Why is this Pull Request needed?
the level/track timeouts override is required for all parts, but its skipping part 0 erroneously because 0 is falsy, 
### Are there any points in the code the reviewer needs to double check?
skipping part 0 maybe on purpose? 
### Resolves issues:
not overriding the level/track timeouts for part 0 for LL-HLS
### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
