### PR TITLE
Add `preferManagedMediaSource` API.md doc entry for ManagedMediaSource usage

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`maxLiveSyncPlaybackRate`](#maxlivesyncplaybackrate)
   - [`liveDurationInfinity`](#livedurationinfinity)
   - [`liveBackBufferLength` (deprecated)](#livebackbufferlength-deprecated)
+  - [`preferManagedMediaSource`](#prefermanagedmediasource)
   - [`enableWorker`](#enableworker)
   - [`workerPath`](#workerpath)
   - [`enableSoftwareAES`](#enablesoftwareaes)
@@ -375,6 +376,7 @@ var config = {
   liveSyncDurationCount: 3,
   liveMaxLatencyDurationCount: Infinity,
   liveDurationInfinity: false,
+  preferManagedMediaSource: false,
   enableWorker: true,
   enableSoftwareAES: true,
   manifestLoadingTimeOut: 10000,
@@ -671,6 +673,12 @@ If you want to have a native Live UI in environments like iOS Safari, Safari, An
 ### `liveBackBufferLength` (deprecated)
 
 `liveBackBufferLength` has been deprecated. Use `backBufferLength` instead.
+
+### `preferManagedMediaSource`
+
+(default `true`)
+
+HLS.js uses the Managed Media Source API (`ManagedMediaSource` global) instead of the `MediaSource` global by default when present. Setting this to `false` will only use `ManagedMediaSource` when `MediaSource` is undefined.
 
 ### `enableWorker`
 

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -936,11 +936,19 @@ export default class BufferController implements ComponentAPI {
           this.addBufferListener(sbName, 'updateend', this._onSBUpdateEnd);
           this.addBufferListener(sbName, 'error', this._onSBUpdateError);
           // ManagedSourceBuffer bufferedchange event
-          this.addBufferListener(sbName, 'bufferedchange', (event) => {
-            this.hls.trigger(Events.BUFFER_FLUSHED, {
-              type: trackName as SourceBufferName,
-            });
-          });
+          this.addBufferListener(
+            sbName,
+            'bufferedchange',
+            (type: SourceBufferName, event: Event) => {
+              // If media was ejected check for a change. Added ranges are redundant with changes on 'updateend' event.
+              const removedRanges = (event as any).removedRanges;
+              if (removedRanges) {
+                this.hls.trigger(Events.BUFFER_FLUSHED, {
+                  type: trackName as SourceBufferName,
+                });
+              }
+            },
+          );
 
           this.tracks[trackName] = {
             buffer: sb,

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -38,6 +38,11 @@ import type { HlsConfig } from '../hls';
 const VIDEO_CODEC_PROFILE_REPLACE =
   /(avc[1234]|hvc1|hev1|dvh[1e]|vp09|av01)(?:\.[^.,]+)+/;
 
+interface BufferedChangeEvent extends Event {
+  readonly addedRanges?: TimeRanges;
+  readonly removedRanges?: TimeRanges;
+}
+
 export default class BufferController implements ComponentAPI {
   // The level details used to determine duration, target-duration and live
   private details: LevelDetails | null = null;
@@ -939,9 +944,9 @@ export default class BufferController implements ComponentAPI {
           this.addBufferListener(
             sbName,
             'bufferedchange',
-            (type: SourceBufferName, event: Event) => {
+            (type: SourceBufferName, event: BufferedChangeEvent) => {
               // If media was ejected check for a change. Added ranges are redundant with changes on 'updateend' event.
-              const removedRanges = (event as any).removedRanges;
+              const removedRanges = event.removedRanges;
               if (removedRanges) {
                 this.hls.trigger(Events.BUFFER_FLUSHED, {
                   type: trackName as SourceBufferName,


### PR DESCRIPTION
### This PR will...
- Add `preferManagedMediaSource` API.md doc entry
- Only emit BUFFER_FLUSHED with removed ranges in ManagedMediaSource "bufferedchange" event

### Why is this Pull Request needed?
 ManagedMediaSource dispatches "bufferedchange" on append and when ejecting media independent of appends. The event includes `removedRanges` when media is ejected from the buffer.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
