### PR TITLE
Fix extraction of NALu overflowing PES packet

### DIFF
--- a/src/demux/video/avc-video-parser.ts
+++ b/src/demux/video/avc-video-parser.ts
@@ -17,7 +17,7 @@ class AvcVideoParser extends BaseVideoParser {
     last: boolean,
     duration: number,
   ) {
-    const units = this.parseNALu(track, pes.data);
+    const units = this.parseNALu(track, pes.data, last);
     const debug = false;
     let VideoSample = this.VideoSample;
     let push: boolean;

--- a/src/demux/video/base-video-parser.ts
+++ b/src/demux/video/base-video-parser.ts
@@ -29,22 +29,6 @@ abstract class BaseVideoParser {
     };
   }
 
-  protected getLastNalUnit(
-    samples: VideoSample[],
-  ): VideoSampleUnit | undefined {
-    let VideoSample = this.VideoSample;
-    let lastUnit: VideoSampleUnit | undefined;
-    // try to fallback to previous sample if current one is empty
-    if (!VideoSample || VideoSample.units.length === 0) {
-      VideoSample = samples[samples.length - 1];
-    }
-    if (VideoSample?.units) {
-      const units = VideoSample.units;
-      lastUnit = units[units.length - 1];
-    }
-    return lastUnit;
-  }
-
   protected pushAccessUnit(
     VideoSample: ParsedVideoSample,
     videoTrack: DemuxedVideoTrack,
@@ -86,6 +70,7 @@ abstract class BaseVideoParser {
   protected parseNALu(
     track: DemuxedVideoTrack,
     array: Uint8Array,
+    last: boolean,
   ): Array<{
     data: Uint8Array;
     type: number;
@@ -133,6 +118,10 @@ abstract class BaseVideoParser {
             data: array.subarray(lastUnitStart, overflow),
             type: lastUnitType,
           };
+          if (track.lastNalu) {
+            units.push(track.lastNalu);
+            track.lastNalu = null;
+          }
           // logger.log('pushing NALU, type/size:' + unit.type + '/' + unit.data.byteLength);
           units.push(unit);
         } else {
@@ -140,7 +129,7 @@ abstract class BaseVideoParser {
           // first check if start code delimiter is overlapping between 2 PES packets,
           // ie it started in last packet (lastState not zero)
           // and ended at the beginning of this PES packet (i <= 4 - lastState)
-          const lastUnit = this.getLastNalUnit(track.samples);
+          const lastUnit = track.lastNalu;
           if (lastUnit) {
             if (lastState && i <= 4 - lastState) {
               // start delimiter overlapping between PES packets
@@ -163,6 +152,8 @@ abstract class BaseVideoParser {
                 array.subarray(0, overflow),
               );
               lastUnit.state = 0;
+              units.push(lastUnit);
+              track.lastNalu = null;
             }
           }
         }
@@ -187,15 +178,21 @@ abstract class BaseVideoParser {
         type: lastUnitType,
         state: state,
       };
-      units.push(unit);
-      // logger.log('pushing NALU, type/size/state:' + unit.type + '/' + unit.data.byteLength + '/' + state);
-    }
-    // no NALu found
-    if (units.length === 0) {
+      if (!last) {
+        track.lastNalu = unit;
+        // logger.log('store NALu to push it on next PES');
+      } else {
+        units.push(unit);
+        // logger.log('pushing NALU, type/size/state:' + unit.type + '/' + unit.data.byteLength + '/' + state);
+      }
+    } else if (units.length === 0) {
+      // no NALu found
       // append pes.data to previous NAL unit
-      const lastUnit = this.getLastNalUnit(track.samples);
+      const lastUnit = track.lastNalu;
       if (lastUnit) {
         lastUnit.data = appendUint8Array(lastUnit.data, array);
+        units.push(lastUnit);
+        track.lastNalu = null;
       }
     }
     track.naluState = state;

--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -16,7 +16,7 @@ class HevcVideoParser extends BaseVideoParser {
     last: boolean,
     duration: number,
   ) {
-    const units = this.parseNALu(track, pes.data);
+    const units = this.parseNALu(track, pes.data, last);
     const debug = false;
     let VideoSample = this.VideoSample;
     let push: boolean;

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -77,6 +77,7 @@ export interface DemuxedVideoTrackBase extends DemuxedTrack {
   pps?: Uint8Array[];
   sps?: Uint8Array[];
   naluState?: number;
+  lastNalu?: VideoSampleUnit | null;
   segmentCodec?: string;
   manifestCodec?: string;
   samples: VideoSample[] | Uint8Array;

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -272,4 +272,11 @@ module.exports = {
     description: 'Advanced stream (HEVC Main 10, MPEG-TS segments)',
     skipFunctionalTests: true,
   },
+  mpegTsBitmovinHevc: {
+    url: 'https://bitmovin-a.akamaihd.net/content/dataset/multi-codec/hevc/v720p_ts.m3u8',
+    description:
+      'HLS M2TS by Bitmovin (HEVC Main, many NALUs overflowing PESes, video only)',
+    abr: false,
+    skipFunctionalTests: true,
+  },
 };


### PR DESCRIPTION
### Why is this Pull Request needed?
It prevents error "Malformed SEI payload. X is too small, only Y bytes left to parse" in case when SEI overflows PES. It also adds new test stream, HEVC in MPEG-TS, with variety of such NAL units of different types.

Test stream: mpegTsBitmovinHevc (see `test-streams.js`)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] functional tests with MPEG-TS playlists passed

PS
In spite of the error video track can be played. Therefore if this PR is approved, the changes can be merged right before 1.6.0 release in order to avoid inconvenience with `patch` branch.
