### PR TITLE
Bugfix/ID3 Decoding On Play Station 4 (1.4.x cherry pick)

### DIFF
--- a/src/demux/id3.ts
+++ b/src/demux/id3.ts
@@ -397,6 +397,12 @@ export const testables = {
 let decoder: TextDecoder;
 
 function getTextDecoder() {
+  // On Play Station 4, TextDecoder is defined but partially implemented.
+  // Manual decoding option is preferable
+  if (navigator.userAgent.includes('PlayStation 4')) {
+    return;
+  }
+
   if (!decoder && typeof self.TextDecoder !== 'undefined') {
     decoder = new self.TextDecoder('utf-8');
   }


### PR DESCRIPTION
On PS4, TextDecoder is defined but it is partially implemented and does not function properly. This will force manual decoding approach for PS4 platform in utf8ArrayToStr function.

### Why is this Pull Request needed?
It is necessary for private id3s to be correctly decoded and converted on Play Station 4 platform.

**Are there any points in the code the reviewer needs to double check?**
**Resolves issues**: https://github.com/video-dev/hls.js/issues/6041

**Checklist**
 changes have been done against master branch, and PR does not conflict
 new unit / functional tests have been added (whenever applicable)
 API or design changes are documented in API.md
