### PR TITLE
Null CMCD callbacks on destroy

### DIFF
--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -80,6 +80,8 @@ export default class CMCDController implements ComponentAPI {
 
     // @ts-ignore
     this.hls = this.config = this.audioBuffer = this.videoBuffer = null;
+    // @ts-ignore
+    this.onWaiting = this.onPlaying = null;
   }
 
   private onMediaAttached(


### PR DESCRIPTION
### This PR will...
Null CMCD callbacks on destroy

### Why is this Pull Request needed?
Inline callback properties like the ones in cmcd-controller are a great alternative to using bind. However, since they end up being declared in the constructor and referencing `this`, they create circular references that can cause leaks when disposing of hls.js player instances. Setting properties these to `null` on destroy removes circular references.

src:
```ts
private onPlaying = () => {
  if (!this.initialized) {
```

dist/hls.js:
```js
function CMCDController(hls) {
  var _this = this;
  this.onPlaying = function () {
    if (_this.initialized) {
```

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
