### PR TITLE
Handle #EXT-X-ENDLIST appended to live playlist without new segment

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -303,6 +303,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected bufferFragmentData(data: RemuxedTrack, frag: Fragment, part: Part | null, chunkMeta: ChunkMetadata, noBacktracking?: boolean): void;
     // (undocumented)
+    protected checkLiveUpdate(details: LevelDetails): void;
+    // (undocumented)
     protected clearTrackerIfNeeded(frag: Fragment): void;
     // (undocumented)
     protected config: HlsConfig;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -511,10 +511,8 @@ class AudioStreamController
     const track = levels[trackId];
     let sliding = 0;
     if (newDetails.live || track.details?.live) {
+      this.checkLiveUpdate(newDetails);
       const mainDetails = this.mainDetails;
-      if (!newDetails.fragments[0]) {
-        newDetails.deltaUpdateFailed = true;
-      }
       if (newDetails.deltaUpdateFailed || !mainDetails) {
         return;
       }

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -151,6 +151,8 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           `live playlist ${index} ${
             details.advanced
               ? 'REFRESHED ' + details.lastPartSn + '-' + details.lastPartIndex
+              : details.updated
+              ? 'UPDATED'
               : 'MISSED'
           }`,
         );

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -433,6 +433,22 @@ export default class BaseStreamController
     }
   }
 
+  protected checkLiveUpdate(details: LevelDetails) {
+    if (details.updated && !details.live) {
+      // Live stream ended, update fragment tracker
+      const lastFragment = details.fragments[details.fragments.length - 1];
+      this.fragmentTracker.detectPartialFragments({
+        frag: lastFragment,
+        part: null,
+        stats: lastFragment.stats,
+        id: lastFragment.type,
+      });
+    }
+    if (!details.fragments[0]) {
+      details.deltaUpdateFailed = true;
+    }
+  }
+
   protected flushMainBuffer(
     startOffset: number,
     endOffset: number,

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -206,7 +206,9 @@ export class FragmentTracker implements ComponentAPI {
     fragmentEntity.loaded = null;
     if (Object.keys(fragmentEntity.range).length) {
       fragmentEntity.buffered = true;
-      if (fragmentEntity.body.endList) {
+      const endList = (fragmentEntity.body.endList =
+        frag.endList || fragmentEntity.body.endList);
+      if (endList) {
         this.endListFragments[fragmentEntity.body.type] = fragmentEntity;
       }
       if (!isPartial(fragmentEntity)) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -657,9 +657,7 @@ export default class StreamController
 
     let sliding = 0;
     if (newDetails.live || curLevel.details?.live) {
-      if (!newDetails.fragments[0]) {
-        newDetails.deltaUpdateFailed = true;
-      }
+      this.checkLiveUpdate(newDetails);
       if (newDetails.deltaUpdateFailed) {
         return;
       }

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -72,7 +72,10 @@ export class LevelDetails {
     const partSnDiff = this.lastPartSn - previous.lastPartSn;
     const partIndexDiff = this.lastPartIndex - previous.lastPartIndex;
     this.updated =
-      this.endSN !== previous.endSN || !!partIndexDiff || !!partSnDiff;
+      this.endSN !== previous.endSN ||
+      !!partIndexDiff ||
+      !!partSnDiff ||
+      !this.live;
     this.advanced =
       this.endSN > previous.endSN ||
       partSnDiff > 0 ||

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -194,6 +194,10 @@ export function mergeDetails(
         newFrag.initSegment = oldFrag.initSegment;
         currentInitSegment = oldFrag.initSegment;
       }
+      if (newFrag.endList) {
+        // Update frag body for fragment-tracker endListFragments
+        oldFrag.endList = true;
+      }
     },
   );
 

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -194,10 +194,6 @@ export function mergeDetails(
         newFrag.initSegment = oldFrag.initSegment;
         currentInitSegment = oldFrag.initSegment;
       }
-      if (newFrag.endList) {
-        // Update frag body for fragment-tracker endListFragments
-        oldFrag.endList = true;
-      }
     },
   );
 


### PR DESCRIPTION
### This PR will...
Treat LevelDetails as `updated` when #EXT-X-ENDLIST is appended to live playlist without new segment. Mark the corresponding segment in the previous details object with `endList = true` so that the fragment-tracker can add it to `endListFragments`.

### Why is this Pull Request needed?
`endListFragments` is used to determine that everything from the playhead to the end of the playlist has been buffered so that the MediaSource and SourceBuffer(s) can be marked as ended.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5777

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
