### PR TITLE
Restore global logger logs in dev

### DIFF
--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -8,7 +8,6 @@ import { appendCmcdQuery } from '@svta/common-media-library/cmcd/appendCmcdQuery
 import type { CmcdEncodeOptions } from '@svta/common-media-library/cmcd/CmcdEncodeOptions';
 import { uuid } from '@svta/common-media-library/utils/uuid';
 import { BufferHelper } from '../utils/buffer-helper';
-import { logger } from '../utils/logger';
 import type { ComponentAPI } from '../types/component-api';
 import type { Fragment } from '../loader/fragment';
 import type { BufferCreatedData, MediaAttachedData } from '../types/events';
@@ -201,7 +200,7 @@ export default class CMCDController implements ComponentAPI {
         su: !this.initialized,
       });
     } catch (error) {
-      logger.warn('Could not generate manifest CMCD data.', error);
+      this.hls.logger.warn('Could not generate manifest CMCD data.', error);
     }
   };
 
@@ -237,7 +236,7 @@ export default class CMCDController implements ComponentAPI {
 
       this.apply(context, data);
     } catch (error) {
-      logger.warn('Could not generate segment CMCD data.', error);
+      this.hls.logger.warn('Could not generate segment CMCD data.', error);
     }
   };
 

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -8,7 +8,6 @@
 
 import { Events } from '../events';
 import { ErrorDetails, ErrorTypes } from '../errors';
-import { logger } from '../utils/logger';
 import M3U8Parser from './m3u8-parser';
 import type { LevelParsed, VariableMap } from '../types/level';
 import type {
@@ -221,10 +220,10 @@ class PlaylistLoader implements NetworkComponentAPI {
         loaderContext.level === context.level
       ) {
         // same URL can't overlap
-        logger.trace('[playlist-loader]: playlist request ongoing');
+        this.hls.logger.trace('[playlist-loader]: playlist request ongoing');
         return;
       }
-      logger.log(
+      this.hls.logger.log(
         `[playlist-loader]: aborting previous loader for type: ${context.type}`,
       );
       loader.abort();
@@ -408,7 +407,7 @@ class PlaylistLoader implements NetworkComponentAPI {
         levels[0].audioCodec &&
         !levels[0].attrs.AUDIO
       ) {
-        logger.log(
+        this.hls.logger.log(
           '[playlist-loader]: audio codec signaled in quality level, but no embedded audio track signaled, create one',
         );
         audioTracks.unshift({
@@ -555,7 +554,7 @@ class PlaylistLoader implements NetworkComponentAPI {
       message += ` id: ${context.id} group-id: "${context.groupId}"`;
     }
     const error = new Error(message);
-    logger.warn(`[playlist-loader]: ${message}`);
+    this.hls.logger.warn(`[playlist-loader]: ${message}`);
     let details = ErrorDetails.UNKNOWN;
     let fatal = false;
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -71,7 +71,7 @@ function getLoggerFn(
     : consolePrintFn(key, id);
 }
 
-let exportedLogger: ILogger = createLogger();
+const exportedLogger: ILogger = createLogger();
 
 export function enableLogs(
   debugConfig: boolean | ILogger,
@@ -107,7 +107,8 @@ export function enableLogs(
       return createLogger();
     }
   }
-  exportedLogger = newLogger;
+  // global exported logger uses the log methods from last call to `enableLogs`
+  Object.assign(exportedLogger, newLogger);
   return newLogger;
 }
 


### PR DESCRIPTION
### This PR will...
Make global exported logger uses the log methods from last call to `enableLogs`

### Why is this Pull Request needed?
Changes to logger ts failed to update the exported logger object methods from `noop` to latest enabled settings. For the log messages still not scoped to a player instance, these logs should behave as they did in earlier releases.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Follow up to #6131

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
