### PR TITLE
Use named exports in ESM output

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -248,12 +248,13 @@ const buildRollupConfig = ({
   includeCoverage,
   sourcemap = true,
   outputFile = null,
+  input = './src/exports-default.ts',
 }) => {
   const outputName = buildTypeToOutputName[type];
   const extension = format === FORMAT.esm ? 'mjs' : 'js';
 
   return {
-    input: './src/hls.ts',
+    input,
     onwarn: (e) => {
       if (allowCircularDeps && e.code === 'CIRCULAR_DEPENDENCY') return;
 
@@ -307,6 +308,7 @@ const configs = Object.entries({
     minified: true,
   }),
   fullEsm: buildRollupConfig({
+    input: './src/exports-named.ts',
     type: BUILD_TYPE.full,
     format: FORMAT.esm,
     minified: false,
@@ -322,6 +324,7 @@ const configs = Object.entries({
     minified: true,
   }),
   lightEsm: buildRollupConfig({
+    input: './src/exports-named.ts',
     type: BUILD_TYPE.light,
     format: FORMAT.esm,
     minified: false,

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -32,7 +32,7 @@ import type { ComponentAPI } from '../types/component-api';
 import type { ChunkMetadata } from '../types/transmuxer';
 import type Hls from '../hls';
 import type { LevelDetails } from '../loader/level-details';
-import type { HlsConfig } from '../hls';
+import type { HlsConfig } from '../config';
 
 const VIDEO_CODEC_PROFILE_REPLACE =
   /(avc[1234]|hvc1|hev1|dvh[1e]|vp09|av01)(?:\.[^.,]+)+/;

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -14,7 +14,7 @@ import type { RetryConfig } from '../config';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type { ErrorData } from '../types/events';
 import type { Fragment } from '../loader/fragment';
-import type { LevelDetails } from '../hls';
+import type { LevelDetails } from '../loader/level-details';
 
 const RENDITION_PENALTY_DURATION_MS = 300000;
 

--- a/src/exports-default.ts
+++ b/src/exports-default.ts
@@ -1,0 +1,3 @@
+import Hls from './hls';
+
+export default Hls;

--- a/src/exports-named.ts
+++ b/src/exports-named.ts
@@ -1,0 +1,57 @@
+import Hls from './hls';
+import { Events } from './events';
+import { ErrorTypes, ErrorDetails } from './errors';
+import { Level } from './types/level';
+import AbrController from './controller/abr-controller';
+import AudioTrackController from './controller/audio-track-controller';
+import AudioStreamController from './controller/audio-stream-controller';
+import BasePlaylistController from './controller/base-playlist-controller';
+import BaseStreamController from './controller/base-stream-controller';
+import BufferController from './controller/buffer-controller';
+import CapLevelController from './controller/cap-level-controller';
+import CMCDController from './controller/cmcd-controller';
+import ContentSteeringController from './controller/content-steering-controller';
+import EMEController from './controller/eme-controller';
+import ErrorController from './controller/error-controller';
+import FPSController from './controller/fps-controller';
+import SubtitleTrackController from './controller/subtitle-track-controller';
+
+export default Hls;
+
+export {
+  Hls,
+  ErrorDetails,
+  ErrorTypes,
+  Events,
+  Level,
+  AbrController,
+  AudioStreamController,
+  AudioTrackController,
+  BasePlaylistController,
+  BaseStreamController,
+  BufferController,
+  CapLevelController,
+  CMCDController,
+  ContentSteeringController,
+  EMEController,
+  ErrorController,
+  FPSController,
+  SubtitleTrackController,
+};
+export { SubtitleStreamController } from './controller/subtitle-stream-controller';
+export { TimelineController } from './controller/timeline-controller';
+export { KeySystems, KeySystemFormats } from './utils/mediakeys-helper';
+export { DateRange } from './loader/date-range';
+export { LoadStats } from './loader/load-stats';
+export { LevelKey } from './loader/level-key';
+export { LevelDetails } from './loader/level-details';
+export { MetadataSchema } from './types/demuxer';
+export { HlsSkip, HlsUrlParameters } from './types/level';
+export { PlaylistLevelType } from './types/loader';
+export { ChunkMetadata } from './types/transmuxer';
+export { BaseSegment, Fragment, Part } from './loader/fragment';
+export {
+  NetworkErrorAction,
+  ErrorActionFlags,
+} from './controller/error-controller';
+export { AttrList } from './utils/attr-list';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
     "src/**/*",
     "tests/**/*",
     "demo/**/*",
-    "tests/**/.eslintrc.js" /* needed for eslint to work for some reason ¯\_(ツ)_/¯ */
+    /* needed for eslint to work for some reason ¯\_(ツ)_/¯ */
+    "tests/**/.eslintrc.js",
+    "rollup.config.js",
+    "build-config.js"
   ]
 }


### PR DESCRIPTION
### This PR will...
Include named exports in ESM output for classes and enums in addition to the default export.

### Why is this Pull Request needed?
Allows import and use of classes and enums in the public API with ESM output. UMD output continues to use default Hls class export only for backwards compatibility.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #5630

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
