### PR TITLE
fix sidx parsing

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -136,11 +136,13 @@ export function parseSegmentIndex(sidx: Uint8Array): SidxInfo | null {
   let firstOffset = 0;
 
   if (version === 0) {
-    earliestPresentationTime = readUint32(sidx, (index += 4));
-    firstOffset = readUint32(sidx, (index += 4));
+    earliestPresentationTime = readUint32(sidx, index);
+    firstOffset = readUint32(sidx, index + 4);
+    index += 8;
   } else {
-    earliestPresentationTime = readUint64(sidx, (index += 8));
-    firstOffset = readUint64(sidx, (index += 8));
+    earliestPresentationTime = readUint64(sidx, index);
+    firstOffset = readUint64(sidx, index + 8);
+    index += 16;
   }
 
   // skip reserved


### PR DESCRIPTION
### This PR will...

fix parsing of earliestPresentationTime in sidx atom.

### Why is this Pull Request needed?

Because earliestPresentationTime and firstOffset are not parsed correctly, the offset arg passed to `readUintXX` is wrong, since `index += Y` is evaluated before the call to `readUintXX`. Reading the value of earliestPresentationTime should be done with an offset of 12, but its actually done with an offset of 16.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [-] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
