### PR TITLE
Fix filtering of "mp4a.40.34" variants in Safari

### DIFF
--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -12,14 +12,13 @@ import Transmuxer, {
 } from '../demux/transmuxer';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
-import { getMediaSource } from '../utils/mediasource-helper';
 import { EventEmitter } from 'eventemitter3';
 import { Fragment, Part } from '../loader/fragment';
+import { getM2TSSupportedAudioTypes } from '../utils/codecs';
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import type Hls from '../hls';
 import type { HlsEventEmitter } from '../events';
 import type { PlaylistLevelType } from '../types/loader';
-import type { TypeSupported } from './tsdemuxer';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
 
 export default class TransmuxerInterface {
@@ -64,16 +63,9 @@ export default class TransmuxerInterface {
     this.observer.on(Events.FRAG_DECRYPTED, forwardMessage);
     this.observer.on(Events.ERROR, forwardMessage);
 
-    const MediaSource = getMediaSource(config.preferManagedMediaSource) || {
-      isTypeSupported: () => false,
-    };
-    const m2tsTypeSupported: TypeSupported = {
-      mpeg: MediaSource.isTypeSupported('audio/mpeg'),
-      mp3: MediaSource.isTypeSupported('audio/mp4; codecs="mp3"'),
-      ac3: __USE_M2TS_ADVANCED_CODECS__
-        ? MediaSource.isTypeSupported('audio/mp4; codecs="ac-3"')
-        : false,
-    };
+    const m2tsTypeSupported = getM2TSSupportedAudioTypes(
+      config.preferManagedMediaSource,
+    );
 
     // navigator.vendor is not always available in Web Worker
     // refer to https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/navigator

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -4,7 +4,7 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import Decrypter from '../crypt/decrypter';
 import AACDemuxer from './audio/aacdemuxer';
 import MP4Demuxer from '../demux/mp4demuxer';
-import TSDemuxer, { TypeSupported } from '../demux/tsdemuxer';
+import TSDemuxer from '../demux/tsdemuxer';
 import MP3Demuxer from './audio/mp3demuxer';
 import { AC3Demuxer } from './audio/ac3-demuxer';
 import MP4Remuxer from '../remux/mp4-remuxer';
@@ -16,6 +16,7 @@ import type { TransmuxerResult, ChunkMetadata } from '../types/transmuxer';
 import type { HlsConfig } from '../config';
 import type { DecryptData } from '../loader/level-key';
 import type { PlaylistLevelType } from '../types/loader';
+import type { TypeSupported } from '../utils/codecs';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
 import { optionalSelf } from '../utils/global';
 

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -20,20 +20,21 @@ import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import type { HlsConfig } from '../config';
 import type { HlsEventEmitter } from '../events';
+import type { TypeSupported } from '../utils/codecs';
 import {
-  DemuxedVideoTrack,
-  DemuxedAudioTrack,
-  DemuxedTrack,
-  Demuxer,
-  DemuxerResult,
-  VideoSample,
-  DemuxedMetadataTrack,
-  DemuxedUserdataTrack,
-  ElementaryStreamData,
-  KeyData,
   MetadataSchema,
+  type DemuxedVideoTrack,
+  type DemuxedAudioTrack,
+  type DemuxedTrack,
+  type Demuxer,
+  type DemuxerResult,
+  type VideoSample,
+  type DemuxedMetadataTrack,
+  type DemuxedUserdataTrack,
+  type ElementaryStreamData,
+  type KeyData,
 } from '../types/demuxer';
-import { AudioFrame } from '../types/demuxer';
+import type { AudioFrame } from '../types/demuxer';
 
 export type ParsedTimestamp = {
   pts?: number;
@@ -47,12 +48,6 @@ export type PES = ParsedTimestamp & {
 
 export type ParsedVideoSample = ParsedTimestamp &
   Omit<VideoSample, 'pts' | 'dts'>;
-
-export interface TypeSupported {
-  mpeg: boolean;
-  mp3: boolean;
-  ac3: boolean;
-}
 
 const PACKET_LENGTH = 188;
 

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -29,6 +29,7 @@ import type { TrackSet } from '../types/track';
 import type { SourceBufferName } from '../types/buffer';
 import type { Fragment } from '../loader/fragment';
 import type { HlsConfig } from '../config';
+import type { TypeSupported } from '../utils/codecs';
 
 const MAX_SILENT_FRAME_DURATION = 10 * 1000; // 10 seconds
 const AAC_SAMPLES_PER_FRAME = 1024;
@@ -41,7 +42,7 @@ let safariWebkitVersion: number | null = null;
 export default class MP4Remuxer implements Remuxer {
   private observer: HlsEventEmitter;
   private config: HlsConfig;
-  private typeSupported: any;
+  private typeSupported: TypeSupported;
   private ISGenerated: boolean = false;
   private _initPTS: RationalTimestamp | null = null;
   private _initDTS: RationalTimestamp | null = null;


### PR DESCRIPTION
### This PR will...
Replace user-agent check for "mp4a.40.34" to "mp3" and "audio/mpeg" fallback with support checks,

### Why is this Pull Request needed?
MSE support checks fail for ISO BMFF "MP3"  identifier for codecs parameter "mp4a.40.34". HLS.js works around this by using "mp3" as the identifier, or by checking support for "audio/mpeg" SourceBuffers. It only does this when the user-agent contains "chrome" or "firefox", but this issue affects other browsers. Removing the UA check and using support checks like we do for the many casings of 'fLaC' is a more elegant solution.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6125

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
