### PR TITLE
Use Content Steering Pathways to manage Redundant Streams

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2311,6 +2311,8 @@ export interface LevelLoadingData {
     // (undocumented)
     level: number;
     // (undocumented)
+    pathwayId: string | undefined;
+    // (undocumented)
     url: string;
 }
 
@@ -3039,6 +3041,8 @@ export interface PlaylistLoaderContext extends LoaderContext {
     level: number | null;
     // (undocumented)
     levelDetails?: LevelDetails;
+    // (undocumented)
+    pathwayId?: string;
     // (undocumented)
     type: PlaylistContextType;
 }

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1625,7 +1625,7 @@ class Hls implements HlsEventEmitter {
     // (undocumented)
     removeAllListeners<E extends keyof HlsListeners>(event?: E | undefined): void;
     // (undocumented)
-    removeLevel(levelIndex: any, urlId?: number): void;
+    removeLevel(levelIndex: number): void;
     resumeBuffering(): void;
     get startLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "startLevel" must appear on the getter, not the setter.
@@ -2003,11 +2003,11 @@ export type LatencyControllerConfig = {
 //
 // @public (undocumented)
 export class Level {
-    constructor(data: LevelParsed);
+    constructor(data: LevelParsed | MediaPlaylist);
     // (undocumented)
-    addFallback(data: LevelParsed): void;
+    addFallback(): void;
     // (undocumented)
-    addGroupId(type: string, groupId: string | undefined, fallbackIndex: number): void;
+    addGroupId(type: string, groupId: string | undefined): void;
     // (undocumented)
     get attrs(): LevelAttributes;
     // (undocumented)
@@ -2017,7 +2017,7 @@ export class Level {
     // (undocumented)
     get audioGroupId(): string | undefined;
     // (undocumented)
-    audioGroupIds?: (string | undefined)[];
+    get audioGroupIds(): (string | undefined)[] | undefined;
     // (undocumented)
     get audioGroups(): (string | undefined)[] | undefined;
     // (undocumented)
@@ -2034,6 +2034,10 @@ export class Level {
     fragmentError: number;
     // (undocumented)
     readonly frameRate: number;
+    // (undocumented)
+    hasAudioGroup(groupId: string | undefined): boolean;
+    // (undocumented)
+    hasSubtitleGroup(groupId: string | undefined): boolean;
     // (undocumented)
     readonly height: number;
     // (undocumented)
@@ -2064,13 +2068,11 @@ export class Level {
     // (undocumented)
     get textGroupId(): string | undefined;
     // (undocumented)
-    textGroupIds?: (string | undefined)[];
-    // (undocumented)
-    readonly unknownCodecs: string[] | undefined;
+    get textGroupIds(): (string | undefined)[] | undefined;
     // (undocumented)
     get uri(): string;
     // (undocumented)
-    url: string[];
+    readonly url: string[];
     // (undocumented)
     get urlId(): number;
     set urlId(value: number);
@@ -2329,8 +2331,6 @@ export interface LevelParsed {
     // (undocumented)
     id?: number;
     // (undocumented)
-    level?: number;
-    // (undocumented)
     name: string;
     // (undocumented)
     textCodec?: string;
@@ -2383,9 +2383,58 @@ export interface LevelSwitchedData {
 // Warning: (ae-missing-release-tag) "LevelSwitchingData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export interface LevelSwitchingData extends Omit<Level, '_urlId'> {
+export interface LevelSwitchingData {
+    // (undocumented)
+    attrs: LevelAttributes;
+    // (undocumented)
+    audioCodec: string | undefined;
+    // (undocumented)
+    audioGroupIds: (string | undefined)[] | undefined;
+    // (undocumented)
+    audioGroups: (string | undefined)[] | undefined;
+    // (undocumented)
+    averageBitrate: number;
+    // (undocumented)
+    bitrate: number;
+    // (undocumented)
+    codecSet: string;
+    // (undocumented)
+    details: LevelDetails | undefined;
+    // (undocumented)
+    fragmentError: number;
+    // (undocumented)
+    height: number;
+    // (undocumented)
+    id: number;
     // (undocumented)
     level: number;
+    // (undocumented)
+    loaded: {
+        bytes: number;
+        duration: number;
+    } | undefined;
+    // (undocumented)
+    loadError: number;
+    // (undocumented)
+    maxBitrate: number;
+    // (undocumented)
+    name: string | undefined;
+    // (undocumented)
+    realBitrate: number;
+    // (undocumented)
+    subtitleGroups: (string | undefined)[] | undefined;
+    // (undocumented)
+    textGroupIds: (string | undefined)[] | undefined;
+    // (undocumented)
+    uri: string;
+    // (undocumented)
+    url: string[];
+    // (undocumented)
+    urlId: 0;
+    // (undocumented)
+    videoCodec: string | undefined;
+    // (undocumented)
+    width: number;
 }
 
 // Warning: (ae-missing-release-tag) "LevelUpdatedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2739,11 +2788,15 @@ export interface MediaKeySessionContext {
 // Warning: (ae-missing-release-tag) "MediaPlaylist" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
+export interface MediaPlaylist {
     // (undocumented)
     attrs: MediaAttributes;
     // (undocumented)
+    audioCodec?: string;
+    // (undocumented)
     autoselect: boolean;
+    // (undocumented)
+    bitrate: number;
     // (undocumented)
     channels?: string;
     // (undocumented)
@@ -2751,9 +2804,13 @@ export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
     // (undocumented)
     default: boolean;
     // (undocumented)
+    details?: LevelDetails;
+    // (undocumented)
     forced: boolean;
     // (undocumented)
     groupId: string;
+    // (undocumented)
+    height?: number;
     // (undocumented)
     id: number;
     // (undocumented)
@@ -2763,7 +2820,17 @@ export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
     // (undocumented)
     name: string;
     // (undocumented)
+    textCodec?: string;
+    // (undocumented)
     type: MediaPlaylistType | 'main';
+    // (undocumented)
+    unknownCodecs?: string[];
+    // (undocumented)
+    url: string;
+    // (undocumented)
+    videoCodec?: string;
+    // (undocumented)
+    width?: number;
 }
 
 // Warning: (ae-missing-release-tag) "MediaPlaylistType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/build-config.js
+++ b/build-config.js
@@ -61,7 +61,7 @@ const buildConstants = (type, additional = {}) => ({
     __USE_EME_DRM__: JSON.stringify(type === BUILD_TYPE.full || addEMESupport),
     __USE_CMCD__: JSON.stringify(type === BUILD_TYPE.full || addCMCDSupport),
     __USE_CONTENT_STEERING__: JSON.stringify(
-      type === BUILD_TYPE.full || addContentSteeringSupport,
+      type === BUILD_TYPE.full || BUILD_TYPE.light || addContentSteeringSupport,
     ),
     __USE_VARIABLE_SUBSTITUTION__: JSON.stringify(
       type === BUILD_TYPE.full || addVariableSubstitutionSupport,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -308,6 +308,7 @@ export default class BaseStreamController
   }
 
   protected onHandlerDestroying() {
+    this.hls.off(Events.MANIFEST_LOADED, this.onManifestLoaded, this);
     this.stopLoad();
     super.onHandlerDestroying();
   }
@@ -548,8 +549,7 @@ export default class BaseStreamController
       !frag ||
       !fragCurrent ||
       frag.level !== fragCurrent.level ||
-      frag.sn !== fragCurrent.sn ||
-      frag.urlId !== fragCurrent.urlId
+      frag.sn !== fragCurrent.sn
     );
   }
 

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -7,7 +7,7 @@ import {
   shouldRetry,
 } from '../utils/error-helper';
 import { findFragmentByPTS } from './fragment-finders';
-import { HdcpLevel, HdcpLevels, type Level } from '../types/level';
+import { HdcpLevel, HdcpLevels } from '../types/level';
 import { logger } from '../utils/logger';
 import type Hls from '../hls';
 import type { RetryConfig } from '../config';
@@ -15,8 +15,6 @@ import type { NetworkComponentAPI } from '../types/component-api';
 import type { ErrorData } from '../types/events';
 import type { Fragment } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
-
-const RENDITION_PENALTY_DURATION_MS = 300000;
 
 export const enum NetworkErrorAction {
   DoNothing = 0,
@@ -186,9 +184,9 @@ export default class ErrorController implements NetworkComponentAPI {
           if (
             level &&
             ((context.type === PlaylistContextType.AUDIO_TRACK &&
-              context.groupId === level.audioGroupId) ||
+              level.hasAudioGroup(context.groupId)) ||
               (context.type === PlaylistContextType.SUBTITLE_TRACK &&
-                context.groupId === level.textGroupId))
+                level.hasSubtitleGroup(context.groupId)))
           ) {
             // Perform Pathway switch or Redundant failover if possible for fastest recovery
             // otherwise allow playlist retry count to reach max error retries
@@ -397,17 +395,21 @@ export default class ErrorController implements NetworkComponentAPI {
             }
           } else if (
             (playlistErrorType === PlaylistContextType.AUDIO_TRACK &&
-              playlistErrorGroupId === levelCandidate.audioGroupId) ||
+              levelCandidate.hasAudioGroup(playlistErrorGroupId)) ||
             (playlistErrorType === PlaylistContextType.SUBTITLE_TRACK &&
-              playlistErrorGroupId === levelCandidate.textGroupId)
+              levelCandidate.hasSubtitleGroup(playlistErrorGroupId))
           ) {
             // For audio/subs playlist errors find another group ID or fallthrough to redundant fail-over
             continue;
           } else if (
             (fragErrorType === PlaylistLevelType.AUDIO &&
-              level.audioGroupId === levelCandidate.audioGroupId) ||
+              level.audioGroups?.some((groupId) =>
+                levelCandidate.hasAudioGroup(groupId),
+              )) ||
             (fragErrorType === PlaylistLevelType.SUBTITLE &&
-              level.textGroupId === levelCandidate.textGroupId) ||
+              level.subtitleGroups?.some((groupId) =>
+                levelCandidate.hasSubtitleGroup(groupId),
+              )) ||
             (findAudioCodecAlternate &&
               level.audioCodec === levelCandidate.audioCodec) ||
             (!findAudioCodecAlternate &&
@@ -476,14 +478,6 @@ export default class ErrorController implements NetworkComponentAPI {
       case ErrorActionFlags.None:
         this.switchLevel(data, nextAutoLevel);
         break;
-      case ErrorActionFlags.MoveAllAlternatesMatchingHost:
-        {
-          // Handle Redundant Levels here. Pathway switching is handled by content-steering-controller
-          if (!errorAction.resolved) {
-            errorAction.resolved = this.redundantFailover(data);
-          }
-        }
-        break;
       case ErrorActionFlags.MoveAllAlternatesMatchingHDCP:
         if (hdcpLevel) {
           hls.maxHdcpLevel = HdcpLevels[HdcpLevels.indexOf(hdcpLevel) - 1];
@@ -509,100 +503,4 @@ export default class ErrorController implements NetworkComponentAPI {
       this.hls.nextLoadLevel = this.hls.nextAutoLevel;
     }
   }
-
-  private redundantFailover(data: ErrorData): boolean {
-    const { hls, penalizedRenditions } = this;
-    const levelIndex: number =
-      data.parent === PlaylistLevelType.MAIN
-        ? (data.level as number) || 0
-        : hls.loadLevel;
-    const level = hls.levels[levelIndex];
-    const redundantLevels = level.url.length;
-    const errorUrlId = data.frag ? data.frag.urlId : level.urlId;
-    if (level.urlId === errorUrlId && (!data.frag || level.details)) {
-      this.penalizeRendition(level, data);
-    }
-    for (let i = 1; i < redundantLevels; i++) {
-      const newUrlId = (errorUrlId + i) % redundantLevels;
-      const penalizedRendition = penalizedRenditions[newUrlId];
-      // Check if rendition is penalized and skip if it is a bad fit for failover
-      if (
-        !penalizedRendition ||
-        checkExpired(penalizedRendition, data, penalizedRenditions[errorUrlId])
-      ) {
-        // delete penalizedRenditions[newUrlId];
-        // Update the url id of all levels so that we stay on the same set of variants when level switching
-        this.warn(
-          `Switching to Redundant Stream ${newUrlId + 1}/${redundantLevels}: "${
-            level.url[newUrlId]
-          }" after ${data.details}`,
-        );
-        this.playlistError = 0;
-        hls.levels.forEach((lv) => {
-          lv.urlId = newUrlId;
-        });
-        hls.nextLoadLevel = levelIndex;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private penalizeRendition(level: Level, data: ErrorData) {
-    const { penalizedRenditions } = this;
-    const penalizedRendition = penalizedRenditions[level.urlId] || {
-      lastErrorPerfMs: 0,
-      errors: [],
-      details: undefined,
-    };
-    penalizedRendition.lastErrorPerfMs = performance.now();
-    penalizedRendition.errors.push(data);
-    penalizedRendition.details = level.details;
-    penalizedRenditions[level.urlId] = penalizedRendition;
-  }
-}
-
-function checkExpired(
-  penalizedRendition: PenalizedRendition,
-  data: ErrorData,
-  currentPenaltyState: PenalizedRendition | undefined,
-): boolean {
-  // Expire penalty for switching back to rendition after RENDITION_PENALTY_DURATION_MS
-  if (
-    performance.now() - penalizedRendition.lastErrorPerfMs >
-    RENDITION_PENALTY_DURATION_MS
-  ) {
-    return true;
-  }
-  // Expire penalty on GAP tag error if rendition has no GAP at position (does not cover media tracks)
-  const lastErrorDetails = penalizedRendition.details;
-  if (data.details === ErrorDetails.FRAG_GAP && lastErrorDetails && data.frag) {
-    const position = data.frag.start;
-    const candidateFrag = findFragmentByPTS(
-      null,
-      lastErrorDetails.fragments,
-      position,
-    );
-    if (candidateFrag && !candidateFrag.gap) {
-      return true;
-    }
-  }
-  // Expire penalty if there are more errors in currentLevel than in penalizedRendition
-  if (
-    currentPenaltyState &&
-    penalizedRendition.errors.length < currentPenaltyState.errors.length
-  ) {
-    const lastCandidateError =
-      penalizedRendition.errors[penalizedRendition.errors.length - 1];
-    if (
-      lastErrorDetails &&
-      lastCandidateError.frag &&
-      data.frag &&
-      Math.abs(lastCandidateError.frag.start - data.frag.start) >
-        lastErrorDetails.targetduration * 3
-    ) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -504,5 +504,5 @@ function isPartial(fragmentEntity: FragmentEntity): boolean {
 }
 
 function getFragmentKey(fragment: Fragment): string {
-  return `${fragment.type}_${fragment.level}_${fragment.urlId}_${fragment.sn}`;
+  return `${fragment.type}_${fragment.level}_${fragment.sn}`;
 }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -610,6 +610,7 @@ export default class LevelController extends BasePlaylistController {
       this.hls.trigger(Events.LEVEL_LOADING, {
         url,
         level: currentLevelIndex,
+        pathwayId: currentLevel.attrs['PATHWAY-ID'],
         id: 0, // Deprecated Level urlId
         deliveryDirectives: hlsUrlParameters || null,
       });

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -656,11 +656,7 @@ export default class StreamController
       (this.state === State.FRAG_LOADING ||
         this.state === State.FRAG_LOADING_WAITING_RETRY)
     ) {
-      if (
-        (fragCurrent.level !== data.level ||
-          fragCurrent.urlId !== curLevel.urlId) &&
-        fragCurrent.loader
-      ) {
+      if (fragCurrent.level !== data.level && fragCurrent.loader) {
         this.abortCurrentFrag();
       }
     }
@@ -1395,8 +1391,7 @@ export default class StreamController
         if (
           !fragPlaying ||
           fragPlayingCurrent.sn !== fragPlaying.sn ||
-          fragPlaying.level !== fragCurrentLevel ||
-          fragPlayingCurrent.urlId !== fragPlaying.urlId
+          fragPlaying.level !== fragCurrentLevel
         ) {
           this.fragPlaying = fragPlayingCurrent;
           this.hls.trigger(Events.FRAG_CHANGED, { frag: fragPlayingCurrent });

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -470,8 +470,8 @@ export default class Hls implements HlsEventEmitter {
     }
   }
 
-  removeLevel(levelIndex, urlId = 0) {
-    this.levelController.removeLevel(levelIndex, urlId);
+  removeLevel(levelIndex: number) {
+    this.levelController.removeLevel(levelIndex);
   }
 
   /**

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -136,7 +136,7 @@ export class Fragment extends BaseSegment {
   public minEndPTS?: number;
   // Load/parse timing information
   public stats: LoadStats = new LoadStats();
-  public urlId: number = 0;
+  // Init Segment bytes (unset for media segments)
   public data?: Uint8Array;
   // A flag indicating whether the segment was downloaded in order to test bitrate, and was not buffered
   public bitrateTest: boolean = false;
@@ -148,6 +148,8 @@ export class Fragment extends BaseSegment {
   public endList?: boolean;
   // Fragment is marked by an EXT-X-GAP tag indicating that it does not contain media data and should not be loaded
   public gap?: boolean;
+  // Deprecated
+  public urlId: number = 0;
 
   constructor(type: PlaylistLevelType, baseurl: string) {
     super(baseurl);

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -213,8 +213,12 @@ class PlaylistLoader implements NetworkComponentAPI {
     // Check if a loader for this context already exists
     let loader = this.getInternalLoader(context);
     if (loader) {
-      const loaderContext = loader.context;
-      if (loaderContext && loaderContext.url === context.url) {
+      const loaderContext = loader.context as PlaylistLoaderContext;
+      if (
+        loaderContext &&
+        loaderContext.url === context.url &&
+        loaderContext.level === context.level
+      ) {
         // same URL can't overlap
         logger.trace('[playlist-loader]: playlist request ongoing');
         return;
@@ -448,10 +452,12 @@ class PlaylistLoader implements NetworkComponentAPI {
     const { id, level, type } = context;
 
     const url = getResponseUrl(response, context);
-    const levelUrlId = Number.isFinite(id as number) ? (id as number) : 0;
+    const levelUrlId = 0;
     const levelId = Number.isFinite(level as number)
       ? (level as number)
-      : levelUrlId;
+      : Number.isFinite(id as number)
+      ? (id as number)
+      : 0;
     const levelType = mapContextToLevelType(context);
     const levelDetails: LevelDetails = M3U8Parser.parseLevelPlaylist(
       response.data as string,

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -162,10 +162,11 @@ class PlaylistLoader implements NetworkComponentAPI {
   }
 
   private onLevelLoading(event: Events.LEVEL_LOADING, data: LevelLoadingData) {
-    const { id, level, url, deliveryDirectives } = data;
+    const { id, level, pathwayId, url, deliveryDirectives } = data;
     this.load({
       id,
       level,
+      pathwayId,
       responseType: 'text',
       type: PlaylistContextType.LEVEL,
       url,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -163,6 +163,7 @@ export interface TrackLoadingData {
 export interface LevelLoadingData {
   id: number;
   level: number;
+  pathwayId: string | undefined;
   url: string;
   deliveryDirectives: HlsUrlParameters | null;
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,6 +7,7 @@ import type {
   HdcpLevel,
   HlsUrlParameters,
   Level,
+  LevelAttributes,
   LevelParsed,
   VariableMap,
 } from './level';
@@ -120,8 +121,32 @@ export interface ManifestParsedData {
   altAudio: boolean;
 }
 
-export interface LevelSwitchingData extends Omit<Level, '_urlId'> {
+export interface LevelSwitchingData {
   level: number;
+  attrs: LevelAttributes;
+  details: LevelDetails | undefined;
+  bitrate: number;
+  averageBitrate: number;
+  maxBitrate: number;
+  realBitrate: number;
+  width: number;
+  height: number;
+  codecSet: string;
+  audioCodec: string | undefined;
+  videoCodec: string | undefined;
+  audioGroups: (string | undefined)[] | undefined;
+  subtitleGroups: (string | undefined)[] | undefined;
+  loaded: { bytes: number; duration: number } | undefined;
+  loadError: number;
+  fragmentError: number;
+  name: string | undefined;
+  id: number;
+  uri: string;
+  // Deprecated (retained for backwards compatibility)
+  url: string[];
+  urlId: 0;
+  audioGroupIds: (string | undefined)[] | undefined;
+  textGroupIds: (string | undefined)[] | undefined;
 }
 
 export interface LevelSwitchedData {

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -183,8 +183,10 @@ export interface PlaylistLoaderContext extends LoaderContext {
   level: number | null;
   // level or track id from LevelLoadingData / TrackLoadingData
   id: number | null;
-  // track group id
+  // Media Playlist Group ID
   groupId?: string;
+  // Content Steering Pathway ID (or undefined for default Pathway ".")
+  pathwayId?: string;
   // internal representation of a parsed m3u8 level playlist
   levelDetails?: LevelDetails;
   // Blocking playlist request delivery directives (or null id none were added to playlist url

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -1,9 +1,5 @@
-import type { LevelParsed } from './level';
 import type { AttrList } from '../utils/attr-list';
-export interface AudioGroup {
-  id?: string;
-  codec?: string;
-}
+import type { LevelDetails } from '../loader/level-details';
 
 export type AudioPlaylistType = 'AUDIO';
 
@@ -14,11 +10,15 @@ export type SubtitlePlaylistType = 'SUBTITLES' | 'CLOSED-CAPTIONS';
 export type MediaPlaylistType = MainPlaylistType | SubtitlePlaylistType;
 
 // audioTracks, captions and subtitles returned by `M3U8Parser.parseMasterPlaylistMedia`
-export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
+export interface MediaPlaylist {
   attrs: MediaAttributes;
+  audioCodec?: string;
   autoselect: boolean; // implicit false if not present
+  bitrate: number;
   channels?: string;
   characteristics?: string;
+  details?: LevelDetails;
+  height?: number;
   default: boolean; // implicit false if not present
   forced: boolean; // implicit false if not present
   groupId: string; // required in HLS playlists
@@ -26,8 +26,13 @@ export interface MediaPlaylist extends Omit<LevelParsed, 'attrs'> {
   instreamId?: string;
   lang?: string;
   name: string;
+  textCodec?: string;
+  unknownCodecs?: string[];
   // 'main' is a custom type added to signal a audioCodec in main track?; see playlist-loader~L310
   type: MediaPlaylistType | 'main';
+  url: string;
+  videoCodec?: string;
+  width?: number;
 }
 
 export interface MediaAttributes extends AttrList {

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -110,6 +110,16 @@ export function mimeTypeForCodec(codec: string, type: CodecType): string {
   return `${type}/mp4;codecs="${codec}"`;
 }
 
+export function videoCodecPreferenceValue(
+  videoCodec: string | undefined,
+): number {
+  if (videoCodec) {
+    const fourCC = videoCodec.substring(0, 4);
+    return sampleEntryCodesISO.video[fourCC];
+  }
+  return 2;
+}
+
 export function codecsSetSelectionPreferenceValue(codecSet: string): number {
   return codecSet.split(',').reduce((num, fourCC) => {
     const preferenceValue = sampleEntryCodesISO.video[fourCC];
@@ -184,4 +194,18 @@ export function pickMostCompleteCodecName(
     return parsedCodec;
   }
   return levelCodec;
+}
+
+export function convertAVC1ToAVCOTI(codec: string) {
+  // Convert avc1 codec string from RFC-4281 to RFC-6381 for MediaSource.isTypeSupported
+  const avcdata = codec.split('.');
+  if (avcdata.length > 2) {
+    let result = avcdata.shift() + '.';
+    result += parseInt(avcdata.shift() as string).toString(16);
+    result += ('000' + parseInt(avcdata.shift() as string).toString(16)).slice(
+      -4,
+    );
+    return result;
+  }
+  return codec;
 }

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -189,7 +189,6 @@ export function mergeDetails(
       newFrag.elementaryStreams = oldFrag.elementaryStreams;
       newFrag.loader = oldFrag.loader;
       newFrag.stats = oldFrag.stats;
-      newFrag.urlId = oldFrag.urlId;
       if (oldFrag.initSegment) {
         newFrag.initSegment = oldFrag.initSegment;
         currentInitSegment = oldFrag.initSegment;

--- a/tests/unit/controller/abr-controller.ts
+++ b/tests/unit/controller/abr-controller.ts
@@ -152,7 +152,7 @@ describe('AbrController', function () {
       expect(abrController.forcedAutoLevel).to.equal(1);
       expect(abrController.nextAutoLevel).to.equal(1);
 
-      loadAndBufferFragment(abrController, 0, 5e6, 1000);
+      loadAndBufferFragment(abrController, 1, 5e6, 1000);
       expect(abrController.forcedAutoLevel).to.equal(-1);
       expect(abrController.nextAutoLevel).to.equal(5);
     });

--- a/tests/unit/controller/audio-track-controller.ts
+++ b/tests/unit/controller/audio-track-controller.ts
@@ -30,7 +30,7 @@ type HlsTestable = Omit<
   'levelController' | 'networkControllers' | 'coreComponents'
 > & {
   levelController: {
-    levels: Pick<Level, 'urlId' | 'audioGroups'>[];
+    levels: Pick<Level, 'audioGroups'>[];
   };
   coreComponents: ComponentAPI[];
   networkControllers: NetworkComponentAPI[];
@@ -53,7 +53,7 @@ type AudioTrackControllerTestable = Omit<
 > & {
   tracks: MediaPlaylist[];
   tracksInGroup: MediaPlaylist[];
-  groupId: string | null;
+  groupIds: (string | undefined)[] | null;
   trackId: number;
   canLoad: boolean;
   timer: number;
@@ -86,7 +86,6 @@ describe('AudioTrackController', function () {
     hls.levelController = {
       levels: [
         {
-          urlId: 1,
           audioGroups: ['2'],
         },
       ],
@@ -233,7 +232,7 @@ describe('AudioTrackController', function () {
     });
 
     const newLevelInfo = hls.levels[0];
-    const newGroupId = newLevelInfo.audioGroupId;
+    const audioGroups = newLevelInfo.audioGroups;
 
     audioTrackController.tracks = tracks;
     // Update the level to set audioGroupId
@@ -250,7 +249,9 @@ describe('AudioTrackController', function () {
     });
 
     // group has switched
-    expect(audioTrackController.groupId).to.equal(newGroupId);
+    expect(audioGroups).to.include(
+      tracks[audioTrackController.audioTrack].groupId,
+    );
     // name is still the same
     expect(tracks[audioTrackController.audioTrack].name).to.equal(
       audioTrackName,
@@ -350,7 +351,7 @@ describe('AudioTrackController', function () {
       };
 
       const newLevelInfo = hls.levels[levelLoadedEvent.level];
-      const newGroupId = newLevelInfo.audioGroupId;
+      const audioGroups = newLevelInfo.audioGroups;
 
       audioTrackController.tracks = tracks;
       audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
@@ -367,7 +368,9 @@ describe('AudioTrackController', function () {
       );
 
       // group has switched
-      expect(audioTrackController.groupId).to.equal(newGroupId);
+      expect(audioGroups).to.include(
+        tracks[audioTrackController.audioTrack].groupId,
+      );
       // name is still the same
       expect(tracks[audioTrackController.audioTrack].name).to.equal(
         audioTrackName,
@@ -398,7 +401,6 @@ describe('AudioTrackController', function () {
       hls.levelController = {
         levels: [
           {
-            urlId: 0,
             audioGroups: ['1'],
           },
         ],
@@ -438,7 +440,6 @@ describe('AudioTrackController', function () {
       hls.levelController = {
         levels: [
           {
-            urlId: 0,
             audioGroups: ['1'],
           },
         ],
@@ -465,7 +466,7 @@ describe('AudioTrackController', function () {
       const currentTrackId = 4;
       const currentGroupId = 'aac';
       audioTrackController.trackId = currentTrackId;
-      audioTrackController.groupId = currentGroupId;
+      audioTrackController.groupIds = [currentGroupId];
       audioTrackController.tracks = tracks;
 
       audioTrackController.onError(Events.ERROR, {

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -740,7 +740,7 @@ segment.mp4
           expect(
             errors,
             'fragment errors after yeilding to second error event',
-          ).to.have.lengthOf(12);
+          ).to.have.lengthOf(8);
           expect(hls.levels[0].uri).to.equal('http://www.baz.com/tier6.m3u8');
           return new Promise((resolve, reject) => {
             hls.on(Events.FRAG_LOADED, (event, data) => {
@@ -759,7 +759,7 @@ segment.mp4
             'Error should not be fatal',
           );
           expect(data.frag.url).to.equal(
-            'http://www.baz.com/audio-segment.mp4',
+            'http://www.baz.com/video-segment.mp4',
           );
         });
     });
@@ -850,7 +850,7 @@ segment.mp4
           expect(
             errors,
             'fragment errors after yeilding to second error event',
-          ).to.have.lengthOf(12);
+          ).to.have.lengthOf(7);
           expect(hls.levels[0].uri).to.equal('http://www.baz.com/tier6.m3u8');
           return new Promise((resolve, reject) => {
             hls.on(Events.FRAG_LOADED, (event, data) => {
@@ -867,7 +867,7 @@ segment.mp4
             'Error should not be fatal',
           );
           expect(data.frag.url).to.equal(
-            'http://www.baz.com/audio-segment.mp4',
+            'http://www.baz.com/video-segment.mp4',
           );
         });
     });


### PR DESCRIPTION
### This PR will...
- Use Content Steering Pathways to manage Redundant Streams and resolve their errors.
- Deprecates Level `urlId` indexes and related Level fields and removes redundant failover error handling.

### Why is this Pull Request needed?

Content Steering error handling is used in place by assigning Redundant Streams a Pathway ID.

Where the default Pathway ID is ".", each Redundant Stream is assigned a Pathway ID based on the number of similar variants encountered: "..", "...", and so on. The Pathway ID assigned is based on the order found in the Multivariant Playlist.

These improvements will help to simplify switching logic with upcoming audio preference API changes (#5532).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
