### PR TITLE
Fix base-stream-controller onHandlerDestroying callback evocation

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -79,6 +79,7 @@ class AudioStreamController
 
   protected onHandlerDestroying() {
     this._unregisterListeners();
+    super.onHandlerDestroying();
     this.mainDetails = null;
     this.bufferedTrack = null;
     this.switchingTrack = null;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -311,6 +311,8 @@ export default class BaseStreamController
     this.hls.off(Events.MANIFEST_LOADED, this.onManifestLoaded, this);
     this.stopLoad();
     super.onHandlerDestroying();
+    // @ts-ignore
+    this.hls = null;
   }
 
   protected onHandlerDestroyed() {

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -108,6 +108,8 @@ export default class BufferController implements ComponentAPI {
     this.unregisterListeners();
     this.details = null;
     this.lastMpegAudioChunk = null;
+    // @ts-ignore
+    this.hls = null;
   }
 
   protected registerListeners() {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -117,7 +117,7 @@ export default class StreamController
 
   protected onHandlerDestroying() {
     this._unregisterListeners();
-    this.onMediaDetaching();
+    super.onHandlerDestroying();
   }
 
   public startLoad(startPosition: number): void {

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -59,6 +59,7 @@ export class SubtitleStreamController
 
   protected onHandlerDestroying() {
     this._unregisterListeners();
+    super.onHandlerDestroying();
     this.mainDetails = null;
   }
 

--- a/tests/unit/hls.js
+++ b/tests/unit/hls.js
@@ -35,5 +35,11 @@ describe('Hls', function () {
       hls.destroy();
       expect(() => hls.startLoad()).to.not.throw();
     });
+
+    it('has no circular references after calling destroy()', function () {
+      const hls = new Hls();
+      hls.destroy();
+      expect(() => JSON.stringify(hls)).to.not.throw();
+    });
   });
 });


### PR DESCRIPTION
### This PR will...
- Fix base-stream-controller onHandlerDestroying callback evocation
- Remove circular references left after destroying player

### Why is this Pull Request needed?
Fixes potential for leaks caused by unremoved media event handlers and circular references.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
