### PR TITLE
Update `karma-rollup-preprocessor` to version that works in watch mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "karma-coverage": "2.2.1",
         "karma-mocha": "2.0.1",
         "karma-mocha-reporter": "2.2.5",
-        "karma-rollup-preprocessor": "7.0.8",
+        "karma-rollup-preprocessor": "github:jlmakes/karma-rollup-preprocessor#7a7268d91149307b3cf2888ee4e65ccd079955a3",
         "karma-sinon-chai": "2.0.2",
         "karma-sourcemap-loader": "0.4.0",
         "lint-staged": "15.1.0",
@@ -8353,9 +8353,10 @@
     },
     "node_modules/karma-rollup-preprocessor": {
       "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz",
-      "integrity": "sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==",
+      "resolved": "git+ssh://git@github.com/jlmakes/karma-rollup-preprocessor.git#7a7268d91149307b3cf2888ee4e65ccd079955a3",
+      "integrity": "sha512-cwwzZBP8eXoUdZkItb1mJn6aAFoLxgM33DnjwwGzhMnrHcL+bZQAgUoN2Htgrs4tprUHN5wE670HhVYqVUB05w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.3.1",
         "debounce": "^1.2.0"
@@ -19157,10 +19158,10 @@
       }
     },
     "karma-rollup-preprocessor": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz",
-      "integrity": "sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==",
+      "version": "git+ssh://git@github.com/jlmakes/karma-rollup-preprocessor.git#7a7268d91149307b3cf2888ee4e65ccd079955a3",
+      "integrity": "sha512-cwwzZBP8eXoUdZkItb1mJn6aAFoLxgM33DnjwwGzhMnrHcL+bZQAgUoN2Htgrs4tprUHN5wE670HhVYqVUB05w==",
       "dev": true,
+      "from": "karma-rollup-preprocessor@github:jlmakes/karma-rollup-preprocessor#7a7268d91149307b3cf2888ee4e65ccd079955a3",
       "requires": {
         "chokidar": "^3.3.1",
         "debounce": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "karma-coverage": "2.2.1",
     "karma-mocha": "2.0.1",
     "karma-mocha-reporter": "2.2.5",
-    "karma-rollup-preprocessor": "7.0.8",
+    "karma-rollup-preprocessor": "github:jlmakes/karma-rollup-preprocessor#7a7268d91149307b3cf2888ee4e65ccd079955a3",
     "karma-sinon-chai": "2.0.2",
     "karma-sourcemap-loader": "0.4.0",
     "lint-staged": "15.1.0",


### PR DESCRIPTION
### This PR will...
Update `karma-rollup-preprocessor` to version that works in watch mode

See https://github.com/jlmakes/karma-rollup-preprocessor/issues/78

### Why is this Pull Request needed?
To fix watch mode for tests. Currently it gets slower and slower before crashing.