### PR TITLE
Store deployments in json file, and generate md and txt file from that

### DIFF
--- a/scripts/build-deployments-readme.js
+++ b/scripts/build-deployments-readme.js
@@ -1,0 +1,76 @@
+/* eslint-disable no-console */
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+
+const itemCountMd = 100;
+const txtFileName = 'deployments.txt';
+
+async function go() {
+  // eslint-disable-next-line no-undef
+  const [, , deploymentsFile, outputDir] = process.argv;
+
+  assert(deploymentsFile, 'Missing deploymentsFile');
+  assert(outputDir, 'Missing outputDir');
+
+  const { stable, latest, individual } = JSON.parse(
+    await fs.promises.readFile(deploymentsFile, { encoding: 'utf-8' }),
+  );
+
+  const mdContent = `# Deployments
+
+- **Stable:** [${stable}](${stable})
+- **Latest:** [${latest}](${latest})
+
+Below you can find the URL's to deployments for individual commits:
+
+${Array.from(individual)
+  .reverse()
+  .slice(0, itemCountMd)
+  .map(
+    ({ commit, version, url }) =>
+      `- [\`${commit.slice(
+        0,
+        8,
+      )} (${version})\`](https://github.com/video-dev/hls.js/commit/${commit}): [${url}](${url})`,
+  )
+  .join('\n')}
+
+  _Note for older deployments please check [${txtFileName}](./${txtFileName})._
+`;
+
+  await fs.promises.writeFile(path.resolve(outputDir, 'README.md'), mdContent, {
+    encoding: 'utf-8',
+  });
+
+  const txtContent = `Deployments
+===========
+
+- Stable: ${stable}
+- Latest: ${latest}
+
+Below you can find the URL's to deployments for individual commits:
+
+${Array.from(individual)
+  .reverse()
+  .map(
+    ({ commit, version, url }) =>
+      `- ${commit.slice(0, 8)} (${version}): ${url}`,
+  )
+  .join('\n')}
+`;
+
+  await fs.promises.writeFile(
+    path.resolve(outputDir, txtFileName),
+    txtContent,
+    {
+      encoding: 'utf-8',
+    },
+  );
+}
+
+go().catch((e) => {
+  console.error(e);
+  // eslint-disable-next-line no-undef
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "tests/**/.eslintrc.js",
     "rollup.config.js",
     "build-config.js",
-    "lint-staged.config.js"
+    "lint-staged.config.js",
+    "scripts/**/*"
   ]
 }


### PR DESCRIPTION
### This PR will...

Update the deployments readme to only contain the most recent 100 deployments in reverse order. The rest will be contained in a new "deployments.txt" file.

"deployments.json" will be a new file on the deployments branch and be the source of truth.

### Why is this Pull Request needed?

The readme is getting truncated by github due to the size.

## TODO
- [x] just before this is merged "deployments.json" needs generating and putting on the deployments branch. [Here's a copy I generated a few days ago](https://gist.github.com/tjenkinson/18f0efaa2cf148c810b281d224e5a89e), but it needs updating with the recent items.