### PR TITLE
Do not include HEVC in TS support in hls.light

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -248,6 +248,7 @@ function getAliasesForLightDist() {
     aliases = {
       ...aliases,
       './ac3-demuxer': '../empty.js',
+      './video/hevc-video-parser': '../empty.js',
     };
   }
 

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -295,7 +295,9 @@ class TSDemuxer implements Demuxer {
                       this.videoParser = new AvcVideoParser();
                       break;
                     case 'hevc':
-                      this.videoParser = new HevcVideoParser();
+                      if (__USE_M2TS_ADVANCED_CODECS__) {
+                        this.videoParser = new HevcVideoParser();
+                      }
                       break;
                   }
                 }
@@ -485,7 +487,9 @@ class TSDemuxer implements Demuxer {
             this.videoParser = new AvcVideoParser();
             break;
           case 'hevc':
-            this.videoParser = new HevcVideoParser();
+            if (__USE_M2TS_ADVANCED_CODECS__) {
+              this.videoParser = new HevcVideoParser();
+            }
             break;
         }
       }
@@ -897,10 +901,14 @@ function parsePMT(
         break;
 
       case 0x24: // ITU-T Rec. H.265 and ISO/IEC 23008-2 (HEVC)
-        if (result.videoPid === -1) {
-          result.videoPid = pid;
-          result.segmentVideoCodec = 'hevc';
-          logger.log('HEVC in M2TS found');
+        if (__USE_M2TS_ADVANCED_CODECS__) {
+          if (result.videoPid === -1) {
+            result.videoPid = pid;
+            result.segmentVideoCodec = 'hevc';
+            logger.log('HEVC in M2TS found');
+          }
+        } else {
+          logger.warn('Unsupported HEVC in M2TS found');
         }
         break;
 


### PR DESCRIPTION
### This PR will...
Remove HEVC in TS support in hls.light.js

### Why is this Pull Request needed?
The light build has AC-3 in TS and other features removed using build consts. HEVC in TS support adds roughly 7kB to the minified hls(.light).js library payload which should not be included in the light build.

### Are there any points in the code the reviewer needs to double check?
Excluded from light build using __USE_M2TS_ADVANCED_CODECS__ build const same as AC-3 in TS.

### Resolves issues:
Follow up to #5847

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
