### PR TITLE
Adjust overlapping M2TS AVC timestamps of sample that overlap with previous segment

### DIFF
--- a/src/demux/video/avc-video-parser.ts
+++ b/src/demux/video/avc-video-parser.ts
@@ -9,7 +9,6 @@ import {
   parseSEIMessageFromNALu,
 } from '../../utils/mp4-tools';
 import ExpGolomb from './exp-golomb';
-import { logger } from '../../utils/logger';
 import type { PES } from '../tsdemuxer';
 
 class AvcVideoParser extends BaseVideoParser {


### PR DESCRIPTION
### This PR will...

### Why is this Pull Request needed?
Prevents vide buffer gaps from being produced on append in Chrome with HLS assets with m2ts segments containing overlapping AVC samples at segment boundaries.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #5759 #4470

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
