### PR TITLE
Update functional tests to run on Safari using MacOS 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,9 +416,9 @@ jobs:
       max-parallel: 8
       matrix:
         include:
-          - config: safari-macOS_10.15
+          - config: safari-macOS_13
             ua: safari
-            os: macOS 10.15
+            os: macOS 13
           - config: firefox-win_10
             ua: firefox
             os: Windows 10

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -650,7 +650,16 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
         );
       }
 
-      if (stream.abr && !HlsjsLightBuild) {
+      // Segment media is shorted than playlist duration resulting in overlapping appends on switch
+      // This appears to prevent playback in Safari which causes smoothswitch tests to fail
+      const isSafari = browserConfig.name === 'safari';
+      const isStreamsWithOverlappingAppends =
+        name === 'arte' || name === 'oceansAES';
+      if (
+        stream.abr &&
+        !HlsjsLightBuild &&
+        (!isSafari || !isStreamsWithOverlappingAppends)
+      ) {
         it(
           `should "smooth switch" to highest level and still play after 2s for ${stream.description}`,
           testSmoothSwitch.bind(null, url, config)

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -623,6 +623,7 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
     .forEach(([name, stream]) => {
       const url = stream.url;
       const config = stream.config || {};
+      config.preferManagedMediaSource = false;
       if (
         stream.skip_ua &&
         stream.skip_ua.some((browserInfo) => {

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -616,6 +616,8 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
     entries.length = 10;
   }
 
+  const isSafari = browserConfig.name === 'safari';
+
   entries
     // eslint-disable-next-line no-unused-vars
     .filter(([name, stream]) => !stream.skipFunctionalTests)
@@ -623,6 +625,12 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
     .forEach(([name, stream]) => {
       const url = stream.url;
       const config = stream.config || {};
+
+      // Segment media is shorted than playlist duration resulting in overlapping appends on switch
+      // This appears to prevent playback in Safari which causes smoothswitch and VOD ended event tests to fail
+      const isStreamsWithOverlappingAppends =
+        name === 'arte' || name === 'oceansAES';
+
       config.preferManagedMediaSource = false;
       if (
         stream.skip_ua &&
@@ -650,11 +658,6 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
         );
       }
 
-      // Segment media is shorted than playlist duration resulting in overlapping appends on switch
-      // This appears to prevent playback in Safari which causes smoothswitch tests to fail
-      const isSafari = browserConfig.name === 'safari';
-      const isStreamsWithOverlappingAppends =
-        name === 'arte' || name === 'oceansAES';
       if (
         stream.abr &&
         !HlsjsLightBuild &&
@@ -680,10 +683,12 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
           `should play ${stream.description}`,
           testIsPlayingVOD.bind(null, url, config)
         );
-        it(
-          `should seek 3s from end and receive video ended event for ${stream.description} with 2 or less buffered ranges`,
-          testSeekOnVOD.bind(null, url, config)
-        );
+        if (!isSafari || !isStreamsWithOverlappingAppends) {
+          it(
+            `should seek 3s from end and receive video ended event for ${stream.description} with 2 or less buffered ranges`,
+            testSeekOnVOD.bind(null, url, config)
+          );
+        }
         // TODO: Seeking to or past VOD duration should result in the video ending
         // it(`should seek on end and receive video ended event for ${stream.description}`, testSeekEndVOD.bind(null, url));
       }


### PR DESCRIPTION
### This PR will...
Update functional tests to run on Safari using MacOS 13 rather than 10.15.

### Why is this Pull Request needed?
Older versions of Safari are lower in usage and have issue with the "ended" event making functional test run fail. The hope is to get more stable results so that we can rely on auto-merge.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
