### PR TITLE
Fix regression in emergency switch down

### DIFF
--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -202,8 +202,9 @@ export function mergeDetails(
       : newDetails.fragments;
     fragmentsToCheck.forEach((frag) => {
       if (
-        !frag.initSegment ||
-        frag.initSegment.relurl === currentInitSegment?.relurl
+        frag &&
+        (!frag.initSegment ||
+          frag.initSegment.relurl === currentInitSegment?.relurl)
       ) {
         frag.initSegment = currentInitSegment;
       }


### PR DESCRIPTION
### This PR will...
- Force auto level on emergency switch down
- Update estimates on frag load timeout
- Do not abort frag load on abandon rules check (wait for new frag request after playlist is loaded to abort)
- Remove two segment forward buffer length limit on abandon rules
- Reset estimate when candidate bitrate is lower than adjusted estimate

### Why is this Pull Request needed?
In low bandwidth conditions where level loading can take several ticks, setting `hls.nextLoadLevel` on emergency switch down gets overridden by new evaluation of `hls.nextAutoLevel`. Setting `hls.nextAutoLevel` forces abr-controller to wait for the playlist to load.

Since low bandwidth conditions can result in frag loading timeouts, especially when the timeout limits are lowered in setup, updating estimates based on the available stats on timeout will help adapting even though lower limits for retries.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6079

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
