### PR TITLE
Use AAC SBR (HE-AAC) workaround on Pale Moon

### DIFF
--- a/src/demux/audio/adts.ts
+++ b/src/demux/audio/adts.ts
@@ -61,8 +61,8 @@ export function getAudioConfig(
   logger.log(
     `manifest codec:${audioCodec}, ADTS type:${adtsObjectType}, samplingIndex:${adtsSamplingIndex}`,
   );
-  // firefox: freq less than 24kHz = AAC SBR (HE-AAC)
-  if (/firefox/i.test(userAgent)) {
+  // Firefox and Pale Moon: freq less than 24kHz = AAC SBR (HE-AAC)
+  if (/firefox|palemoon/i.test(userAgent)) {
     if (adtsSamplingIndex >= 6) {
       adtsObjectType = 5;
       config = new Array(4);


### PR DESCRIPTION
### This PR will...

Apply the Firefox AAC SBR (HE-AAC) workaround to Pale Moon (confirmed working on my end).

### Why is this Pull Request needed?

Without this change, Pale Moon plays sound on some streams at an extremely low pitch with crackling.

### Are there any points in the code the reviewer needs to double check?

Correct regex?

### Resolves issues: #6110

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
  - I've unsuccessfully tried creating a test for Pale Moon in particular (adapting the Firefox low-frequency sound test for Pale Moon did not result in a failing test, even before this change is implemented), although existing tests continue to pass.
- [x] API or design changes are documented in API.md