### PR TITLE
Don't pass log functions with player id to global logger

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -64,7 +64,7 @@ function consolePrintFn(type: string, id: string | undefined): ILogFunction {
 function getLoggerFn(
   key: string,
   debugConfig: boolean | Partial<ILogger>,
-  id: string | undefined,
+  id?: string,
 ): ILogFunction {
   return debugConfig[key]
     ? debugConfig[key].bind(debugConfig)
@@ -106,9 +106,14 @@ export function enableLogs(
       /* log fn threw an exception. All logger methods are no-ops. */
       return createLogger();
     }
+    // global exported logger uses the same functions as new logger without `id`
+    keys.forEach((key) => {
+      exportedLogger[key] = getLoggerFn(key, debugConfig);
+    });
+  } else {
+    // Reset global exported logger
+    Object.assign(exportedLogger, newLogger);
   }
-  // global exported logger uses the log methods from last call to `enableLogs`
-  Object.assign(exportedLogger, newLogger);
   return newLogger;
 }
 


### PR DESCRIPTION
### This PR will...
When updating the exported singleton logger, don't copy new logger functions with player ids.

### Why is this Pull Request needed?
In places where `logger` is used without player context (Hls instance) the id of the last player to call `enableLogs` should not be prefixed to log messages.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
