### PR TITLE
Ignore #EXT-X-INDEPENDENT-SEGMENTS

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -60,7 +60,7 @@ const LEVEL_PLAYLIST_REGEX_SLOW = new RegExp(
     /#(EXTM3U)/.source,
     /#EXT-X-(DATERANGE|DEFINE|KEY|MAP|PART|PART-INF|PLAYLIST-TYPE|PRELOAD-HINT|RENDITION-REPORT|SERVER-CONTROL|SKIP|START):(.+)/
       .source,
-    /#EXT-X-(BITRATE|DISCONTINUITY-SEQUENCE|MEDIA-SEQUENCE|TARGETDURATION|VERSION): *(\d+)/
+    /#EXT-X-(BITRATE|DISCONTINUITY-SEQUENCE|MEDIA-SEQUENCE|TARGETDURATION|VERSION|INDEPENDENT-SEGMENTS): *(\d+)/
       .source,
     /#EXT-X-(DISCONTINUITY|ENDLIST|GAP)/.source,
     /(#)([^:]*):(.*)/.source,
@@ -499,6 +499,7 @@ export default class M3U8Parser {
           case 'VERSION':
             level.version = parseInt(value1);
             break;
+          case 'INDEPENDENT-SEGMENTS':
           case 'EXTM3U':
             break;
           case 'ENDLIST':


### PR DESCRIPTION
### This PR will...
Ignore #EXT-X-INDEPENDENT-SEGMENTS so that it is not added to Fragment tagList.

### Why is this Pull Request needed?
INDEPENDENT-SEGMENTS is global to the Playlist and should not be associated with any specific fragment.

HLS.js does not use INDEPENDENT-SEGMENTS because there is no advantage to knowing that all segments have at least one key-frame somewhere. For best performance, HLS.js needs each segment to begin with a key-frame (not just have at least one somewhere). Only streams that have segments that do not start with a key-frame get flagged for backtracking which impacts fragment selection on switch and seek.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
