### PR TITLE
Fix support of skip directive without block reload

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -228,7 +228,7 @@ export default class BasePlaylistController implements NetworkComponentAPI {
           this.loadPlaylist(deliveryDirectives);
           return;
         }
-      } else if (details.canBlockReload) {
+      } else if (details.canBlockReload || details.canSkipUntil) {
         deliveryDirectives = this.getDeliveryDirectives(
           details,
           data.deliveryDirectives,


### PR DESCRIPTION
### This PR will...
Fix support of skip directive without block reload.

### Why is this Pull Request needed?
Playlist request directives are only being added when SERVER-CONTROL contains CAN-BLOCK-RELOAD=YES.

Regressed in v1.4.0 with:
- #5317

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
https://github.com/video-dev/hls.js/issues/3644#issuecomment-1700656757

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
