### PR TITLE
fix(mp4-tools): Fix two AV1 parsing issues

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -352,7 +352,7 @@ function parseStsd(stsd: Uint8Array): { codec: string; encrypted: boolean } {
     }
     case 'av01': {
       const av1CBox = findBox(sampleEntriesEnd, ['av1C'])[0];
-      const profile = av1CBox[1] >>> 3;
+      const profile = av1CBox[1] >>> 5;
       const level = av1CBox[1] & 0x1f;
       const tierFlag = av1CBox[2] >>> 7 ? 'H' : 'M';
       const highBitDepth = (av1CBox[2] & 0x40) >> 6;

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -369,6 +369,13 @@ function parseStsd(stsd: Uint8Array): { codec: string; encrypted: boolean } {
       const chromaSubsamplingX = (av1CBox[2] & 0x08) >> 3;
       const chromaSubsamplingY = (av1CBox[2] & 0x04) >> 2;
       const chromaSamplePosition = av1CBox[2] & 0x03;
+      // TODO: parse color_description_present_flag
+      // default it to BT.709/limited range for now
+      // more info https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
+      const colorPrimaries = 1;
+      const transferCharacteristics = 1;
+      const matrixCoefficients = 1;
+      const videoFullRangeFlag = 0;
       codec +=
         '.' +
         profile +
@@ -382,7 +389,15 @@ function parseStsd(stsd: Uint8Array): { codec: string; encrypted: boolean } {
         '.' +
         chromaSubsamplingX +
         chromaSubsamplingY +
-        chromaSamplePosition;
+        chromaSamplePosition +
+        '.' +
+        addLeadingZero(colorPrimaries) +
+        '.' +
+        addLeadingZero(transferCharacteristics) +
+        '.' +
+        addLeadingZero(matrixCoefficients) +
+        '.' +
+        videoFullRangeFlag;
       break;
     }
     case 'ac-3':


### PR DESCRIPTION
### This PR will...

Fix two AV1 parsing issues that make Firefox fails to play HLS stream

### Why is this Pull Request needed?

- fix(mp4-tools): Fix AV1 profile parsing

    Profile: unsigned right shift 5-bits for the 2nd av1CBox
    Level: bitwise AND the 2nd av1CBox with 0b11111(0x1f)

    Without this, Main `av01.0.15M.08` is parsed as High `av01.1.15M.08`.
    In this case the High profile is not supprted in Firefox.

- fix(mp4-tools): set default color descriptions to satisfy Firefox

    In Firefox either you omit the chroma values, or you have to complete the rest of the color descriptions.

    Otherwise even the most basic AV1 Main 4:2:0 8-bit video will be reported as unsupported in HTMLMediaElement.canPlayType and MediaSource.isTypeSupported. Chromium is not affected by this.

### Are there any points in the code the reviewer needs to double check?

See also
- https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
- https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#choosing_a_video_codec
- https://aomediacodec.github.io/av1-spec/#color-config-semantics

### Resolves issues:
- av1 Main is mistakenly parsed as High profile and eventually fails in Firefox
playlist:
![image](https://github.com/video-dev/hls.js/assets/14953024/48deda5e-d3a5-4771-9a6a-8eebf6dae844)
log:
![image](https://github.com/video-dev/hls.js/assets/14953024/f8d4c019-3ba7-4768-9021-5d973fbdef72)

- Firefox is unhapply with the chroma values
![firefox](https://github.com/video-dev/hls.js/assets/14953024/698f53d0-7265-49e9-a6bd-76cd72025580)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
