### PR TITLE
Fix audio codec alternate error fallback

### DIFF
--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -410,9 +410,10 @@ export default class ErrorController implements NetworkComponentAPI {
               level.textGroupId === levelCandidate.textGroupId) ||
             (findAudioCodecAlternate &&
               level.audioCodec === levelCandidate.audioCodec) ||
+            (!findAudioCodecAlternate &&
+              level.audioCodec !== levelCandidate.audioCodec) ||
             (findVideoCodecAlternate &&
-              level.codecSet === levelCandidate.codecSet) ||
-            level.audioCodec !== levelCandidate.audioCodec
+              level.codecSet === levelCandidate.codecSet)
           ) {
             // For video/audio/subs frag errors find another group ID or fallthrough to redundant fail-over
             continue;


### PR DESCRIPTION
### This PR will...
Fix selection of levels with alternate audio codecs on frag parsing error of audio segment.

### Why is this Pull Request needed?
Fixes handing of frag parsing error of containerless EC-3 segments when HLS asset has other audio codec renditions.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #4958

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
