### PR TITLE
Do not exit from stall detection when playhead is at or past end of buffer

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -92,13 +92,7 @@ export default class GapController {
     }
 
     const bufferInfo = BufferHelper.bufferInfo(media, currentTime, 0);
-    const isBuffered = bufferInfo.len > 0;
     const nextStart = bufferInfo.nextStart || 0;
-
-    // There is no playable buffer (seeked, waiting for buffer)
-    if (!isBuffered && !nextStart) {
-      return;
-    }
 
     if (seeking) {
       // Waiting for seeking in a buffered range to complete
@@ -119,6 +113,11 @@ export default class GapController {
     // Skip start gaps if we haven't played, but the last poll detected the start of a stall
     // The addition poll gives the browser a chance to jump the gap for us
     if (!this.moved && this.stalled !== null) {
+      // There is no playable buffer (seeked, waiting for buffer)
+      const isBuffered = bufferInfo.len > 0;
+      if (!isBuffered && !nextStart) {
+        return;
+      }
       // Jump start gaps within jump threshold
       const startJump =
         Math.max(nextStart, bufferInfo.start || 0) - currentTime;


### PR DESCRIPTION
### This PR will...
Allow stalls to be reported when playhead at the edge or outside a buffered range.

### Why is this Pull Request needed?
Playback doesn't always stall inside a buffered range. Typically it stalls at the end of one.

### Are there any points in the code the reviewer needs to double check?
The code being moved is to prevent stalls from being reported and stall nudges from being performed while seeking. The issue _was_ that some clients resolve seeking before media is buffered.

### Resolves issues:
Resolves part of #5759

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
