### PR TITLE
Redundant Stream grouping enhancements

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2005,6 +2005,8 @@ export class Level {
     // (undocumented)
     addFallback(data: LevelParsed): void;
     // (undocumented)
+    addGroupId(type: string, groupId: string | undefined, fallbackIndex: number): void;
+    // (undocumented)
     get attrs(): LevelAttributes;
     // (undocumented)
     readonly _attrs: LevelAttributes[];
@@ -2014,6 +2016,8 @@ export class Level {
     get audioGroupId(): string | undefined;
     // (undocumented)
     audioGroupIds?: (string | undefined)[];
+    // (undocumented)
+    get audioGroups(): (string | undefined)[] | undefined;
     // (undocumented)
     get averageBitrate(): number;
     // (undocumented)
@@ -2049,6 +2053,8 @@ export class Level {
     realBitrate: number;
     // (undocumented)
     get score(): number;
+    // (undocumented)
+    get subtitleGroups(): (string | undefined)[] | undefined;
     // (undocumented)
     supportedPromise?: Promise<MediaDecodingInfo>;
     // (undocumented)
@@ -2737,6 +2743,10 @@ export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
     // (undocumented)
     autoselect: boolean;
     // (undocumented)
+    channels?: string;
+    // (undocumented)
+    characteristics?: string;
+    // (undocumented)
     default: boolean;
     // (undocumented)
     forced: boolean;
@@ -3049,8 +3059,6 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     protected getMaxBufferLength(mainBufferLength?: number): number;
     // (undocumented)
     _handleFragmentLoadComplete(fragLoadedData: FragLoadedData): void;
-    // (undocumented)
-    protected levels: Array<Level>;
     // (undocumented)
     protected loadFragment(frag: Fragment, level: Level, targetBufferTime: number): void;
     // (undocumented)

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -111,7 +111,6 @@ class AbrController implements AbrComponentAPI {
     this.lastLoadedFragLevel = -1;
     this.lastLevelLoadSec = 0;
     this.fragCurrent = this.partCurrent = null;
-    this.audioTracksByGroup = null;
     this.onLevelsUpdated();
     this.clearTimer();
   }
@@ -123,6 +122,7 @@ class AbrController implements AbrComponentAPI {
     this._nextAutoLevel = -1;
     this.nextAutoLevelKey = '';
     this.codecTiers = null;
+    this.audioTracksByGroup = null;
   }
 
   protected onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -1,5 +1,5 @@
 import { Events } from '../events';
-import { Level, addGroupId } from '../types/level';
+import { Level } from '../types/level';
 import { reassignFragmentLevelIndexes } from '../utils/level-helper';
 import { AttrList } from '../utils/attr-list';
 import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
@@ -313,8 +313,8 @@ export default class ContentSteeringController implements NetworkComponentAPI {
           }
           levelParsed.attrs = attributes;
           const clonedLevel = new Level(levelParsed);
-          addGroupId(clonedLevel, 'audio', clonedAudioGroupId);
-          addGroupId(clonedLevel, 'text', clonedSubtitleGroupId);
+          clonedLevel.addGroupId('audio', clonedAudioGroupId, -1);
+          clonedLevel.addGroupId('text', clonedSubtitleGroupId, -1);
           return clonedLevel;
         },
       );

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -410,10 +410,10 @@ export class TimelineController implements ComponentAPI {
   private _captionsOrSubtitlesFromCharacteristics(
     track: MediaPlaylist,
   ): TextTrackKind {
-    if (track.attrs.CHARACTERISTICS) {
+    if (track.characteristics) {
       if (
-        /transcribes-spoken-dialog/gi.test(track.attrs.CHARACTERISTICS) &&
-        /describes-music-and-sound/gi.test(track.attrs.CHARACTERISTICS)
+        /transcribes-spoken-dialog/gi.test(track.characteristics) &&
+        /describes-music-and-sound/gi.test(track.characteristics)
       ) {
         return 'captions';
       }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -494,8 +494,7 @@ export default class Hls implements HlsEventEmitter {
    */
   set currentLevel(newLevel: number) {
     logger.log(`set currentLevel:${newLevel}`);
-    this.loadLevel = newLevel;
-    this.abrController.clearTimer();
+    this.levelController.manualLevel = newLevel;
     this.streamController.immediateLevelSwitch();
   }
 

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -317,20 +317,32 @@ export default class M3U8Parser {
             'CHANNELS',
           ]);
         }
+        const lang = attrs.LANGUAGE;
+        const channels = attrs.CHANNELS;
+        const characteristics = attrs.CHARACTERISTICS;
+        const instreamId = attrs['INSTREAM-ID'];
         const media: MediaPlaylist = {
           attrs,
           bitrate: 0,
           id: id++,
           groupId: attrs['GROUP-ID'] || '',
-          instreamId: attrs['INSTREAM-ID'],
-          name: attrs.NAME || attrs.LANGUAGE || '',
+          name: attrs.NAME || lang || '',
           type,
           default: attrs.bool('DEFAULT'),
           autoselect: attrs.bool('AUTOSELECT'),
           forced: attrs.bool('FORCED'),
-          lang: attrs.LANGUAGE,
+          lang: lang,
           url: attrs.URI ? M3U8Parser.resolve(attrs.URI, baseurl) : '',
         };
+        if (channels) {
+          media.channels = channels;
+        }
+        if (characteristics) {
+          media.characteristics = characteristics;
+        }
+        if (instreamId) {
+          media.instreamId = instreamId;
+        }
 
         if (groups?.length) {
           // If there are audio or text groups signalled in the manifest, let's look for a matching codec string for this track

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -17,6 +17,8 @@ export type MediaPlaylistType = MainPlaylistType | SubtitlePlaylistType;
 export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
   attrs: MediaAttributes;
   autoselect: boolean; // implicit false if not present
+  channels?: string;
+  characteristics?: string;
   default: boolean; // implicit false if not present
   forced: boolean; // implicit false if not present
   groupId: string; // required in HLS playlists

--- a/src/utils/media-option-attributes.ts
+++ b/src/utils/media-option-attributes.ts
@@ -10,7 +10,7 @@ export function subtitleOptionsIdentical(
   }
   for (let i = 0; i < trackList1.length; i++) {
     if (
-      !subtitleAttributesIdentical(
+      !mediaAttributesIdentical(
         trackList1[i].attrs as MediaAttributes,
         trackList2[i].attrs,
       )
@@ -21,24 +21,28 @@ export function subtitleOptionsIdentical(
   return true;
 }
 
-export function subtitleAttributesIdentical(
+export function mediaAttributesIdentical(
   attrs1: MediaAttributes,
   attrs2: MediaAttributes,
+  customAttributes?: string[],
 ): boolean {
   // Media options with the same rendition ID must be bit identical
   const stableRenditionId = attrs1['STABLE-RENDITION-ID'];
-  if (stableRenditionId) {
+  if (stableRenditionId && !customAttributes) {
     return stableRenditionId === attrs2['STABLE-RENDITION-ID'];
   }
   // When rendition ID is not present, compare attributes
-  return ![
-    'LANGUAGE',
-    'NAME',
-    'CHARACTERISTICS',
-    'AUTOSELECT',
-    'DEFAULT',
-    'FORCED',
-  ].some(
+  return !(
+    customAttributes || [
+      'LANGUAGE',
+      'ASSOC-LANGUAGE',
+      'NAME',
+      'CHARACTERISTICS',
+      'AUTOSELECT',
+      'DEFAULT',
+      'FORCED',
+    ]
+  ).some(
     (subtitleAttribute) =>
       attrs1[subtitleAttribute] !== attrs2[subtitleAttribute],
   );

--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -163,7 +163,7 @@ export function getAudioTracksByGroup(allAudioTracks: MediaPlaylist[]) {
         };
       }
       trackGroup.tracks.push(track);
-      const channelsKey = track.attrs.CHANNELS || '2';
+      const channelsKey = track.channels || '2';
       trackGroup.channels[channelsKey] =
         (trackGroup.channels[channelsKey] || 0) + 1;
       trackGroup.hasDefault = trackGroup.hasDefault || track.default;

--- a/tests/unit/controller/audio-track-controller.ts
+++ b/tests/unit/controller/audio-track-controller.ts
@@ -30,7 +30,7 @@ type HlsTestable = Omit<
   'levelController' | 'networkControllers' | 'coreComponents'
 > & {
   levelController: {
-    levels: Partial<Level>[];
+    levels: Pick<Level, 'urlId' | 'audioGroups'>[];
   };
   coreComponents: ComponentAPI[];
   networkControllers: NetworkComponentAPI[];
@@ -87,7 +87,7 @@ describe('AudioTrackController', function () {
       levels: [
         {
           urlId: 1,
-          audioGroupIds: ['1', '2'],
+          audioGroups: ['2'],
         },
       ],
     };
@@ -180,7 +180,7 @@ describe('AudioTrackController', function () {
   });
 
   describe('onLevelLoading', function () {
-    it('should set the audioTracks contained in the event data and trigger AUDIO_TRACKS_UPDATED', function () {
+    it('should set the audioTracks to those in the level audio group ("2") and trigger AUDIO_TRACKS_UPDATED', function () {
       const audioTracksUpdatedCallback = sinon.spy();
       hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, audioTracksUpdatedCallback);
 
@@ -197,6 +197,31 @@ describe('AudioTrackController', function () {
         Events.AUDIO_TRACKS_UPDATED,
         {
           audioTracks: tracks.slice(3, 6),
+        },
+      );
+    });
+
+    it('should set the audioTracks to those in the level audio groups ("1" and "2") and trigger AUDIO_TRACKS_UPDATED', function () {
+      const audioTracksUpdatedCallback = sinon.spy();
+      hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, audioTracksUpdatedCallback);
+
+      const audioGroups = hls.levelController.levels[0].audioGroups as any;
+      audioGroups.length = 0;
+      audioGroups.push('1', '2');
+
+      audioTrackController.onManifestParsed(Events.MANIFEST_PARSED, {
+        audioTracks: tracks,
+      });
+      audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
+        level: 0,
+      });
+
+      expect(audioTrackController.tracks).to.equal(tracks);
+      expect(audioTracksUpdatedCallback).to.be.calledOnce;
+      expect(audioTracksUpdatedCallback).to.be.calledWith(
+        Events.AUDIO_TRACKS_UPDATED,
+        {
+          audioTracks: tracks.slice(),
         },
       );
     });
@@ -374,7 +399,7 @@ describe('AudioTrackController', function () {
         levels: [
           {
             urlId: 0,
-            audioGroupIds: ['1'],
+            audioGroups: ['1'],
           },
         ],
       };
@@ -414,7 +439,7 @@ describe('AudioTrackController', function () {
         levels: [
           {
             urlId: 0,
-            audioGroupIds: ['1'],
+            audioGroups: ['1'],
           },
         ],
       };

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -31,8 +31,8 @@ describe('SubtitleTrackController', function () {
       {
         id: 1,
         groupId: 'default-text-group',
-        lang: 'en',
-        name: 'English',
+        lang: 'sv',
+        name: 'Swedish',
         type: 'SUBTITLES',
         url: 'bar',
       },
@@ -40,7 +40,7 @@ describe('SubtitleTrackController', function () {
         id: 2,
         groupId: 'default-text-group',
         lang: 'en',
-        name: 'English',
+        name: 'Untitled CC',
         type: 'SUBTITLES',
         url: 'foo',
         details: { live: true },
@@ -48,7 +48,7 @@ describe('SubtitleTrackController', function () {
     ];
 
     const textTrack1 = videoElement.addTextTrack('subtitles', 'English', 'en');
-    const textTrack2 = videoElement.addTextTrack('subtitles', 'Swedish', 'se');
+    const textTrack2 = videoElement.addTextTrack('subtitles', 'Swedish', 'sv');
     const textTrack3 = videoElement.addTextTrack(
       'captions',
       'Untitled CC',
@@ -148,7 +148,7 @@ describe('SubtitleTrackController', function () {
         {
           id: 1,
           groupId: 'default-text-group',
-          name: 'English',
+          name: 'Swedish',
           type: 'SUBTITLES',
           url: 'bar',
         },
@@ -267,6 +267,7 @@ describe('SubtitleTrackController', function () {
 
         const mockLoadedEvent = {
           id: 999,
+          groupId: 'default-text-group',
           details: { foo: 'bar' },
           stats: new LoadStats(),
         };
@@ -300,7 +301,12 @@ describe('SubtitleTrackController', function () {
         subtitleTrackController.trackId = 1;
         subtitleTrackController.onSubtitleTrackLoaded(
           Events.SUBTITLE_TRACK_LOADED,
-          { id: 1, details, stats: new LoadStats() },
+          {
+            id: 1,
+            groupId: 'default-text-group',
+            details,
+            stats: new LoadStats(),
+          },
         );
         expect(subtitleTrackController.timer).to.equal(-1);
       });
@@ -311,7 +317,12 @@ describe('SubtitleTrackController', function () {
         subtitleTrackController.trackId = 1;
         subtitleTrackController.onSubtitleTrackLoaded(
           Events.SUBTITLE_TRACK_LOADED,
-          { id: 1, details, stats: new LoadStats() },
+          {
+            id: 1,
+            groupId: 'default-text-group',
+            details,
+            stats: new LoadStats(),
+          },
         );
         expect(subtitleTrackController.timer).to.exist;
       });
@@ -323,7 +334,12 @@ describe('SubtitleTrackController', function () {
         subtitleTrackController.timer = self.setTimeout(() => {}, 0);
         subtitleTrackController.onSubtitleTrackLoaded(
           Events.SUBTITLE_TRACK_LOADED,
-          { id: 1, details, stats: new LoadStats() },
+          {
+            id: 1,
+            groupId: 'default-text-group',
+            details,
+            stats: new LoadStats(),
+          },
         );
         expect(subtitleTrackController.timer).to.equal(-1);
       });

--- a/tests/unit/controller/timeline-controller.js
+++ b/tests/unit/controller/timeline-controller.js
@@ -97,15 +97,16 @@ describe('TimelineController', function () {
   describe('text track kind', function () {
     it('should be kind captions when there is both transcribes-spoken-dialog and describes-music-and-sound', function () {
       hls.subtitleTrackController = { subtitleDisplay: false };
-
+      const characteristics =
+        'public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound';
       timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
         subtitleTracks: [
           {
             id: 0,
             name: 'en',
+            characteristics,
             attrs: {
-              CHARACTERISTICS:
-                'public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound',
+              CHARACTERISTICS: characteristics,
             },
           },
         ],


### PR DESCRIPTION
### This PR will...
- Treat STREAM-INFs with the same attributes and URL as a single Level AND:
  - List `audioTracks` and `subtitleTracks` across multiple GroupIDs that share the same Variant (#5302)
- Add VIDEO_RANGE and HDCP attribute values to Redundant Stream group splitting
- Add `channels` and `characteristics` to `MediaPlaylist` objects (`hls.audioTracks` and `hls.subtitleTracks`)
- Improve selection of matching alternate tracks (audio and subtitles) when switching variants

### Why is this Pull Request needed?
> - Treat STREAM-INFs with the same attributes and URL as a single Level AND:
>  - List `audioTracks` and `subtitleTracks` across multiple GroupIDs that share the same Variant (#5302)
> - Add VIDEO_RANGE and HDCP attribute values to Redundant Stream group splitting

HLS assets can have audio or subtitle groups with different sets of members (#5302). Compliant assets should have the same set of NAME and LANGUAGE options across all groups. In some cases a groups with a more limited set is created containing limited options in a more advanced codec like (multi-channel audio for example).

This change prevents variants ("levels") with different audio or subtitle options from being grouped as Redundant Streams.


> - Add `channels` and `characteristics` to `MediaPlaylist` objects (`hls.audioTracks` and `hls.subtitleTracks`)

`channels` and `characteristics` properties aid with these changes and upcoming selection API enhancements.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #5302

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
