### PR TITLE
Account for overlapping sidx subsegment durations by parsing earlierstPresentationTime

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -38,6 +38,13 @@ export function readUint32(buffer: Uint8Array, offset: number): number {
   return val < 0 ? 4294967296 + val : val;
 }
 
+export function readUint64(buffer: Uint8Array, offset: number) {
+  let result = readUint32(buffer, offset);
+  result *= Math.pow(2, 32);
+  result += readUint32(buffer, offset + 4);
+  return result;
+}
+
 export function readSint32(buffer: Uint8Array, offset: number): number {
   return (
     (buffer[offset] << 24) |
@@ -125,15 +132,15 @@ export function parseSegmentIndex(sidx: Uint8Array): SidxInfo | null {
   const timescale = readUint32(sidx, index);
   index += 4;
 
-  // TODO: parse earliestPresentationTime and firstOffset
-  // usually zero in our case
-  const earliestPresentationTime = 0;
-  const firstOffset = 0;
+  let earliestPresentationTime = 0;
+  let firstOffset = 0;
 
   if (version === 0) {
-    index += 8;
+    earliestPresentationTime = readUint32(sidx, (index += 4));
+    firstOffset = readUint32(sidx, (index += 4));
   } else {
-    index += 16;
+    earliestPresentationTime = readUint64(sidx, (index += 8));
+    firstOffset = readUint64(sidx, (index += 8));
   }
 
   // skip reserved
@@ -677,19 +684,31 @@ export function getDuration(data: Uint8Array, initData: InitData) {
   }
   if (videoDuration === 0 && audioDuration === 0) {
     // If duration samples are not available in the traf use sidx subsegment_duration
+    let sidxMinStart = Infinity;
+    let sidxMaxEnd = 0;
     let sidxDuration = 0;
     const sidxs = findBox(data, ['sidx']);
     for (let i = 0; i < sidxs.length; i++) {
       const sidx = parseSegmentIndex(sidxs[i]);
       if (sidx?.references) {
-        sidxDuration += sidx.references.reduce(
+        sidxMinStart = Math.min(
+          sidxMinStart,
+          sidx.earliestPresentationTime / sidx.timescale,
+        );
+        const subSegmentDuration = sidx.references.reduce(
           (dur, ref) => dur + ref.info.duration || 0,
           0,
         );
+        sidxMaxEnd = Math.max(
+          sidxMaxEnd,
+          subSegmentDuration + sidx.earliestPresentationTime / sidx.timescale,
+        );
+        sidxDuration = sidxMaxEnd - sidxMinStart;
       }
     }
-
-    return sidxDuration;
+    if (sidxDuration && Number.isFinite(sidxDuration)) {
+      return sidxDuration;
+    }
   }
   if (videoDuration) {
     return videoDuration;


### PR DESCRIPTION
### This PR will...
Account for overlapping sidx subsegment durations by parsing earlierstPresentationTime

### Why is this Pull Request needed?
Summing up all sidx box subsegment durations to get segment duration will add muxed audio and video track durations together without accounting for overlap. This bug was introduced with #4849 because earlierstPresentationTime was never parsed and potential for overlap was never taken into account.

### Are there any points in the code the reviewer needs to double check?
I found overlapping sidx boxes in media from #1510 but had to change mp4-tools `getDuration` temporarily to ignore trun durations to see the impact that using overlapping durations from sidx boxes would have. This fix has not been verified against #6191 because a sample that reproduces the issue has not been provided.

### Resolves issues:
Fixes #6191

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
