### PR TITLE
fix(buffer-controller): Fix fLaC and Opus playback in multiplexed stream

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -351,7 +351,8 @@ export default class BufferController implements ComponentAPI {
             '$1',
           );
           if (currentCodec !== nextCodec) {
-            if (trackName.slice(0, 5) === 'audio') {
+            const trackType = trackName.slice(0, 5);
+            if (trackType === 'audio' || trackType === 'video') {
               trackCodec = getCodecCompatibleName(
                 trackCodec,
                 this.hls.config.preferManagedMediaSource,
@@ -840,7 +841,8 @@ export default class BufferController implements ComponentAPI {
         // use levelCodec as first priority
         let codec = track.levelCodec || track.codec;
         if (codec) {
-          if (trackName.slice(0, 5) === 'audio') {
+          const trackType = trackName.slice(0, 5);
+          if (trackType === 'audio' || trackType === 'video') {
             codec = getCodecCompatibleName(
               codec,
               this.hls.config.preferManagedMediaSource,


### PR DESCRIPTION
### This PR will...

Fix `fLaC` and `Opus` playback in multiplexed HLS stream

### Why is this Pull Request needed?

`fLaC` and `Opus` also exist in video mimetype such as `CODECS="hvc1.2.4.L120.B0,Opus"`

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes 1edd029

![1](https://github.com/video-dev/hls.js/assets/14953024/7f8652f5-6d50-43b6-97ff-c1636151fa49)
![2](https://github.com/video-dev/hls.js/assets/14953024/4d02b222-aa62-400c-bd8b-961c7ef3d0d3)


### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
