### PR TITLE
Fix for aligning live alt audio and subtitle playlists on msn without PDT

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -295,7 +295,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected afterBufferFlushed(media: Bufferable, bufferType: SourceBufferName, playlistType: PlaylistLevelType): void;
     // (undocumented)
-    protected alignPlaylists(details: LevelDetails, previousDetails?: LevelDetails): number;
+    protected alignPlaylists(details: LevelDetails, previousDetails: LevelDetails | undefined, switchDetails: LevelDetails | undefined): number;
     // (undocumented)
     protected bitrateTest: boolean;
     // Warning: (ae-forgotten-export) The symbol "RemuxedTrack" needs to be exported by the entry point hls.d.ts
@@ -385,7 +385,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected lastCurrentTime: number;
     // (undocumented)
-    protected levelLastLoaded: number | null;
+    protected levelLastLoaded: Level | null;
     // (undocumented)
     protected levels: Array<Level> | null;
     // (undocumented)
@@ -445,7 +445,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected resetLoadingState(): void;
     // (undocumented)
-    protected resetStartWhenNotLoaded(level: number): void;
+    protected resetStartWhenNotLoaded(level: Level | null): void;
     // (undocumented)
     protected resetTransmuxer(): void;
     // (undocumented)

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -295,7 +295,11 @@ export class SubtitleStreamController
           addSliding(newDetails, sliding);
         }
       } else {
-        sliding = this.alignPlaylists(newDetails, track.details);
+        sliding = this.alignPlaylists(
+          newDetails,
+          track.details,
+          this.levelLastLoaded?.details,
+        );
         if (sliding === 0 && mainSlidingStartFragment) {
           // realign with main when there is no overlap with last refresh
           sliding = mainSlidingStartFragment.start;
@@ -304,7 +308,7 @@ export class SubtitleStreamController
       }
     }
     track.details = newDetails;
-    this.levelLastLoaded = trackId;
+    this.levelLastLoaded = track;
 
     if (!this.startFragRequested && (this.mainDetails || !newDetails.live)) {
       this.setStartPosition(track.details, sliding);

--- a/tests/unit/utils/discontinuities.ts
+++ b/tests/unit/utils/discontinuities.ts
@@ -469,7 +469,11 @@ describe('discontinuities', function () {
       endCC: 1,
     });
 
-    const actual = shouldAlignOnDiscontinuities(null, lastLevel, curDetails);
+    const actual = shouldAlignOnDiscontinuities(
+      null,
+      lastLevel.details,
+      curDetails,
+    );
     expect(actual).to.be.true;
   });
 
@@ -487,7 +491,7 @@ describe('discontinuities', function () {
 
     const actual = shouldAlignOnDiscontinuities(
       lastFrag,
-      lastLevel,
+      lastLevel.details,
       curDetails,
     );
     expect(actual).to.be.true;
@@ -507,7 +511,7 @@ describe('discontinuities', function () {
 
     const actual = shouldAlignOnDiscontinuities(
       lastFrag,
-      lastLevel,
+      lastLevel.details,
       curDetails,
     );
     expect(actual).to.be.false;
@@ -525,7 +529,7 @@ describe('discontinuities', function () {
 
     const actual = shouldAlignOnDiscontinuities(
       lastFrag,
-      lastLevel,
+      lastLevel.details,
       curDetails,
     );
     expect(actual).to.be.false;


### PR DESCRIPTION
### This PR will...
Keep a reference to the last loaded level or track playlist object, and use it when aligning live playlists without PDT.

### Why is this Pull Request needed?
Track group id changes replace track list, making it impossible to access the level or details object used prior to the switch using `level[index]`.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #5802

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
