### PR TITLE
Skip large video start gaps using GAP flag

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -7,7 +7,7 @@ import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import { ElementaryStreamTypes, Fragment } from '../loader/fragment';
 import TransmuxerInterface from '../demux/transmuxer-interface';
 import { ChunkMetadata } from '../types/transmuxer';
-import GapController from './gap-controller';
+import GapController, { MAX_START_GAP_JUMP } from './gap-controller';
 import { ErrorDetails } from '../errors';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type Hls from '../hls';
@@ -1164,6 +1164,9 @@ export default class StreamController
               endDTS,
               true,
             );
+          } else if (isFirstFragment && startPTS > MAX_START_GAP_JUMP) {
+            // Mark segment with a gap to skip large start gap
+            frag.gap = true;
           }
         }
         frag.setElementaryStreamInfo(


### PR DESCRIPTION
### This PR will...
Skip large video start gaps using the Fragment gap flag.

### Why is this Pull Request needed?
The gap-controller only skips start gaps less than two seconds in length. HLS.js can jump larger gaps and will for any fragment marked with a gap flag. There are already cases where this flag is added when segments are found to be _a)_ completely missing all video samples or _b)_ dropping initial samples because of not starting with a key-frame. This change adds the case where nothing is dropped from the segment, but it still starts more than 2 seconds after the start of the audio track.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #4975


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
