### PR TITLE
Fix loop loading in fmp4 sample with gaps

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -276,13 +276,17 @@ export class FragmentTracker implements ComponentAPI {
         });
         break;
       } else if (startPTS < endTime && endPTS > startTime) {
-        buffered.partial = true;
-        // Check for intersection with buffer
-        // Get playable sections of the fragment
-        buffered.time.push({
-          startPTS: Math.max(startPTS, timeRange.start(i)),
-          endPTS: Math.min(endPTS, timeRange.end(i)),
-        });
+        const start = Math.max(startPTS, timeRange.start(i));
+        const end = Math.min(endPTS, timeRange.end(i));
+        if (end > start) {
+          buffered.partial = true;
+          // Check for intersection with buffer
+          // Get playable sections of the fragment
+          buffered.time.push({
+            startPTS: start,
+            endPTS: end,
+          });
+        }
       } else if (endPTS <= startTime) {
         // No need to check the rest of the timeRange as it is in order
         break;


### PR DESCRIPTION
### This PR will...
Fix loop loading in fmp4 sample with gaps

### Why is this Pull Request needed?
Gap at sn 13 causes loop loading in https://efa8a4bc.hls-js-dev.pages.dev/demo/?src=https%3A%2F%2Fbitmovin-a.akamaihd.net%2Fcontent%2Fdataset%2Fmulti-codec%2Fhevc%2Fstream_fmp4.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOmZhbHNlLCJzdG9wT25TdGFsbCI6ZmFsc2UsImR1bXBmTVA0IjpmYWxzZSwibGV2ZWxDYXBwaW5nIjotMSwibGltaXRNZXRyaWNzIjotMX0=

The range detected as "partial" which results in additional frag load attempts is invalid because the `bufferPadding` added. The gap actually starts and ends before sn 13, and since the range has an end time which is less than the start it can be ignored.

### Are there any points in the code the reviewer needs to double check?
Not sure if overlapping appends are causing the gaps. Could be an issue with the decode timestamps found in the media - haven't checked or compared to playlist times.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
