### PR TITLE
Fix subtitle stream controller buffered TimeRanges

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -218,7 +218,7 @@ export class SubtitleStreamController
     event: Events.SUBTITLE_TRACKS_UPDATED,
     { subtitleTracks }: SubtitleTracksUpdatedData,
   ) {
-    if (!this.levels || subtitleOptionsIdentical(this.levels, subtitleTracks)) {
+    if (this.levels && subtitleOptionsIdentical(this.levels, subtitleTracks)) {
       this.levels = subtitleTracks.map(
         (mediaPlaylist) => new Level(mediaPlaylist),
       );


### PR DESCRIPTION
### This PR will...
Fix subtitle stream controller buffered TimeRanges

### Why is this Pull Request needed?
This change https://github.com/video-dev/hls.js/pull/5855/files#diff-52308993b5a4ac80d82fb9f7849cb4c4e3a9986b3f5ea29d3c77d354a3378a87R220 prevents the subtitle controller `tracksBuffered` from being populated. This is needed to track the end of the subtitle track buffer.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
