### PR TITLE
Load last alt-audio segment even when is starts after the end of the …

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -330,10 +330,6 @@ class AudioStreamController
     const bufferLen = bufferInfo.len;
     const maxBufLen = this.getMaxBufferLength(mainBufferInfo?.len);
 
-    // if buffer length is less than maxBufLen try to load a new fragment
-    if (bufferLen >= maxBufLen && !switchingTrack) {
-      return;
-    }
     const fragments = trackDetails.fragments;
     const start = fragments[0].start;
     let targetBufferTime = bufferInfo.end;
@@ -353,6 +349,15 @@ class AudioStreamController
           media.currentTime = start + 0.05;
         }
       }
+    }
+
+    // if buffer length is less than maxBufLen, or near the end, find a fragment to load
+    if (
+      bufferLen >= maxBufLen &&
+      !switchingTrack &&
+      targetBufferTime < fragments[fragments.length - 1].start
+    ) {
+      return;
     }
 
     let frag = this.getNextFragment(targetBufferTime, trackDetails);

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -882,7 +882,7 @@ export default class BufferController implements ComponentAPI {
       : Infinity;
     const removeStart = Math.max(0, startOffset);
     const removeEnd = Math.min(endOffset, mediaDuration, msDuration);
-    if (removeEnd > removeStart && !sb.ending) {
+    if (removeEnd > removeStart && (!sb.ending || sb.ended)) {
       sb.ended = false;
       this.log(
         `Removing [${removeStart},${removeEnd}] from the ${type} SourceBuffer`


### PR DESCRIPTION
### This PR will...
- Load last alt-audio segment even when is starts after the end of the main playlist
- Flush SourceBuffer when marked `ended` (even if still marked `ending` because other track is busy)

### Why is this Pull Request needed?

> Load last alt-audio segment even when is starts after the end of the main playlist

Alt-audio playlist segments which start after the end of the main playlist were never loaded by the audio-stream-controller, because the main buffer length could never exceeded their start time. Not loading the last segment prevented the audio SourceBuffer from reaching the ending and ended states. 

> Flush SourceBuffer when marked `ended` (even if still marked `ending` because other track is busy)

Flushing a SourceBuffer is required for an immediate switch, but was blocked when the SourceBuffer was ending. This was prolonged when the other SourceBuffer never reached `ending` so now we allow `ended`  SourceBuffers to take flush operations so that immediate switches can be made even when all media of one buffer is appended while the other is not.

Sub-context: audio and video SourceBuffers can be marked as `ending` and `ended` independently, but both have to be `ended` for the `ending` flag to be removed; Both SourceBuffers are flagged `ending` and subsequently `ended` until the MediaSource is ended (all segments up to the end are appended and the video element playback can have ended when the end is reached). 

### Are there any points in the code the reviewer needs to double check?

> Flush SourceBuffer when marked `ended` (even if still marked `ending` because other track is busy)

- Changes logic added in #5131 to fix #5000. More specifically, allowing flushes of ended SourceBuffers could introduce end-of-playlist quality changes or appends that break HTML5MediaElement ended event logic, and/or lead to additional loading at the end of the program in auto-mode.

### Resolves issues:
Fixes #5687

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
