### PR TITLE
Support `startLevel` above max level index

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -737,7 +737,7 @@ Enable to use JavaScript version AES decryption for fallback of WebCrypto API.
 
 (default: `undefined`)
 
-When set, use this level as the default hls.startLevel. Keep in mind that the startLevel set with the API takes precedence over config.startLevel configuration parameter.
+When set, use this level as the default `hls.startLevel`. Keep in mind that the `startLevel` set with the API takes precedence over config.startLevel configuration parameter. `startLevel` should be set to value between 0 and the maximum index of `hls.levels`.
 
 ### `fragLoadingTimeOut` / `manifestLoadingTimeOut` / `levelLoadingTimeOut` (deprecated)
 

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -870,8 +870,9 @@ class AbrController implements AbrComponentAPI {
   }
 
   public set nextAutoLevel(nextLevel: number) {
-    const value = Math.max(this.hls.minAutoLevel, nextLevel);
-    if (this._nextAutoLevel != value) {
+    const { maxAutoLevel, minAutoLevel } = this.hls;
+    const value = Math.min(Math.max(nextLevel, minAutoLevel), maxAutoLevel);
+    if (this._nextAutoLevel !== value) {
       this.nextAutoLevelKey = '';
       this._nextAutoLevel = value;
     }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -140,7 +140,8 @@ export default class StreamController
         }
         // set new level to playlist loader : this will trigger start level load
         // hls.nextLoadLevel remains until it is set to a new value or until a new frag is successfully loaded
-        this.level = hls.nextLoadLevel = startLevel;
+        hls.nextLoadLevel = startLevel;
+        this.level = hls.loadLevel;
         this.loadedmetadata = false;
       }
       // if startPosition undefined but lastCurrentTime set, set startPosition to last currentTime


### PR DESCRIPTION
### This PR will...
Fix regression that removed (unofficial) support for `startLevel` above max level index. Update docs to note that `startLevel`  _should_ be set to a valid level index.

### Why is this Pull Request needed?
Setting `startLevel` to Infinity is used to start on max level index even though the player emits a non-fatal error. Since the error is non-fatal playback and streaming should not fail.

### Are there any points in the code the reviewer needs to double check?
Changing stream-controller `startLoad` logic can have side-effects. This change is an improvement that will keep the stream-controller's level index aligned with the level controllers load level index.

### Resolves issues:
Fixes #6172

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
