### PR TITLE
Fix regression in hls.light.js selection

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -772,7 +772,8 @@ class AbrController implements AbrComponentAPI {
         (!upSwitch &&
           currentFrameRate > 0 &&
           currentFrameRate < levelInfo.frameRate) ||
-        !levelInfo.supportedResult?.decodingInfoResults?.[0].smooth
+        (levelInfo.supportedResult &&
+          !levelInfo.supportedResult.decodingInfoResults?.[0].smooth)
       ) {
         levelsSkipped.push(i);
         continue;

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -649,7 +649,7 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
         );
       }
 
-      if (stream.abr && !HlsjsLightBuild) {
+      if (stream.abr) {
         it(
           `should "smooth switch" to highest level and still play after 2s for ${stream.description}`,
           testSmoothSwitch.bind(null, url, config)


### PR DESCRIPTION
### This PR will...
- Fix regression in hls.light.js selection
- Enable smooth switch functional tests for light build

### Why is this Pull Request needed?
Changes in 1.5 use MediaCapabilities to filter adaptive qualities. When using this feature is disabled (like in the light build by default) all variants are filtered out, resulting in a downswitch to 0.

### Are there any points in the code the reviewer needs to double check?
This also impacts the standard build with config option `useMediaCapabilities: false`.

### Resolves issues:
Fixes #6151

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
