### PR TITLE
Fix issues with detached and destroyed level selection

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -221,14 +221,13 @@ export default class StreamController
 
   private doTickIdle() {
     const { hls, levelLastLoaded, levels, media } = this;
-    const { config, nextLoadLevel: level } = hls;
 
     // if start level not parsed yet OR
     // if video not attached AND start fragment already requested OR start frag prefetch not enabled
     // exit loop, as we either need more info (level not parsed) or we need media to be attached to load new fragment
     if (
       levelLastLoaded === null ||
-      (!media && (this.startFragRequested || !config.startFragPrefetch))
+      (!media && (this.startFragRequested || !hls.config.startFragPrefetch))
     ) {
       return;
     }
@@ -238,6 +237,7 @@ export default class StreamController
       return;
     }
 
+    const level = hls.nextLoadLevel;
     if (!levels?.[level]) {
       return;
     }


### PR DESCRIPTION
### This PR will...
- Set buffer starvation delay to Infinity when media is detached
- Exit early from MediaCapabilities decodingInfo Promise callback after player has been destroyed
- Limit polling of next level when detached to start frag prefetch

### Why is this Pull Request needed?
- Prevents excessive logging from selection fallback when buffer is deemed empty because media is detached
- Prevents exception on resolving decodingInfo after player is destroyed
- Reduce redundant logs in detached prefetch or loading state

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
