### PR TITLE
Adding AES-256 and AES-256-CTR encryption methods

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -9,6 +9,10 @@ import { PlaylistLevelType } from '../types/loader';
 import { Level } from '../types/level';
 import { subtitleOptionsIdentical } from '../utils/media-option-attributes';
 import { ErrorDetails, ErrorTypes } from '../errors';
+import {
+  isFullSegmentEncryption,
+  getAesModeFromFullSegmentMethod,
+} from '../utils/encryption-methods-util';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type Hls from '../hls';
 import type { FragmentTracker } from './fragment-tracker';
@@ -360,7 +364,7 @@ export class SubtitleStreamController
       payload.byteLength > 0 &&
       decryptData?.key &&
       decryptData.iv &&
-      decryptData.method === 'AES-128'
+      isFullSegmentEncryption(decryptData.method)
     ) {
       const startTime = performance.now();
       // decrypt the subtitles
@@ -369,6 +373,7 @@ export class SubtitleStreamController
           new Uint8Array(payload),
           decryptData.key.buffer,
           decryptData.iv.buffer,
+          getAesModeFromFullSegmentMethod(decryptData.method),
         )
         .catch((err) => {
           hls.trigger(Events.ERROR, {

--- a/src/crypt/aes-crypto.ts
+++ b/src/crypt/aes-crypto.ts
@@ -1,13 +1,32 @@
+import { DecrypterAesMode } from './decrypter-aes-mode';
+
 export default class AESCrypto {
   private subtle: SubtleCrypto;
   private aesIV: Uint8Array;
+  private aesMode: DecrypterAesMode;
 
-  constructor(subtle: SubtleCrypto, iv: Uint8Array) {
+  constructor(subtle: SubtleCrypto, iv: Uint8Array, aesMode: DecrypterAesMode) {
     this.subtle = subtle;
     this.aesIV = iv;
+    this.aesMode = aesMode;
   }
 
   decrypt(data: ArrayBuffer, key: CryptoKey) {
-    return this.subtle.decrypt({ name: 'AES-CBC', iv: this.aesIV }, key, data);
+    switch (this.aesMode) {
+      case DecrypterAesMode.cbc:
+        return this.subtle.decrypt(
+          { name: 'AES-CBC', iv: this.aesIV },
+          key,
+          data,
+        );
+      case DecrypterAesMode.ctr:
+        return this.subtle.decrypt(
+          { name: 'AES-CTR', counter: this.aesIV, length: 64 }, //64 : NIST SP800-38A standard suggests that the counter should occupy half of the counter block
+          key,
+          data,
+        );
+      default:
+        throw new Error(`[AESCrypto] invalid aes mode ${this.aesMode}`);
+    }
   }
 }

--- a/src/crypt/decrypter-aes-mode.ts
+++ b/src/crypt/decrypter-aes-mode.ts
@@ -1,0 +1,4 @@
+export const enum DecrypterAesMode {
+  cbc = 0,
+  ctr = 1,
+}

--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -4,6 +4,7 @@ import AESDecryptor, { removePadding } from './aes-decryptor';
 import { logger } from '../utils/logger';
 import { appendUint8Array } from '../utils/mp4-tools';
 import { sliceUint8 } from '../utils/typed-array';
+import { DecrypterAesMode } from './decrypter-aes-mode';
 import type { HlsConfig } from '../config';
 
 const CHUNK_SIZE = 16; // 16 bytes, 128 bits
@@ -81,10 +82,11 @@ export default class Decrypter {
     data: Uint8Array | ArrayBuffer,
     key: ArrayBuffer,
     iv: ArrayBuffer,
+    aesMode: DecrypterAesMode,
   ): Promise<ArrayBuffer> {
     if (this.useSoftware) {
       return new Promise((resolve, reject) => {
-        this.softwareDecrypt(new Uint8Array(data), key, iv);
+        this.softwareDecrypt(new Uint8Array(data), key, iv, aesMode);
         const decryptResult = this.flush();
         if (decryptResult) {
           resolve(decryptResult.buffer);
@@ -93,7 +95,7 @@ export default class Decrypter {
         }
       });
     }
-    return this.webCryptoDecrypt(new Uint8Array(data), key, iv);
+    return this.webCryptoDecrypt(new Uint8Array(data), key, iv, aesMode);
   }
 
   // Software decryption is progressive. Progressive decryption may not return a result on each call. Any cached
@@ -102,8 +104,13 @@ export default class Decrypter {
     data: Uint8Array,
     key: ArrayBuffer,
     iv: ArrayBuffer,
+    aesMode: DecrypterAesMode,
   ): ArrayBuffer | null {
     const { currentIV, currentResult, remainderData } = this;
+    if (aesMode !== DecrypterAesMode.cbc || key.byteLength !== 16) {
+      logger.warn('SoftwareDecrypt: can only handle AES-128-CBC');
+      return null;
+    }
     this.logOnce('JS AES decrypt');
     // The output is staggered during progressive parsing - the current result is cached, and emitted on the next call
     // This is done in order to strip PKCS7 padding, which is found at the end of each segment. We only know we've reached
@@ -146,21 +153,22 @@ export default class Decrypter {
     data: Uint8Array,
     key: ArrayBuffer,
     iv: ArrayBuffer,
+    aesMode: DecrypterAesMode,
   ): Promise<ArrayBuffer> {
     const subtle = this.subtle;
     if (this.key !== key || !this.fastAesKey) {
       this.key = key;
-      this.fastAesKey = new FastAESKey(subtle, key);
+      this.fastAesKey = new FastAESKey(subtle, key, aesMode);
     }
     return this.fastAesKey
       .expandKey()
-      .then((aesKey) => {
+      .then((aesKey: CryptoKey) => {
         // decrypt using web crypto
         if (!subtle) {
           return Promise.reject(new Error('web crypto not initialized'));
         }
         this.logOnce('WebCrypto AES decrypt');
-        const crypto = new AESCrypto(subtle, new Uint8Array(iv));
+        const crypto = new AESCrypto(subtle, new Uint8Array(iv), aesMode);
         return crypto.decrypt(data.buffer, aesKey);
       })
       .catch((err) => {
@@ -168,16 +176,16 @@ export default class Decrypter {
           `[decrypter]: WebCrypto Error, disable WebCrypto API, ${err.name}: ${err.message}`,
         );
 
-        return this.onWebCryptoError(data, key, iv);
+        return this.onWebCryptoError(data, key, iv, aesMode);
       });
   }
 
-  private onWebCryptoError(data, key, iv): ArrayBuffer | never {
+  private onWebCryptoError(data, key, iv, aesMode): ArrayBuffer | never {
     const enableSoftwareAES = this.enableSoftwareAES;
     if (enableSoftwareAES) {
       this.useSoftware = true;
       this.logEnabled = true;
-      this.softwareDecrypt(data, key, iv);
+      this.softwareDecrypt(data, key, iv, aesMode);
       const decryptResult = this.flush();
       if (decryptResult) {
         return decryptResult.buffer;

--- a/src/crypt/fast-aes-key.ts
+++ b/src/crypt/fast-aes-key.ts
@@ -1,16 +1,35 @@
+import { DecrypterAesMode } from './decrypter-aes-mode';
+
 export default class FastAESKey {
   private subtle: any;
   private key: ArrayBuffer;
+  private aesMode: DecrypterAesMode;
 
-  constructor(subtle, key) {
+  constructor(subtle, key, aesMode: DecrypterAesMode) {
     this.subtle = subtle;
     this.key = key;
+    this.aesMode = aesMode;
   }
 
   expandKey() {
-    return this.subtle.importKey('raw', this.key, { name: 'AES-CBC' }, false, [
-      'encrypt',
-      'decrypt',
-    ]);
+    const subtleAlgoName = getSubtleAlgoName(this.aesMode);
+    return this.subtle.importKey(
+      'raw',
+      this.key,
+      { name: subtleAlgoName },
+      false,
+      ['encrypt', 'decrypt'],
+    );
+  }
+}
+
+function getSubtleAlgoName(aesMode: DecrypterAesMode) {
+  switch (aesMode) {
+    case DecrypterAesMode.cbc:
+      return 'AES-CBC';
+    case DecrypterAesMode.ctr:
+      return 'AES-CTR';
+    default:
+      throw new Error(`[FastAESKey] invalid aes mode ${aesMode}`);
   }
 }

--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -4,6 +4,7 @@
 
 import { HlsConfig } from '../config';
 import Decrypter from '../crypt/decrypter';
+import { DecrypterAesMode } from '../crypt/decrypter-aes-mode';
 import { HlsEventEmitter } from '../events';
 import type {
   AudioSample,
@@ -30,6 +31,7 @@ class SampleAesDecrypter {
       encryptedData,
       this.keyData.key.buffer,
       this.keyData.iv.buffer,
+      DecrypterAesMode.cbc,
     );
   }
 

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -336,8 +336,11 @@ function createLoaderContext(
   if (Number.isFinite(start) && Number.isFinite(end)) {
     let byteRangeStart = start;
     let byteRangeEnd = end;
-    if (frag.sn === 'initSegment' && frag.decryptdata?.method === 'AES-128') {
-      // MAP segment encrypted with method 'AES-128', when served with HTTP Range,
+    if (
+      frag.sn === 'initSegment' &&
+      isMethodFullSegmentAesCbc(frag.decryptdata?.method)
+    ) {
+      // MAP segment encrypted with method 'AES-128' or 'AES-256' (cbc), when served with HTTP Range,
       // has the unencrypted size specified in the range.
       // Ref: https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-08#section-6.3.6
       const fragmentLen = end - start;
@@ -370,6 +373,10 @@ function createGapLoadError(frag: Fragment, part?: Part): LoadError {
   }
   (part ? part : frag).stats.aborted = true;
   return new LoadError(errorData);
+}
+
+function isMethodFullSegmentAesCbc(method) {
+  return method === 'AES-128' || method === 'AES-256';
 }
 
 export class LoadError extends Error {

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -194,6 +194,8 @@ export default class KeyLoader implements ComponentAPI {
         }
         return this.loadKeyEME(keyInfo, frag);
       case 'AES-128':
+      case 'AES-256':
+      case 'AES-256-CTR':
         return this.loadKeyHTTP(keyInfo, frag);
       default:
         return Promise.reject(

--- a/src/utils/encryption-methods-util.ts
+++ b/src/utils/encryption-methods-util.ts
@@ -1,0 +1,21 @@
+import { DecrypterAesMode } from '../crypt/decrypter-aes-mode';
+
+export function isFullSegmentEncryption(method: string): boolean {
+  return (
+    method === 'AES-128' || method === 'AES-256' || method === 'AES-256-CTR'
+  );
+}
+
+export function getAesModeFromFullSegmentMethod(
+  method: string,
+): DecrypterAesMode {
+  switch (method) {
+    case 'AES-128':
+    case 'AES-256':
+      return DecrypterAesMode.cbc;
+    case 'AES-256-CTR':
+      return DecrypterAesMode.ctr;
+    default:
+      throw new Error(`invalid full segment method ${method}`);
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -26,6 +26,7 @@ import './unit/controller/subtitle-track-controller';
 import './unit/controller/timeline-controller-nonnative';
 import './unit/controller/timeline-controller';
 import './unit/crypt/aes-decryptor';
+import './unit/crypt/decrypter';
 import './unit/demuxer/adts';
 import './unit/demuxer/base-audio-demuxer';
 import './unit/demuxer/id3';

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -262,4 +262,9 @@ module.exports = {
        NAL units are not starting right at the beginning of the PES packet when using hardware accelerated decoding.`,
     abr: false,
   },
+  aes256: {
+    url: 'https://jvaryhlstests.blob.core.windows.net/hlstestdata/playlist_encrypted.m3u8',
+    description: 'aes-256 and aes-256-ctr full segment encryption',
+    abr: false,
+  },
 };

--- a/tests/unit/crypt/decrypter.js
+++ b/tests/unit/crypt/decrypter.js
@@ -1,0 +1,123 @@
+import Decrypter from '../../../src/crypt/decrypter';
+
+describe('Decrypter', function () {
+  it('decripts correctly aes-128-cbc software mode', function () {
+    const data = get128cbcData();
+
+    const config = { enableSoftwareAES: true };
+    const decrypter = new Decrypter(config, { removePKCS7Padding: true });
+    const cbcMode = 0;
+
+    decrypter.softwareDecrypt(data.encrypted, data.key, data.iv, cbcMode);
+    const decrypted = decrypter.flush();
+    expect(new Uint8Array(decrypted)).to.deep.equal(data.expected);
+  });
+
+  it('decripts correctly aes-128-cbc webCrypto mode', async function () {
+    const data = get128cbcData();
+
+    const config = { enableSoftwareAES: false };
+    const decrypter = new Decrypter(config);
+    const cbcMode = 0;
+    const decrypted = await decrypter.webCryptoDecrypt(
+      data.encrypted,
+      data.key,
+      data.iv,
+      cbcMode,
+    );
+    expect(new Uint8Array(decrypted)).to.deep.equal(data.expected);
+  });
+
+  it('decripts correctly aes-128-cbc', async function () {
+    const data = get128cbcData();
+
+    const config = { enableSoftwareAES: true };
+    const decrypter = new Decrypter(config);
+    const cbcMode = 0;
+    const decrypted = await decrypter.decrypt(
+      data.encrypted,
+      data.key,
+      data.iv,
+      cbcMode,
+    );
+    expect(new Uint8Array(decrypted)).to.deep.equal(data.expected);
+  });
+
+  it('decripts correctly aes-256-cbc', async function () {
+    const data = get256cbcData();
+
+    const config = { enableSoftwareAES: false };
+    const decrypter = new Decrypter(config);
+    const cbcMode = 0;
+    const decrypted = await decrypter.decrypt(
+      data.encrypted,
+      data.key,
+      data.iv,
+      cbcMode,
+    );
+    expect(new Uint8Array(decrypted)).to.deep.equal(data.expected);
+  });
+
+  it('decripts correctly aes-256-ctr', async function () {
+    const data = get256ctrData();
+
+    const config = { enableSoftwareAES: false };
+    const decrypter = new Decrypter(config);
+    const ctrMode = 1;
+    const decrypted = await decrypter.decrypt(
+      data.encrypted,
+      data.key,
+      data.iv,
+      ctrMode,
+    );
+    expect(new Uint8Array(decrypted)).to.deep.equal(data.expected);
+  });
+});
+
+function get128cbcData() {
+  const key = new Uint8Array([
+    0xe5, 0xe9, 0xfa, 0x1b, 0xa3, 0x1e, 0xcd, 0x1a, 0xe8, 0x4f, 0x75, 0xca,
+    0xaa, 0x47, 0x4f, 0x3a,
+  ]).buffer;
+  const iv = new Uint8Array([
+    0x66, 0x3f, 0x05, 0xf4, 0x12, 0x02, 0x8f, 0x81, 0xda, 0x65, 0xd2, 0x6e,
+    0xe5, 0x64, 0x24, 0xb2,
+  ]).buffer;
+  const encrypted = new Uint8Array([
+    0x2c, 0x94, 0xcf, 0xc0, 0x91, 0xff, 0x0e, 0xcc, 0x98, 0x66, 0xcc, 0x83,
+    0x0d, 0xd7, 0xc3, 0x55,
+  ]);
+  const expected = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0x0a]);
+  return { key: key, iv: iv, encrypted: encrypted, expected: expected };
+}
+
+function get256Data() {
+  const key = new Uint8Array([
+    0xe5, 0xe9, 0xfa, 0x1b, 0xa3, 0x1e, 0xcd, 0x1a, 0xe8, 0x4f, 0x75, 0xca,
+    0xaa, 0x47, 0x4f, 0x3a, 0x66, 0x3f, 0x05, 0xf4, 0x12, 0x02, 0x8f, 0x81,
+    0xda, 0x65, 0xd2, 0x6e, 0xe5, 0x64, 0x24, 0xb2,
+  ]).buffer;
+  const iv = new Uint8Array([
+    0xf4, 0x8c, 0xef, 0xa0, 0xad, 0x59, 0xc9, 0xa5, 0x60, 0x16, 0xcf, 0xbb,
+    0x26, 0x5b, 0xee, 0x8c,
+  ]).buffer;
+  const expected = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0x0a]);
+  return { key: key, iv: iv, expected: expected };
+}
+
+function get256cbcData() {
+  const some256data = get256Data();
+  const encrypted = new Uint8Array([
+    0xe7, 0x25, 0x6a, 0x77, 0x3a, 0xa5, 0x43, 0x59, 0xaf, 0x60, 0xc1, 0xd3,
+    0xed, 0x31, 0xc4, 0x01,
+  ]);
+  some256data.encrypted = encrypted;
+  return some256data;
+}
+
+function get256ctrData() {
+  const some256data = get256Data();
+  const encrypted = new Uint8Array([0xb8, 0xd1, 0xcf, 0x15, 0x0d, 0x34, 0x12]);
+  some256data.encrypted = encrypted;
+  return some256data;
+}


### PR DESCRIPTION
### Description
Adding AES-256 and AES-256-CTR encryption methods (full segment, as AES-128)

### Context
Need stronger encryption scheme than AES-128 for CCTV scenario, in the short-mid term.

See more context & informal addendum to rfc8216 at :
https://mailarchive.ietf.org/arch/msg/hls-interest/RZBgatOvI4W0M0J5cShuXWzdigg/

### Are there any points in the code the reviewer needs to double check?

- I have very little experience in JavaScript/TypeScript, please assume that everything is wrong language wise :-)
- Error handling
- Everything crypto related

### Limitations

 - Does not enforce the presence of explicit IV in AES-256 & AES-256-CTR (when the rfc informal proposal stated they SHALL be present, and different for each segment).
 - AES-256 & AES-256-CTR will only work with WebCrypto, not the JavaScript implementation.
 - Range access ‘adjustment’ is not implemented for CTR mode (don’t re-compute nonce counter based on block offset)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md 
       -  Not an official change yet?
