### PR TITLE
Disable `AppleAdvancedHevcAvcHls` stream for now due to cors errors

### DIFF
--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -222,11 +222,11 @@ module.exports = {
     // abr: true,
     startSeek: true,
   },
-  AppleAdvancedHevcAvcHls: {
-    url: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8',
-    description:
-      'Advanced stream (HEVC/H.264, AC-3/AAC,  WebVTT, fMP4 segments)',
-  },
+  // AppleAdvancedHevcAvcHls: {
+  //   url: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8',
+  //   description:
+  //     'Advanced stream (HEVC/H.264, AC-3/AAC,  WebVTT, fMP4 segments)',
+  // },
   MuxLowLatencyHls: {
     url: 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8',
     description:


### PR DESCRIPTION
### This PR will...

Disable `AppleAdvancedHevcAvcHls` stream for now due to cors errors. It's causing a build up of dependency updates.

### Why is this Pull Request needed?

`https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8` currently fails because cors headers are missing 😢 

@robwalch maybe you could get this fixed? :)