### PR TITLE
Skip Low-Latency HLS segment and part directives after long delay

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -192,7 +192,19 @@ export default class BasePlaylistController
           details.targetduration * 1.5,
         );
         if (currentGoal > 0) {
-          if (previousDetails && currentGoal > previousDetails.tuneInGoal) {
+          if (cdnAge > details.targetduration * 3) {
+            // Omit segment and part directives when the last response was more than 3 target durations ago,
+            this.log(
+              `Playlist last advanced ${lastAdvanced.toFixed(
+                2,
+              )}s ago. Omitting segment and part directives.`,
+            );
+            msn = undefined;
+            part = undefined;
+          } else if (
+            previousDetails?.tuneInGoal &&
+            cdnAge - details.partTarget > previousDetails.tuneInGoal
+          ) {
             // If we attempted to get the next or latest playlist update, but currentGoal increased,
             // then we either can't catchup, or the "age" header cannot be trusted.
             this.warn(

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -556,7 +556,13 @@ export default class LevelController extends BasePlaylistController {
       if (curLevel.fragmentError === 0) {
         curLevel.loadError = 0;
       }
-      this.playlistLoaded(level, data, curLevel.details);
+      // Ignore matching details populated by loading a Media Playlist directly
+      let previousDetails = curLevel.details;
+      if (previousDetails === data.details && previousDetails.advanced) {
+        previousDetails = undefined;
+      }
+
+      this.playlistLoaded(level, data, previousDetails);
     } else if (data.deliveryDirectives?.skip) {
       // received a delta playlist update that cannot be merged
       details.deltaUpdateFailed = true;


### PR DESCRIPTION
### This PR will...
- Skip segment and part directives when last LL-HLS response is older than three target durations
- Fix Media Playlist 'advanced' state when no Multivariant Playlist is provided Related to #6076

### Why is this Pull Request needed?
Prevents requests for stale playlists.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #6076

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
