### PR TITLE
Fix live frag finding after detach and re-attach past live window

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1040,12 +1040,13 @@ export default class BaseStreamController
       // Do not load using live logic if the starting frag is requested - we want to use getFragmentAtPosition() so that
       // we get the fragment matching that start time
       if (
-        !levelDetails.PTSKnown &&
-        !this.startFragRequested &&
-        this.startPosition === -1
+        (!levelDetails.PTSKnown &&
+          !this.startFragRequested &&
+          this.startPosition === -1) ||
+        pos < start
       ) {
         frag = this.getInitialLiveFragment(levelDetails, fragments);
-        this.startPosition = frag
+        this.startPosition = this.nextLoadPosition = frag
           ? this.hls.liveSyncPosition || frag.start
           : pos;
       }


### PR DESCRIPTION
### This PR will...
When looking for the next fragment to load, if the target position is less than the start of the playlist, reset `startPosition` and `nextLoadPosition` to `liveSyncPosition`. Setting `nextLoadPosition` ensures that the audio-stream-controller can properly evaluate the main buffer before SourceBuffers have been added to the MediaSource.

### Why is this Pull Request needed?
audio-stream-controller exits before loading anything when main's `nextLoadPosition`  is incorrect in some cases.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5741

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
