### PR TITLE
fix: generate silent aac frame based on original codec

### DIFF
--- a/src/demux/audio/adts.ts
+++ b/src/demux/audio/adts.ts
@@ -17,7 +17,7 @@ type AudioConfig = {
   samplerate: number;
   channelCount: number;
   codec: string;
-  originalCodec: string;
+  parsedCodec: string;
   manifestCodec: string;
 };
 
@@ -170,7 +170,7 @@ export function getAudioConfig(
     samplerate: adtsSamplingRates[adtsSamplingIndex],
     channelCount: adtsChannelConfig,
     codec: 'mp4a.40.' + adtsObjectType,
-    originalCodec: 'mp4a.40.' + originalAdtsObjectType,
+    parsedCodec: 'mp4a.40.' + originalAdtsObjectType,
     manifestCodec,
   };
 }
@@ -248,9 +248,9 @@ export function initTrackConfig(
     track.channelCount = config.channelCount;
     track.codec = config.codec;
     track.manifestCodec = config.manifestCodec;
-    track.originalCodec = config.originalCodec;
+    track.parsedCodec = config.parsedCodec;
     logger.log(
-      `parsed codec:${track.codec}, originalCodec:${track.originalCodec}, rate:${config.samplerate}, channels:${config.channelCount}`,
+      `parsed codec:${track.parsedCodec}, codec:${track.codec}, rate:${config.samplerate}, channels:${config.channelCount}`,
     );
   }
 }

--- a/src/demux/audio/adts.ts
+++ b/src/demux/audio/adts.ts
@@ -17,6 +17,7 @@ type AudioConfig = {
   samplerate: number;
   channelCount: number;
   codec: string;
+  originalCodec: string;
   manifestCodec: string;
 };
 
@@ -32,6 +33,7 @@ export function getAudioConfig(
   audioCodec: string,
 ): AudioConfig | void {
   let adtsObjectType: number;
+  let originalAdtsObjectType: number;
   let adtsExtensionSamplingIndex: number;
   let adtsChannelConfig: number;
   let config: number[];
@@ -42,7 +44,8 @@ export function getAudioConfig(
     8000, 7350,
   ];
   // byte 2
-  adtsObjectType = ((data[offset + 2] & 0xc0) >>> 6) + 1;
+  adtsObjectType = originalAdtsObjectType =
+    ((data[offset + 2] & 0xc0) >>> 6) + 1;
   const adtsSamplingIndex = (data[offset + 2] & 0x3c) >>> 2;
   if (adtsSamplingIndex > adtsSamplingRates.length - 1) {
     const error = new Error(`invalid ADTS sampling index:${adtsSamplingIndex}`);
@@ -167,6 +170,7 @@ export function getAudioConfig(
     samplerate: adtsSamplingRates[adtsSamplingIndex],
     channelCount: adtsChannelConfig,
     codec: 'mp4a.40.' + adtsObjectType,
+    originalCodec: 'mp4a.40.' + originalAdtsObjectType,
     manifestCodec,
   };
 }
@@ -244,8 +248,9 @@ export function initTrackConfig(
     track.channelCount = config.channelCount;
     track.codec = config.codec;
     track.manifestCodec = config.manifestCodec;
+    track.originalCodec = config.originalCodec;
     logger.log(
-      `parsed codec:${track.codec}, rate:${config.samplerate}, channels:${config.channelCount}`,
+      `parsed codec:${track.codec}, originalCodec:${track.originalCodec}, rate:${config.samplerate}, channels:${config.channelCount}`,
     );
   }
 }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -927,7 +927,7 @@ export default class MP4Remuxer implements Remuxer {
           for (let j = 0; j < missing; j++) {
             const newStamp = Math.max(nextPts as number, 0);
             let fillFrame = AAC.getSilentFrame(
-              track.manifestCodec || track.codec,
+              track.manifestCodec || track.originalCodec || track.codec,
               track.channelCount,
             );
             if (!fillFrame) {
@@ -1077,7 +1077,7 @@ export default class MP4Remuxer implements Remuxer {
     const nbSamples: number = Math.ceil((endDTS - startDTS) / frameDuration);
     // silent frame
     const silentFrame: Uint8Array | undefined = AAC.getSilentFrame(
-      track.manifestCodec || track.codec,
+      track.manifestCodec || track.originalCodec || track.codec,
       track.channelCount,
     );
 

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -927,7 +927,7 @@ export default class MP4Remuxer implements Remuxer {
           for (let j = 0; j < missing; j++) {
             const newStamp = Math.max(nextPts as number, 0);
             let fillFrame = AAC.getSilentFrame(
-              track.manifestCodec || track.originalCodec || track.codec,
+              track.parsedCodec || track.manifestCodec || track.codec,
               track.channelCount,
             );
             if (!fillFrame) {
@@ -1077,7 +1077,7 @@ export default class MP4Remuxer implements Remuxer {
     const nbSamples: number = Math.ceil((endDTS - startDTS) / frameDuration);
     // silent frame
     const silentFrame: Uint8Array | undefined = AAC.getSilentFrame(
-      track.manifestCodec || track.originalCodec || track.codec,
+      track.parsedCodec || track.manifestCodec || track.codec,
       track.channelCount,
     );
 

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -64,6 +64,7 @@ export interface DemuxedAudioTrack extends DemuxedTrack {
   segmentCodec?: string;
   channelCount?: number;
   manifestCodec?: string;
+  originalCodec?: string;
   samples: AudioSample[];
 }
 

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -64,7 +64,7 @@ export interface DemuxedAudioTrack extends DemuxedTrack {
   segmentCodec?: string;
   channelCount?: number;
   manifestCodec?: string;
-  originalCodec?: string;
+  parsedCodec?: string;
   samples: AudioSample[];
 }
 

--- a/tests/unit/demuxer/adts.js
+++ b/tests/unit/demuxer/adts.js
@@ -44,6 +44,7 @@ describe('getAudioConfig', function () {
       samplerate: 96000,
       channelCount: 0,
       codec: 'mp4a.40.2',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.29',
     });
   });
@@ -61,6 +62,7 @@ describe('getAudioConfig', function () {
       samplerate: 11025,
       channelCount: 0,
       codec: 'mp4a.40.5',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.29',
     });
   });
@@ -78,6 +80,7 @@ describe('getAudioConfig', function () {
       samplerate: 11025,
       channelCount: 0,
       codec: 'mp4a.40.2',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.29',
     });
   });
@@ -95,6 +98,7 @@ describe('getAudioConfig', function () {
       samplerate: 11025,
       channelCount: 0,
       codec: 'mp4a.40.5',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.29',
     });
   });
@@ -112,6 +116,7 @@ describe('getAudioConfig', function () {
       samplerate: 11025,
       channelCount: 0,
       codec: 'mp4a.40.5',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: undefined,
     });
   });
@@ -129,6 +134,7 @@ describe('getAudioConfig', function () {
       samplerate: 64000,
       channelCount: 0,
       codec: 'mp4a.40.5',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: undefined,
     });
   });
@@ -146,6 +152,7 @@ describe('getAudioConfig', function () {
       samplerate: 11025,
       channelCount: 0,
       codec: 'mp4a.40.5',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.5',
     });
   });
@@ -164,6 +171,7 @@ describe('getAudioConfig', function () {
       samplerate: 11025,
       channelCount: 1,
       codec: 'mp4a.40.2',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.2',
     });
   });
@@ -181,6 +189,7 @@ describe('getAudioConfig', function () {
       samplerate: 64000,
       channelCount: 0,
       codec: 'mp4a.40.2',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.2',
     });
   });
@@ -350,6 +359,7 @@ describe('initTrackConfig', function () {
       samplerate: 11025,
       channelCount: 0,
       codec: 'mp4a.40.5',
+      parsedCodec: 'mp4a.40.1',
       manifestCodec: 'mp4a.40.29',
     });
   });


### PR DESCRIPTION
### This PR will...

Prefer to use originalCodec when generating silent aac frame.

### Why is this Pull Request needed?

As https://github.com/video-dev/hls.js/blob/master/src/demux/audio/adts.ts#L87 mentioned, audio type will always force to be HE-AAC SBR in some browsers.
When I play {codec: mp4a.40.2, channelCount: 2} stream with gaps in Chrome, MP4Remuxer will inject mp4a.40.5 frame, which sounds noisy.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
