### PR TITLE
Check ManagedMediaSource removedRanges length on "bufferedchange" event

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -16,7 +16,6 @@ import {
   SourceBufferName,
   SourceBufferListeners,
 } from '../types/buffer';
-import CapLevelController from './cap-level-controller';
 import type {
   LevelUpdatedData,
   BufferAppendingData,

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -942,7 +942,7 @@ export default class BufferController implements ComponentAPI {
             (type: SourceBufferName, event: BufferedChangeEvent) => {
               // If media was ejected check for a change. Added ranges are redundant with changes on 'updateend' event.
               const removedRanges = event.removedRanges;
-              if (removedRanges) {
+              if (removedRanges?.length) {
                 this.hls.trigger(Events.BUFFER_FLUSHED, {
                   type: trackName as SourceBufferName,
                 });


### PR DESCRIPTION
### This PR will...
Check ManagedMediaSource `removedRanges` length on "bufferedchange" event.

### Why is this Pull Request needed?
`removedRanges` should be defined and have a positive length before it is assumed that media was ejected from the buffer.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
