### PR TITLE
Support #EXT-X-BYTERANGE before #EXT-X-MAP tag

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -270,11 +270,11 @@ export class BaseSegment {
     // (undocumented)
     readonly baseurl: string;
     // (undocumented)
-    get byteRange(): number[];
+    get byteRange(): [number, number] | [];
     // (undocumented)
-    get byteRangeEndOffset(): number;
+    get byteRangeEndOffset(): number | undefined;
     // (undocumented)
-    get byteRangeStartOffset(): number;
+    get byteRangeStartOffset(): number | undefined;
     // (undocumented)
     elementaryStreams: ElementaryStreams;
     // (undocumented)

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -331,8 +331,8 @@ function createLoaderContext(
     rangeStart: 0,
     rangeEnd: 0,
   };
-  const start = segment.byteRangeStartOffset;
-  const end = segment.byteRangeEndOffset;
+  const start = segment.byteRangeStartOffset as number;
+  const end = segment.byteRangeEndOffset as number;
   if (Number.isFinite(start) && Number.isFinite(end)) {
     let byteRangeStart = start;
     let byteRangeEnd = end;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -30,7 +30,7 @@ export type ElementaryStreams = Record<
 >;
 
 export class BaseSegment {
-  private _byteRange: number[] | null = null;
+  private _byteRange: [number, number] | null = null;
   private _url: string | null = null;
 
   // baseurl is the URL to the playlist
@@ -51,17 +51,16 @@ export class BaseSegment {
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
   setByteRange(value: string, previous?: BaseSegment) {
     const params = value.split('@', 2);
-    const byteRange: number[] = [];
+    let start: number;
     if (params.length === 1) {
-      byteRange[0] = previous ? previous.byteRangeEndOffset : 0;
+      start = previous?.byteRangeEndOffset || 0;
     } else {
-      byteRange[0] = parseInt(params[1]);
+      start = parseInt(params[1]);
     }
-    byteRange[1] = parseInt(params[0]) + byteRange[0];
-    this._byteRange = byteRange;
+    this._byteRange = [start, parseInt(params[0]) + start];
   }
 
-  get byteRange(): number[] {
+  get byteRange(): [number, number] | [] {
     if (!this._byteRange) {
       return [];
     }
@@ -69,11 +68,11 @@ export class BaseSegment {
     return this._byteRange;
   }
 
-  get byteRangeStartOffset(): number {
+  get byteRangeStartOffset(): number | undefined {
     return this.byteRange[0];
   }
 
-  get byteRangeEndOffset(): number {
+  get byteRangeEndOffset(): number | undefined {
     return this.byteRange[1];
   }
 

--- a/tests/unit/loader/playlist-loader.ts
+++ b/tests/unit/loader/playlist-loader.ts
@@ -725,6 +725,52 @@ lo008ts`;
     expect(result.fragments[9].byteRangeEndOffset).to.equal(817988);
   });
 
+  it('parse level with #EXT-X-BYTERANGE before #EXT-X-MAP tag', function () {
+    const level = `#EXTM3U
+#EXT-X-ALLOW-CACHE:YES
+#EXT-X-VERSION:6
+#EXT-X-TARGETDURATION:4
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-BYTERANGE:10000@24000
+#EXT-X-MAP:URI="initsegment.m4v",BYTERANGE="24000@0"
+#EXTINF:4.000,
+lo007.m4v
+#EXT-X-BYTERANGE:30000@34000
+#EXTINF:4.000,
+lo007.m4v
+#EXT-X-BYTERANGE:40000@64000
+#EXTINF:4.000,
+lo007.m4v
+#EXT-X-ENDLIST`;
+
+    const result = M3U8Parser.parseLevelPlaylist(
+      level,
+      'http://dummy.com/playlist.m3u8',
+      0,
+      PlaylistLevelType.MAIN,
+      0,
+      null,
+    );
+    expect(result.fragments.length).to.equal(3);
+    expect(result.fragments[0].initSegment?.url).to.equal(
+      'http://dummy.com/initsegment.m4v',
+    );
+    expect(result.fragments[0].initSegment?.byteRangeStartOffset).to.equal(0);
+    expect(result.fragments[0].initSegment?.byteRangeEndOffset).to.equal(
+      24000,
+      'init end',
+    );
+    expect(result.fragments[0].url).to.equal('http://dummy.com/lo007.m4v');
+    expect(result.fragments[0].byteRangeStartOffset).to.equal(24000, '1 start');
+    expect(result.fragments[0].byteRangeEndOffset).to.equal(34000, '1 end');
+    expect(result.fragments[1].url).to.equal('http://dummy.com/lo007.m4v');
+    expect(result.fragments[1].byteRangeStartOffset).to.equal(34000, '2 start');
+    expect(result.fragments[1].byteRangeEndOffset).to.equal(64000, '2 end');
+    expect(result.fragments[2].url).to.equal('http://dummy.com/lo007.m4v');
+    expect(result.fragments[2].byteRangeStartOffset).to.equal(64000, '3 start');
+    expect(result.fragments[2].byteRangeEndOffset).to.equal(104000, '3 end');
+  });
+
   it('parse level with #EXT-X-BYTERANGE without offset', function () {
     const level = `#EXTM3U
 #EXT-X-VERSION:4


### PR DESCRIPTION
### This PR will...
- Support #EXT-X-BYTERANGE before #EXT-X-MAP tag
- Update Fragment `byteRange`, `byteRangeEndOffset`, `byteRangeStartOffset` typing to reflect actual return types.
  -  `fragment.byteRange` returns a number tuple or an empty array
  - `byteRangeEndOffset` and `byteRangeStartOffset` both return numbers or both return undefined

### Why is this Pull Request needed?
Handle odd tag order in media playlists and better reflect data types.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
