### PR TITLE
Fix detach attach behavior dropping one of two SourceBuffers

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -380,8 +380,7 @@ export default class BufferController implements ComponentAPI {
           ',',
         )}`,
       );
-      this.bufferCodecEventsExpected = this._bufferCodecEventsTotal =
-        bufferCodecEventsExpected;
+      this.bufferCodecEventsExpected = bufferCodecEventsExpected;
     }
     if (this.mediaSource && this.mediaSource.readyState === 'open') {
       this.checkPendingTracks();


### PR DESCRIPTION
### This PR will...
Fix SourceBuffer reset regression introduced in dev with #5911 (not reproducible in v1.14.x).

### Why is this Pull Request needed?
`_bufferCodecEventsTotal` should not be reset on BUFFER_CODECS. It is only set once on manifest parsed and its value is needed to reset SourceBuffers on detach/attach or recoverMediaError with unmuxed HLS assets.

### Are there any points in the code the reviewer needs to double check?
We may want to replace `_bufferCodecEventsTotal` and `bufferCodecEventsExpected` with a map of tracks/SourceBuffer types ('audio' and/or 'video' or 'audiovideo') to manage SourceBuffer creation on init segment parsed. If you have trouble with MSE setup/reset or an irregular stream like #1510 leave a comment or file an issue mentioning this note.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
