### PR TITLE
Exit gracefully when switching to an audio group with no tracks

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -132,7 +132,10 @@ class AudioTrackController extends BasePlaylistController {
       ) {
         this.selectDefaultTrack = false;
       }
-
+      if (!audioTracks.length) {
+        this.trackId = -1;
+        this.currentTrack = null;
+      }
       this.tracksInGroup = audioTracks;
       const audioTracksUpdated: AudioTracksUpdatedData = { audioTracks };
       this.log(
@@ -213,6 +216,9 @@ class AudioTrackController extends BasePlaylistController {
 
   private selectInitialTrack(): void {
     const audioTracks = this.tracksInGroup;
+    if (!audioTracks.length) {
+      return;
+    }
     let trackId = this.findTrackId(this.currentTrack);
     if (trackId === -1) {
       trackId = this.findTrackId(null);


### PR DESCRIPTION
### This PR will...
Exit gracefully when switching to an audio group with no (supported) tracks

### Why is this Pull Request needed?
Users report receiving a fatal error in streams with no audio tracks (but audio groups?)

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #4602

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
