### PR TITLE
Align playlists streaming start position with mismatched end-list tags

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -555,7 +555,7 @@ class AudioStreamController
 
     // compute start position if we are aligned with the main playlist
     if (!this.startFragRequested && (this.mainDetails || !newDetails.live)) {
-      this.setStartPosition(track.details, sliding);
+      this.setStartPosition(this.mainDetails || newDetails, sliding);
     }
     // only switch back to IDLE state if we were waiting for track to start downloading a new fragment
     if (

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -320,7 +320,7 @@ export class SubtitleStreamController
     this.levelLastLoaded = track;
 
     if (!this.startFragRequested && (this.mainDetails || !newDetails.live)) {
-      this.setStartPosition(track.details, sliding);
+      this.setStartPosition(this.mainDetails || newDetails, sliding);
     }
 
     // trigger handler right now


### PR DESCRIPTION
### This PR will...
Use main playlist details to determine start position of audio and subtitle streaming controllers

### Why is this Pull Request needed?
Startup worked (corrected itself) in 1.4 but regressed in 1.5 to only load live edge on live media playlists (audio) and first segment in vod media playlists (main) which results in playback not starting (no combined buffer) until a seek.

### Are there any points in the code the reviewer needs to double check?
How does this impact live start? So far looks like a more aligned start time results in fast start times when initial live playlist are not perfectly aligned. Not sure if there are some edge cases where the main start time presents a problem for audio or sub playlists abnormal starts or alignment.

### Resolves issues:
Fixes #6126

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
