### PR TITLE
Block audio append queue to keep AV appends in lock-step

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -144,8 +144,6 @@ export class AudioStreamController extends BaseStreamController implements Netwo
     // (undocumented)
     doTick(): void;
     // (undocumented)
-    protected getMaxBufferLength(mainBufferLength?: number): number;
-    // (undocumented)
     protected _handleFragmentLoadComplete(fragLoadedData: FragLoadedData): void;
     // (undocumented)
     _handleFragmentLoadProgress(data: FragLoadedData): void;
@@ -567,9 +565,9 @@ export interface BufferCodecsData {
 //
 // @public (undocumented)
 export class BufferController extends Logger implements ComponentAPI {
-    constructor(hls: Hls);
+    constructor(hls: Hls, fragmentTracker: FragmentTracker);
     // (undocumented)
-    protected appendChangeType(type: any, mimeType: any): void;
+    protected appendChangeType(type: SourceBufferName, mimeType: string): void;
     // (undocumented)
     appendErrors: {
         audio: number;
@@ -628,8 +626,6 @@ export class BufferController extends Logger implements ComponentAPI {
     trimBuffers(): void;
     // (undocumented)
     protected unregisterListeners(): void;
-    // (undocumented)
-    updateSeekableRange(levelDetails: any): void;
 }
 
 // Warning: (ae-missing-release-tag) "BufferControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1620,6 +1616,8 @@ class Hls implements HlsEventEmitter {
     get mainForwardBufferInfo(): BufferInfo | null;
     get manualLevel(): number;
     get maxAutoLevel(): number;
+    // (undocumented)
+    get maxBufferLength(): number;
     // (undocumented)
     get maxHdcpLevel(): HdcpLevel;
     set maxHdcpLevel(value: HdcpLevel);
@@ -3214,8 +3212,6 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     constructor(hls: Hls, fragmentTracker: FragmentTracker, keyLoader: KeyLoader);
     // (undocumented)
     doTick(): void;
-    // (undocumented)
-    protected getMaxBufferLength(mainBufferLength?: number): number;
     // (undocumented)
     _handleFragmentLoadComplete(fragLoadedData: FragLoadedData): void;
     // (undocumented)

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -539,6 +539,9 @@ class AbrController extends Logger implements AbrComponentAPI {
 
   private getNextABRAutoLevel(): number {
     const { fragCurrent, partCurrent, hls } = this;
+    if (hls.levels.length <= 1) {
+      return hls.loadLevel;
+    }
     const { maxAutoLevel, config, minAutoLevel } = hls;
     const currentFragDuration = partCurrent
       ? partCurrent.duration

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1102,7 +1102,10 @@ export default class BaseStreamController
     // Workaround flaw in getting forward buffer when maxBufferHole is smaller than gap at current pos
     if (bufferInfo.len === 0 && bufferInfo.nextStart !== undefined) {
       const bufferedFragAtPos = this.fragmentTracker.getBufferedFrag(pos, type);
-      if (bufferedFragAtPos && bufferInfo.nextStart < bufferedFragAtPos.end) {
+      if (
+        bufferedFragAtPos &&
+        (bufferInfo.nextStart <= bufferedFragAtPos.end || bufferedFragAtPos.gap)
+      ) {
         return BufferHelper.bufferInfo(
           bufferable,
           pos,
@@ -1115,7 +1118,7 @@ export default class BaseStreamController
 
   protected getMaxBufferLength(levelBitrate?: number): number {
     const { config } = this;
-    let maxBufLen;
+    let maxBufLen: number;
     if (levelBitrate) {
       maxBufLen = Math.max(
         (8 * config.maxBufferSize) / levelBitrate,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1338,6 +1338,15 @@ export default class StreamController
     );
   }
 
+  public get maxBufferLength(): number {
+    const { levels, level } = this;
+    const levelInfo = levels?.[level];
+    if (!levelInfo) {
+      return this.config.maxBufferLength;
+    }
+    return this.getMaxBufferLength(levelInfo.maxBitrate);
+  }
+
   private backtrack(frag: Fragment) {
     this.couldBacktrack = true;
     // Causes findFragments to backtrack through fragments to find the keyframe

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -418,15 +418,9 @@ export class SubtitleStreamController
         config.maxBufferHole,
       );
       const { end: targetBufferTime, len: bufferLen } = bufferedInfo;
-
-      const mainBufferInfo = this.getFwdBufferInfo(
-        this.media,
-        PlaylistLevelType.MAIN,
-      );
       const trackDetails = track.details as LevelDetails;
       const maxBufLen =
-        this.getMaxBufferLength(mainBufferInfo?.len) +
-        trackDetails.levelTargetDuration;
+        this.hls.maxBufferLength + trackDetails.levelTargetDuration;
 
       if (bufferLen > maxBufLen) {
         return;
@@ -480,14 +474,6 @@ export class SubtitleStreamController
         this.loadFragment(foundFrag, track, targetBufferTime);
       }
     }
-  }
-
-  protected getMaxBufferLength(mainBufferLength?: number): number {
-    const maxConfigBuffer = super.getMaxBufferLength();
-    if (!mainBufferLength) {
-      return maxConfigBuffer;
-    }
-    return Math.max(maxConfigBuffer, mainBufferLength);
   }
 
   protected loadFragment(

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -171,8 +171,10 @@ export default class Hls implements HlsEventEmitter {
     } = config;
     const errorController = new ConfigErrorController(this);
     const abrController = (this.abrController = new ConfigAbrController(this));
+    // FragmentTracker must be defined before StreamController because the order of event handling is important
+    const fragmentTracker = new FragmentTracker(this);
     const bufferController = (this.bufferController =
-      new ConfigBufferController(this));
+      new ConfigBufferController(this, fragmentTracker));
     const capLevelController = (this.capLevelController =
       new ConfigCapLevelController(this));
 
@@ -189,8 +191,6 @@ export default class Hls implements HlsEventEmitter {
       this,
       contentSteering,
     ));
-    // FragmentTracker must be defined before StreamController because the order of event handling is important
-    const fragmentTracker = new FragmentTracker(this);
     const keyLoader = new KeyLoader(this.config);
     const streamController = (this.streamController = new StreamController(
       this,
@@ -800,6 +800,10 @@ export default class Hls implements HlsEventEmitter {
 
   public get mainForwardBufferInfo(): BufferInfo | null {
     return this.streamController.getMainFwdBufferInfo();
+  }
+
+  public get maxBufferLength(): number {
+    return this.streamController.maxBufferLength;
   }
 
   /**

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -193,7 +193,7 @@ export function getCodecCompatibleName(
 }
 
 export function pickMostCompleteCodecName(
-  parsedCodec: string,
+  parsedCodec: string | undefined,
   levelCodec: string | undefined,
 ): string | undefined {
   // Parsing of mp4a codecs strings in mp4-tools from media is incomplete as of d8c6c7a

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -8,6 +8,7 @@ import BufferController from '../../../src/controller/buffer-controller';
 import { BufferOperation, SourceBufferName } from '../../../src/types/buffer';
 import { BufferAppendingData } from '../../../src/types/events';
 import { Events } from '../../../src/events';
+import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import { ElementaryStreamTypes, Fragment } from '../../../src/loader/fragment';
 import { PlaylistLevelType } from '../../../src/types/loader';
@@ -135,7 +136,7 @@ describe('BufferController', function () {
     hls.networkControllers.length = 0;
     hls.coreComponents.forEach((component) => component.destroy());
     hls.coreComponents.length = 0;
-    bufferController = new BufferController(hls);
+    bufferController = new BufferController(hls, new FragmentTracker(hls));
     bufferController.media = mockMedia = new MockMediaElement();
     bufferController.mediaSource = mockMediaSource = new MockMediaSource();
     bufferController.createSourceBuffers({
@@ -328,7 +329,6 @@ describe('BufferController', function () {
       frag.setElementaryStreamInfo(ElementaryStreamTypes.VIDEO, 0, 0, 0, 0);
 
       bufferController.onFragParsed(Events.FRAG_PARSED, { frag });
-      expect(queueAppendBlockerSpy).to.have.been.calledTwice;
       return new Promise<void>((resolve, reject) => {
         hls.on(Events.FRAG_BUFFERED, (event, data) => {
           try {
@@ -345,9 +345,6 @@ describe('BufferController', function () {
           }
           resolve();
         });
-      }).then(() => {
-        expect(shiftAndExecuteNextSpy, 'The queues should have been cycled').to
-          .have.been.calledTwice;
       });
     });
   });
@@ -673,12 +670,6 @@ describe('BufferController', function () {
       expect(bufferController.details).to.equal(data.details);
     });
 
-    it('enqueues a blocking operation which updates the MediaSource duration', function () {
-      bufferController.onLevelUpdated(Events.LEVEL_UPDATED, data);
-      expect(queueAppendBlockerSpy).to.have.been.calledTwice;
-      // Updating the duration is aync and has no event to signal completion, so we are unable to test for it directly
-    });
-
     it('synchronously sets media duration if no SourceBuffers exist', function () {
       bufferController.sourceBuffer = {};
       bufferController.onLevelUpdated(Events.LEVEL_UPDATED, data);
@@ -709,7 +700,6 @@ describe('BufferController', function () {
     it('marks the ExtendedSourceBuffer as ended', function () {
       // No type arg ends both SourceBuffers
       bufferController.onBufferEos(Events.BUFFER_EOS, {});
-      expect(queueAppendBlockerSpy).to.have.been.calledTwice;
       queueNames.forEach((type) => {
         const buffer = bufferController.sourceBuffer[type];
         expect(buffer.ended, 'ExtendedSourceBuffer.ended').to.be.true;


### PR DESCRIPTION
### This PR will...
Block audio append queue to keep AV appends in lock-step

### Why is this Pull Request needed?
Keeping audio and video appends in sync can improve streaming performance by throttles audio requests that are not yet required, and allow stalls to occur when video is not loading fast enough.

### Are there any points in the code the reviewer needs to double check?
This change will also help in buffering media up to an Interstitial break, although additional work is needed to set boundaries on active Interstitial timeline segments.

### Resolves issues:


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
