### PR TITLE
Add strict type checking for Uint8Array/ArrayBuffer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,9 @@ module.exports = {
   },
   overrides: [
     {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
       files: ['*.ts'],
       rules: {
         'no-unused-vars': 0,

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -251,7 +251,7 @@ class AudioStreamController
           if (this.initPTS[frag.cc] !== undefined) {
             this.waitingData = null;
             this.state = State.FRAG_LOADING;
-            const payload = cache.flush();
+            const payload = cache.flush().buffer;
             const data: FragLoadedData = {
               frag,
               part,

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -347,7 +347,7 @@ class EMEController extends Logger implements ComponentAPI {
         this.generateRequestWithPreferredKeySession(
           keySessionContext,
           scheme,
-          decryptdata.pssh,
+          decryptdata.pssh.buffer,
           'expired',
         );
     } else {
@@ -449,10 +449,11 @@ class EMEController extends Logger implements ComponentAPI {
       const keySessionContextPromise = (this.keyIdToKeySessionPromise[keyId] =
         keyContextPromise.then((keySessionContext) => {
           const scheme = 'cenc';
+          const initData = decryptdata.pssh ? decryptdata.pssh.buffer : null;
           return this.generateRequestWithPreferredKeySession(
             keySessionContext,
             scheme,
-            decryptdata.pssh,
+            initData,
             'playlist-key',
           );
         }));
@@ -730,9 +731,8 @@ class EMEController extends Logger implements ComponentAPI {
           );
         }
         initDataType = mappedInitData.initDataType;
-        initData = context.decryptdata.pssh = mappedInitData.initData
-          ? new Uint8Array(mappedInitData.initData)
-          : null;
+        initData = mappedInitData.initData ? mappedInitData.initData : null;
+        context.decryptdata.pssh = initData ? new Uint8Array(initData) : null;
       } catch (error) {
         this.warn(error.message);
         if (this.hls?.config.debug) {

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -546,7 +546,7 @@ class EMEController extends Logger implements ComponentAPI {
       const json = bin2str(new Uint8Array(initData));
       try {
         const sinf = base64Decode(JSON.parse(json).sinf);
-        const tenc = parseSinf(new Uint8Array(sinf));
+        const tenc = parseSinf(sinf);
         if (!tenc) {
           throw new Error(
             `'schm' box missing or not cbcs/cenc with schi > tenc`,

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -577,7 +577,7 @@ export class TimelineController implements ComponentAPI {
     const hls = this.hls;
     // Parse the WebVTT file contents.
     const payloadWebVTT = frag.initSegment?.data
-      ? appendUint8Array(frag.initSegment.data, new Uint8Array(payload))
+      ? appendUint8Array(frag.initSegment.data, new Uint8Array(payload)).buffer
       : payload;
     parseWebVTT(
       payloadWebVTT,

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -86,7 +86,8 @@ export default class Decrypter {
   ): Promise<ArrayBuffer> {
     if (this.useSoftware) {
       return new Promise((resolve, reject) => {
-        this.softwareDecrypt(new Uint8Array(data), key, iv, aesMode);
+        const dataView = ArrayBuffer.isView(data) ? data : new Uint8Array(data);
+        this.softwareDecrypt(dataView, key, iv, aesMode);
         const decryptResult = this.flush();
         if (decryptResult) {
           resolve(decryptResult.buffer);

--- a/src/demux/chunk-cache.ts
+++ b/src/demux/chunk-cache.ts
@@ -9,7 +9,7 @@ export default class ChunkCache {
 
   flush(): Uint8Array {
     const { chunks, dataLength } = this;
-    let result;
+    let result: Uint8Array;
     if (!chunks.length) {
       return new Uint8Array(0);
     } else if (chunks.length === 1) {

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -135,7 +135,8 @@ export default class Transmuxer {
         // For Low-Latency HLS Parts, decrypt in place, since part parsing is expected on push progress
         const loadingParts = chunkMeta.part > -1;
         if (loadingParts) {
-          decryptedData = decrypter.flush();
+          const data = decrypter.flush();
+          decryptedData = data ? data.buffer : data;
         }
         if (!decryptedData) {
           stats.executeEnd = now();
@@ -248,7 +249,7 @@ export default class Transmuxer {
       if (decryptedData) {
         // Push always returns a TransmuxerResult if decryptdata is null
         transmuxResults.push(
-          this.push(decryptedData, null, chunkMeta) as TransmuxerResult,
+          this.push(decryptedData.buffer, null, chunkMeta) as TransmuxerResult,
         );
       }
     }

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -1,3 +1,12 @@
+declare global {
+  interface ArrayBuffer {
+    ' buffer_kind'?: 'array';
+  }
+  interface Uint8Array {
+    ' buffer_kind'?: 'uint8';
+  }
+}
+
 export type SourceBufferName = 'video' | 'audio' | 'audiovideo';
 
 /* eslint-disable no-restricted-globals */

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -237,7 +237,7 @@ class FetchLoader implements Loader<LoaderContext> {
         .then((data) => {
           if (data.done) {
             if (chunkCache.dataLength) {
-              onProgress(stats, context, chunkCache.flush(), response);
+              onProgress(stats, context, chunkCache.flush().buffer, response);
             }
 
             return Promise.resolve(new ArrayBuffer(0));
@@ -251,12 +251,12 @@ class FetchLoader implements Loader<LoaderContext> {
             chunkCache.push(chunk);
             if (chunkCache.dataLength >= highWaterMark) {
               // flush in order to join the typed arrays
-              onProgress(stats, context, chunkCache.flush(), response);
+              onProgress(stats, context, chunkCache.flush().buffer, response);
             }
           } else {
             // If there's nothing cached already, and the chache is large enough
             // just emit the progress event
-            onProgress(stats, context, chunk, response);
+            onProgress(stats, context, chunk.buffer, response);
           }
           return pump();
         })

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -218,7 +218,7 @@ describe('TransmuxerInterface tests', function () {
     newFrag.level = 2;
     newFrag.start = 1000;
     const part = null;
-    const data = new Uint8Array(new ArrayBuffer(8));
+    const data = new ArrayBuffer(8);
     const initSegmentData = new Uint8Array(0);
     const audioCodec = '';
     const videoCodec = '';


### PR DESCRIPTION
### This PR will...
- Add strict type checking for Uint8Array/ArrayBuffer and fix errors.
- Include tsconfig in eslint settings.

### Why is this Pull Request needed?
Enforce the use of ArrayBuffers vs Uint8Array so that we pass the correct type to user-agents that may be strict about the type provided.

This should also help avoid unnecessary copying of data by creating new views from typed arrays (`copy = new Uint8Array(uint8Arr)`).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
