### PR TITLE
Handle ManagedMediaSource endStreaming events without aborting requests

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -329,6 +329,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected bufferFragmentData(data: RemuxedTrack, frag: Fragment, part: Part | null, chunkMeta: ChunkMetadata, noBacktracking?: boolean): void;
     // (undocumented)
+    protected buffering: boolean;
+    // (undocumented)
     protected checkLiveUpdate(details: LevelDetails): void;
     // (undocumented)
     protected clearTrackerIfNeeded(frag: Fragment): void;
@@ -453,6 +455,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected onTickEnd(): void;
     // (undocumented)
+    pauseBuffering(): void;
+    // (undocumented)
     protected playlistType: PlaylistLevelType;
     // (undocumented)
     protected recoverWorkerError(data: ErrorData): void;
@@ -476,6 +480,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     protected resetTransmuxer(): void;
     // (undocumented)
     protected resetWhenMissingContext(chunkMeta: ChunkMetadata): void;
+    // (undocumented)
+    resumeBuffering(): void;
     // (undocumented)
     protected retryDate: number;
     // (undocumented)
@@ -2945,6 +2951,10 @@ export type MP4RemuxerConfig = {
 //
 // @public (undocumented)
 export interface NetworkComponentAPI extends ComponentAPI {
+    // (undocumented)
+    pauseBuffering?(): void;
+    // (undocumented)
+    resumeBuffering?(): void;
     // (undocumented)
     startLoad(startPosition: number): void;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -278,12 +278,14 @@ class AudioStreamController
     const { hls, levels, media, trackId } = this;
     const config = hls.config;
 
-    // 1. if video not attached AND
+    // 1. if buffering is suspended
+    // 2. if video not attached AND
     //    start fragment already requested OR start frag prefetch not enabled
-    // 2. if tracks or track not loaded and selected
+    // 3. if tracks or track not loaded and selected
     // then exit loop
     // => if media not attached but start frag prefetch is enabled and start frag not requested yet, we will not exit loop
     if (
+      !this.buffering ||
       (!media && (this.startFragRequested || !config.startFragPrefetch)) ||
       !levels?.[trackId]
     ) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -100,6 +100,7 @@ export default class BaseStreamController
   protected startFragRequested: boolean = false;
   protected decrypter: Decrypter;
   protected initPTS: RationalTimestamp[] = [];
+  protected buffering: boolean = true;
 
   constructor(
     hls: Hls,
@@ -159,6 +160,14 @@ export default class BaseStreamController
     this.clearInterval();
     this.clearNextTick();
     this.state = State.STOPPED;
+  }
+
+  public pauseBuffering() {
+    this.buffering = false;
+  }
+
+  public resumeBuffering() {
+    this.buffering = true;
   }
 
   protected _streamEnded(

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -295,6 +295,7 @@ export default class BufferController extends Logger implements ComponentAPI {
       this.resetBuffer(type);
     });
     this._initSourceBuffer();
+    this.hls.resumeBuffering();
   }
 
   private resetBuffer(type: SourceBufferName) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -231,7 +231,7 @@ export default class StreamController
       return;
     }
 
-    if (!levels?.[level]) {
+    if (!this.buffering || !levels?.[level]) {
       return;
     }
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -66,7 +66,6 @@ export default class Hls implements HlsEventEmitter {
 
   private coreComponents: ComponentAPI[];
   private networkControllers: NetworkComponentAPI[];
-  private started: boolean = false;
   private _emitter: HlsEventEmitter = new EventEmitter();
   private _autoLevelCapping: number = -1;
   private _maxHdcpLevel: HdcpLevel = null;
@@ -441,7 +440,6 @@ export default class Hls implements HlsEventEmitter {
    */
   startLoad(startPosition: number = -1) {
     this.logger.log(`startLoad(${startPosition})`);
-    this.started = true;
     this.networkControllers.forEach((controller) => {
       controller.startLoad(startPosition);
     });
@@ -452,33 +450,30 @@ export default class Hls implements HlsEventEmitter {
    */
   stopLoad() {
     this.logger.log('stopLoad');
-    this.started = false;
     this.networkControllers.forEach((controller) => {
       controller.stopLoad();
     });
   }
 
   /**
-   * Resumes stream controller segment loading if previously started.
+   * Resumes stream controller segment loading after `pauseBuffering` has been called.
    */
   resumeBuffering() {
-    if (this.started) {
-      this.networkControllers.forEach((controller) => {
-        if ('fragmentLoader' in controller) {
-          controller.startLoad(-1);
-        }
-      });
-    }
+    this.networkControllers.forEach((controller) => {
+      if (controller.resumeBuffering) {
+        controller.resumeBuffering();
+      }
+    });
   }
 
   /**
-   * Stops stream controller segment loading without changing 'started' state like stopLoad().
+   * Prevents stream controller from loading new segments until `resumeBuffering` is called.
    * This allows for media buffering to be paused without interupting playlist loading.
    */
   pauseBuffering() {
     this.networkControllers.forEach((controller) => {
-      if ('fragmentLoader' in controller) {
-        controller.stopLoad();
+      if (controller.pauseBuffering) {
+        controller.pauseBuffering();
       }
     });
   }

--- a/src/types/component-api.ts
+++ b/src/types/component-api.ts
@@ -15,4 +15,6 @@ export interface AbrComponentAPI extends ComponentAPI {
 export interface NetworkComponentAPI extends ComponentAPI {
   startLoad(startPosition: number): void;
   stopLoad(): void;
+  pauseBuffering?(): void;
+  resumeBuffering?(): void;
 }


### PR DESCRIPTION
### This PR will...
Handle ManagedMediaSource "endStreaming" events without aborting requests.

### Why is this Pull Request needed?
Using start/stopLoad to throttle buffering aborts active requests which can make the use of ManagedMediaSource less efficient when resources must be re-requested.

### Are there any points in the code the reviewer needs to double check?
This change is against development and will go into v1.6.0. Leave a comment if you would like it picked into patch/v1.5.x.

### Resolves issues:
Related to #6181

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
