### PR TITLE
Use average for level sorting and abandon rules check

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -286,7 +286,7 @@ class AbrController implements AbrComponentAPI {
     const level = levels[frag.level];
     const expectedLen =
       stats.total ||
-      Math.max(stats.loaded, Math.round((duration * level.maxBitrate) / 8));
+      Math.max(stats.loaded, Math.round((duration * level.averageBitrate) / 8));
     let timeStreaming = loadedFirstByte ? timeLoading - ttfb : timeLoading;
     if (timeStreaming < 1 && loadedFirstByte) {
       timeStreaming = Math.min(timeLoading, (stats.loaded * 8) / bwEstimate);
@@ -346,7 +346,7 @@ class AbrController implements AbrComponentAPI {
       // If there has been no loading progress, sample TTFB
       this.bwEstimator.sampleTTFB(timeLoading);
     }
-    const nextLoadLevelBitrate = levels[nextLoadLevel].bitrate;
+    const nextLoadLevelBitrate = levels[nextLoadLevel].maxBitrate;
     if (
       this.getBwEstimate() * this.hls.config.abrBandWidthUpFactor >
       nextLoadLevelBitrate

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -307,8 +307,8 @@ export default class LevelController extends BasePlaylistController {
           return valueB - valueA;
         }
       }
-      if (a.bitrate !== b.bitrate) {
-        return a.bitrate - b.bitrate;
+      if (a.averageBitrate !== b.averageBitrate) {
+        return a.averageBitrate - b.averageBitrate;
       }
       return 0;
     });


### PR DESCRIPTION
### This PR will...
Fixes a regression where using max bitrate to estimate time to load a segment could result in more emergency aborts and less stable playback when the the max is unusually larger than the average and/or larger than that of some upper tiers.

### Resolves issues:
Fixes #6122

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
