### PR TITLE
fix(Remuxer): Safari segment overlap ensure PTS order

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -584,6 +584,11 @@ export default class MP4Remuxer implements Remuxer {
       nbNalu += nbUnits;
       sample.length = sampleLen;
 
+      // ensure sample increasing PTS
+      if (i > 0 && safariWebkitVersion) {
+        sample.pts = Math.max(inputSamples[i - 1].pts + 1, sample.pts);
+      }
+
       // ensure sample monotonic DTS
       if (sample.dts < dtsStep) {
         sample.dts = dtsStep;

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -560,10 +560,8 @@ export default class MP4Remuxer implements Remuxer {
                 const nextSamplePTS = inputSamples[i + 1].pts;
                 const currentSamplePTS = inputSamples[i].pts;
 
-                const currentOrder = Math.sign(
-                  nextSamplePTS - currentSamplePTS,
-                );
-                const prevOrder = Math.sign(nextSamplePTS - prevPTS);
+                const currentOrder = nextSamplePTS - currentSamplePTS < 0;
+                const prevOrder = nextSamplePTS - prevPTS < 0;
 
                 isPTSOrderRetained = currentOrder == prevOrder;
               }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -560,8 +560,8 @@ export default class MP4Remuxer implements Remuxer {
                 const nextSamplePTS = inputSamples[i + 1].pts;
                 const currentSamplePTS = inputSamples[i].pts;
 
-                const currentOrder = nextSamplePTS - currentSamplePTS <= 0;
-                const prevOrder = nextSamplePTS - prevPTS <= 0;
+                const currentOrder = nextSamplePTS <= currentSamplePTS;
+                const prevOrder = nextSamplePTS <= prevPTS;
 
                 isPTSOrderRetained = currentOrder == prevOrder;
               }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -560,8 +560,8 @@ export default class MP4Remuxer implements Remuxer {
                 const nextSamplePTS = inputSamples[i + 1].pts;
                 const currentSamplePTS = inputSamples[i].pts;
 
-                const currentOrder = nextSamplePTS - currentSamplePTS < 0;
-                const prevOrder = nextSamplePTS - prevPTS < 0;
+                const currentOrder = nextSamplePTS - currentSamplePTS <= 0;
+                const prevOrder = nextSamplePTS - prevPTS <= 0;
 
                 isPTSOrderRetained = currentOrder == prevOrder;
               }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -544,12 +544,29 @@ export default class MP4Remuxer implements Remuxer {
             inputSamples[0].dts = firstDTS;
             inputSamples[0].pts = firstPTS;
           } else {
+            let isPTSOrderRetained = true;
             for (let i = 0; i < inputSamples.length; i++) {
-              if (inputSamples[i].dts > firstPTS) {
+              if (inputSamples[i].dts > firstPTS && isPTSOrderRetained) {
                 break;
               }
+
+              const prevPTS = inputSamples[i].pts;
               inputSamples[i].dts -= delta;
               inputSamples[i].pts -= delta;
+
+              // check to see if this sample's PTS order has changed
+              // relative to the next one
+              if (i < inputSamples.length - 1) {
+                const nextSamplePTS = inputSamples[i + 1].pts;
+                const currentSamplePTS = inputSamples[i].pts;
+
+                const currentOrder = Math.sign(
+                  nextSamplePTS - currentSamplePTS,
+                );
+                const prevOrder = Math.sign(nextSamplePTS - prevPTS);
+
+                isPTSOrderRetained = currentOrder == prevOrder;
+              }
             }
           }
           logger.log(
@@ -583,11 +600,6 @@ export default class MP4Remuxer implements Remuxer {
       naluLen += sampleLen;
       nbNalu += nbUnits;
       sample.length = sampleLen;
-
-      // ensure sample increasing PTS
-      if (i > 0 && safariWebkitVersion) {
-        sample.pts = Math.max(inputSamples[i - 1].pts + 1, sample.pts);
-      }
 
       // ensure sample monotonic DTS
       if (sample.dts < dtsStep) {


### PR DESCRIPTION
### This PR will...
Ensure PTS order while remuxing an overlapping segments.

### Why is this Pull Request needed?
We are experiencing the following scenario

_GIVEN_
    Variable frame rate stream where we have:

    - Two contiguous segments (SegA and SegB) which have an overlap
    - mp4SampleDuration of the last sample of SegA is 7508 
    - delta of -4505 with SegB
    - SegB has initial couple of samples with duration of 3003
    - timebase of 90000

_WHEN_
    The remuxVideo gets invoked AND the overlap logic triggers
_THEN_
    the PTS becomes misaligned and Safari throws a **_Media failed to decode_** error code 3 (MEDIA_ERR_DECODE) on the DOM Node

Chrome handles this scenario well and has no issues, but seems Safari is quite strict about things like this.

```
// inputSamples before PTS/DTS adjustments:
// [
//    {key: true, frame: true, pts: 270270, dts: 270270, units: Array(4), …},
//    {key: false, frame: true, pts: 273273, dts: 273273, units: Array(2), …},
//    {key: false, frame: true, pts: 277777, dts: 277777, units: Array(2), …},
//    {key: false, frame: true, pts: 280780, dts: 280780, units: Array(2), …},
//         ....
//    ]
         .....
         ....
          if (foundHole) {
            inputSamples[0].dts = firstDTS;
            inputSamples[0].pts = firstPTS;
          } else {
            for (let i = 0; i < inputSamples.length; i++) {
              if (inputSamples[i].dts > firstPTS) {
                break; // < --- here we break out of the loop leaving the PTS misaligned
              }
              inputSamples[i].dts -= delta;
              inputSamples[i].pts -= delta;
            }
          }
         .....
         .....

// inputSamples after PTS/DTS adjustments:
// [
//    {key: true, frame: true, pts: 274775, dts: 274775, units: Array(4), …}
//    {key: false, frame: true, pts: 277778, dts: 277778, units: Array(2), …}
//    {key: false, frame: true, pts: 277777, dts: 277777, units: Array(2), …}
//    {key: false, frame: true, pts: 280780, dts: 280780, units: Array(2), …}
//         ....
//    ]
         .....
         .....

// DTS is later ensured to be monotonic but the PTS remains misaligned

      // ensure sample monotonic DTS
      if (sample.dts < dtsStep) {
        sample.dts = dtsStep;
        dtsStep += (averageSampleDuration / 4) | 0 || 1;
      } else {
        dtsStep = sample.dts;
      }

// inputSamples after ensuring DTS is monotonic:
// [
//    {key: true, frame: true, pts: 274775, dts: 274775, units: Array(4), …}
//    {key: false, frame: true, pts: 277778, dts: 277778, units: Array(2), …}
//    {key: false, frame: true, pts: 277777, dts: 277778, units: Array(2), …}
//    {key: false, frame: true, pts: 280780, dts: 280780, units: Array(2), …}
//         ....
//    ]

```

### Are there any points in the code the reviewer needs to double check?
Not to my knowledge

### Resolves issues:
**_Media failed to decode_** in Safari (error code 3/**MEDIA_ERR_DECODE**)
Underlying WebKit error looks like this:
```
2024-01-23 09:14:46.752 com.apple.WebKit.GPU.Development[6045:76916] AVSampleBufferDisplayLayerFailedToDecodeNotification: Error Domain=AVFoundationErrorDomain Code=-11821 "Cannot Decode" UserInfo={AVErrorMediaSubTypeKey=(
    1635148593
), NSLocalizedDescription=Cannot Decode, NSLocalizedFailureReason=The media data could not be decoded. It may be damaged., AVErrorMediaTypeKey=vide, AVErrorPresentationTimeStampKey=CMTime: {277777/90000 = 3.086}, NSUnderlyingError=0x11d172150 {Error Domain=NSOSStatusErrorDomain Code=-12909 "(null)"}}
2024-01-23 09:14:46.752 com.apple.WebKit.GPU.Development[6045:76916] AVSampleBufferDisplayLayerFailedToDecodeNotification: Error Domain=AVFoundationErrorDomain Code=-11821 "Cannot Decode" UserInfo={AVErrorMediaSubTypeKey=(
    1635148593
), NSLocalizedDescription=Cannot Decode, NSLocalizedFailureReason=The media data could not be decoded. It may be damaged., AVErrorMediaTypeKey=vide, AVErrorPresentationTimeStampKey=CMTime: {277778/90000 = 3.086}, NSUnderlyingError=0x11d05df60 {Error Domain=NSOSStatusErrorDomain Code=-12909 "(null)"}}
2024-01-23 09:14:46.752 com.apple.WebKit.GPU.Development[6045:76916] AVSampleBufferDisplayLayerFailedToDecodeNotification: Error Domain=AVFoundationErrorDomain Code=-11821 "Cannot Decode" UserInfo={AVErrorMediaSubTypeKey=(
    1635148593
), NSLocalizedDescription=Cannot Decode, NSLocalizedFailureReason=The media data could not be decoded. It may be damaged., AVErrorMediaTypeKey=vide, AVErrorPresentationTimeStampKey=CMTime: {280780/90000 = 3.120}, NSUnderlyingError=0x10470d980 {Error Domain=NSOSStatusErrorDomain Code=-12909 "(null)"}}
....
```

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable) 
- [ ] API or design changes are documented in API.md 


Notes:
Unfortunately I am unable to disclose the segments/stream.
I would have added a functional test for this, but decided against it as I can't provide sample content unfortunately and the functional tests are targeting Chrome which does not experience this issue.
