### PR TITLE
Fix subtitle track selection when reusing media element with mismatched TextTracks

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -277,6 +277,13 @@ class AudioTrackController extends BasePlaylistController {
         ) {
           return track.id;
         }
+        if (
+          mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
+            'LANGUAGE',
+          ])
+        ) {
+          return track.id;
+        }
       }
     }
     return -1;

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -257,29 +257,28 @@ class AudioTrackController extends BasePlaylistController {
     const audioTracks = this.tracksInGroup;
     for (let i = 0; i < audioTracks.length; i++) {
       const track = audioTracks[i];
-      if (!this.selectDefaultTrack || track.default) {
-        if (
-          !currentTrack ||
-          mediaAttributesIdentical(currentTrack.attrs, track.attrs)
-        ) {
-          return track.id;
-        }
-        if (
-          mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
-            'LANGUAGE',
-            'ASSOC-LANGUAGE',
-            'CHARACTERISTICS',
-          ])
-        ) {
-          return track.id;
-        }
-        if (
-          mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
-            'LANGUAGE',
-          ])
-        ) {
-          return track.id;
-        }
+      if (this.selectDefaultTrack && !track.default) {
+        continue;
+      }
+      if (
+        !currentTrack ||
+        mediaAttributesIdentical(currentTrack.attrs, track.attrs)
+      ) {
+        return track.id;
+      }
+      if (
+        mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
+          'LANGUAGE',
+          'ASSOC-LANGUAGE',
+          'CHARACTERISTICS',
+        ])
+      ) {
+        return track.id;
+      }
+      if (
+        mediaAttributesIdentical(currentTrack.attrs, track.attrs, ['LANGUAGE'])
+      ) {
+        return track.id;
       }
     }
     return -1;

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -58,10 +58,10 @@ class AudioTrackController extends BasePlaylistController {
 
   protected onManifestLoading(): void {
     this.tracks = [];
-    this.groupIds = null;
     this.tracksInGroup = [];
-    this.trackId = -1;
+    this.groupIds = null;
     this.currentTrack = null;
+    this.trackId = -1;
     this.selectDefaultTrack = true;
   }
 
@@ -113,40 +113,48 @@ class AudioTrackController extends BasePlaylistController {
 
   private switchLevel(levelIndex: number) {
     const levelInfo = this.hls.levels[levelIndex];
-
     if (!levelInfo) {
       return;
     }
-
     const audioGroups = levelInfo.audioGroups || null;
     const currentGroups = this.groupIds;
+    const currentTrack = this.currentTrack;
     if (
       !audioGroups ||
       currentGroups?.length !== audioGroups?.length ||
       audioGroups?.some((groupId) => currentGroups?.indexOf(groupId) === -1)
     ) {
       this.groupIds = audioGroups;
+      this.trackId = -1;
+      this.currentTrack = null;
 
       const audioTracks = this.tracks.filter(
         (track): boolean =>
           !audioGroups || audioGroups.indexOf(track.groupId) !== -1,
       );
+      if (audioTracks.length) {
+        // Disable selectDefaultTrack if there are no default tracks
+        if (
+          this.selectDefaultTrack &&
+          !audioTracks.some((track) => track.default)
+        ) {
+          this.selectDefaultTrack = false;
+        }
+        // track.id should match hls.audioTracks index
+        audioTracks.forEach((track, i) => {
+          track.id = i;
+        });
+      } else if (!currentTrack && !this.tracksInGroup.length) {
+        // Do not dispatch AUDIO_TRACKS_UPDATED when there were and are no tracks
+        return;
+      }
 
-      // Disable selectDefaultTrack if there are no default tracks
-      if (
-        this.selectDefaultTrack &&
-        !audioTracks.some((track) => track.default)
-      ) {
-        this.selectDefaultTrack = false;
-      }
-      if (!audioTracks.length) {
-        this.trackId = -1;
-        this.currentTrack = null;
-      }
-      audioTracks.forEach((track, i) => {
-        track.id = i;
-      });
       this.tracksInGroup = audioTracks;
+      let trackId = this.findTrackId(currentTrack);
+      if (trackId === -1 && currentTrack) {
+        trackId = this.findTrackId(null);
+      }
+
       const audioTracksUpdated: AudioTracksUpdatedData = { audioTracks };
       this.log(
         `Updating audio tracks, ${
@@ -155,8 +163,25 @@ class AudioTrackController extends BasePlaylistController {
       );
       this.hls.trigger(Events.AUDIO_TRACKS_UPDATED, audioTracksUpdated);
 
-      this.selectInitialTrack();
-    } else if (this.shouldReloadPlaylist(this.currentTrack)) {
+      const selectedTrackId = this.trackId;
+      if (trackId !== -1 && selectedTrackId === -1) {
+        this.setAudioTrack(trackId);
+      } else if (audioTracks.length && selectedTrackId === -1) {
+        const error = new Error(
+          `No audio track selected for current audio group-ID(s): ${this.groupIds?.join(
+            ',',
+          )} track count: ${audioTracks.length}`,
+        );
+        this.warn(error.message);
+
+        this.hls.trigger(Events.ERROR, {
+          type: ErrorTypes.MEDIA_ERROR,
+          details: ErrorDetails.AUDIO_TRACK_LOAD_ERROR,
+          fatal: true,
+          error,
+        });
+      }
+    } else if (this.shouldReloadPlaylist(currentTrack)) {
       // Retry playlist loading if no playlist is or has been loaded yet
       this.setAudioTrack(this.trackId);
     }
@@ -226,35 +251,6 @@ class AudioTrackController extends BasePlaylistController {
     }
     const hlsUrlParameters = this.switchParams(track.url, lastTrack?.details);
     this.loadPlaylist(hlsUrlParameters);
-  }
-
-  private selectInitialTrack(): void {
-    const audioTracks = this.tracksInGroup;
-    if (!audioTracks.length) {
-      return;
-    }
-    let trackId = this.findTrackId(this.currentTrack);
-    if (trackId === -1) {
-      trackId = this.findTrackId(null);
-    }
-
-    if (trackId !== -1) {
-      this.setAudioTrack(trackId);
-    } else {
-      const error = new Error(
-        `No track found for running audio group-ID(s): ${this.groupIds?.join(
-          ',',
-        )} track count: ${audioTracks.length}`,
-      );
-      this.warn(error.message);
-
-      this.hls.trigger(Events.ERROR, {
-        type: ErrorTypes.MEDIA_ERROR,
-        details: ErrorDetails.AUDIO_TRACK_LOAD_ERROR,
-        fatal: true,
-        error,
-      });
-    }
   }
 
   private findTrackId(currentTrack: MediaPlaylist | null): number {

--- a/src/utils/media-option-attributes.ts
+++ b/src/utils/media-option-attributes.ts
@@ -35,12 +35,12 @@ export function mediaAttributesIdentical(
   return !(
     customAttributes || [
       'LANGUAGE',
-      'ASSOC-LANGUAGE',
       'NAME',
       'CHARACTERISTICS',
       'AUTOSELECT',
       'DEFAULT',
       'FORCED',
+      'ASSOC-LANGUAGE',
     ]
   ).some(
     (subtitleAttribute) =>

--- a/src/utils/media-option-attributes.ts
+++ b/src/utils/media-option-attributes.ts
@@ -47,3 +47,15 @@ export function mediaAttributesIdentical(
       attrs1[subtitleAttribute] !== attrs2[subtitleAttribute],
   );
 }
+
+export function subtitleTrackMatchesTextTrack(
+  subtitleTrack: Pick<MediaPlaylist, 'name' | 'lang' | 'attrs'>,
+  textTrack: TextTrack,
+) {
+  return (
+    textTrack.label.toLowerCase() === subtitleTrack.name.toLowerCase() &&
+    (!textTrack.language ||
+      textTrack.language.toLowerCase() ===
+        (subtitleTrack.lang || '').toLowerCase())
+  );
+}

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -148,3 +148,20 @@ export function getCuesInRange(
   }
   return cuesFound;
 }
+
+export function filterSubtitleTracks(
+  textTrackList: TextTrackList,
+): TextTrack[] {
+  const tracks: TextTrack[] = [];
+  for (let i = 0; i < textTrackList.length; i++) {
+    const track = textTrackList[i];
+    // Edge adds a track without a label; we don't want to use it
+    if (
+      (track.kind === 'subtitles' || track.kind === 'captions') &&
+      track.label
+    ) {
+      tracks.push(textTrackList[i]);
+    }
+  }
+  return tracks;
+}

--- a/tests/unit/controller/timeline-controller.js
+++ b/tests/unit/controller/timeline-controller.js
@@ -62,8 +62,18 @@ describe('TimelineController', function () {
 
       timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
         subtitleTracks: [
-          { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
-          { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
+          {
+            id: 0,
+            name: 'en',
+            lang: 'en',
+            attrs: { LANGUAGE: 'en', NAME: 'en' },
+          },
+          {
+            id: 1,
+            name: 'ru',
+            lang: 'ru',
+            attrs: { LANGUAGE: 'ru', NAME: 'ru' },
+          },
         ],
       });
 
@@ -78,8 +88,18 @@ describe('TimelineController', function () {
 
       timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
         subtitleTracks: [
-          { id: 0, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
-          { id: 1, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
+          {
+            id: 0,
+            name: 'ru',
+            lang: 'ru',
+            attrs: { LANGUAGE: 'ru', NAME: 'ru' },
+          },
+          {
+            id: 1,
+            name: 'en',
+            lang: 'en',
+            attrs: { LANGUAGE: 'en', NAME: 'en' },
+          },
         ],
       });
 


### PR DESCRIPTION
### This PR will...
Use subtitle track name and language to find and match subtitle/captions TextTrack rather than subtitleTrack index.

Logs a warning when loading a new source with subtitle options that do not completely overlap with the attached media element's existing TextTracks:
```
Media element contains unused subtitle tracks: {TRACK LABEL CSVs}.
Replace media element for each source to clear TextTracks and captions menu.
```

Default subtitle track selection is updated to pick first default | forced | autoselect track to more closely match default behavior with Safari HLS playback.

If the user sets `hls.audioTrack` to a valid index on AUDIO_TRACKS_UPDATED, that selection will not be replaced with the default audio track immediately after (similar to existing initial subtitle track selection logic).

### Why is this Pull Request needed?
Lack of `removeTextTrack` in HTMLMediaElement standard (https://github.com/whatwg/html/issues/1921).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #4571
Replaces #5371

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
