### PR TITLE
Fix codec parsing for AVC streams

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -309,10 +309,12 @@ function parseStsd(stsd: Uint8Array): { codec: string; encrypted: boolean } {
     case 'avc1':
     case 'avc2':
     case 'avc3':
-    case 'avc4':
-      // profile + compatibility + level
-      codec += '.' + toHex(stsd[111]) + toHex(stsd[112]) + toHex(stsd[113]);
+    case 'avc4': {
+      // extract profile + compatibility + level out of avcC box
+      const avcCBox = findBox(sampleEntriesEnd, ['avcC'])[0];
+      codec += '.' + toHex(avcCBox[1]) + toHex(avcCBox[2]) + toHex(avcCBox[3]);
       break;
+    }
     case 'mp4a': {
       const codecBox = findBox(sampleEntries, [fourCC])[0];
       const esdsBox = findBox(codecBox.subarray(28), ['esds'])[0];


### PR DESCRIPTION
### This PR will...
Fix the `codec` parsing for MP4 AVC streams.

### Why is this Pull Request needed?
Previously the codec was wrongly parsed (the extraction of profile + compatibility + level) at a wrong offset.

From a certain version, the source buffer started to get created based on codecs present in init segment instead of the playlist's codecs, resulting in an error since e.g. profile was zero.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
