### PR TITLE
Prevent ADTS probe false positives when bytes following ID3 are a match for MPEG audio

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -337,20 +337,20 @@ export default class BufferController implements ComponentAPI {
         if (track && typeof track.buffer.changeType === 'function') {
           const { id, codec, levelCodec, container, metadata } =
             data[trackName];
-          const currentCodedFull = pickMostCompleteCodecName(
+          const currentCodecFull = pickMostCompleteCodecName(
             track.codec,
             track.levelCodec,
           );
-          const currentCodec = currentCodedFull.replace(
+          const currentCodec = currentCodecFull?.replace(
             VIDEO_CODEC_PROFILE_REPLACE,
             '$1',
           );
           let trackCodec = pickMostCompleteCodecName(codec, levelCodec);
-          const nextCodec = trackCodec.replace(
+          const nextCodec = trackCodec?.replace(
             VIDEO_CODEC_PROFILE_REPLACE,
             '$1',
           );
-          if (currentCodec !== nextCodec) {
+          if (trackCodec && currentCodec !== nextCodec) {
             if (trackName.slice(0, 5) === 'audio') {
               trackCodec = getCodecCompatibleName(
                 trackCodec,
@@ -359,7 +359,7 @@ export default class BufferController implements ComponentAPI {
             }
             const mimeType = `${container};codecs=${trackCodec}`;
             this.appendChangeType(trackName, mimeType);
-            this.log(`switching codec ${currentCodedFull} to ${trackCodec}`);
+            this.log(`switching codec ${currentCodecFull} to ${trackCodec}`);
             this.tracks[trackName] = {
               buffer: track.buffer,
               codec,

--- a/src/demux/audio/aacdemuxer.ts
+++ b/src/demux/audio/aacdemuxer.ts
@@ -3,6 +3,7 @@
  */
 import BaseAudioDemuxer from './base-audio-demuxer';
 import * as ADTS from './adts';
+import * as MpegAudio from './mpegaudio';
 import { logger } from '../../utils/logger';
 import * as ID3 from '../id3';
 import type { HlsEventEmitter } from '../../events';
@@ -50,8 +51,12 @@ class AACDemuxer extends BaseAudioDemuxer {
     // Look for ADTS header | 1111 1111 | 1111 X00X | where X can be either 0 or 1
     // Layer bits (position 14 and 15) in header should be always 0 for ADTS
     // More info https://wiki.multimedia.cx/index.php?title=ADTS
-    const id3Data = ID3.getID3Data(data, 0) || [];
-    let offset = id3Data.length;
+    const id3Data = ID3.getID3Data(data, 0);
+    let offset = id3Data?.length || 0;
+
+    if (MpegAudio.probe(data, offset)) {
+      return false;
+    }
 
     for (let length = data.length; offset < length; offset++) {
       if (ADTS.probe(data, offset)) {

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -176,8 +176,8 @@ export function getCodecCompatibleName(
 
 export function pickMostCompleteCodecName(
   parsedCodec: string,
-  levelCodec: string,
-): string {
+  levelCodec: string | undefined,
+): string | undefined {
   // Parsing of mp4a codecs strings in mp4-tools from media is incomplete as of d8c6c7a
   // so use level codec is parsed codec is unavailable or incomplete
   if (parsedCodec && parsedCodec !== 'mp4a') {


### PR DESCRIPTION
### This PR will...
Prevent ADTS probe false positives when bytes following ID3 are a match for MPEG audio

### Why is this Pull Request needed?
TS/ADTS/MP3 probe methods scan through all or most bytes to find a sync word, and as a result sometimes find a false positive. We tried removing this in v1.2.x, but users with malformed content (media segments starting with JPEG bytes) reported that they depended on it this functionality so it was kept in (#5002).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5782

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
