### PR TITLE
API enhancements for audio and subtitle selection

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -13,7 +13,13 @@ export interface AbrComponentAPI extends ComponentAPI {
     // (undocumented)
     readonly bwEstimator?: EwmaBandWidthEstimator;
     // (undocumented)
+    firstAutoLevel: number;
+    // (undocumented)
+    forcedAutoLevel: number;
+    // (undocumented)
     nextAutoLevel: number;
+    // (undocumented)
+    resetEstimator(abrEwmaDefaultEstimate: number): any;
 }
 
 // Warning: (ae-missing-release-tag) "AbrController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -112,6 +118,19 @@ export class AttrList {
 // @public (undocumented)
 export type AudioPlaylistType = 'AUDIO';
 
+// Warning: (ae-missing-release-tag) "AudioSelectionOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type AudioSelectionOption = {
+    lang?: string;
+    assocLang?: string;
+    characteristics?: string;
+    channels?: string;
+    name?: string;
+    audioCodec?: string;
+    groupId?: string;
+};
+
 // Warning: (ae-missing-release-tag) "AudioStreamController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -189,6 +208,8 @@ export class AudioTrackController extends BasePlaylistController {
     protected onManifestLoading(): void;
     // (undocumented)
     protected onManifestParsed(event: Events.MANIFEST_PARSED, data: ManifestParsedData): void;
+    // (undocumented)
+    setAudioOption(audioOption: MediaPlaylist | AudioSelectionOption | undefined): MediaPlaylist | null;
 }
 
 // Warning: (ae-missing-release-tag) "AudioTrackLoadedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1621,6 +1642,8 @@ class Hls implements HlsEventEmitter {
     // (undocumented)
     removeLevel(levelIndex: number): void;
     resumeBuffering(): void;
+    setAudioOption(audioOption: MediaPlaylist | AudioSelectionOption | undefined): MediaPlaylist | null;
+    setSubtitleOption(subtitleOption: MediaPlaylist | SubtitleSelectionOption | undefined): MediaPlaylist | null;
     get startLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "startLevel" must appear on the getter, not the setter.
     set startLevel(newLevel: number);
@@ -1688,7 +1711,7 @@ export type HlsConfig = {
     fpsController: typeof FPSController;
     progressive: boolean;
     lowLatencyMode: boolean;
-} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & LevelControllerConfig & MP4RemuxerConfig & StreamControllerConfig & LatencyControllerConfig & MetadataControllerConfig & TimelineControllerConfig & TSDemuxerConfig & HlsLoadPolicies & FragmentLoaderConfig & PlaylistLoaderConfig;
+} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & LevelControllerConfig & MP4RemuxerConfig & StreamControllerConfig & SelectionPreferences & LatencyControllerConfig & MetadataControllerConfig & TimelineControllerConfig & TSDemuxerConfig & HlsLoadPolicies & FragmentLoaderConfig & PlaylistLoaderConfig;
 
 // Warning: (ae-missing-release-tag) "HlsEventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2046,7 +2069,7 @@ export class Level {
     // (undocumented)
     get maxBitrate(): number;
     // (undocumented)
-    readonly name: string | undefined;
+    readonly name: string;
     // (undocumented)
     get pathwayId(): string;
     // (undocumented)
@@ -2129,7 +2152,7 @@ export type LevelControllerConfig = {
 //
 // @public
 export class LevelDetails {
-    constructor(baseUrl: any);
+    constructor(baseUrl: string);
     // (undocumented)
     advanced: boolean;
     // (undocumented)
@@ -2786,6 +2809,8 @@ export interface MediaKeySessionContext {
 // @public (undocumented)
 export interface MediaPlaylist {
     // (undocumented)
+    assocLang?: string;
+    // (undocumented)
     attrs: MediaAttributes;
     // (undocumented)
     audioCodec?: string;
@@ -3052,6 +3077,14 @@ export type RetryConfig = {
     shouldRetry?: (retryConfig: RetryConfig | null | undefined, retryCount: number, isTimeout: boolean, loaderResponse: LoaderResponse | undefined, retry: boolean) => boolean;
 };
 
+// Warning: (ae-missing-release-tag) "SelectionPreferences" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SelectionPreferences = {
+    audioPreference?: AudioSelectionOption;
+    subtitlePreference?: SubtitleSelectionOption;
+};
+
 // Warning: (ae-missing-release-tag) "SourceBufferName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -3114,6 +3147,17 @@ export interface SubtitleFragProcessedData {
 //
 // @public (undocumented)
 export type SubtitlePlaylistType = 'SUBTITLES' | 'CLOSED-CAPTIONS';
+
+// Warning: (ae-missing-release-tag) "SubtitleSelectionOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SubtitleSelectionOption = {
+    lang?: string;
+    assocLang?: string;
+    characteristics?: string;
+    name?: string;
+    groupId?: string;
+};
 
 // Warning: (ae-missing-release-tag) "SubtitleStreamController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3187,6 +3231,8 @@ export class SubtitleTrackController extends BasePlaylistController {
     protected onMediaDetaching(): void;
     // (undocumented)
     protected onSubtitleTrackLoaded(event: Events.SUBTITLE_TRACK_LOADED, data: TrackLoadedData): void;
+    // (undocumented)
+    setSubtitleOption(subtitleOption: MediaPlaylist | SubtitleSelectionOption | undefined): MediaPlaylist | null;
     // (undocumented)
     get subtitleDisplay(): boolean;
     set subtitleDisplay(value: boolean);

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,10 @@ import type {
   LoaderResponse,
   PlaylistLoaderContext,
 } from './types/loader';
+import type {
+  AudioSelectionOption,
+  SubtitleSelectionOption,
+} from './types/media-playlist';
 
 export type ABRControllerConfig = {
   abrEwmaFastLive: number;
@@ -218,6 +222,11 @@ export type StreamControllerConfig = {
   testBandwidth: boolean;
 };
 
+export type SelectionPreferences = {
+  audioPreference?: AudioSelectionOption;
+  subtitlePreference?: SubtitleSelectionOption;
+};
+
 export type LatencyControllerConfig = {
   liveSyncDurationCount: number;
   liveMaxLatencyDurationCount: number;
@@ -299,6 +308,7 @@ export type HlsConfig = {
   LevelControllerConfig &
   MP4RemuxerConfig &
   StreamControllerConfig &
+  SelectionPreferences &
   LatencyControllerConfig &
   MetadataControllerConfig &
   TimelineControllerConfig &

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -3,8 +3,17 @@ import { Events } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { PlaylistContextType } from '../types/loader';
 import { mediaAttributesIdentical } from '../utils/media-option-attributes';
+import {
+  audioMatchPredicate,
+  findClosestLevelWithAudioGroup,
+  findMatchingOption,
+  matchesOption,
+} from '../utils/rendition-helper';
 import type Hls from '../hls';
-import type { MediaPlaylist } from '../types/media-playlist';
+import type {
+  AudioSelectionOption,
+  MediaPlaylist,
+} from '../types/media-playlist';
 import type { HlsUrlParameters } from '../types/level';
 import type {
   ManifestParsedData,
@@ -118,7 +127,7 @@ class AudioTrackController extends BasePlaylistController {
     }
     const audioGroups = levelInfo.audioGroups || null;
     const currentGroups = this.groupIds;
-    const currentTrack = this.currentTrack;
+    let currentTrack = this.currentTrack;
     if (
       !audioGroups ||
       currentGroups?.length !== audioGroups?.length ||
@@ -147,6 +156,10 @@ class AudioTrackController extends BasePlaylistController {
       } else if (!currentTrack && !this.tracksInGroup.length) {
         // Do not dispatch AUDIO_TRACKS_UPDATED when there were and are no tracks
         return;
+      }
+
+      if (!currentTrack) {
+        currentTrack = this.setAudioOption(this.hls.config.audioPreference);
       }
 
       this.tracksInGroup = audioTracks;
@@ -220,6 +233,69 @@ class AudioTrackController extends BasePlaylistController {
     this.setAudioTrack(newId);
   }
 
+  public setAudioOption(
+    audioOption: MediaPlaylist | AudioSelectionOption | undefined,
+  ): MediaPlaylist | null {
+    const hls = this.hls;
+    hls.config.audioPreference = audioOption;
+    if (audioOption) {
+      const allAudioTracks = this.allAudioTracks;
+      this.selectDefaultTrack = false;
+      if (allAudioTracks.length) {
+        // First see if current option matches (no switch op)
+        const currentTrack = this.currentTrack;
+        if (
+          currentTrack &&
+          matchesOption(audioOption, currentTrack, audioMatchPredicate)
+        ) {
+          return currentTrack;
+        }
+        // Find option in available tracks (tracksInGroup)
+        const groupIndex = findMatchingOption(
+          audioOption,
+          this.tracksInGroup,
+          audioMatchPredicate,
+        );
+        if (groupIndex > -1) {
+          const track = this.tracksInGroup[groupIndex];
+          this.setAudioTrack(groupIndex);
+          return track;
+        } else if (currentTrack) {
+          // Find option in nearest level audio group
+          let searchIndex = hls.loadLevel;
+          if (searchIndex === -1) {
+            searchIndex = hls.firstAutoLevel;
+          }
+          const switchIndex = findClosestLevelWithAudioGroup(
+            audioOption,
+            hls.levels,
+            allAudioTracks,
+            searchIndex,
+            audioMatchPredicate,
+          );
+          if (switchIndex === -1) {
+            // could not find matching variant
+            return null;
+          }
+          // and switch level to acheive the audio group switch
+          hls.nextLoadLevel = switchIndex;
+        }
+        if (audioOption.channels || audioOption.audioCodec) {
+          // Could not find a match with codec / channels predicate
+          // Find a match without channels or codec
+          const withoutCodecAndChannelsMatch = findMatchingOption(
+            audioOption,
+            allAudioTracks,
+          );
+          if (withoutCodecAndChannelsMatch > -1) {
+            return allAudioTracks[withoutCodecAndChannelsMatch];
+          }
+        }
+      }
+    }
+    return null;
+  }
+
   private setAudioTrack(newId: number): void {
     const tracks = this.tracksInGroup;
 
@@ -240,7 +316,7 @@ class AudioTrackController extends BasePlaylistController {
       return;
     }
     this.log(
-      `Switching to audio-track ${newId} "${track.name}" lang:${track.lang} group:${track.groupId}`,
+      `Switching to audio-track ${newId} "${track.name}" lang:${track.lang} group:${track.groupId} channels:${track.channels}`,
     );
     this.trackId = newId;
     this.currentTrack = track;
@@ -262,23 +338,47 @@ class AudioTrackController extends BasePlaylistController {
       }
       if (
         !currentTrack ||
-        mediaAttributesIdentical(currentTrack.attrs, track.attrs)
+        matchesOption(currentTrack, track, audioMatchPredicate)
       ) {
-        return track.id;
+        return i;
       }
-      if (
-        mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
-          'LANGUAGE',
-          'ASSOC-LANGUAGE',
-          'CHARACTERISTICS',
-        ])
-      ) {
-        return track.id;
+    }
+    if (currentTrack) {
+      const { name, lang, assocLang, characteristics, audioCodec, channels } =
+        currentTrack;
+      for (let i = 0; i < audioTracks.length; i++) {
+        const track = audioTracks[i];
+        if (
+          matchesOption(
+            { name, lang, assocLang, characteristics, audioCodec, channels },
+            track,
+            audioMatchPredicate,
+          )
+        ) {
+          return i;
+        }
       }
-      if (
-        mediaAttributesIdentical(currentTrack.attrs, track.attrs, ['LANGUAGE'])
-      ) {
-        return track.id;
+      for (let i = 0; i < audioTracks.length; i++) {
+        const track = audioTracks[i];
+        if (
+          mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
+            'LANGUAGE',
+            'ASSOC-LANGUAGE',
+            'CHARACTERISTICS',
+          ])
+        ) {
+          return i;
+        }
+      }
+      for (let i = 0; i < audioTracks.length; i++) {
+        const track = audioTracks[i];
+        if (
+          mediaAttributesIdentical(currentTrack.attrs, track.attrs, [
+            'LANGUAGE',
+          ])
+        ) {
+          return i;
+        }
       }
     }
     return -1;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -548,8 +548,8 @@ export default class BaseStreamController
     return (
       !frag ||
       !fragCurrent ||
-      frag.level !== fragCurrent.level ||
-      frag.sn !== fragCurrent.sn
+      frag.sn !== fragCurrent.sn ||
+      frag.level !== fragCurrent.level
     );
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -589,20 +589,14 @@ export default class StreamController
     event: Events.MANIFEST_PARSED,
     data: ManifestParsedData,
   ) {
+    // detect if we have different kind of audio codecs used amongst playlists
     let aac = false;
     let heaac = false;
-    let codec;
     data.levels.forEach((level) => {
-      // detect if we have different kind of audio codecs used amongst playlists
-      codec = level.audioCodec;
+      const codec = level.audioCodec;
       if (codec) {
-        if (codec.indexOf('mp4a.40.2') !== -1) {
-          aac = true;
-        }
-
-        if (codec.indexOf('mp4a.40.5') !== -1) {
-          heaac = true;
-        }
+        aac = aac || codec.indexOf('mp4a.40.2') !== -1;
+        heaac = heaac || codec.indexOf('mp4a.40.5') !== -1;
       }
     });
     this.audioCodecSwitch = aac && heaac && !changeTypeSupported();

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -21,8 +21,16 @@ import type CapLevelController from './controller/cap-level-controller';
 import type CMCDController from './controller/cmcd-controller';
 import type EMEController from './controller/eme-controller';
 import type SubtitleTrackController from './controller/subtitle-track-controller';
-import type { ComponentAPI, NetworkComponentAPI } from './types/component-api';
-import type { MediaPlaylist } from './types/media-playlist';
+import type {
+  AbrComponentAPI,
+  ComponentAPI,
+  NetworkComponentAPI,
+} from './types/component-api';
+import type {
+  AudioSelectionOption,
+  MediaPlaylist,
+  SubtitleSelectionOption,
+} from './types/media-playlist';
 import type { HlsConfig } from './config';
 import type { BufferInfo } from './utils/buffer-helper';
 import type AudioStreamController from './controller/audio-stream-controller';
@@ -55,7 +63,7 @@ export default class Hls implements HlsEventEmitter {
   private _emitter: HlsEventEmitter = new EventEmitter();
   private _autoLevelCapping: number = -1;
   private _maxHdcpLevel: HdcpLevel = null;
-  private abrController: AbrController;
+  private abrController: AbrComponentAPI;
   private bufferController: BufferController;
   private capLevelController: CapLevelController;
   private latencyController: LatencyController;
@@ -772,6 +780,26 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
+   * Find and select the best matching audio track, making a level switch when a Group change is necessary.
+   * Updates `hls.config.audioPreference`. Returns the selected track, or null when no matching track is found.
+   */
+  public setAudioOption(
+    audioOption: MediaPlaylist | AudioSelectionOption | undefined,
+  ): MediaPlaylist | null {
+    return this.audioTrackController?.setAudioOption(audioOption);
+  }
+  /**
+   * Find and select the best matching subtitle track, making a level switch when a Group change is necessary.
+   * Updates `hls.config.subtitlePreference`. Returns the selected track, or null when no matching track is found.
+   */
+  public setSubtitleOption(
+    subtitleOption: MediaPlaylist | SubtitleSelectionOption | undefined,
+  ): MediaPlaylist | null {
+    this.subtitleTrackController?.setSubtitleOption(subtitleOption);
+    return null;
+  }
+
+  /**
    * Get the complete list of audio tracks across all media groups
    */
   get allAudioTracks(): Array<MediaPlaylist> {
@@ -929,6 +957,8 @@ export default class Hls implements HlsEventEmitter {
 }
 
 export type {
+  AudioSelectionOption,
+  SubtitleSelectionOption,
   MediaPlaylist,
   ErrorDetails,
   ErrorTypes,
@@ -977,6 +1007,7 @@ export type {
   PlaylistLoaderConfig,
   PlaylistLoaderConstructor,
   RetryConfig,
+  SelectionPreferences,
   StreamControllerConfig,
   LatencyControllerConfig,
   MetadataControllerConfig,

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -56,7 +56,7 @@ export class LevelDetails {
   public variableList: VariableMap | null = null;
   public hasVariableRefs = false;
 
-  constructor(baseUrl) {
+  constructor(baseUrl: string) {
     this.fragments = [];
     this.encryptedFragments = [];
     this.dateRanges = {};

--- a/src/types/component-api.ts
+++ b/src/types/component-api.ts
@@ -5,8 +5,11 @@ export interface ComponentAPI {
 }
 
 export interface AbrComponentAPI extends ComponentAPI {
+  firstAutoLevel: number;
+  forcedAutoLevel: number;
   nextAutoLevel: number;
   readonly bwEstimator?: EwmaBandWidthEstimator;
+  resetEstimator(abrEwmaDefaultEstimate: number);
 }
 
 export interface NetworkComponentAPI extends ComponentAPI {

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -106,7 +106,7 @@ export class Level {
   public readonly frameRate: number;
   public readonly height: number;
   public readonly id: number;
-  public readonly name: string | undefined;
+  public readonly name: string;
   public readonly videoCodec: string | undefined;
   public readonly width: number;
   public details?: LevelDetails;
@@ -134,7 +134,7 @@ export class Level {
     this.width = data.width || 0;
     this.height = data.height || 0;
     this.frameRate = data.attrs.optionalFloat('FRAME-RATE', 0);
-    this._avgBitrate = this.attrs.decimalInteger('AVERAGE-BANDWIDTH');
+    this._avgBitrate = data.attrs.decimalInteger('AVERAGE-BANDWIDTH');
     this.audioCodec = data.audioCodec;
     this.videoCodec = data.videoCodec;
     this.codecSet = [data.videoCodec, data.audioCodec]

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -9,6 +9,24 @@ export type SubtitlePlaylistType = 'SUBTITLES' | 'CLOSED-CAPTIONS';
 
 export type MediaPlaylistType = MainPlaylistType | SubtitlePlaylistType;
 
+export type AudioSelectionOption = {
+  lang?: string;
+  assocLang?: string;
+  characteristics?: string;
+  channels?: string;
+  name?: string;
+  audioCodec?: string;
+  groupId?: string;
+};
+
+export type SubtitleSelectionOption = {
+  lang?: string;
+  assocLang?: string;
+  characteristics?: string;
+  name?: string;
+  groupId?: string;
+};
+
 // audioTracks, captions and subtitles returned by `M3U8Parser.parseMasterPlaylistMedia`
 export interface MediaPlaylist {
   attrs: MediaAttributes;
@@ -25,6 +43,7 @@ export interface MediaPlaylist {
   id: number; // incrementing number to track media playlists
   instreamId?: string;
   lang?: string;
+  assocLang?: string;
   name: string;
   textCodec?: string;
   unknownCodecs?: string[];


### PR DESCRIPTION
### This PR will...
Adds config options and API methods for selecting audio and subtitles based on the attributes of media options (language, characteristics, associated language, channels, codec, name, group).

### Why is this Pull Request needed?
The primary goal of this feature is to simplify the initial selection of audio and subtitles on startup.

By default, the player will attempt to start playback using default audio (stereo) and default subtitle options. These options and methods allow for the selection of audio and subtitles on startup and during playback, both with and without specific knowledge of the renditions available in an HLS asset.

Since the change from one audio group to another can necessitate a level switch, this API performs these changes when needed. This API allows for switching between change sets, which is impossible using the audioTrack setters (since audioTracks only expose the options with the groups available to the current level).

### Are there any points in the code the reviewer needs to double check?

Safari supports all audio codec families in the Advanced stream example (mp4a, ac-3, ec-3):
https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8 

[Branch test URL](https://feature-api-audio-subtitle-s.hls-js-4zn.pages.dev/demo/?src=https%3A%2F%2Fdevstreaming-cdn.apple.com%2Fvideos%2Fstreaming%2Fexamples%2Fadv_dv_atmos%2Fmain.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOmZhbHNlLCJzdG9wT25TdGFsbCI6ZmFsc2UsImR1bXBmTVA0IjpmYWxzZSwibGV2ZWxDYXBwaW5nIjotMSwibGltaXRNZXRyaWNzIjotMX0=)

The preferences can be tested on the demo page by adding them to the config:
```json
"audioPreference": {
  "audioCodec": "ec-3",
  "characteristics": "public.accessibility.describes-video"
},
"subtitlePreference": {
  "name": "English"
 }
```

Options can be changed at runtime
```js
// switch to DVS audio
hls.setAudioOption({ characteristics: 'public.accessibility.describes-video' });

// switch to English SDH audio
hls.setSubtitleOption({
  lang: 'en-US',
  characteristics: 'public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound'
});
```
The preferences and setters support both track objects as input (`hls.audioTracks | subtitleTracks | allAudioTracks | allSubtitleTracks`) as well as an object with any number of supported fields. The player will look for an exact match in the active groups first. If none is found it will look across all groups for an exact match which will requires a level change to complete.


### Resolves issues:
Resolves #5532

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
