### PR TITLE
Fix fetch loader abort in progressive mode

### DIFF
--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -62,8 +62,7 @@ class FetchLoader implements Loader<LoaderContext> {
   }
 
   abortInternal(): void {
-    const response = this.response;
-    if (this.controller && !response?.ok) {
+    if (this.controller && !this.stats.loading.end) {
       this.stats.aborted = true;
       this.controller.abort();
     }


### PR DESCRIPTION
### This PR will...
Abort fetch loader as long as loading has not ended.

### Why is this Pull Request needed?
Fetch response.ok is true as soon as status 200 is returned. In progressive mode, this is set and can be read before all data is loaded and the handling the response is complete.

### Are there any points in the code the reviewer needs to double check?
Instead of checking the response status, `!stats.loading.end` indicates that loading is incomplete and it is OK to abort. `stats.loading.end` is only set after receiving all data and handling the final response before invoking the loader `onSuccess` callback.

### Resolves issues:
Fixes #6054

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
