### PR TITLE
Fix DATERANGE parser handling of `clientAttrs` property

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -85,6 +85,8 @@ export class AttrList {
     // (undocumented)
     bool(attrName: string): boolean;
     // (undocumented)
+    get clientAttrs(): string[];
+    // (undocumented)
     decimalFloatingPoint(attrName: string): number;
     // (undocumented)
     decimalInteger(attrName: string): number;

--- a/src/utils/attr-list.ts
+++ b/src/utils/attr-list.ts
@@ -9,16 +9,11 @@ export class AttrList {
     if (typeof attrs === 'string') {
       attrs = AttrList.parseAttrList(attrs);
     }
+    Object.assign(this, attrs);
+  }
 
-    for (const attr in attrs) {
-      if (attrs.hasOwnProperty(attr)) {
-        if (attr.substring(0, 2) === 'X-') {
-          this.clientAttrs = this.clientAttrs || [];
-          this.clientAttrs.push(attr);
-        }
-        this[attr] = attrs[attr];
-      }
-    }
+  get clientAttrs(): string[] {
+    return Object.keys(this).filter((attr) => attr.substring(0, 2) === 'X-');
   }
 
   decimalInteger(attrName: string): number {


### PR DESCRIPTION
### This PR will...
Replace the `AttrList` class `clientAttrs` property with a getter so that the `DateRange` constructor does not confuse the property with other attributes when merging DATERANGE tags with the same ID.

### Why is this Pull Request needed?
Fixes logger warning `DATERANGE tag attribute: "clientAttrs" does not match for tags with ID: "${DATERANGE ID}"`.
https://github.com/video-dev/hls.js/blob/470a29f47d2cd2155afadfb7d97b19e4e3e1cc2a/src/loader/date-range.ts#L41-L50

It also improves Typing since `clientAttrs` was treated as `any` but could have been `string[] | undefined`. Now it is always `string[]` as it was expected to be in the m3u8-parser:
https://github.com/video-dev/hls.js/blob/470a29f47d2cd2155afadfb7d97b19e4e3e1cc2a/src/loader/m3u8-parser.ts#L551-L554

### Are there any points in the code the reviewer needs to double-check?
`clientAttrs` is only read in one place (above when parsing a new DATERANGE) so the impact of filtering attribute names in the getter should be minimal and hopefully offset by faster instantiation of `AttrList` instances.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
