### PR TITLE
Switch on smaller fmp4 segments that align with buffered segment boundaries

### DIFF
--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -65,12 +65,18 @@ export function findFragmentByPTS(
       fragments[
         (fragPrevious.sn as number) - (fragments[0].sn as number) + 1
       ] || null;
+    // check for buffer-end rounding error
+    const bufferEdgeError = fragPrevious.endDTS - bufferEnd;
+    if (bufferEdgeError > 0 && bufferEdgeError < 0.0000015) {
+      bufferEnd += 0.0000015;
+    }
   } else if (bufferEnd === 0 && fragments[0].start === 0) {
     fragNext = fragments[0];
   }
   // Prefer the next fragment if it's within tolerance
   if (
     fragNext &&
+    (!fragPrevious || fragPrevious.level === fragNext.level) &&
     fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext) ===
       0
   ) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -464,9 +464,9 @@ export default class StreamController
               Math.min(
                 Math.max(
                   fragDuration - this.config.maxFragLookUpTolerance,
-                  fragDuration * 0.5,
+                  fragDuration * (this.couldBacktrack ? 0.5 : 0.125),
                 ),
-                fragDuration * 0.75,
+                fragDuration * (this.couldBacktrack ? 0.75 : 0.25),
               ),
           );
           this.flushMainBuffer(startPts, Number.POSITIVE_INFINITY);

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -32,8 +32,9 @@ describe('Fragment finders', function () {
     });
 
     it('finds a fragment with SN sequential to the previous fragment', function () {
+      const fragPreviousSameLevel = { ...fragPrevious, level: 2 };
       const actual = findFragmentByPTS(
-        fragPrevious,
+        fragPreviousSameLevel,
         mockFragments,
         bufferEnd,
         tolerance,


### PR DESCRIPTION
### This PR will...
Switch on smaller fmp4 segments that align with buffered segment boundaries

### Why is this Pull Request needed?
Prevents vide buffer gaps from being produced on append in Chrome with HLS assets with fmp4 segments of different durations as in #5743.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #5743

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
