### PR TITLE
Reset init segment when M2TS video configuration changes

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -612,6 +612,9 @@ class AbrController implements AbrComponentAPI {
       lastLoadedFragLevel === -1 ? this.hls.firstLevel : lastLoadedFragLevel;
     const { fragCurrent, partCurrent } = this;
     const { levels, allAudioTracks, loadLevel } = this.hls;
+    if (levels.length === 1) {
+      return 0;
+    }
     const level: Level | undefined = levels[selectionBaseLevel];
     const live = !!level?.details?.live;
     const firstSelection = loadLevel === -1 || lastLoadedFragLevel === -1;


### PR DESCRIPTION
### This PR will...
Reset init segment when M2TS video configuration changes

### Why is this Pull Request needed?
Some MSE implementations do not handle video configuration (resolution) changes without appending a new init segment or changeType append to prepare the decoder for the change.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #2062 (and stale duplicates #1842 #967)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
