### PR TITLE
Expand isSupported check to allow alternative codecs

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1592,6 +1592,8 @@ class Hls implements HlsEventEmitter {
     // Warning: (ae-setter-with-docs) The doc comment for the property "firstLevel" must appear on the getter, not the setter.
     set firstLevel(newLevel: number);
     get forceStartLoad(): boolean;
+    static getMediaSource(): typeof MediaSource | undefined;
+    static isMSESupported(): boolean;
     static isSupported(): boolean;
     get latency(): number;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,15 +190,26 @@ First include `https://cdn.jsdelivr.net/npm/hls.js@1` (or `/hls.js` for unminifi
 <script src="//cdn.jsdelivr.net/npm/hls.js@1"></script>
 ```
 
-Invoke the following static method: `Hls.isSupported()` to check whether your browser is supporting [MediaSource Extensions](http://w3c.github.io/media-source/).
+Invoke the following static method: `Hls.isSupported()` to check whether your browser supports [MediaSource Extensions](http://w3c.github.io/media-source/) with any baseline codecs.
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
 <script>
   if (Hls.isSupported()) {
-    console.log('hello hls.js!');
+    console.log('Hello HLS.js!');
   }
 </script>
+```
+
+If you want to test for MSE support without testing for baseline codecs, use `isMSESupported`:
+
+```js
+if (
+  Hls.isMSESupported() &&
+  Hls.getMediaSource().isTypeSupported('video/mp4;codecs="av01.0.01M.08"')
+) {
+  console.log('Hello AV1 playback! AVC who?');
+}
 ```
 
 ### Second step: instantiate Hls object and bind it to `<video>` element

--- a/src/exports-named.ts
+++ b/src/exports-named.ts
@@ -55,3 +55,5 @@ export {
   ErrorActionFlags,
 } from './controller/error-controller';
 export { AttrList } from './utils/attr-list';
+export { isSupported, isMSESupported } from './is-supported';
+export { getMediaSource } from './utils/mediasource-helper';

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -6,7 +6,8 @@ import LevelController from './controller/level-controller';
 import { FragmentTracker } from './controller/fragment-tracker';
 import KeyLoader from './loader/key-loader';
 import StreamController from './controller/stream-controller';
-import { isSupported } from './is-supported';
+import { isMSESupported, isSupported } from './is-supported';
+import { getMediaSource } from './utils/mediasource-helper';
 import { logger, enableLogs } from './utils/logger';
 import { enableStreamingMode, hlsDefaultConfig, mergeConfig } from './config';
 import { EventEmitter } from 'eventemitter3';
@@ -87,8 +88,22 @@ export default class Hls implements HlsEventEmitter {
   /**
    * Check if the required MediaSource Extensions are available.
    */
+  static isMSESupported(): boolean {
+    return isMSESupported();
+  }
+
+  /**
+   * Check if MediaSource Extensions are available and isTypeSupported checks pass for any baseline codecs.
+   */
   static isSupported(): boolean {
     return isSupported();
+  }
+
+  /**
+   * Get the MediaSource global used for MSE playback (ManagedMediaSource, MediaSource, or WebKitMediaSource).
+   */
+  static getMediaSource(): typeof MediaSource | undefined {
+    return getMediaSource();
   }
 
   static get Events(): typeof Events {

--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -1,23 +1,17 @@
 import { getMediaSource } from './utils/mediasource-helper';
+import { getCodecCompatibleName, mimeTypeForCodec } from './utils/codecs';
 import type { ExtendedSourceBuffer } from './types/buffer';
 
 function getSourceBuffer(): typeof self.SourceBuffer {
   return self.SourceBuffer || (self as any).WebKitSourceBuffer;
 }
 
-/**
- * @ignore
- */
 export function isSupported(): boolean {
   const mediaSource = getMediaSource();
   if (!mediaSource) {
     return false;
   }
   const sourceBuffer = getSourceBuffer();
-  const isTypeSupported =
-    mediaSource &&
-    typeof mediaSource.isTypeSupported === 'function' &&
-    mediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E,mp4a.40.2"');
 
   // if SourceBuffer is exposed ensure its API is valid
   // Older browsers do not expose SourceBuffer globally so checking SourceBuffer.prototype is impossible
@@ -26,12 +20,40 @@ export function isSupported(): boolean {
     (sourceBuffer.prototype &&
       typeof sourceBuffer.prototype.appendBuffer === 'function' &&
       typeof sourceBuffer.prototype.remove === 'function');
-  return !!isTypeSupported && !!sourceBufferValidAPI;
+  if (!sourceBufferValidAPI) {
+    return false;
+  }
+
+  return (
+    !!mediaSource &&
+    typeof mediaSource.isTypeSupported === 'function' &&
+    ([
+      'avc1.42E01E,mp4a.40.2',
+      'hvc1.1.6.L123.B0',
+      'av01.0.01M.08',
+      'vp09.00.50.08',
+    ].some((codecsForVideoContainer) =>
+      isMimeTypeSupported(
+        mediaSource,
+        mimeTypeForCodec(codecsForVideoContainer, 'video'),
+      ),
+    ) ||
+      ['mp4a.40.2', 'fLaC'].some((codecForAudioContainer) =>
+        isMimeTypeSupported(
+          mediaSource,
+          mimeTypeForCodec(codecForAudioContainer, 'audio'),
+        ),
+      ))
+  );
 }
 
-/**
- * @ignore
- */
+function isMimeTypeSupported(
+  mediaSource: typeof MediaSource,
+  mimeType: string,
+): boolean {
+  return mediaSource.isTypeSupported(mimeType);
+}
+
 export function changeTypeSupported(): boolean {
   const sourceBuffer = getSourceBuffer();
   return (

--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -1,57 +1,48 @@
 import { getMediaSource } from './utils/mediasource-helper';
-import { getCodecCompatibleName, mimeTypeForCodec } from './utils/codecs';
+import { mimeTypeForCodec } from './utils/codecs';
 import type { ExtendedSourceBuffer } from './types/buffer';
 
 function getSourceBuffer(): typeof self.SourceBuffer {
   return self.SourceBuffer || (self as any).WebKitSourceBuffer;
 }
 
-export function isSupported(): boolean {
+export function isMSESupported(): boolean {
   const mediaSource = getMediaSource();
   if (!mediaSource) {
     return false;
   }
-  const sourceBuffer = getSourceBuffer();
 
   // if SourceBuffer is exposed ensure its API is valid
   // Older browsers do not expose SourceBuffer globally so checking SourceBuffer.prototype is impossible
-  const sourceBufferValidAPI =
+  const sourceBuffer = getSourceBuffer();
+  return (
     !sourceBuffer ||
     (sourceBuffer.prototype &&
       typeof sourceBuffer.prototype.appendBuffer === 'function' &&
-      typeof sourceBuffer.prototype.remove === 'function');
-  if (!sourceBufferValidAPI) {
+      typeof sourceBuffer.prototype.remove === 'function')
+  );
+}
+
+export function isSupported(): boolean {
+  if (!isMSESupported()) {
     return false;
   }
 
+  const mediaSource = getMediaSource();
   return (
-    !!mediaSource &&
-    typeof mediaSource.isTypeSupported === 'function' &&
-    ([
-      'avc1.42E01E,mp4a.40.2',
-      'hvc1.1.6.L123.B0',
-      'av01.0.01M.08',
-      'vp09.00.50.08',
-    ].some((codecsForVideoContainer) =>
-      isMimeTypeSupported(
-        mediaSource,
-        mimeTypeForCodec(codecsForVideoContainer, 'video'),
-      ),
+    typeof mediaSource?.isTypeSupported === 'function' &&
+    (['avc1.42E01E,mp4a.40.2', 'av01.0.01M.08', 'vp09.00.50.08'].some(
+      (codecsForVideoContainer) =>
+        mediaSource.isTypeSupported(
+          mimeTypeForCodec(codecsForVideoContainer, 'video'),
+        ),
     ) ||
       ['mp4a.40.2', 'fLaC'].some((codecForAudioContainer) =>
-        isMimeTypeSupported(
-          mediaSource,
+        mediaSource.isTypeSupported(
           mimeTypeForCodec(codecForAudioContainer, 'audio'),
         ),
       ))
   );
-}
-
-function isMimeTypeSupported(
-  mediaSource: typeof MediaSource,
-  mimeType: string,
-): boolean {
-  return mediaSource.isTypeSupported(mimeType);
 }
 
 export function changeTypeSupported(): boolean {


### PR DESCRIPTION
### This PR will...
- Expand `isSupported` check to test alternate baseline codecs. At least one `isTypeSupported` check must pass for `isSupported` to return true
  - (Resolves #6004)
- Add `isMSESupported` check (checks for MediaSource API without `isTypeSupported` checks)
- Add named exports for and expose statically: `isSupported`, `isMSESupported`, and `getMediaSource`
  - (Resolves #5593)

### Why is this Pull Request needed?
Not all platforms support AVC/AAC via MSE.

Applications needing more fine grained support checks based on expected delivery formats can implement those checks in their app layer using `isMSESupported` and `getMediaSource().isTypeSupported(mimeType)`.

### Are there any points in the code the reviewer needs to double check?

Ideally the list of codecs checked will be kept short. It should only contain the most widely supported codecs required for compatibility. Changes can be contributed given specific device or platform specifications that demonstrate the need for such a change.

### Resolves issues:
Resolves #6004, #5593

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
