### PR TITLE
Null inline class JavaScript Event callback properties on destroy

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -443,15 +443,11 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected onMediaDetaching(): void;
     // (undocumented)
-    protected onMediaEnded(): void;
+    protected onMediaEnded: () => void;
     // (undocumented)
-    protected onMediaSeeking(): void;
+    protected onMediaSeeking: () => void;
     // (undocumented)
     protected onTickEnd(): void;
-    // (undocumented)
-    protected onvended: EventListener | null;
-    // (undocumented)
-    protected onvseeking: EventListener | null;
     // (undocumented)
     protected playlistType: PlaylistLevelType;
     // (undocumented)

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -110,6 +110,12 @@ export default class BufferController implements ComponentAPI {
     this.lastMpegAudioChunk = null;
     // @ts-ignore
     this.hls = null;
+    // @ts-ignore
+    this._onMediaSourceOpen = this._onMediaSourceClose = null;
+    // @ts-ignore
+    this._onMediaSourceEnded = null;
+    // @ts-ignore
+    this._onStartStreaming = this._onEndStreaming = null;
   }
 
   protected registerListeners() {

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -90,8 +90,6 @@ class EMEController implements ComponentAPI {
   private setMediaKeysQueue: Promise<void>[] = EMEController.CDMCleanupPromise
     ? [EMEController.CDMCleanupPromise]
     : [];
-  private onMediaEncrypted = this._onMediaEncrypted.bind(this);
-  private onWaitingForKey = this._onWaitingForKey.bind(this);
 
   private debug: (msg: any) => void = logger.debug.bind(logger, LOGGER_PREFIX);
   private log: (msg: any) => void = logger.log.bind(logger, LOGGER_PREFIX);
@@ -113,13 +111,9 @@ class EMEController implements ComponentAPI {
     config.licenseXhrSetup = config.licenseResponseCallback = undefined;
     config.drmSystems = config.drmSystemOptions = {};
     // @ts-ignore
-    this.hls =
-      this.onMediaEncrypted =
-      this.onWaitingForKey =
-      this.keyIdToKeySessionPromise =
-        null as any;
+    this.hls = this.config = this.keyIdToKeySessionPromise = null;
     // @ts-ignore
-    this.config = null;
+    this.onMediaEncrypted = this.onWaitingForKey = null;
   }
 
   private registerListeners() {
@@ -523,7 +517,7 @@ class EMEController implements ComponentAPI {
     return this.attemptKeySystemAccess(keySystemsToAttempt);
   }
 
-  private _onMediaEncrypted(event: MediaEncryptedEvent) {
+  private onMediaEncrypted = (event: MediaEncryptedEvent) => {
     const { initDataType, initData } = event;
     this.debug(`"${event.type}" event: init data type: "${initDataType}"`);
 
@@ -639,11 +633,11 @@ class EMEController implements ComponentAPI {
         );
     }
     keySessionContextPromise.catch((error) => this.handleError(error));
-  }
+  };
 
-  private _onWaitingForKey(event: Event) {
+  private onWaitingForKey = (event: Event) => {
     this.log(`"${event.type}" event`);
-  }
+  };
 
   private attemptSetMediaKeys(
     keySystem: KeySystems,

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -19,7 +19,6 @@ export default class LatencyController implements ComponentAPI {
   private currentTime: number = 0;
   private stallCount: number = 0;
   private _latency: number | null = null;
-  private timeupdateHandler = () => this.timeupdate();
 
   constructor(hls: Hls) {
     this.hls = hls;
@@ -126,7 +125,7 @@ export default class LatencyController implements ComponentAPI {
     this.onMediaDetaching();
     this.levelDetails = null;
     // @ts-ignore
-    this.hls = this.timeupdateHandler = null;
+    this.hls = this.onTimeupdate = null;
   }
 
   private registerListeners() {
@@ -150,12 +149,12 @@ export default class LatencyController implements ComponentAPI {
     data: MediaAttachingData,
   ) {
     this.media = data.media;
-    this.media.addEventListener('timeupdate', this.timeupdateHandler);
+    this.media.addEventListener('timeupdate', this.onTimeupdate);
   }
 
   private onMediaDetaching() {
     if (this.media) {
-      this.media.removeEventListener('timeupdate', this.timeupdateHandler);
+      this.media.removeEventListener('timeupdate', this.onTimeupdate);
       this.media = null;
     }
   }
@@ -172,10 +171,10 @@ export default class LatencyController implements ComponentAPI {
   ) {
     this.levelDetails = details;
     if (details.advanced) {
-      this.timeupdate();
+      this.onTimeupdate();
     }
     if (!details.live && this.media) {
-      this.media.removeEventListener('timeupdate', this.timeupdateHandler);
+      this.media.removeEventListener('timeupdate', this.onTimeupdate);
     }
   }
 
@@ -191,7 +190,7 @@ export default class LatencyController implements ComponentAPI {
     }
   }
 
-  private timeupdate() {
+  private onTimeupdate = () => {
     const { media, levelDetails } = this;
     if (!media || !levelDetails) {
       return;
@@ -242,7 +241,7 @@ export default class LatencyController implements ComponentAPI {
     } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
       media.playbackRate = 1;
     }
-  }
+  };
 
   private estimateLiveEdge(): number | null {
     const { levelDetails } = this;

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -35,10 +35,11 @@ class SubtitleTrackController extends BasePlaylistController {
   private currentTrack: MediaPlaylist | null = null;
   private selectDefaultTrack: boolean = true;
   private queuedDefaultTrack: number = -1;
-  private asyncPollTrackChange: () => void = () => this.pollTrackChange(0);
   private useTextTrackPolling: boolean = false;
   private subtitlePollingInterval: number = -1;
   private _subtitleDisplay: boolean = true;
+
+  private asyncPollTrackChange = () => this.pollTrackChange(0);
 
   constructor(hls: Hls) {
     super(hls, '[subtitle-track-controller]');
@@ -50,7 +51,8 @@ class SubtitleTrackController extends BasePlaylistController {
     this.tracks.length = 0;
     this.tracksInGroup.length = 0;
     this.currentTrack = null;
-    this.onTextTracksChanged = this.asyncPollTrackChange = null as any;
+    // @ts-ignore
+    this.onTextTracksChanged = this.asyncPollTrackChange = null;
     super.destroy();
   }
 

--- a/tests/unit/controller/latency-controller.ts
+++ b/tests/unit/controller/latency-controller.ts
@@ -79,7 +79,7 @@ describe('LatencyController', function () {
     currentTimeStub.get(() => currentTime);
     currentTimeStub.set((value: number) => {
       currentTime = value;
-      latencyController['timeupdate']();
+      latencyController['onTimeupdate']();
     });
   });
 


### PR DESCRIPTION
### This PR will...
Prefer inline callback properties to binding methods to new properties, and null referenced on destroy.

### Why is this Pull Request needed?
Reduce retained references after destroying the player in UAs that cannot remove circular references to class instance "_this" hoisted into callbacks defined in the constructor (Follows up on #6098).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
