### PR TITLE
Move automated tests to Safari 17 for "ended" event fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,9 +416,10 @@ jobs:
       max-parallel: 8
       matrix:
         include:
-          - config: safari-macOS_10.15
+          - config: safari-macOS_13
             ua: safari
-            os: macOS 10.15
+            os: macOS 13
+            uaVersion: '17'
           - config: firefox-win_10
             ua: firefox
             os: Windows 10


### PR DESCRIPTION
### This PR will...
Move automated tests to Safari 17 for "ended" event fix

### Why is this Pull Request needed?
Older versions of Safari fail to emit the "ended" event in many cases when the MediaSource and SourceBuffers are in the ended state prior to the playhead reaching the end. This can be seen in CI test results where other UAs pass, and Safari fails on several test assets. Updating the UA version should provide more stable results. 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
