### PR TITLE
MEDIA_ENDED event

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1239,6 +1239,8 @@ export enum Events {
     // (undocumented)
     MEDIA_DETACHING = "hlsMediaDetaching",
     // (undocumented)
+    MEDIA_ENDED = "hlsMediaEnded",
+    // (undocumented)
     NON_NATIVE_TEXT_TRACKS_FOUND = "hlsNonNativeTextTracksFound",
     // (undocumented)
     STEERING_MANIFEST_LOADED = "hlsSteeringManifestLoaded",
@@ -1835,6 +1837,8 @@ export interface HlsListeners {
     [Events.MEDIA_DETACHED]: (event: Events.MEDIA_DETACHED) => void;
     // (undocumented)
     [Events.MEDIA_DETACHING]: (event: Events.MEDIA_DETACHING) => void;
+    // (undocumented)
+    [Events.MEDIA_ENDED]: (event: Events.MEDIA_ENDED, data: MediaEndedData) => void;
     // (undocumented)
     [Events.NON_NATIVE_TEXT_TRACKS_FOUND]: (event: Events.NON_NATIVE_TEXT_TRACKS_FOUND, data: NonNativeTextTracksData) => void;
     // (undocumented)
@@ -2799,6 +2803,14 @@ export type MediaDecodingInfo = {
     decodingInfoResults: readonly MediaCapabilitiesDecodingInfo[];
     error?: Error;
 };
+
+// Warning: (ae-missing-release-tag) "MediaEndedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface MediaEndedData {
+    // (undocumented)
+    stalled: boolean;
+}
 
 // Warning: (ae-missing-release-tag) "MediaKeyFunc" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -309,6 +309,11 @@ export default class BaseStreamController
   protected onMediaEnded = () => {
     // reset startPosition and lastCurrentTime to restart playback @ stream beginning
     this.startPosition = this.lastCurrentTime = 0;
+    if (this.playlistType === PlaylistLevelType.MAIN) {
+      this.hls.trigger(Events.MEDIA_ENDED, {
+        stalled: false,
+      });
+    }
   };
 
   protected onManifestLoaded(

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -16,7 +16,6 @@ import {
   codecsSetSelectionPreferenceValue,
   convertAVC1ToAVCOTI,
   getCodecCompatibleName,
-  getM2TSSupportedAudioTypes,
   videoCodecPreferenceValue,
 } from '../utils/codecs';
 import BasePlaylistController from './base-playlist-controller';

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -932,8 +932,10 @@ export default class StreamController
 
     if (this.loadedmetadata || !BufferHelper.getBuffered(media).length) {
       // Resolve gaps using the main buffer, whose ranges are the intersections of the A/V sourcebuffers
-      const activeFrag = this.state !== State.IDLE ? this.fragCurrent : null;
-      gapController.poll(this.lastCurrentTime, activeFrag);
+      const state = this.state;
+      const activeFrag = state !== State.IDLE ? this.fragCurrent : null;
+      const levelDetails = this.getLevelDetails();
+      gapController.poll(this.lastCurrentTime, activeFrag, levelDetails, state);
     }
 
     this.lastCurrentTime = media.currentTime;

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,6 +3,7 @@ import {
   ManifestLoadingData,
   MediaAttachedData,
   MediaAttachingData,
+  MediaEndedData,
   LevelLoadingData,
   LevelLoadedData,
   ManifestParsedData,
@@ -60,6 +61,8 @@ export enum Events {
   MEDIA_DETACHING = 'hlsMediaDetaching',
   // Fired when MediaSource has been detached from media element
   MEDIA_DETACHED = 'hlsMediaDetached',
+  // Fired when HTMLMediaElement dispatches "ended" event, or stalls at end of VOD program
+  MEDIA_ENDED = 'hlsMediaEnded',
   // Fired when the buffer is going to be reset
   BUFFER_RESET = 'hlsBufferReset',
   // Fired when we know about the codecs that we need buffers for to push into - data: {tracks : { container, codec, levelCodec, initSegment, metadata }}
@@ -184,6 +187,10 @@ export interface HlsListeners {
   ) => void;
   [Events.MEDIA_DETACHING]: (event: Events.MEDIA_DETACHING) => void;
   [Events.MEDIA_DETACHED]: (event: Events.MEDIA_DETACHED) => void;
+  [Events.MEDIA_ENDED]: (
+    event: Events.MEDIA_ENDED,
+    data: MediaEndedData,
+  ) => void;
   [Events.BUFFER_RESET]: (event: Events.BUFFER_RESET) => void;
   [Events.BUFFER_CODECS]: (
     event: Events.BUFFER_CODECS,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1159,6 +1159,7 @@ export type {
   ManifestParsedData,
   MediaAttachedData,
   MediaAttachingData,
+  MediaEndedData,
   NonNativeTextTrack,
   NonNativeTextTracksData,
   SteeringManifestLoadedData,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -42,6 +42,10 @@ export interface MediaAttachedData {
   mediaSource?: MediaSource;
 }
 
+export interface MediaEndedData {
+  stalled: boolean;
+}
+
 export interface BufferCodecsData {
   video?: Track;
   audio?: Track;

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -330,10 +330,16 @@ async function testSeekOnVOD(url, config) {
           });
         }
       };
-      video.onended = function () {
-        console.log('[test] > video  "ended"');
-        callback({ code: 'ended', logs: self.logString });
-      };
+      self.hls.on(self.Hls.Events.MEDIA_ENDED, function (eventName, data) {
+        console.log(
+          '[test] > video  "ended"' + data.stalled ? ' (stalled near end)' : ''
+        );
+        callback({
+          code: 'ended',
+          stalled: data.stalled,
+          logs: self.logString,
+        });
+      });
 
       video.oncanplaythrough = video.onwaiting = function (e) {
         console.log(


### PR DESCRIPTION
### This PR will...
Add a MEDIA_ENDED event. This event emits when the media element dispatches its "ended" event or when stalling has begun near end of VOD.

### Why is this Pull Request needed?
This event is useful in apps that need to do something when VOD playback has ended, but the user-agent does not dispatch "ended" reliably (common on older WebKit UAs).

### Are there any points in the code the reviewer needs to double check?
Note that Safari 17 significantly improves the handling of "ended" event dispatching at the end of VODs, so the issues this resolved may be more difficult to reproduce than it was in past versions with most HLS assets.

### Resolves issues:
Resolves #5274
- #5274

Related to:
- #5703
- #5168

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
