### PR TITLE
Add config flag for maximum front buffer `frontBufferFlushThreshold`

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -18,6 +18,13 @@ Set `backBufferLength` to `Infinity` and `liveBackBufferLength` to `90` if you w
 eviction for Live and VOD streams as older versions did. While `liveBackBufferLength` can still be used, it has been
 marked deprecated and may be removed in an upcoming minor release.
 
+### Front Buffer Eviction
+
+The new `frontBufferFlushThreshold` setting defaults to Infinity seconds and governs active eviction of buffered ranges outside of
+the current contiguous front buffer. For example, given currentTime=0 and bufferedRanges=[[0, 100], [150, 200]] with
+a configured frontBufferFlushThreshold=60, we will only remove the range from [150, 200] as it lies outside of the target buffer length
+and is not contiguous with the forward buffer from the currentTime of 0.
+
 ### Low Latency Streams
 
 The new `lowLatencyMode` setting is enabled by default. Set to `false` to disable Low-latency part loading and target

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -553,7 +553,9 @@ export class BufferController implements ComponentAPI {
     // (undocumented)
     protected error: (msg: any, obj?: any) => void;
     // (undocumented)
-    flushBackBuffer(): void;
+    flushBackBuffer(currentTime: number, targetDuration: number, targetBackBufferPosition: number): void;
+    // (undocumented)
+    flushFrontBuffer(currentTime: number, targetDuration: number, targetFrontBufferPosition: number): void;
     // (undocumented)
     hasSourceTypes(): boolean;
     // (undocumented)
@@ -593,6 +595,8 @@ export class BufferController implements ComponentAPI {
     // (undocumented)
     tracks: TrackSet;
     // (undocumented)
+    trimBuffers(): void;
+    // (undocumented)
     protected unregisterListeners(): void;
     // (undocumented)
     updateSeekableRange(levelDetails: any): void;
@@ -606,6 +610,7 @@ export class BufferController implements ComponentAPI {
 export type BufferControllerConfig = {
     appendErrorMaxRetry: number;
     backBufferLength: number;
+    frontBufferFlushThreshold: number;
     liveDurationInfinity: boolean;
     liveBackBufferLength: number | null;
 };

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`initialLiveManifestSize`](#initiallivemanifestsize)
   - [`maxBufferLength`](#maxbufferlength)
   - [`backBufferLength`](#backbufferlength)
+  - [`frontBufferFlushThreshold`](#frontbufferflushthreshold)
   - [`maxBufferSize`](#maxbuffersize)
   - [`maxBufferHole`](#maxbufferhole)
   - [`maxStarvationDelay`](#maxstarvationdelay)
@@ -357,6 +358,7 @@ var config = {
   maxBufferLength: 30,
   maxMaxBufferLength: 600,
   backBufferLength: Infinity,
+  frontBufferFlushThreshold: Infinity,
   maxBufferSize: 60 * 1000 * 1000,
   maxBufferHole: 0.5,
   highBufferWatchdogPeriod: 2,
@@ -510,6 +512,12 @@ This is the guaranteed buffer length hls.js will try to reach, regardless of max
 (default: `Infinity`)
 
 The maximum duration of buffered media to keep once it has been played, in seconds. Any video buffered past this duration will be evicted. `Infinity` means no restriction on back buffer length; `0` keeps the minimum amount. The minimum amount is equal to the target duration of a segment to ensure that current playback is not interrupted.
+
+### `frontBufferFlushThreshold`
+
+(default: `Infinity`)
+
+The maximum duration of buffered media, in seconds, from the play position to keep before evicting non-contiguous forward ranges. A value of `Infinity` means no active eviction will take place; This value will always be at least the `maxBufferLength`.
 
 ### `maxBufferSize`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ export type ABRControllerConfig = {
 export type BufferControllerConfig = {
   appendErrorMaxRetry: number;
   backBufferLength: number;
+  frontBufferFlushThreshold: number;
   liveDurationInfinity: boolean;
   /**
    * @deprecated use backBufferLength
@@ -320,6 +321,7 @@ export const hlsDefaultConfig: HlsConfig = {
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller
   backBufferLength: Infinity, // used by buffer-controller
+  frontBufferFlushThreshold: Infinity,
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
   maxBufferHole: 0.1, // used by stream-controller
   highBufferWatchdogPeriod: 2, // used by stream-controller


### PR DESCRIPTION
### This PR will...
Allow users to specify a maximum forward buffer to give control of media buffer memory usage.

### Why is this Pull Request needed?
Some devices have poor MSE buffer cleanup and run out of memory instead of evicting segments far ahead of the playhead.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5479
Fixes #5587

### Authored by
@iamboorrito

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
