### PR TITLE
Fix issues parsing sei_messages

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -1005,7 +1005,6 @@ export function parseSEIMessageFromNALu(
       }
       b = data[seiPtr++];
       payloadSize += b;
-      payloadSize &= 0xff;
     } while (b === 0xff);
 
     const leftOver = data.length - seiPtr;
@@ -1018,8 +1017,9 @@ export function parseSEIMessageFromNALu(
     } else if (payloadSize > leftOver) {
       // Some type of corruption has happened?
       logger.error(
-        `SEI payload of ${payloadSize} is too small, only ${leftOver} bytes left.`,
+        `Malformed SEI payload. ${payloadSize} is too small, only ${leftOver} bytes left to parse.`,
       );
+      // We might be able to parse some data, but let's be safe and ignore it.
       break;
     }
 


### PR DESCRIPTION
In mp4-tools.ts
* Fixed parsing for sei_message to remove the incorrect masking to 8 bits for the sei message size.

### This PR will...
Removes an incorrect masking of payloadSize to 8 bits, allowing payloadSize to be larger than 256, as per the spec.
 
### Why is this Pull Request needed?
My previous pull request added an incorrect masking to the payloadSize, and this removes that.

### Are there any points in the code the reviewer needs to double check?
Not in the code. I am curious about thoughts on masking the payloadType. The spec doesn't have any values over 255 that are parsed, however according the spec's parsing logic, it should be permitted to be larger than 255.  I left the mask in, as I doubt it really matters either way.

### Resolves issues:

### Checklist

- [x ] changes have been done against master branch, and PR does not conflict
- [x ] new unit / functional tests have been added (whenever applicable)
- [x ] API or design changes are documented in API.md
