### PR TITLE
MP4Demuxer probe fix for large "emsg" payloads

### DIFF
--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -19,6 +19,7 @@ import {
   parseSamples,
   parseInitSegment,
   RemuxerTrackIdConfig,
+  hasMoofData,
 } from '../utils/mp4-tools';
 import { dummyTrack } from './dummy-demuxed-track';
 import type { HlsEventEmitter } from '../events';
@@ -92,9 +93,7 @@ class MP4Demuxer implements Demuxer {
   }
 
   static probe(data: Uint8Array) {
-    // ensure we find a moof box in the first 16 kB
-    data = data.length > 16384 ? data.subarray(0, 16384) : data;
-    return findBox(data, ['moof']).length > 0;
+    return hasMoofData(data);
   }
 
   public demux(data: Uint8Array, timeOffset: number): DemuxerResult {

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -54,6 +54,25 @@ export function writeUint32(buffer: Uint8Array, offset: number, value: number) {
   buffer[offset + 3] = value & 0xff;
 }
 
+// Find "moof" box
+export function hasMoofData(data: Uint8Array): boolean {
+  const end = data.byteLength;
+  for (let i = 0; i < end; ) {
+    const size = readUint32(data, i);
+    if (
+      size > 8 &&
+      data[i + 4] === 0x6d &&
+      data[i + 5] === 0x6f &&
+      data[i + 6] === 0x6f &&
+      data[i + 7] === 0x66
+    ) {
+      return true;
+    }
+    i = size > 1 ? i + size : end;
+  }
+  return false;
+}
+
 // Find the data for a box specified by its path
 export function findBox(data: Uint8Array, path: string[]): Uint8Array[] {
   const results = [] as Uint8Array[];
@@ -743,9 +762,7 @@ export function segmentValidRange(data: Uint8Array): SegmentedRange {
   };
 
   const moofs = findBox(data, ['moof']);
-  if (!moofs) {
-    return segmentedRange;
-  } else if (moofs.length < 2) {
+  if (moofs.length < 2) {
     segmentedRange.remainder = data;
     return segmentedRange;
   }


### PR DESCRIPTION
### This PR will...
Remove 16kB constraint on "moof" offset when probing segments to detect fmp4.

### Why is this Pull Request needed?
Segments with large or many emsg boxes can push the moof box offset to much further out in the segment. This is not uncommon for media carrying image data over id3 emsg.

### Are there any points in the code the reviewer needs to double check?
Added a new method optimized to exit on the first moof box found and skip quickly over others. When testing how this worked with TS and unwrapped audio the method tended to exit after first iteration because `size` was out of bounds (which is good). 

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
