### PR TITLE
Export simple types in place of enums that can't be used at runtime

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -1,5 +1,5 @@
 import EwmaBandWidthEstimator from '../utils/ewma-bandwidth-estimator';
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { PlaylistLevelType } from '../types/loader';
 import { logger } from '../utils/logger';
 import type { Fragment } from '../loader/fragment';
@@ -76,7 +76,10 @@ class AbrController implements AbrComponentAPI {
     this.fragCurrent = this.partCurrent = null;
   }
 
-  protected onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {
+  protected onFragLoading(
+    event: EventsType['FRAG_LOADING'],
+    data: FragLoadingData
+  ) {
     const frag = data.frag;
     if (this.ignoreFragment(frag)) {
       return;
@@ -88,7 +91,7 @@ class AbrController implements AbrComponentAPI {
   }
 
   protected onLevelSwitching(
-    event: Events.LEVEL_SWITCHING,
+    event: EventsType['LEVEL_SWITCHING'],
     data: LevelSwitchingData
   ): void {
     this.clearTimer();
@@ -105,7 +108,10 @@ class AbrController implements AbrComponentAPI {
     return fragLoadSec + playlistLoadSec;
   }
 
-  protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
+  protected onLevelLoaded(
+    event: EventsType['LEVEL_LOADED'],
+    data: LevelLoadedData
+  ) {
     const config = this.hls.config;
     const { total, bwEstimate } = data.stats;
     // Total is the bytelength and bwEstimate in bits/sec
@@ -273,7 +279,7 @@ class AbrController implements AbrComponentAPI {
   }
 
   protected onFragLoaded(
-    event: Events.FRAG_LOADED,
+    event: EventsType['FRAG_LOADED'],
     { frag, part }: FragLoadedData
   ) {
     const stats = part ? part.stats : frag.stats;
@@ -314,7 +320,7 @@ class AbrController implements AbrComponentAPI {
   }
 
   protected onFragBuffered(
-    event: Events.FRAG_BUFFERED,
+    event: EventsType['FRAG_BUFFERED'],
     data: FragBufferedData
   ) {
     const { frag, part } = data;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -1,5 +1,5 @@
 import BaseStreamController, { State } from './base-stream-controller';
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { Bufferable, BufferHelper } from '../utils/buffer-helper';
 import { FragmentState } from './fragment-tracker';
 import { Level } from '../types/level';
@@ -117,7 +117,7 @@ class AudioStreamController
 
   // INIT_PTS_FOUND is triggered when the video track parsed in the stream-controller has a new PTS value
   onInitPtsFound(
-    event: Events.INIT_PTS_FOUND,
+    event: EventsType['INIT_PTS_FOUND'],
     { frag, id, initPTS, timescale }: InitPTSFoundData
   ) {
     // Always update the new INIT PTS
@@ -423,7 +423,7 @@ class AudioStreamController
   }
 
   onAudioTracksUpdated(
-    event: Events.AUDIO_TRACKS_UPDATED,
+    event: EventsType['AUDIO_TRACKS_UPDATED'],
     { audioTracks }: AudioTracksUpdatedData
   ) {
     this.resetTransmuxer();
@@ -431,7 +431,7 @@ class AudioStreamController
   }
 
   onAudioTrackSwitching(
-    event: Events.AUDIO_TRACK_SWITCHING,
+    event: EventsType['AUDIO_TRACK_SWITCHING'],
     data: AudioTrackSwitchingData
   ) {
     // if any URL found on new audio track, it is an alternate audio track
@@ -481,7 +481,7 @@ class AudioStreamController
     this.trackId = this.videoTrackCC = this.waitingVideoCC = -1;
   }
 
-  onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
+  onLevelLoaded(event: EventsType['LEVEL_LOADED'], data: LevelLoadedData) {
     this.mainDetails = data.details;
     if (this.cachedTrackLoadedData !== null) {
       this.hls.trigger(Events.AUDIO_TRACK_LOADED, this.cachedTrackLoadedData);
@@ -489,7 +489,10 @@ class AudioStreamController
     }
   }
 
-  onAudioTrackLoaded(event: Events.AUDIO_TRACK_LOADED, data: TrackLoadedData) {
+  onAudioTrackLoaded(
+    event: EventsType['AUDIO_TRACK_LOADED'],
+    data: TrackLoadedData
+  ) {
     if (this.mainDetails == null) {
       this.cachedTrackLoadedData = data;
       return;
@@ -638,13 +641,16 @@ class AudioStreamController
     super._handleFragmentLoadComplete(fragLoadedData);
   }
 
-  onBufferReset(/* event: Events.BUFFER_RESET */) {
+  onBufferReset(/* event: EventsType['BUFFER_RESET'] */) {
     // reset reference to sourcebuffers
     this.mediaBuffer = this.videoBuffer = null;
     this.loadedmetadata = false;
   }
 
-  onBufferCreated(event: Events.BUFFER_CREATED, data: BufferCreatedData) {
+  onBufferCreated(
+    event: EventsType['BUFFER_CREATED'],
+    data: BufferCreatedData
+  ) {
     const audioTrack = data.tracks.audio;
     if (audioTrack) {
       this.mediaBuffer = audioTrack.buffer || null;
@@ -654,7 +660,7 @@ class AudioStreamController
     }
   }
 
-  onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
+  onFragBuffered(event: EventsType['FRAG_BUFFERED'], data: FragBufferedData) {
     const { frag, part } = data;
     if (frag.type !== PlaylistLevelType.AUDIO) {
       if (!this.loadedmetadata && frag.type === PlaylistLevelType.MAIN) {
@@ -694,7 +700,7 @@ class AudioStreamController
     this.fragBufferedComplete(frag, part);
   }
 
-  private onError(event: Events.ERROR, data: ErrorData) {
+  private onError(event: EventsType['ERROR'], data: ErrorData) {
     if (data.fatal) {
       this.state = State.ERROR;
       return;
@@ -744,7 +750,7 @@ class AudioStreamController
   }
 
   private onBufferFlushed(
-    event: Events.BUFFER_FLUSHED,
+    event: EventsType['BUFFER_FLUSHED'],
     { type }: BufferFlushedData
   ) {
     if (type === ElementaryStreamTypes.AUDIO) {

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import {
   ManifestParsedData,
@@ -65,14 +65,14 @@ class AudioTrackController extends BasePlaylistController {
   }
 
   protected onManifestParsed(
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ): void {
     this.tracks = data.audioTracks || [];
   }
 
   protected onAudioTrackLoaded(
-    event: Events.AUDIO_TRACK_LOADED,
+    event: EventsType['AUDIO_TRACK_LOADED'],
     data: AudioTrackLoadedData
   ): void {
     const { id, groupId, details } = data;
@@ -97,14 +97,14 @@ class AudioTrackController extends BasePlaylistController {
   }
 
   protected onLevelLoading(
-    event: Events.LEVEL_LOADING,
+    event: EventsType['LEVEL_LOADING'],
     data: LevelLoadingData
   ): void {
     this.switchLevel(data.level);
   }
 
   protected onLevelSwitching(
-    event: Events.LEVEL_SWITCHING,
+    event: EventsType['LEVEL_SWITCHING'],
     data: LevelSwitchingData
   ): void {
     this.switchLevel(data.level);
@@ -147,7 +147,7 @@ class AudioTrackController extends BasePlaylistController {
     }
   }
 
-  protected onError(event: Events.ERROR, data: ErrorData): void {
+  protected onError(event: EventsType['ERROR'], data: ErrorData): void {
     if (data.fatal || !data.context) {
       return;
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2,7 +2,7 @@ import TaskLoop from '../task-loop';
 import { FragmentState } from './fragment-tracker';
 import { Bufferable, BufferHelper, BufferInfo } from '../utils/buffer-helper';
 import { logger } from '../utils/logger';
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { ChunkMetadata } from '../types/transmuxer';
 import { appendUint8Array } from '../utils/mp4-tools';
@@ -193,7 +193,7 @@ export default class BaseStreamController
   }
 
   protected onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ) {
     const media = (this.media = this.mediaBuffer = data.media);
@@ -300,7 +300,7 @@ export default class BaseStreamController
   }
 
   protected onManifestLoaded(
-    event: Events.MANIFEST_LOADED,
+    event: EventsType['MANIFEST_LOADED'],
     data: ManifestLoadedData
   ): void {
     this.startTimeOffset = data.startTimeOffset;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { logger } from '../utils/logger';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { BufferHelper } from '../utils/buffer-helper';
@@ -148,7 +148,7 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onManifestParsed(
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ) {
     // in case of alt audio 2 BUFFER_CODECS events will be triggered, one per stream controller
@@ -164,7 +164,7 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onMediaAttaching(
-    event: Events.MEDIA_ATTACHING,
+    event: EventsType['MEDIA_ATTACHING'],
     data: MediaAttachingData
   ) {
     const media = (this.media = data.media);
@@ -255,7 +255,7 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onBufferCodecs(
-    event: Events.BUFFER_CODECS,
+    event: EventsType['BUFFER_CODECS'],
     data: BufferCodecsData
   ) {
     const sourceBufferCount = this.getSourceBufferTypes().length;
@@ -335,7 +335,7 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onBufferAppending(
-    event: Events.BUFFER_APPENDING,
+    event: EventsType['BUFFER_APPENDING'],
     eventData: BufferAppendingData
   ) {
     const { hls, operationQueue, tracks } = this;
@@ -454,7 +454,7 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onBufferFlushing(
-    event: Events.BUFFER_FLUSHING,
+    event: EventsType['BUFFER_FLUSHING'],
     data: BufferFlushingData
   ) {
     const { operationQueue } = this;
@@ -486,7 +486,10 @@ export default class BufferController implements ComponentAPI {
     }
   }
 
-  protected onFragParsed(event: Events.FRAG_PARSED, data: FragParsedData) {
+  protected onFragParsed(
+    event: EventsType['FRAG_PARSED'],
+    data: FragParsedData
+  ) {
     const { frag, part } = data;
     const buffersAppendedTo: Array<SourceBufferName> = [];
     const elementaryStreams = part
@@ -527,13 +530,16 @@ export default class BufferController implements ComponentAPI {
     this.blockBuffers(onUnblocked, buffersAppendedTo);
   }
 
-  private onFragChanged(event: Events.FRAG_CHANGED, data: FragChangedData) {
+  private onFragChanged(
+    event: EventsType['FRAG_CHANGED'],
+    data: FragChangedData
+  ) {
     this.flushBackBuffer();
   }
 
   // on BUFFER_EOS mark matching sourcebuffer(s) as ended and trigger checkEos()
   // an undefined data.type will mark all buffers as EOS.
-  protected onBufferEos(event: Events.BUFFER_EOS, data: BufferEOSData) {
+  protected onBufferEos(event: EventsType['BUFFER_EOS'], data: BufferEOSData) {
     const ended = this.getSourceBufferTypes().reduce((acc, type) => {
       const sb = this.sourceBuffer[type];
       if (sb && (!data.type || data.type === type)) {
@@ -572,7 +578,7 @@ export default class BufferController implements ComponentAPI {
   }
 
   protected onLevelUpdated(
-    event: Events.LEVEL_UPDATED,
+    event: EventsType['LEVEL_UPDATED'],
     { details }: LevelUpdatedData
   ) {
     if (!details.fragments.length) {

--- a/src/controller/cap-level-controller.ts
+++ b/src/controller/cap-level-controller.ts
@@ -2,7 +2,7 @@
  * cap stream level to media size dimension controller
  */
 
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import type { Level } from '../types/level';
 import type {
   ManifestParsedData,
@@ -72,7 +72,7 @@ class CapLevelController implements ComponentAPI {
   }
 
   protected onFpsDropLevelCapping(
-    event: Events.FPS_DROP_LEVEL_CAPPING,
+    event: EventsType['FPS_DROP_LEVEL_CAPPING'],
     data: FPSDropLevelCappingData
   ) {
     // Don't add a restricted level more than once
@@ -87,7 +87,7 @@ class CapLevelController implements ComponentAPI {
   }
 
   protected onMediaAttaching(
-    event: Events.MEDIA_ATTACHING,
+    event: EventsType['MEDIA_ATTACHING'],
     data: MediaAttachingData
   ) {
     this.media = data.media instanceof HTMLVideoElement ? data.media : null;
@@ -95,7 +95,7 @@ class CapLevelController implements ComponentAPI {
   }
 
   protected onManifestParsed(
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ) {
     const hls = this.hls;
@@ -110,7 +110,7 @@ class CapLevelController implements ComponentAPI {
   // Only activate capping when playing a video stream; otherwise, multi-bitrate audio-only streams will be restricted
   // to the first level
   protected onBufferCodecs(
-    event: Events.BUFFER_CODECS,
+    event: EventsType['BUFFER_CODECS'],
     data: BufferCodecsData
   ) {
     const hls = this.hls;

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import Hls from '../hls';
 import {
   CMCD,
@@ -82,7 +82,7 @@ export default class CMCDController implements ComponentAPI {
   }
 
   private onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ) {
     this.media = data.media;
@@ -103,7 +103,7 @@ export default class CMCDController implements ComponentAPI {
   }
 
   private onBufferCreated(
-    event: Events.BUFFER_CREATED,
+    event: EventsType['BUFFER_CREATED'],
     data: BufferCreatedData
   ) {
     this.audioBuffer = data.tracks.audio?.buffer;

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { Level, addGroupId } from '../types/level';
 import { AttrList } from '../utils/attr-list';
 import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
@@ -146,7 +146,7 @@ export default class ContentSteeringController implements NetworkComponentAPI {
   }
 
   private onManifestLoaded(
-    event: Events.MANIFEST_LOADED,
+    event: EventsType['MANIFEST_LOADED'],
     data: ManifestLoadedData
   ) {
     const { contentSteering } = data;
@@ -161,14 +161,14 @@ export default class ContentSteeringController implements NetworkComponentAPI {
   }
 
   private onManifestParsed(
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ) {
     this.audioTracks = data.audioTracks;
     this.subtitleTracks = data.subtitleTracks;
   }
 
-  private onError(event: Events.ERROR, data: ErrorData) {
+  private onError(event: EventsType['ERROR'], data: ErrorData) {
     const { errorAction } = data;
     if (
       errorAction?.action === NetworkErrorAction.SendAlternateToPenaltyBox &&

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -3,7 +3,7 @@
  *
  * DRM support for Hls.js
  */
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import {
@@ -1124,7 +1124,7 @@ class EMEController implements ComponentAPI {
   }
 
   private onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ) {
     if (!this.config.emeEnabled) {
@@ -1188,7 +1188,7 @@ class EMEController implements ComponentAPI {
   }
 
   private onManifestLoaded(
-    event: Events.MANIFEST_LOADED,
+    event: EventsType['MANIFEST_LOADED'],
     { sessionKeys }: ManifestLoadedData
   ) {
     if (!sessionKeys || !this.config.emeEnabled) {

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import {
@@ -114,7 +114,7 @@ export default class ErrorController implements NetworkComponentAPI {
     this.playlistError = 0;
   }
 
-  private onError(event: Events.ERROR, data: ErrorData) {
+  private onError(event: EventsType['ERROR'], data: ErrorData) {
     if (data.fatal) {
       return;
     }
@@ -405,7 +405,7 @@ export default class ErrorController implements NetworkComponentAPI {
     };
   }
 
-  public onErrorOut(event: Events.ERROR, data: ErrorData) {
+  public onErrorOut(event: EventsType['ERROR'], data: ErrorData) {
     switch (data.errorAction?.action) {
       case NetworkErrorAction.DoNothing:
         break;

--- a/src/controller/fps-controller.ts
+++ b/src/controller/fps-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { logger } from '../utils/logger';
 import type { ComponentAPI } from '../types/component-api';
 import type Hls from '../hls';
@@ -45,7 +45,7 @@ class FPSController implements ComponentAPI {
   }
 
   protected onMediaAttaching(
-    event: Events.MEDIA_ATTACHING,
+    event: EventsType['MEDIA_ATTACHING'],
     data: MediaAttachingData
   ) {
     const config = this.hls.config;

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { Fragment, Part } from '../loader/fragment';
 import { PlaylistLevelType } from '../types/loader';
 import type { SourceBufferName } from '../types/buffer';
@@ -370,7 +370,7 @@ export class FragmentTracker implements ComponentAPI {
     return false;
   }
 
-  private onFragLoaded(event: Events.FRAG_LOADED, data: FragLoadedData) {
+  private onFragLoaded(event: EventsType['FRAG_LOADED'], data: FragLoadedData) {
     const { frag, part } = data;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
@@ -392,7 +392,7 @@ export class FragmentTracker implements ComponentAPI {
   }
 
   private onBufferAppended(
-    event: Events.BUFFER_APPENDED,
+    event: EventsType['BUFFER_APPENDED'],
     data: BufferAppendedData
   ) {
     const { frag, part, timeRanges } = data;
@@ -420,7 +420,10 @@ export class FragmentTracker implements ComponentAPI {
     });
   }
 
-  private onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
+  private onFragBuffered(
+    event: EventsType['FRAG_BUFFERED'],
+    data: FragBufferedData
+  ) {
     this.detectPartialFragments(data);
   }
 

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import {
   sendAddTrackEvent,
   clearCurrentCues,
@@ -109,7 +109,7 @@ class ID3TrackController implements ComponentAPI {
 
   // Add ID3 metatadata text track.
   protected onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ): void {
     this.media = data.media;
@@ -153,7 +153,7 @@ class ID3TrackController implements ComponentAPI {
   }
 
   onFragParsingMetadata(
-    event: Events.FRAG_PARSING_METADATA,
+    event: EventsType['FRAG_PARSING_METADATA'],
     data: FragParsingMetadataData
   ) {
     if (!this.media) {
@@ -237,7 +237,7 @@ class ID3TrackController implements ComponentAPI {
   }
 
   onBufferFlushing(
-    event: Events.BUFFER_FLUSHING,
+    event: EventsType['BUFFER_FLUSHING'],
     { startOffset, endOffset, type }: BufferFlushingData
   ) {
     const { id3Track, hls } = this;
@@ -268,7 +268,10 @@ class ID3TrackController implements ComponentAPI {
     }
   }
 
-  onLevelUpdated(event: Events.LEVEL_UPDATED, { details }: LevelUpdatedData) {
+  onLevelUpdated(
+    event: EventsType['LEVEL_UPDATED'],
+    { details }: LevelUpdatedData
+  ) {
     if (
       !this.media ||
       !details.hasProgramDateTime ||

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -1,6 +1,6 @@
 import { LevelDetails } from '../loader/level-details';
 import { ErrorDetails } from '../errors';
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import type {
   ErrorData,
   LevelUpdatedData,
@@ -146,7 +146,7 @@ export default class LatencyController implements ComponentAPI {
   }
 
   private onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachingData
   ) {
     this.media = data.media;
@@ -167,7 +167,7 @@ export default class LatencyController implements ComponentAPI {
   }
 
   private onLevelUpdated(
-    event: Events.LEVEL_UPDATED,
+    event: EventsType['LEVEL_UPDATED'],
     { details }: LevelUpdatedData
   ) {
     this.levelDetails = details;
@@ -179,7 +179,7 @@ export default class LatencyController implements ComponentAPI {
     }
   }
 
-  private onError(event: Events.ERROR, data: ErrorData) {
+  private onError(event: EventsType['ERROR'], data: ErrorData) {
     if (data.details !== ErrorDetails.BUFFER_STALLED_ERROR) {
       return;
     }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -14,7 +14,7 @@ import {
   ManifestLoadingData,
 } from '../types/events';
 import { Level, addGroupId } from '../types/level';
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import {
   getCodecCompatibleName,
@@ -100,14 +100,14 @@ export default class LevelController extends BasePlaylistController {
   }
 
   private onManifestLoading(
-    event: Events.MANIFEST_LOADING,
+    event: EventsType['MANIFEST_LOADING'],
     data: ManifestLoadingData
   ) {
     this.resetLevels();
   }
 
   protected onManifestLoaded(
-    event: Events.MANIFEST_LOADED,
+    event: EventsType['MANIFEST_LOADED'],
     data: ManifestLoadedData
   ) {
     const levels: Level[] = [];
@@ -450,7 +450,7 @@ export default class LevelController extends BasePlaylistController {
     this._startLevel = newLevel;
   }
 
-  protected onError(event: Events.ERROR, data: ErrorData) {
+  protected onError(event: EventsType['ERROR'], data: ErrorData) {
     if (data.fatal || !data.context) {
       return;
     }
@@ -464,7 +464,10 @@ export default class LevelController extends BasePlaylistController {
   }
 
   // reset errors on the successful load of a fragment
-  protected onFragLoaded(event: Events.FRAG_LOADED, { frag }: FragLoadedData) {
+  protected onFragLoaded(
+    event: EventsType['FRAG_LOADED'],
+    { frag }: FragLoadedData
+  ) {
     if (frag !== undefined && frag.type === PlaylistLevelType.MAIN) {
       const level = this._levels[frag.level];
       if (level !== undefined) {
@@ -473,7 +476,10 @@ export default class LevelController extends BasePlaylistController {
     }
   }
 
-  protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
+  protected onLevelLoaded(
+    event: EventsType['LEVEL_LOADED'],
+    data: LevelLoadedData
+  ) {
     const { level, details } = data;
     const curLevel = this._levels[level];
 
@@ -499,7 +505,7 @@ export default class LevelController extends BasePlaylistController {
   }
 
   protected onAudioTrackSwitched(
-    event: Events.AUDIO_TRACK_SWITCHED,
+    event: EventsType['AUDIO_TRACK_SWITCHED'],
     data: TrackSwitchedData
   ) {
     const currentLevel = this.currentLevel;
@@ -620,7 +626,7 @@ export default class LevelController extends BasePlaylistController {
   }
 
   private onLevelsUpdated(
-    event: Events.LEVELS_UPDATED,
+    event: EventsType['LEVELS_UPDATED'],
     { levels }: LevelsUpdatedData
   ) {
     levels.forEach((level, index) => {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1,6 +1,6 @@
 import BaseStreamController, { State } from './base-stream-controller';
 import { changeTypeSupported } from '../is-supported';
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { BufferHelper, BufferInfo } from '../utils/buffer-helper';
 import { FragmentState } from './fragment-tracker';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
@@ -504,7 +504,7 @@ export default class StreamController
   }
 
   protected onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ) {
     super.onMediaAttached(event, data);
@@ -576,7 +576,7 @@ export default class StreamController
   }
 
   private onManifestParsed(
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ) {
     let aac = false;
@@ -606,7 +606,10 @@ export default class StreamController
     this.startFragRequested = false;
   }
 
-  private onLevelLoading(event: Events.LEVEL_LOADING, data: LevelLoadingData) {
+  private onLevelLoading(
+    event: EventsType['LEVEL_LOADING'],
+    data: LevelLoadingData
+  ) {
     const { levels } = this;
     if (!levels || this.state !== State.IDLE) {
       return;
@@ -621,7 +624,10 @@ export default class StreamController
     }
   }
 
-  private onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
+  private onLevelLoaded(
+    event: EventsType['LEVEL_LOADED'],
+    data: LevelLoadedData
+  ) {
     const { levels } = this;
     const newLevelId = data.level;
     const newDetails = data.details;
@@ -755,7 +761,7 @@ export default class StreamController
   }
 
   private onAudioTrackSwitching(
-    event: Events.AUDIO_TRACK_SWITCHING,
+    event: EventsType['AUDIO_TRACK_SWITCHING'],
     data: AudioTrackSwitchingData
   ) {
     // if any URL found on new audio track, it is an alternate audio track
@@ -800,7 +806,7 @@ export default class StreamController
   }
 
   private onAudioTrackSwitched(
-    event: Events.AUDIO_TRACK_SWITCHED,
+    event: EventsType['AUDIO_TRACK_SWITCHED'],
     data: AudioTrackSwitchedData
   ) {
     const trackId = data.id;
@@ -820,7 +826,7 @@ export default class StreamController
   }
 
   private onBufferCreated(
-    event: Events.BUFFER_CREATED,
+    event: EventsType['BUFFER_CREATED'],
     data: BufferCreatedData
   ) {
     const tracks = data.tracks;
@@ -853,7 +859,10 @@ export default class StreamController
     }
   }
 
-  private onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
+  private onFragBuffered(
+    event: EventsType['FRAG_BUFFERED'],
+    data: FragBufferedData
+  ) {
     const { frag, part } = data;
     if (frag && frag.type !== PlaylistLevelType.MAIN) {
       return;
@@ -881,7 +890,7 @@ export default class StreamController
     this.fragBufferedComplete(frag, part);
   }
 
-  private onError(event: Events.ERROR, data: ErrorData) {
+  private onError(event: EventsType['ERROR'], data: ErrorData) {
     if (data.fatal) {
       this.state = State.ERROR;
       return;
@@ -958,7 +967,7 @@ export default class StreamController
   }
 
   private onBufferFlushed(
-    event: Events.BUFFER_FLUSHED,
+    event: EventsType['BUFFER_FLUSHED'],
     { type }: BufferFlushedData
   ) {
     if (
@@ -975,7 +984,7 @@ export default class StreamController
   }
 
   private onLevelsUpdated(
-    event: Events.LEVELS_UPDATED,
+    event: EventsType['LEVELS_UPDATED'],
     data: LevelsUpdatedData
   ) {
     this.levels = data.levels;

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { Bufferable, BufferHelper } from '../utils/buffer-helper';
 import { findFragmentByPTS } from './fragment-finders';
 import { alignMediaPlaylistByPDT } from '../utils/discontinuities';
@@ -118,12 +118,12 @@ export class SubtitleStreamController
     super.onMediaDetaching();
   }
 
-  onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
+  onLevelLoaded(event: EventsType['LEVEL_LOADED'], data: LevelLoadedData) {
     this.mainDetails = data.details;
   }
 
   onSubtitleFragProcessed(
-    event: Events.SUBTITLE_FRAG_PROCESSED,
+    event: EventsType['SUBTITLE_FRAG_PROCESSED'],
     data: SubtitleFragProcessed
   ) {
     const { frag, success } = data;
@@ -162,7 +162,10 @@ export class SubtitleStreamController
     this.fragmentTracker.fragBuffered(frag);
   }
 
-  onBufferFlushing(event: Events.BUFFER_FLUSHING, data: BufferFlushingData) {
+  onBufferFlushing(
+    event: EventsType['BUFFER_FLUSHING'],
+    data: BufferFlushingData
+  ) {
     const { startOffset, endOffset } = data;
     if (startOffset === 0 && endOffset !== Number.POSITIVE_INFINITY) {
       const endOffsetSubtitles = endOffset - 1;
@@ -191,7 +194,7 @@ export class SubtitleStreamController
     }
   }
 
-  onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData) {
+  onFragBuffered(event: EventsType['FRAG_BUFFERED'], data: FragBufferedData) {
     if (!this.loadedmetadata && data.frag.type === PlaylistLevelType.MAIN) {
       if (this.media?.buffered.length) {
         this.loadedmetadata = true;
@@ -200,7 +203,7 @@ export class SubtitleStreamController
   }
 
   // If something goes wrong, proceed to next frag, if we were processing one.
-  onError(event: Events.ERROR, data: ErrorData) {
+  onError(event: EventsType['ERROR'], data: ErrorData) {
     const frag = data.frag;
 
     if (frag?.type === PlaylistLevelType.SUBTITLE) {
@@ -215,7 +218,7 @@ export class SubtitleStreamController
 
   // Got all new subtitle levels.
   onSubtitleTracksUpdated(
-    event: Events.SUBTITLE_TRACKS_UPDATED,
+    event: EventsType['SUBTITLE_TRACKS_UPDATED'],
     { subtitleTracks }: SubtitleTracksUpdatedData
   ) {
     if (subtitleOptionsIdentical(this.levels, subtitleTracks)) {
@@ -240,7 +243,7 @@ export class SubtitleStreamController
   }
 
   onSubtitleTrackSwitch(
-    event: Events.SUBTITLE_TRACK_SWITCH,
+    event: EventsType['SUBTITLE_TRACK_SWITCH'],
     data: TrackSwitchedData
   ) {
     this.currentTrackId = data.id;
@@ -264,7 +267,7 @@ export class SubtitleStreamController
 
   // Got a new set of subtitle fragments.
   onSubtitleTrackLoaded(
-    event: Events.SUBTITLE_TRACK_LOADED,
+    event: EventsType['SUBTITLE_TRACK_LOADED'],
     data: TrackLoadedData
   ) {
     const { details: newDetails, id: trackId } = data;

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import { clearCurrentCues } from '../utils/texttrack-utils';
 import BasePlaylistController from './base-playlist-controller';
 import type { HlsUrlParameters } from '../types/level';
@@ -78,7 +78,7 @@ class SubtitleTrackController extends BasePlaylistController {
 
   // Listen for subtitle track change, then extract the current track ID.
   protected onMediaAttached(
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ): void {
     this.media = data.media;
@@ -149,14 +149,14 @@ class SubtitleTrackController extends BasePlaylistController {
 
   // Fired whenever a new manifest is loaded.
   protected onManifestParsed(
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ): void {
     this.tracks = data.subtitleTracks;
   }
 
   protected onSubtitleTrackLoaded(
-    event: Events.SUBTITLE_TRACK_LOADED,
+    event: EventsType['SUBTITLE_TRACK_LOADED'],
     data: TrackLoadedData
   ): void {
     const { id, details } = data;
@@ -180,14 +180,14 @@ class SubtitleTrackController extends BasePlaylistController {
   }
 
   protected onLevelLoading(
-    event: Events.LEVEL_LOADING,
+    event: EventsType['LEVEL_LOADING'],
     data: LevelLoadingData
   ): void {
     this.switchLevel(data.level);
   }
 
   protected onLevelSwitching(
-    event: Events.LEVEL_SWITCHING,
+    event: EventsType['LEVEL_SWITCHING'],
     data: LevelSwitchingData
   ): void {
     this.switchLevel(data.level);
@@ -241,7 +241,7 @@ class SubtitleTrackController extends BasePlaylistController {
     return -1;
   }
 
-  protected onError(event: Events.ERROR, data: ErrorData): void {
+  protected onError(event: EventsType['ERROR'], data: ErrorData): void {
     if (data.fatal || !data.context) {
       return;
     }

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -1,4 +1,4 @@
-import { Events } from '../events';
+import { Events, EventsType } from '../events';
 import Cea608Parser, { CaptionScreen } from '../utils/cea-608-parser';
 import OutputFilter from '../utils/output-filter';
 import { parseWebVTT } from '../utils/webvtt-parser';
@@ -189,7 +189,7 @@ export class TimelineController implements ComponentAPI {
 
   // Triggered when an initial PTS is found; used for synchronisation of WebVTT.
   private onInitPtsFound(
-    event: Events.INIT_PTS_FOUND,
+    event: EventsType['INIT_PTS_FOUND'],
     { frag, id, initPTS, timescale }: InitPTSFoundData
   ) {
     const { unparsedVttFrags } = this;
@@ -284,7 +284,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   private onMediaAttaching(
-    event: Events.MEDIA_ATTACHING,
+    event: EventsType['MEDIA_ATTACHING'],
     data: MediaAttachingData
   ) {
     this.media = data.media;
@@ -337,7 +337,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   private onSubtitleTracksUpdated(
-    event: Events.SUBTITLE_TRACKS_UPDATED,
+    event: EventsType['SUBTITLE_TRACKS_UPDATED'],
     data: SubtitleTracksUpdatedData
   ) {
     const tracks: Array<MediaPlaylist> = data.subtitleTracks || [];
@@ -423,7 +423,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   private onManifestLoaded(
-    event: Events.MANIFEST_LOADED,
+    event: EventsType['MANIFEST_LOADED'],
     data: ManifestLoadedData
   ) {
     if (this.config.enableCEA708Captions && data.captions) {
@@ -455,7 +455,10 @@ export class TimelineController implements ComponentAPI {
     return level?.attrs['CLOSED-CAPTIONS'];
   }
 
-  private onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {
+  private onFragLoading(
+    event: EventsType['FRAG_LOADING'],
+    data: FragLoadingData
+  ) {
     const { cea608Parser1, cea608Parser2, lastCc, lastSn, lastPartIndex } =
       this;
     if (!this.enabled || !(cea608Parser1 && cea608Parser2)) {
@@ -482,7 +485,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   private onFragLoaded(
-    event: Events.FRAG_LOADED,
+    event: EventsType['FRAG_LOADED'],
     data: FragDecryptedData | FragLoadedData
   ) {
     const { frag, payload } = data;
@@ -638,7 +641,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   private onFragDecrypted(
-    event: Events.FRAG_DECRYPTED,
+    event: EventsType['FRAG_DECRYPTED'],
     data: FragDecryptedData
   ) {
     const { frag } = data;
@@ -653,7 +656,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   private onFragParsingUserdata(
-    event: Events.FRAG_PARSING_USERDATA,
+    event: EventsType['FRAG_PARSING_USERDATA'],
     data: FragParsingUserdataData
   ) {
     if (!this.enabled) {
@@ -684,7 +687,7 @@ export class TimelineController implements ComponentAPI {
   }
 
   onBufferFlushing(
-    event: Events.BUFFER_FLUSHING,
+    event: EventsType['BUFFER_FLUSHING'],
     { startOffset, endOffset, endOffsetSubtitles, type }: BufferFlushingData
   ) {
     const { media } = this;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,90 +1,98 @@
-export enum ErrorTypes {
+export const ErrorTypes = {
   // Identifier for a network error (loading error / timeout ...)
-  NETWORK_ERROR = 'networkError',
+  NETWORK_ERROR: 'networkError',
   // Identifier for a media Error (video/parsing/mediasource error)
-  MEDIA_ERROR = 'mediaError',
+  MEDIA_ERROR: 'mediaError',
   // EME (encrypted media extensions) errors
-  KEY_SYSTEM_ERROR = 'keySystemError',
+  KEY_SYSTEM_ERROR: 'keySystemError',
   // Identifier for a mux Error (demuxing/remuxing)
-  MUX_ERROR = 'muxError',
+  MUX_ERROR: 'muxError',
   // Identifier for all other errors
-  OTHER_ERROR = 'otherError',
-}
+  OTHER_ERROR: 'otherError',
+} as const;
 
-export enum ErrorDetails {
-  KEY_SYSTEM_NO_KEYS = 'keySystemNoKeys',
-  KEY_SYSTEM_NO_ACCESS = 'keySystemNoAccess',
-  KEY_SYSTEM_NO_SESSION = 'keySystemNoSession',
-  KEY_SYSTEM_NO_CONFIGURED_LICENSE = 'keySystemNoConfiguredLicense',
-  KEY_SYSTEM_LICENSE_REQUEST_FAILED = 'keySystemLicenseRequestFailed',
-  KEY_SYSTEM_SERVER_CERTIFICATE_REQUEST_FAILED = 'keySystemServerCertificateRequestFailed',
-  KEY_SYSTEM_SERVER_CERTIFICATE_UPDATE_FAILED = 'keySystemServerCertificateUpdateFailed',
-  KEY_SYSTEM_SESSION_UPDATE_FAILED = 'keySystemSessionUpdateFailed',
-  KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED = 'keySystemStatusOutputRestricted',
-  KEY_SYSTEM_STATUS_INTERNAL_ERROR = 'keySystemStatusInternalError',
+export type ErrorTypesType = typeof ErrorTypes;
+export type ErrorTypesValue = ErrorTypesType[keyof ErrorTypesType];
+
+export const ErrorDetails = {
+  KEY_SYSTEM_NO_KEYS: 'keySystemNoKeys',
+  KEY_SYSTEM_NO_ACCESS: 'keySystemNoAccess',
+  KEY_SYSTEM_NO_SESSION: 'keySystemNoSession',
+  KEY_SYSTEM_NO_CONFIGURED_LICENSE: 'keySystemNoConfiguredLicense',
+  KEY_SYSTEM_LICENSE_REQUEST_FAILED: 'keySystemLicenseRequestFailed',
+  KEY_SYSTEM_SERVER_CERTIFICATE_REQUEST_FAILED:
+    'keySystemServerCertificateRequestFailed',
+  KEY_SYSTEM_SERVER_CERTIFICATE_UPDATE_FAILED:
+    'keySystemServerCertificateUpdateFailed',
+  KEY_SYSTEM_SESSION_UPDATE_FAILED: 'keySystemSessionUpdateFailed',
+  KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED: 'keySystemStatusOutputRestricted',
+  KEY_SYSTEM_STATUS_INTERNAL_ERROR: 'keySystemStatusInternalError',
   // Identifier for a manifest load error - data: { url : faulty URL, response : { code: error code, text: error text }}
-  MANIFEST_LOAD_ERROR = 'manifestLoadError',
+  MANIFEST_LOAD_ERROR: 'manifestLoadError',
   // Identifier for a manifest load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}
-  MANIFEST_LOAD_TIMEOUT = 'manifestLoadTimeOut',
+  MANIFEST_LOAD_TIMEOUT: 'manifestLoadTimeOut',
   // Identifier for a manifest parsing error - data: { url : faulty URL, reason : error reason}
-  MANIFEST_PARSING_ERROR = 'manifestParsingError',
+  MANIFEST_PARSING_ERROR: 'manifestParsingError',
   // Identifier for a manifest with only incompatible codecs error - data: { url : faulty URL, reason : error reason}
-  MANIFEST_INCOMPATIBLE_CODECS_ERROR = 'manifestIncompatibleCodecsError',
+  MANIFEST_INCOMPATIBLE_CODECS_ERROR: 'manifestIncompatibleCodecsError',
   // Identifier for a level which contains no fragments - data: { url: faulty URL, reason: "no fragments found in level", level: index of the bad level }
-  LEVEL_EMPTY_ERROR = 'levelEmptyError',
+  LEVEL_EMPTY_ERROR: 'levelEmptyError',
   // Identifier for a level load error - data: { url : faulty URL, response : { code: error code, text: error text }}
-  LEVEL_LOAD_ERROR = 'levelLoadError',
+  LEVEL_LOAD_ERROR: 'levelLoadError',
   // Identifier for a level load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}
-  LEVEL_LOAD_TIMEOUT = 'levelLoadTimeOut',
+  LEVEL_LOAD_TIMEOUT: 'levelLoadTimeOut',
   // Identifier for a level parse error - data: { url : faulty URL, error: Error, reason: error message }
-  LEVEL_PARSING_ERROR = 'levelParsingError',
+  LEVEL_PARSING_ERROR: 'levelParsingError',
   // Identifier for a level switch error - data: { level : faulty level Id, event : error description}
-  LEVEL_SWITCH_ERROR = 'levelSwitchError',
+  LEVEL_SWITCH_ERROR: 'levelSwitchError',
   // Identifier for an audio track load error - data: { url : faulty URL, response : { code: error code, text: error text }}
-  AUDIO_TRACK_LOAD_ERROR = 'audioTrackLoadError',
+  AUDIO_TRACK_LOAD_ERROR: 'audioTrackLoadError',
   // Identifier for an audio track load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}
-  AUDIO_TRACK_LOAD_TIMEOUT = 'audioTrackLoadTimeOut',
+  AUDIO_TRACK_LOAD_TIMEOUT: 'audioTrackLoadTimeOut',
   // Identifier for a subtitle track load error - data: { url : faulty URL, response : { code: error code, text: error text }}
-  SUBTITLE_LOAD_ERROR = 'subtitleTrackLoadError',
+  SUBTITLE_LOAD_ERROR: 'subtitleTrackLoadError',
   // Identifier for a subtitle track load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}
-  SUBTITLE_TRACK_LOAD_TIMEOUT = 'subtitleTrackLoadTimeOut',
+  SUBTITLE_TRACK_LOAD_TIMEOUT: 'subtitleTrackLoadTimeOut',
   // Identifier for fragment load error - data: { frag : fragment object, response : { code: error code, text: error text }}
-  FRAG_LOAD_ERROR = 'fragLoadError',
+  FRAG_LOAD_ERROR: 'fragLoadError',
   // Identifier for fragment load timeout error - data: { frag : fragment object}
-  FRAG_LOAD_TIMEOUT = 'fragLoadTimeOut',
+  FRAG_LOAD_TIMEOUT: 'fragLoadTimeOut',
   // Identifier for a fragment decryption error event - data: {id : demuxer Id,frag: fragment object, reason : parsing error description }
-  FRAG_DECRYPT_ERROR = 'fragDecryptError',
+  FRAG_DECRYPT_ERROR: 'fragDecryptError',
   // Identifier for a fragment parsing error event - data: { id : demuxer Id, reason : parsing error description }
   // will be renamed DEMUX_PARSING_ERROR and switched to MUX_ERROR in the next major release
-  FRAG_PARSING_ERROR = 'fragParsingError',
+  FRAG_PARSING_ERROR: 'fragParsingError',
   // Identifier for a fragment or part load skipped because of a GAP tag or attribute
-  FRAG_GAP = 'fragGap',
+  FRAG_GAP: 'fragGap',
   // Identifier for a remux alloc error event - data: { id : demuxer Id, frag : fragment object, bytes : nb of bytes on which allocation failed , reason : error text }
-  REMUX_ALLOC_ERROR = 'remuxAllocError',
+  REMUX_ALLOC_ERROR: 'remuxAllocError',
   // Identifier for decrypt key load error - data: { frag : fragment object, response : { code: error code, text: error text }}
-  KEY_LOAD_ERROR = 'keyLoadError',
+  KEY_LOAD_ERROR: 'keyLoadError',
   // Identifier for decrypt key load timeout error - data: { frag : fragment object}
-  KEY_LOAD_TIMEOUT = 'keyLoadTimeOut',
+  KEY_LOAD_TIMEOUT: 'keyLoadTimeOut',
   // Triggered when an exception occurs while adding a sourceBuffer to MediaSource - data : { error : exception , mimeType : mimeType }
-  BUFFER_ADD_CODEC_ERROR = 'bufferAddCodecError',
+  BUFFER_ADD_CODEC_ERROR: 'bufferAddCodecError',
   // Triggered when source buffer(s) could not be created using level (manifest CODECS attribute), parsed media, or best guess codec(s) - data: { reason : error reason }
-  BUFFER_INCOMPATIBLE_CODECS_ERROR = 'bufferIncompatibleCodecsError',
+  BUFFER_INCOMPATIBLE_CODECS_ERROR: 'bufferIncompatibleCodecsError',
   // Identifier for a buffer append error - data: append error description
-  BUFFER_APPEND_ERROR = 'bufferAppendError',
+  BUFFER_APPEND_ERROR: 'bufferAppendError',
   // Identifier for a buffer appending error event - data: appending error description
-  BUFFER_APPENDING_ERROR = 'bufferAppendingError',
+  BUFFER_APPENDING_ERROR: 'bufferAppendingError',
   // Identifier for a buffer stalled error event
-  BUFFER_STALLED_ERROR = 'bufferStalledError',
+  BUFFER_STALLED_ERROR: 'bufferStalledError',
   // Identifier for a buffer full event
-  BUFFER_FULL_ERROR = 'bufferFullError',
+  BUFFER_FULL_ERROR: 'bufferFullError',
   // Identifier for a buffer seek over hole event
-  BUFFER_SEEK_OVER_HOLE = 'bufferSeekOverHole',
+  BUFFER_SEEK_OVER_HOLE: 'bufferSeekOverHole',
   // Identifier for a buffer nudge on stall (playback is stuck although currentTime is in a buffered area)
-  BUFFER_NUDGE_ON_STALL = 'bufferNudgeOnStall',
+  BUFFER_NUDGE_ON_STALL: 'bufferNudgeOnStall',
   // Identifier for an internal exception happening inside hls.js while handling an event
-  INTERNAL_EXCEPTION = 'internalException',
+  INTERNAL_EXCEPTION: 'internalException',
   // Identifier for an internal call to abort a loader
-  INTERNAL_ABORTED = 'aborted',
+  INTERNAL_ABORTED: 'aborted',
   // Uncategorized error
-  UNKNOWN = 'unknown',
-}
+  UNKNOWN: 'unknown',
+} as const;
+
+export type ErrorDetailsType = typeof ErrorDetails;
+export type ErrorDetailsValue = ErrorDetailsType[keyof ErrorDetailsType];

--- a/src/events.ts
+++ b/src/events.ts
@@ -50,322 +50,331 @@ import {
   SteeringManifestLoadedData,
 } from './types/events';
 
-export enum Events {
+export const Events = {
   // Fired before MediaSource is attaching to media element
-  MEDIA_ATTACHING = 'hlsMediaAttaching',
+  MEDIA_ATTACHING: 'hlsMediaAttaching',
   // Fired when MediaSource has been successfully attached to media element
-  MEDIA_ATTACHED = 'hlsMediaAttached',
+  MEDIA_ATTACHED: 'hlsMediaAttached',
   // Fired before detaching MediaSource from media element
-  MEDIA_DETACHING = 'hlsMediaDetaching',
+  MEDIA_DETACHING: 'hlsMediaDetaching',
   // Fired when MediaSource has been detached from media element
-  MEDIA_DETACHED = 'hlsMediaDetached',
+  MEDIA_DETACHED: 'hlsMediaDetached',
   // Fired when the buffer is going to be reset
-  BUFFER_RESET = 'hlsBufferReset',
+  BUFFER_RESET: 'hlsBufferReset',
   // Fired when we know about the codecs that we need buffers for to push into - data: {tracks : { container, codec, levelCodec, initSegment, metadata }}
-  BUFFER_CODECS = 'hlsBufferCodecs',
+  BUFFER_CODECS: 'hlsBufferCodecs',
   // fired when sourcebuffers have been created - data: { tracks : tracks }
-  BUFFER_CREATED = 'hlsBufferCreated',
+  BUFFER_CREATED: 'hlsBufferCreated',
   // fired when we append a segment to the buffer - data: { segment: segment object }
-  BUFFER_APPENDING = 'hlsBufferAppending',
+  BUFFER_APPENDING: 'hlsBufferAppending',
   // fired when we are done with appending a media segment to the buffer - data : { parent : segment parent that triggered BUFFER_APPENDING, pending : nb of segments waiting for appending for this segment parent}
-  BUFFER_APPENDED = 'hlsBufferAppended',
+  BUFFER_APPENDED: 'hlsBufferAppended',
   // fired when the stream is finished and we want to notify the media buffer that there will be no more data - data: { }
-  BUFFER_EOS = 'hlsBufferEos',
+  BUFFER_EOS: 'hlsBufferEos',
   // fired when the media buffer should be flushed - data { startOffset, endOffset }
-  BUFFER_FLUSHING = 'hlsBufferFlushing',
+  BUFFER_FLUSHING: 'hlsBufferFlushing',
   // fired when the media buffer has been flushed - data: { }
-  BUFFER_FLUSHED = 'hlsBufferFlushed',
+  BUFFER_FLUSHED: 'hlsBufferFlushed',
   // fired to signal that a manifest loading starts - data: { url : manifestURL}
-  MANIFEST_LOADING = 'hlsManifestLoading',
+  MANIFEST_LOADING: 'hlsManifestLoading',
   // fired after manifest has been loaded - data: { levels : [available quality levels], audioTracks : [ available audio tracks ], url : manifestURL, stats : LoaderStats }
-  MANIFEST_LOADED = 'hlsManifestLoaded',
+  MANIFEST_LOADED: 'hlsManifestLoaded',
   // fired after manifest has been parsed - data: { levels : [available quality levels], firstLevel : index of first quality level appearing in Manifest}
-  MANIFEST_PARSED = 'hlsManifestParsed',
+  MANIFEST_PARSED: 'hlsManifestParsed',
   // fired when a level switch is requested - data: { level : id of new level }
-  LEVEL_SWITCHING = 'hlsLevelSwitching',
+  LEVEL_SWITCHING: 'hlsLevelSwitching',
   // fired when a level switch is effective - data: { level : id of new level }
-  LEVEL_SWITCHED = 'hlsLevelSwitched',
+  LEVEL_SWITCHED: 'hlsLevelSwitched',
   // fired when a level playlist loading starts - data: { url : level URL, level : id of level being loaded}
-  LEVEL_LOADING = 'hlsLevelLoading',
+  LEVEL_LOADING: 'hlsLevelLoading',
   // fired when a level playlist loading finishes - data: { details : levelDetails object, level : id of loaded level, stats : LoaderStats }
-  LEVEL_LOADED = 'hlsLevelLoaded',
+  LEVEL_LOADED: 'hlsLevelLoaded',
   // fired when a level's details have been updated based on previous details, after it has been loaded - data: { details : levelDetails object, level : id of updated level }
-  LEVEL_UPDATED = 'hlsLevelUpdated',
+  LEVEL_UPDATED: 'hlsLevelUpdated',
   // fired when a level's PTS information has been updated after parsing a fragment - data: { details : levelDetails object, level : id of updated level, drift: PTS drift observed when parsing last fragment }
-  LEVEL_PTS_UPDATED = 'hlsLevelPtsUpdated',
+  LEVEL_PTS_UPDATED: 'hlsLevelPtsUpdated',
   // fired to notify that levels have changed after removing a level - data: { levels : [available quality levels] }
-  LEVELS_UPDATED = 'hlsLevelsUpdated',
+  LEVELS_UPDATED: 'hlsLevelsUpdated',
   // fired to notify that audio track lists has been updated - data: { audioTracks : audioTracks }
-  AUDIO_TRACKS_UPDATED = 'hlsAudioTracksUpdated',
+  AUDIO_TRACKS_UPDATED: 'hlsAudioTracksUpdated',
   // fired when an audio track switching is requested - data: { id : audio track id }
-  AUDIO_TRACK_SWITCHING = 'hlsAudioTrackSwitching',
+  AUDIO_TRACK_SWITCHING: 'hlsAudioTrackSwitching',
   // fired when an audio track switch actually occurs - data: { id : audio track id }
-  AUDIO_TRACK_SWITCHED = 'hlsAudioTrackSwitched',
+  AUDIO_TRACK_SWITCHED: 'hlsAudioTrackSwitched',
   // fired when an audio track loading starts - data: { url : audio track URL, id : audio track id }
-  AUDIO_TRACK_LOADING = 'hlsAudioTrackLoading',
+  AUDIO_TRACK_LOADING: 'hlsAudioTrackLoading',
   // fired when an audio track loading finishes - data: { details : levelDetails object, id : audio track id, stats : LoaderStats }
-  AUDIO_TRACK_LOADED = 'hlsAudioTrackLoaded',
+  AUDIO_TRACK_LOADED: 'hlsAudioTrackLoaded',
   // fired to notify that subtitle track lists has been updated - data: { subtitleTracks : subtitleTracks }
-  SUBTITLE_TRACKS_UPDATED = 'hlsSubtitleTracksUpdated',
+  SUBTITLE_TRACKS_UPDATED: 'hlsSubtitleTracksUpdated',
   // fired to notify that subtitle tracks were cleared as a result of stopping the media
-  SUBTITLE_TRACKS_CLEARED = 'hlsSubtitleTracksCleared',
+  SUBTITLE_TRACKS_CLEARED: 'hlsSubtitleTracksCleared',
   // fired when an subtitle track switch occurs - data: { id : subtitle track id }
-  SUBTITLE_TRACK_SWITCH = 'hlsSubtitleTrackSwitch',
+  SUBTITLE_TRACK_SWITCH: 'hlsSubtitleTrackSwitch',
   // fired when a subtitle track loading starts - data: { url : subtitle track URL, id : subtitle track id }
-  SUBTITLE_TRACK_LOADING = 'hlsSubtitleTrackLoading',
+  SUBTITLE_TRACK_LOADING: 'hlsSubtitleTrackLoading',
   // fired when a subtitle track loading finishes - data: { details : levelDetails object, id : subtitle track id, stats : LoaderStats }
-  SUBTITLE_TRACK_LOADED = 'hlsSubtitleTrackLoaded',
+  SUBTITLE_TRACK_LOADED: 'hlsSubtitleTrackLoaded',
   // fired when a subtitle fragment has been processed - data: { success : boolean, frag : the processed frag }
-  SUBTITLE_FRAG_PROCESSED = 'hlsSubtitleFragProcessed',
+  SUBTITLE_FRAG_PROCESSED: 'hlsSubtitleFragProcessed',
   // fired when a set of VTTCues to be managed externally has been parsed - data: { type: string, track: string, cues: [ VTTCue ] }
-  CUES_PARSED = 'hlsCuesParsed',
+  CUES_PARSED: 'hlsCuesParsed',
   // fired when a text track to be managed externally is found - data: { tracks: [ { label: string, kind: string, default: boolean } ] }
-  NON_NATIVE_TEXT_TRACKS_FOUND = 'hlsNonNativeTextTracksFound',
+  NON_NATIVE_TEXT_TRACKS_FOUND: 'hlsNonNativeTextTracksFound',
   // fired when the first timestamp is found - data: { id : demuxer id, initPTS: initPTS, timescale: timescale, frag : fragment object }
-  INIT_PTS_FOUND = 'hlsInitPtsFound',
+  INIT_PTS_FOUND: 'hlsInitPtsFound',
   // fired when a fragment loading starts - data: { frag : fragment object }
-  FRAG_LOADING = 'hlsFragLoading',
+  FRAG_LOADING: 'hlsFragLoading',
   // fired when a fragment loading is progressing - data: { frag : fragment object, { trequest, tfirst, loaded } }
-  // FRAG_LOAD_PROGRESS = 'hlsFragLoadProgress',
+  // FRAG_LOAD_PROGRESS: 'hlsFragLoadProgress',
   // Identifier for fragment load aborting for emergency switch down - data: { frag : fragment object }
-  FRAG_LOAD_EMERGENCY_ABORTED = 'hlsFragLoadEmergencyAborted',
+  FRAG_LOAD_EMERGENCY_ABORTED: 'hlsFragLoadEmergencyAborted',
   // fired when a fragment loading is completed - data: { frag : fragment object, payload : fragment payload, stats : LoaderStats }
-  FRAG_LOADED = 'hlsFragLoaded',
+  FRAG_LOADED: 'hlsFragLoaded',
   // fired when a fragment has finished decrypting - data: { id : demuxer id, frag: fragment object, payload : fragment payload, stats : { tstart, tdecrypt } }
-  FRAG_DECRYPTED = 'hlsFragDecrypted',
+  FRAG_DECRYPTED: 'hlsFragDecrypted',
   // fired when Init Segment has been extracted from fragment - data: { id : demuxer id, frag: fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment }
-  FRAG_PARSING_INIT_SEGMENT = 'hlsFragParsingInitSegment',
+  FRAG_PARSING_INIT_SEGMENT: 'hlsFragParsingInitSegment',
   // fired when parsing sei text is completed - data: { id : demuxer id, frag: fragment object, samples : [ sei samples pes ] }
-  FRAG_PARSING_USERDATA = 'hlsFragParsingUserdata',
+  FRAG_PARSING_USERDATA: 'hlsFragParsingUserdata',
   // fired when parsing id3 is completed - data: { id : demuxer id, frag: fragment object, samples : [ id3 samples pes ] }
-  FRAG_PARSING_METADATA = 'hlsFragParsingMetadata',
+  FRAG_PARSING_METADATA: 'hlsFragParsingMetadata',
   // fired when data have been extracted from fragment - data: { id : demuxer id, frag: fragment object, data1 : moof MP4 box or TS fragments, data2 : mdat MP4 box or null}
-  // FRAG_PARSING_DATA = 'hlsFragParsingData',
+  // FRAG_PARSING_DATA: 'hlsFragParsingData',
   // fired when fragment parsing is completed - data: { id : demuxer id, frag: fragment object }
-  FRAG_PARSED = 'hlsFragParsed',
+  FRAG_PARSED: 'hlsFragParsed',
   // fired when fragment remuxed MP4 boxes have all been appended into SourceBuffer - data: { id : demuxer id, frag : fragment object, stats : LoaderStats }
-  FRAG_BUFFERED = 'hlsFragBuffered',
+  FRAG_BUFFERED: 'hlsFragBuffered',
   // fired when fragment matching with current media position is changing - data : { id : demuxer id, frag : fragment object }
-  FRAG_CHANGED = 'hlsFragChanged',
+  FRAG_CHANGED: 'hlsFragChanged',
   // Identifier for a FPS drop event - data: { currentDropped, currentDecoded, totalDroppedFrames }
-  FPS_DROP = 'hlsFpsDrop',
+  FPS_DROP: 'hlsFpsDrop',
   // triggered when FPS drop triggers auto level capping - data: { level, droppedLevel }
-  FPS_DROP_LEVEL_CAPPING = 'hlsFpsDropLevelCapping',
+  FPS_DROP_LEVEL_CAPPING: 'hlsFpsDropLevelCapping',
   // Identifier for an error event - data: { type : error type, details : error details, fatal : if true, hls.js cannot/will not try to recover, if false, hls.js will try to recover,other error specific data }
-  ERROR = 'hlsError',
+  ERROR: 'hlsError',
   // fired when hls.js instance starts destroying. Different from MEDIA_DETACHED as one could want to detach and reattach a media to the instance of hls.js to handle mid-rolls for example - data: { }
-  DESTROYING = 'hlsDestroying',
+  DESTROYING: 'hlsDestroying',
   // fired when a decrypt key loading starts - data: { frag : fragment object }
-  KEY_LOADING = 'hlsKeyLoading',
+  KEY_LOADING: 'hlsKeyLoading',
   // fired when a decrypt key loading is completed - data: { frag : fragment object, keyInfo : KeyLoaderInfo }
-  KEY_LOADED = 'hlsKeyLoaded',
+  KEY_LOADED: 'hlsKeyLoaded',
   // deprecated; please use BACK_BUFFER_REACHED - data : { bufferEnd: number }
-  LIVE_BACK_BUFFER_REACHED = 'hlsLiveBackBufferReached',
+  LIVE_BACK_BUFFER_REACHED: 'hlsLiveBackBufferReached',
   // fired when the back buffer is reached as defined by the backBufferLength config option - data : { bufferEnd: number }
-  BACK_BUFFER_REACHED = 'hlsBackBufferReached',
+  BACK_BUFFER_REACHED: 'hlsBackBufferReached',
   // fired after steering manifest has been loaded - data: { steeringManifest: SteeringManifest object, url: steering manifest URL }
-  STEERING_MANIFEST_LOADED = 'hlsSteeringManifestLoaded',
-}
+  STEERING_MANIFEST_LOADED: 'hlsSteeringManifestLoaded',
+} as const;
+
+export type EventsType = typeof Events;
+export type EventsValue = EventsType[keyof EventsType];
 
 /**
  * Defines each Event type and payload by Event name. Used in {@link hls.js#HlsEventEmitter} to strongly type the event listener API.
  */
 export interface HlsListeners {
   [Events.MEDIA_ATTACHING]: (
-    event: Events.MEDIA_ATTACHING,
+    event: EventsType['MEDIA_ATTACHING'],
     data: MediaAttachingData
   ) => void;
   [Events.MEDIA_ATTACHED]: (
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ) => void;
-  [Events.MEDIA_DETACHING]: (event: Events.MEDIA_DETACHING) => void;
-  [Events.MEDIA_DETACHED]: (event: Events.MEDIA_DETACHED) => void;
-  [Events.BUFFER_RESET]: (event: Events.BUFFER_RESET) => void;
+  [Events.MEDIA_DETACHING]: (event: EventsType['MEDIA_DETACHING']) => void;
+  [Events.MEDIA_DETACHED]: (event: EventsType['MEDIA_DETACHED']) => void;
+  [Events.BUFFER_RESET]: (event: EventsType['BUFFER_RESET']) => void;
   [Events.BUFFER_CODECS]: (
-    event: Events.BUFFER_CODECS,
+    event: EventsType['BUFFER_CODECS'],
     data: BufferCodecsData
   ) => void;
   [Events.BUFFER_CREATED]: (
-    event: Events.BUFFER_CREATED,
+    event: EventsType['BUFFER_CREATED'],
     data: BufferCreatedData
   ) => void;
   [Events.BUFFER_APPENDING]: (
-    event: Events.BUFFER_APPENDING,
+    event: EventsType['BUFFER_APPENDING'],
     data: BufferAppendingData
   ) => void;
   [Events.BUFFER_APPENDED]: (
-    event: Events.BUFFER_APPENDED,
+    event: EventsType['BUFFER_APPENDED'],
     data: BufferAppendedData
   ) => void;
-  [Events.BUFFER_EOS]: (event: Events.BUFFER_EOS, data: BufferEOSData) => void;
+  [Events.BUFFER_EOS]: (
+    event: EventsType['BUFFER_EOS'],
+    data: BufferEOSData
+  ) => void;
   [Events.BUFFER_FLUSHING]: (
-    event: Events.BUFFER_FLUSHING,
+    event: EventsType['BUFFER_FLUSHING'],
     data: BufferFlushingData
   ) => void;
   [Events.BUFFER_FLUSHED]: (
-    event: Events.BUFFER_FLUSHED,
+    event: EventsType['BUFFER_FLUSHED'],
     data: BufferFlushedData
   ) => void;
   [Events.MANIFEST_LOADING]: (
-    event: Events.MANIFEST_LOADING,
+    event: EventsType['MANIFEST_LOADING'],
     data: ManifestLoadingData
   ) => void;
   [Events.MANIFEST_LOADED]: (
-    event: Events.MANIFEST_LOADED,
+    event: EventsType['MANIFEST_LOADED'],
     data: ManifestLoadedData
   ) => void;
   [Events.MANIFEST_PARSED]: (
-    event: Events.MANIFEST_PARSED,
+    event: EventsType['MANIFEST_PARSED'],
     data: ManifestParsedData
   ) => void;
   [Events.LEVEL_SWITCHING]: (
-    event: Events.LEVEL_SWITCHING,
+    event: EventsType['LEVEL_SWITCHING'],
     data: LevelSwitchingData
   ) => void;
   [Events.LEVEL_SWITCHED]: (
-    event: Events.LEVEL_SWITCHED,
+    event: EventsType['LEVEL_SWITCHED'],
     data: LevelSwitchedData
   ) => void;
   [Events.LEVEL_LOADING]: (
-    event: Events.LEVEL_LOADING,
+    event: EventsType['LEVEL_LOADING'],
     data: LevelLoadingData
   ) => void;
   [Events.LEVEL_LOADED]: (
-    event: Events.LEVEL_LOADED,
+    event: EventsType['LEVEL_LOADED'],
     data: LevelLoadedData
   ) => void;
   [Events.LEVEL_UPDATED]: (
-    event: Events.LEVEL_UPDATED,
+    event: EventsType['LEVEL_UPDATED'],
     data: LevelUpdatedData
   ) => void;
   [Events.LEVEL_PTS_UPDATED]: (
-    event: Events.LEVEL_PTS_UPDATED,
+    event: EventsType['LEVEL_PTS_UPDATED'],
     data: LevelPTSUpdatedData
   ) => void;
   [Events.LEVELS_UPDATED]: (
-    event: Events.LEVELS_UPDATED,
+    event: EventsType['LEVELS_UPDATED'],
     data: LevelsUpdatedData
   ) => void;
   [Events.AUDIO_TRACKS_UPDATED]: (
-    event: Events.AUDIO_TRACKS_UPDATED,
+    event: EventsType['AUDIO_TRACKS_UPDATED'],
     data: AudioTracksUpdatedData
   ) => void;
   [Events.AUDIO_TRACK_SWITCHING]: (
-    event: Events.AUDIO_TRACK_SWITCHING,
+    event: EventsType['AUDIO_TRACK_SWITCHING'],
     data: AudioTrackSwitchingData
   ) => void;
   [Events.AUDIO_TRACK_SWITCHED]: (
-    event: Events.AUDIO_TRACK_SWITCHED,
+    event: EventsType['AUDIO_TRACK_SWITCHED'],
     data: AudioTrackSwitchedData
   ) => void;
   [Events.AUDIO_TRACK_LOADING]: (
-    event: Events.AUDIO_TRACK_LOADING,
+    event: EventsType['AUDIO_TRACK_LOADING'],
     data: TrackLoadingData
   ) => void;
   [Events.AUDIO_TRACK_LOADED]: (
-    event: Events.AUDIO_TRACK_LOADED,
+    event: EventsType['AUDIO_TRACK_LOADED'],
     data: AudioTrackLoadedData
   ) => void;
   [Events.SUBTITLE_TRACKS_UPDATED]: (
-    event: Events.SUBTITLE_TRACKS_UPDATED,
+    event: EventsType['SUBTITLE_TRACKS_UPDATED'],
     data: SubtitleTracksUpdatedData
   ) => void;
   [Events.SUBTITLE_TRACKS_CLEARED]: (
-    event: Events.SUBTITLE_TRACKS_CLEARED
+    event: EventsType['SUBTITLE_TRACKS_CLEARED']
   ) => void;
   [Events.SUBTITLE_TRACK_SWITCH]: (
-    event: Events.SUBTITLE_TRACK_SWITCH,
+    event: EventsType['SUBTITLE_TRACK_SWITCH'],
     data: SubtitleTrackSwitchData
   ) => void;
   [Events.SUBTITLE_TRACK_LOADING]: (
-    event: Events.SUBTITLE_TRACK_LOADING,
+    event: EventsType['SUBTITLE_TRACK_LOADING'],
     data: TrackLoadingData
   ) => void;
   [Events.SUBTITLE_TRACK_LOADED]: (
-    event: Events.SUBTITLE_TRACK_LOADED,
+    event: EventsType['SUBTITLE_TRACK_LOADED'],
     data: SubtitleTrackLoadedData
   ) => void;
   [Events.SUBTITLE_FRAG_PROCESSED]: (
-    event: Events.SUBTITLE_FRAG_PROCESSED,
+    event: EventsType['SUBTITLE_FRAG_PROCESSED'],
     data: SubtitleFragProcessedData
   ) => void;
   [Events.CUES_PARSED]: (
-    event: Events.CUES_PARSED,
+    event: EventsType['CUES_PARSED'],
     data: CuesParsedData
   ) => void;
   [Events.NON_NATIVE_TEXT_TRACKS_FOUND]: (
-    event: Events.NON_NATIVE_TEXT_TRACKS_FOUND,
+    event: EventsType['NON_NATIVE_TEXT_TRACKS_FOUND'],
     data: NonNativeTextTracksData
   ) => void;
   [Events.INIT_PTS_FOUND]: (
-    event: Events.INIT_PTS_FOUND,
+    event: EventsType['INIT_PTS_FOUND'],
     data: InitPTSFoundData
   ) => void;
   [Events.FRAG_LOADING]: (
-    event: Events.FRAG_LOADING,
+    event: EventsType['FRAG_LOADING'],
     data: FragLoadingData
   ) => void;
   // [Events.FRAG_LOAD_PROGRESS]: TodoEventType
   [Events.FRAG_LOAD_EMERGENCY_ABORTED]: (
-    event: Events.FRAG_LOAD_EMERGENCY_ABORTED,
+    event: EventsType['FRAG_LOAD_EMERGENCY_ABORTED'],
     data: FragLoadEmergencyAbortedData
   ) => void;
   [Events.FRAG_LOADED]: (
-    event: Events.FRAG_LOADED,
+    event: EventsType['FRAG_LOADED'],
     data: FragLoadedData
   ) => void;
   [Events.FRAG_DECRYPTED]: (
-    event: Events.FRAG_DECRYPTED,
+    event: EventsType['FRAG_DECRYPTED'],
     data: FragDecryptedData
   ) => void;
   [Events.FRAG_PARSING_INIT_SEGMENT]: (
-    event: Events.FRAG_PARSING_INIT_SEGMENT,
+    event: EventsType['FRAG_PARSING_INIT_SEGMENT'],
     data: FragParsingInitSegmentData
   ) => void;
   [Events.FRAG_PARSING_USERDATA]: (
-    event: Events.FRAG_PARSING_USERDATA,
+    event: EventsType['FRAG_PARSING_USERDATA'],
     data: FragParsingUserdataData
   ) => void;
   [Events.FRAG_PARSING_METADATA]: (
-    event: Events.FRAG_PARSING_METADATA,
+    event: EventsType['FRAG_PARSING_METADATA'],
     data: FragParsingMetadataData
   ) => void;
   // [Events.FRAG_PARSING_DATA]: TodoEventType
   [Events.FRAG_PARSED]: (
-    event: Events.FRAG_PARSED,
+    event: EventsType['FRAG_PARSED'],
     data: FragParsedData
   ) => void;
   [Events.FRAG_BUFFERED]: (
-    event: Events.FRAG_BUFFERED,
+    event: EventsType['FRAG_BUFFERED'],
     data: FragBufferedData
   ) => void;
   [Events.FRAG_CHANGED]: (
-    event: Events.FRAG_CHANGED,
+    event: EventsType['FRAG_CHANGED'],
     data: FragChangedData
   ) => void;
-  [Events.FPS_DROP]: (event: Events.FPS_DROP, data: FPSDropData) => void;
+  [Events.FPS_DROP]: (event: EventsType['FPS_DROP'], data: FPSDropData) => void;
   [Events.FPS_DROP_LEVEL_CAPPING]: (
-    event: Events.FPS_DROP_LEVEL_CAPPING,
+    event: EventsType['FPS_DROP_LEVEL_CAPPING'],
     data: FPSDropLevelCappingData
   ) => void;
-  [Events.ERROR]: (event: Events.ERROR, data: ErrorData) => void;
-  [Events.DESTROYING]: (event: Events.DESTROYING) => void;
+  [Events.ERROR]: (event: EventsType['ERROR'], data: ErrorData) => void;
+  [Events.DESTROYING]: (event: EventsType['DESTROYING']) => void;
   [Events.KEY_LOADING]: (
-    event: Events.KEY_LOADING,
+    event: EventsType['KEY_LOADING'],
     data: KeyLoadingData
   ) => void;
-  [Events.KEY_LOADED]: (event: Events.KEY_LOADED, data: KeyLoadedData) => void;
+  [Events.KEY_LOADED]: (
+    event: EventsType['KEY_LOADED'],
+    data: KeyLoadedData
+  ) => void;
   [Events.LIVE_BACK_BUFFER_REACHED]: (
-    event: Events.LIVE_BACK_BUFFER_REACHED,
+    event: EventsType['LIVE_BACK_BUFFER_REACHED'],
     data: LiveBackBufferData
   ) => void;
   [Events.BACK_BUFFER_REACHED]: (
-    event: Events.BACK_BUFFER_REACHED,
+    event: EventsType['BACK_BUFFER_REACHED'],
     data: BackBufferData
   ) => void;
   [Events.STEERING_MANIFEST_LOADED]: (
-    event: Events.STEERING_MANIFEST_LOADED,
+    event: EventsType['STEERING_MANIFEST_LOADED'],
     data: SteeringManifestLoadedData
   ) => void;
 }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -10,8 +10,13 @@ import { isSupported } from './is-supported';
 import { logger, enableLogs } from './utils/logger';
 import { enableStreamingMode, hlsDefaultConfig, mergeConfig } from './config';
 import { EventEmitter } from 'eventemitter3';
-import { Events } from './events';
-import { ErrorTypes, ErrorDetails } from './errors';
+import { Events, EventsType } from './events';
+import {
+  ErrorTypes,
+  ErrorDetails,
+  ErrorTypesType,
+  ErrorDetailsType,
+} from './errors';
 import { HdcpLevels } from './types/level';
 import type { HlsEventEmitter, HlsListeners } from './events';
 import type AudioTrackController from './controller/audio-track-controller';
@@ -880,9 +885,9 @@ export default class Hls implements HlsEventEmitter {
 
 export type {
   MediaPlaylist,
-  ErrorDetails,
-  ErrorTypes,
-  Events,
+  ErrorDetailsType as ErrorDetails,
+  ErrorTypesType as ErrorTypes,
+  EventsType as Events,
   Level,
   HlsListeners,
   HlsEventEmitter,

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -1,4 +1,4 @@
-import { ErrorTypes, ErrorDetails } from '../errors';
+import { ErrorTypes, ErrorDetails, ErrorDetailsValue } from '../errors';
 import {
   LoaderStats,
   LoaderResponse,
@@ -71,7 +71,7 @@ export default class KeyLoader implements ComponentAPI {
 
   createKeyLoadError(
     frag: Fragment,
-    details: ErrorDetails = ErrorDetails.KEY_LOAD_ERROR,
+    details: ErrorDetailsValue = ErrorDetails.KEY_LOAD_ERROR,
     error: Error,
     networkDetails?: any,
     response?: { url: string; data: undefined; code: number; text: string }

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -6,8 +6,8 @@
  * Uses loader(s) set in config to do actual internal loading of resource tasks.
  */
 
-import { Events } from '../events';
-import { ErrorDetails, ErrorTypes } from '../errors';
+import { Events, EventsType } from '../events';
+import { ErrorDetails, ErrorDetailsValue, ErrorTypes } from '../errors';
 import { logger } from '../utils/logger';
 import M3U8Parser from './m3u8-parser';
 import type { LevelParsed, VariableMap } from '../types/level';
@@ -146,7 +146,7 @@ class PlaylistLoader implements NetworkComponentAPI {
   }
 
   private onManifestLoading(
-    event: Events.MANIFEST_LOADING,
+    event: EventsType['MANIFEST_LOADING'],
     data: ManifestLoadingData
   ) {
     const { url } = data;
@@ -161,7 +161,10 @@ class PlaylistLoader implements NetworkComponentAPI {
     });
   }
 
-  private onLevelLoading(event: Events.LEVEL_LOADING, data: LevelLoadingData) {
+  private onLevelLoading(
+    event: EventsType['LEVEL_LOADING'],
+    data: LevelLoadingData
+  ) {
     const { id, level, url, deliveryDirectives } = data;
     this.load({
       id,
@@ -174,7 +177,7 @@ class PlaylistLoader implements NetworkComponentAPI {
   }
 
   private onAudioTrackLoading(
-    event: Events.AUDIO_TRACK_LOADING,
+    event: EventsType['AUDIO_TRACK_LOADING'],
     data: TrackLoadingData
   ) {
     const { id, groupId, url, deliveryDirectives } = data;
@@ -190,7 +193,7 @@ class PlaylistLoader implements NetworkComponentAPI {
   }
 
   private onSubtitleTrackLoading(
-    event: Events.SUBTITLE_TRACK_LOADING,
+    event: EventsType['SUBTITLE_TRACK_LOADING'],
     data: TrackLoadingData
   ) {
     const { id, groupId, url, deliveryDirectives } = data;
@@ -549,7 +552,7 @@ class PlaylistLoader implements NetworkComponentAPI {
     }
     const error = new Error(message);
     logger.warn(`[playlist-loader]: ${message}`);
-    let details = ErrorDetails.UNKNOWN;
+    let details: ErrorDetailsValue = ErrorDetails.UNKNOWN;
     let fatal = false;
 
     const loader = this.getInternalLoader(context);

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -22,7 +22,7 @@ import type { Track, TrackSet } from './track';
 import type { SourceBufferName } from './buffer';
 import type { ChunkMetadata } from './transmuxer';
 import type { LoadStats } from '../loader/load-stats';
-import type { ErrorDetails, ErrorTypes } from '../errors';
+import type { ErrorDetailsValue, ErrorTypesValue } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type { AttrList } from '../utils/attr-list';
 import type { HlsListeners } from '../events';
@@ -222,8 +222,8 @@ export interface FPSDropLevelCappingData {
 }
 
 export interface ErrorData {
-  type: ErrorTypes;
-  details: ErrorDetails;
+  type: ErrorTypesValue;
+  details: ErrorDetailsValue;
   error: Error;
   fatal: boolean;
   errorAction?: IErrorAction;

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -4,7 +4,7 @@ import EMEController, {
 import HlsMock from '../../mocks/hls.mock';
 import { EventEmitter } from 'eventemitter3';
 import { ErrorDetails } from '../../../src/errors';
-import { Events } from '../../../src/events';
+import { Events, EventsType } from '../../../src/events';
 
 import sinon from 'sinon';
 import chai from 'chai';
@@ -24,7 +24,7 @@ type EMEControllerTestable = Omit<
   };
   mediaKeySessions: MediaKeySessionContext[];
   onMediaAttached: (
-    event: Events.MEDIA_ATTACHED,
+    event: EventsType['MEDIA_ATTACHED'],
     data: MediaAttachedData
   ) => void;
   onMediaDetached: () => void;

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -1,6 +1,10 @@
 import Hls from '../../../src/hls';
 import { Events } from '../../../src/events';
-import { ErrorDetails, ErrorTypes } from '../../../src/errors';
+import {
+  ErrorDetails,
+  ErrorDetailsValue,
+  ErrorTypes,
+} from '../../../src/errors';
 import type {
   ErrorData,
   FragLoadedData,
@@ -974,7 +978,7 @@ function loadingEventCallback(server, timers) {
 
 function expectFatalErrorEventToStopPlayer(
   hls: Hls,
-  withErrorDetails: ErrorDetails,
+  withErrorDetails: ErrorDetailsValue,
   withErrorMessage: string
 ) {
   return (data: ErrorData) => {

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -1,7 +1,12 @@
 import LevelController from '../../../src/controller/level-controller';
 import HlsMock from '../../mocks/hls.mock';
 import { Events } from '../../../src/events';
-import { ErrorDetails, ErrorTypes } from '../../../src/errors';
+import {
+  ErrorDetails,
+  ErrorDetailsValue,
+  ErrorTypes,
+  ErrorTypesValue,
+} from '../../../src/errors';
 import { Level } from '../../../src/types/level';
 import { AttrList } from '../../../src/utils/attr-list';
 import {
@@ -40,8 +45,8 @@ type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
   onError: (
     event: string,
     data: {
-      type: ErrorTypes;
-      details: ErrorDetails;
+      type: ErrorTypesValue;
+      details: ErrorDetailsValue;
       context?: PlaylistLoaderContext;
       frag?: Fragment;
       level?: number;


### PR DESCRIPTION
### This PR will...

Replaces https://github.com/video-dev/hls.js/pull/5685

This refactors a few enums that are exported to instead be consts with separately exported types. This is a breaking change because previously something like `HlsListeners[Events.MEDIA_ATTACHED]` could be done, but now I think it would need to be `HlsListeners[Events['MEDIA_ATTACHED']]`. There are other exported enums, but I wanted to get feedback on this approach first.

### Why is this Pull Request needed?

Currently, enums are exported as types. They aren't bundled in a way that they can be used at runtime, but TypeScript allows it to happen because the enum is included in the declaration file as it's exported as a type. It's possible to run into errors like this at runtime without TypeScript catching the errors at compile time:

> Uncaught TypeError: Cannot read properties of undefined (reading 'MEDIA_ATTACHED')

### Are there any points in the code the reviewer needs to double check?

Users who rely on these exported enums as types would need to update to use the bracket notation instead of dot notation.

### Resolves issues:

Closes #5630

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
