### PR TITLE
Bugfix: Reset gap-controller `nudgeRetry`

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -58,6 +58,9 @@ export default class GapController {
     // The playhead is moving, no-op
     if (currentTime !== lastCurrentTime) {
       this.moved = true;
+      if (!seeking) {
+        this.nudgeRetry = 0;
+      }
       if (stalled !== null) {
         // The playhead is now moving, but was previously stalled
         if (this.stallReported) {
@@ -70,7 +73,6 @@ export default class GapController {
           this.stallReported = false;
         }
         this.stalled = null;
-        this.nudgeRetry = 0;
       }
       return;
     }
@@ -88,6 +90,7 @@ export default class GapController {
       media.playbackRate === 0 ||
       !BufferHelper.getBuffered(media).length
     ) {
+      this.nudgeRetry = 0;
       return;
     }
 


### PR DESCRIPTION
### This PR will...
Reset gap-controller nudgeRetry count after playhead moves, pauses, or ends while not seeking.

### Why is this Pull Request needed?
When `nudgeRetry` reaches `nudgeMaxRetry`, the error is escalated to fatal (expected):

https://github.com/video-dev/hls.js/blob/46a7ca29bec3453bf39bc9919aba5ce189d17895/src/controller/gap-controller.ts#L334-L365

`nudgeRetry` is reset when polling `currentTime`. The expectation is that this runs after currentTime has advanced naturally. Note that `stalled` must not be `null` - the think here is that this is reset when exiting a stall, but this does not work if stalled is reset before reaching this point:
https://github.com/video-dev/hls.js/blob/46a7ca29bec3453bf39bc9919aba5ce189d17895/src/controller/gap-controller.ts#L47-L73

And here we see that `stalled` is reset to null before nudging, so `nudgeRetry` will never be reset:
https://github.com/video-dev/hls.js/blob/46a7ca29bec3453bf39bc9919aba5ce189d17895/src/controller/gap-controller.ts#L206-L211

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #5873

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
