### PR TITLE
[DRAFT] Mark fragments with empty appends with gap

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1862,7 +1862,7 @@ export default class BaseStreamController
         fatal: false,
         error,
         frag,
-        reason: `Found no media in msn ${frag.sn} of level "${level.url}"`,
+        reason: error.message,
       });
       if (!this.hls) {
         return;

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -1,6 +1,7 @@
 import { Events } from '../events';
 import { Fragment, Part } from '../loader/fragment';
 import { PlaylistLevelType } from '../types/loader';
+import { ErrorDetails, ErrorTypes } from '../errors';
 import type { SourceBufferName } from '../types/buffer';
 import type {
   FragmentBufferedRange,
@@ -299,6 +300,17 @@ export class FragmentTracker implements ComponentAPI {
       fragment.gap = true;
       this.removeFragment(fragment);
       this.fragBuffered(fragment, true);
+      const error = new Error(
+        `No media appended for msn ${fragment.sn} of level "${fragment.level}"`,
+      );
+      this.hls.trigger(Events.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.FRAG_PARSING_ERROR,
+        fatal: false,
+        error,
+        frag: fragment,
+        reason: error.message,
+      });
     }
     return buffered;
   }

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -294,6 +294,12 @@ export class FragmentTracker implements ComponentAPI {
         break;
       }
     }
+    if (buffered.time.length === 0) {
+      // Nothing found in buffer, mark as gap
+      fragment.gap = true;
+      this.removeFragment(fragment);
+      this.fragBuffered(fragment, true);
+    }
     return buffered;
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -8,7 +8,7 @@ import { ElementaryStreamTypes, Fragment } from '../loader/fragment';
 import TransmuxerInterface from '../demux/transmuxer-interface';
 import { ChunkMetadata } from '../types/transmuxer';
 import GapController, { MAX_START_GAP_JUMP } from './gap-controller';
-import { ErrorDetails } from '../errors';
+import { ErrorDetails, ErrorTypes } from '../errors';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type Hls from '../hls';
 import type { Level } from '../types/level';
@@ -1348,6 +1348,18 @@ export default class StreamController
     this.fragPrevious = null;
     this.nextLoadPosition = frag.start;
     this.state = State.IDLE;
+    // Frag parsing error will force a level switch
+    const error = new Error(
+      `Backtrack for msn ${frag.sn} of level "${frag.level}"`,
+    );
+    this.hls.trigger(Events.ERROR, {
+      type: ErrorTypes.MEDIA_ERROR,
+      details: ErrorDetails.FRAG_PARSING_ERROR,
+      fatal: false,
+      error,
+      frag,
+      reason: error.message,
+    });
   }
 
   private checkFragmentChanged() {

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -8,7 +8,7 @@ import {
   patchEncyptionData,
 } from '../utils/mp4-tools';
 import {
-  getDuration,
+  getSampleData,
   getStartDTS,
   offsetStartDTS,
   parseInitSegment,
@@ -40,6 +40,7 @@ class PassThroughRemuxer implements Remuxer {
   private initPTS: RationalTimestamp | null = null;
   private initTracks?: TrackSet;
   private lastEndTime: number | null = null;
+  private isVideoContiguous: boolean = false;
 
   public destroy() {}
 
@@ -49,6 +50,7 @@ class PassThroughRemuxer implements Remuxer {
   }
 
   public resetNextTimestamp() {
+    this.isVideoContiguous = false;
     this.lastEndTime = null;
   }
 
@@ -168,7 +170,10 @@ class PassThroughRemuxer implements Remuxer {
       this.emitInitSegment = false;
     }
 
-    const duration = getDuration(data, initData);
+    const { duration, firstKeyFrame, sampleCount } = getSampleData(
+      data,
+      initData,
+    );
     const startDTS = getStartDTS(initData, data);
     const decodeTime = startDTS === null ? timeOffset : startDTS;
     if (
@@ -212,6 +217,7 @@ class PassThroughRemuxer implements Remuxer {
       type += 'video';
     }
 
+    const independent = firstKeyFrame !== -1;
     const track: RemuxedTrack = {
       data1: data,
       startPTS: startTime,
@@ -225,8 +231,33 @@ class PassThroughRemuxer implements Remuxer {
       dropped: 0,
     };
 
-    result.audio = track.type === 'audio' ? track : undefined;
-    result.video = track.type !== 'audio' ? track : undefined;
+    result.audio = hasAudio && !hasVideo ? track : undefined;
+    result.video = hasVideo ? track : undefined;
+    if (hasVideo && sampleCount) {
+      track.nb = sampleCount;
+      (track.dropped =
+        this.isVideoContiguous || firstKeyFrame === 0
+          ? 0
+          : firstKeyFrame === -1
+            ? sampleCount
+            : firstKeyFrame),
+        (track.independent = independent);
+      track.firstKeyFrame = firstKeyFrame;
+      if (independent && firstKeyFrame) {
+        track.firstKeyFramePTS =
+          startTime + (duration * firstKeyFrame) / sampleCount;
+      }
+      if (!this.isVideoContiguous) {
+        result.independent = independent;
+      }
+      this.isVideoContiguous ||= independent;
+      if (track.dropped) {
+        logger.warn(
+          `fmp4 does not start with IDR: firstIDR ${firstKeyFrame}/${sampleCount} dropped: ${track.dropped} pts: ${track.firstKeyFramePTS || 'NA'}`,
+        );
+      }
+    }
+
     result.initSegment = initSegment;
     result.id3 = flushTextTrackMetadataCueSamples(
       id3Track,


### PR DESCRIPTION
### This PR will...
- Mark fragments with empty appends with gap
- Find first keyframe in video fmp4 and detect non-independent segments and transmux results for mp4
- Error on empty append and on non-independent fragment parsing (backtrack handler)

### Why is this Pull Request needed?
mp4 segments missing IDR frames at the start will result in nothing added to the buffer after first append.

Frag parsing error events resolve with a level switch which can result in an alternative to media missing an IDR.

HLS mp4 segments should always start with an IDR frame (ISO BMFF) so warning when that is not the case and it is expected to result in gaps (non-contiguous append) will help to identify bad HLS assets.

### Are there any points in the code the reviewer needs to double check?
Backtracking was tuned to work with the TS pipeline (primarily muxed content). It won't always find the ideal candidate. Erroring helps if there are alternatives, but if there are none HLS.js may still end up loop loading around gaps.

### Relates to:
- #6171
  - #5153
- #6853
  - #5153
  - #5647
  - #6741

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
