### PR TITLE
Implement event for maxAutoLevel change

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1208,6 +1208,8 @@ export enum Events {
     // (undocumented)
     MANIFEST_PARSED = "hlsManifestParsed",
     // (undocumented)
+    MAX_AUTO_LEVEL_UPDATED = "hlsMaxAutoLevelUpdated",
+    // (undocumented)
     MEDIA_ATTACHED = "hlsMediaAttached",
     // (undocumented)
     MEDIA_ATTACHING = "hlsMediaAttaching",
@@ -1792,6 +1794,10 @@ export interface HlsListeners {
     [Events.MANIFEST_LOADING]: (event: Events.MANIFEST_LOADING, data: ManifestLoadingData) => void;
     // (undocumented)
     [Events.MANIFEST_PARSED]: (event: Events.MANIFEST_PARSED, data: ManifestParsedData) => void;
+    // Warning: (ae-forgotten-export) The symbol "MaxAutoLevelUpdatedData" needs to be exported by the entry point hls.d.ts
+    //
+    // (undocumented)
+    [Events.MAX_AUTO_LEVEL_UPDATED]: (event: Events.MAX_AUTO_LEVEL_UPDATED, data: MaxAutoLevelUpdatedData) => void;
     // (undocumented)
     [Events.MEDIA_ATTACHED]: (event: Events.MEDIA_ATTACHED, data: MediaAttachedData) => void;
     // (undocumented)

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -40,6 +40,7 @@ let chromeOrFirefox: boolean;
 export default class LevelController extends BasePlaylistController {
   private _levels: Level[] = [];
   private _firstLevel: number = -1;
+  private _maxAutoLevel: number = -1;
   private _startLevel?: number;
   private currentLevel: Level | null = null;
   private currentLevelIndex: number = -1;
@@ -104,6 +105,7 @@ export default class LevelController extends BasePlaylistController {
     this.currentLevelIndex = -1;
     this.currentLevel = null;
     this._levels = [];
+    this._maxAutoLevel = -1;
   }
 
   private onManifestLoading(
@@ -661,6 +663,20 @@ export default class LevelController extends BasePlaylistController {
     { levels }: LevelsUpdatedData,
   ) {
     this._levels = levels;
+  }
+
+  public checkMaxAutoUpdated() {
+    const { autoLevelCapping, maxAutoLevel, maxHdcpLevel } = this.hls;
+    if (this._maxAutoLevel !== maxAutoLevel) {
+      this._maxAutoLevel = maxAutoLevel;
+      this.hls.trigger(Events.MAX_AUTO_LEVEL_UPDATED, {
+        autoLevelCapping,
+        levels: this.levels,
+        maxAutoLevel,
+        minAutoLevel: this.hls.minAutoLevel,
+        maxHdcpLevel,
+      });
+    }
   }
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -35,6 +35,7 @@ import {
   BufferFlushingData,
   BufferEOSData,
   LevelSwitchingData,
+  MaxAutoLevelUpdatedData,
   FPSDropLevelCappingData,
   FPSDropData,
   BufferCreatedData,
@@ -151,6 +152,8 @@ export enum Events {
   FPS_DROP = 'hlsFpsDrop',
   // triggered when FPS drop triggers auto level capping - data: { level, droppedLevel }
   FPS_DROP_LEVEL_CAPPING = 'hlsFpsDropLevelCapping',
+  // triggered when maxAutoLevel changes - data { autoLevelCapping, levels, maxAutoLevel, minAutoLevel, maxHdcpLevel }
+  MAX_AUTO_LEVEL_UPDATED = 'hlsMaxAutoLevelUpdated',
   // Identifier for an error event - data: { type : error type, details : error details, fatal : if true, hls.js cannot/will not try to recover, if false, hls.js will try to recover,other error specific data }
   ERROR = 'hlsError',
   // fired when hls.js instance starts destroying. Different from MEDIA_DETACHED as one could want to detach and reattach a media to the instance of hls.js to handle mid-rolls for example - data: { }
@@ -348,6 +351,10 @@ export interface HlsListeners {
   [Events.FPS_DROP_LEVEL_CAPPING]: (
     event: Events.FPS_DROP_LEVEL_CAPPING,
     data: FPSDropLevelCappingData,
+  ) => void;
+  [Events.MAX_AUTO_LEVEL_UPDATED]: (
+    event: Events.MAX_AUTO_LEVEL_UPDATED,
+    data: MaxAutoLevelUpdatedData,
   ) => void;
   [Events.ERROR]: (event: Events.ERROR, data: ErrorData) => void;
   [Events.DESTROYING]: (event: Events.DESTROYING) => void;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -52,7 +52,7 @@ export default class Hls implements HlsEventEmitter {
   private coreComponents: ComponentAPI[];
   private networkControllers: NetworkComponentAPI[];
   private _emitter: HlsEventEmitter = new EventEmitter();
-  private _autoLevelCapping: number;
+  private _autoLevelCapping: number = -1;
   private _maxHdcpLevel: HdcpLevel = null;
   private abrController: AbrController;
   private bufferController: BufferController;
@@ -120,8 +120,6 @@ export default class Hls implements HlsEventEmitter {
     enableLogs(userConfig.debug || false, 'Hls instance');
     const config = (this.config = mergeConfig(Hls.DefaultConfig, userConfig));
     this.userConfig = userConfig;
-
-    this._autoLevelCapping = -1;
 
     if (config.progressive) {
       enableStreamingMode(config);
@@ -382,6 +380,8 @@ export default class Hls implements HlsEventEmitter {
         alwaysNormalize: true,
       },
     ));
+    this._autoLevelCapping = -1;
+    this._maxHdcpLevel = null;
     logger.log(`loadSource:${loadingSource}`);
     if (
       media &&
@@ -637,6 +637,7 @@ export default class Hls implements HlsEventEmitter {
     if (this._autoLevelCapping !== newLevel) {
       logger.log(`set autoLevelCapping:${newLevel}`);
       this._autoLevelCapping = newLevel;
+      this.levelController.checkMaxAutoUpdated();
     }
   }
 
@@ -645,8 +646,9 @@ export default class Hls implements HlsEventEmitter {
   }
 
   set maxHdcpLevel(value: HdcpLevel) {
-    if (isHdcpLevel(value)) {
+    if (isHdcpLevel(value) && this._maxHdcpLevel !== value) {
       this._maxHdcpLevel = value;
+      this.levelController.checkMaxAutoUpdated();
     }
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -4,6 +4,7 @@ import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 import type {
+  HdcpLevel,
   HlsUrlParameters,
   Level,
   LevelParsed,
@@ -219,6 +220,14 @@ export interface FPSDropData {
 export interface FPSDropLevelCappingData {
   droppedLevel: number;
   level: number;
+}
+
+export interface MaxAutoLevelUpdatedData {
+  autoLevelCapping: number;
+  levels: Level[] | null;
+  maxAutoLevel: number;
+  minAutoLevel: number;
+  maxHdcpLevel: HdcpLevel;
 }
 
 export interface ErrorData {


### PR DESCRIPTION
### This PR will...
Implement `MAX_AUTO_LEVEL_UPDATED` event for maxAutoLevel change.

### Why is this Pull Request needed?
Used when presenting selection options and those options change based on supported HDCP levels, or `hls.autoLevelCapping` is set by fps/cap-level controller.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #4521

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
