### PR TITLE
Fix light ESM build

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -202,60 +202,62 @@ const basePlugins = [
   commonjs({ transformMixedEsModules: true }),
 ];
 
-function getAliasesForLightDist() {
+function getAliasesForLightDist(format) {
+  const emptyFile = format === 'esm' ? 'empty-es.js' : 'empty.js';
+
   let aliases = {};
 
   if (!addEMESupport) {
     aliases = {
       ...aliases,
-      './controller/eme-controller': './empty.js',
-      './utils/mediakeys-helper': './empty.js',
-      '../utils/mediakeys-helper': '../empty.js',
+      './controller/eme-controller': `./${emptyFile}`,
+      './utils/mediakeys-helper': `./${emptyFile}`,
+      '../utils/mediakeys-helper': `../${emptyFile}`,
     };
   }
 
   if (!addCMCDSupport) {
-    aliases = { ...aliases, './controller/cmcd-controller': './empty.js' };
+    aliases = { ...aliases, './controller/cmcd-controller': `./${emptyFile}` };
   }
 
   if (!addSubtitleSupport) {
     aliases = {
       ...aliases,
-      './utils/cues': './empty.js',
-      './controller/timeline-controller': './empty.js',
-      './controller/subtitle-track-controller': './empty.js',
-      './controller/subtitle-stream-controller': './empty.js',
+      './utils/cues': `./${emptyFile}`,
+      './controller/timeline-controller': `./${emptyFile}`,
+      './controller/subtitle-track-controller': `./${emptyFile}`,
+      './controller/subtitle-stream-controller': `./${emptyFile}`,
     };
   }
 
   if (!addAltAudioSupport) {
     aliases = {
       ...aliases,
-      './controller/audio-track-controller': './empty.js',
-      './controller/audio-stream-controller': './empty.js',
+      './controller/audio-track-controller': `./${emptyFile}`,
+      './controller/audio-stream-controller': `./${emptyFile}`,
     };
   }
 
   if (!addVariableSubstitutionSupport) {
     aliases = {
       ...aliases,
-      './utils/variable-substitution': './empty.js',
-      '../utils/variable-substitution': '../empty.js',
+      './utils/variable-substitution': `./${emptyFile}`,
+      '../utils/variable-substitution': `../${emptyFile}`,
     };
   }
 
   if (!addM2TSAdvancedCodecSupport) {
     aliases = {
       ...aliases,
-      './ac3-demuxer': '../empty.js',
-      './video/hevc-video-parser': '../empty.js',
+      './ac3-demuxer': `../${emptyFile}`,
+      './video/hevc-video-parser': `../${emptyFile}`,
     };
   }
 
   if (!addMediaCapabilitiesSupport) {
     aliases = {
       ...aliases,
-      '../utils/mediacapabilities-helper': '../empty.js',
+      '../utils/mediacapabilities-helper': `../${emptyFile}`,
     };
   }
 
@@ -300,7 +302,7 @@ const buildRollupConfig = ({
         ? [alias({ entries: { './transmuxer-worker': '../empty.js' } })]
         : []),
       ...(type === BUILD_TYPE.light
-        ? [alias({ entries: getAliasesForLightDist() })]
+        ? [alias({ entries: getAliasesForLightDist(format) })]
         : []),
       ...(format === 'esm'
         ? [buildBabelEsm({ stripConsole: true })]

--- a/src/empty-es.js
+++ b/src/empty-es.js
@@ -1,0 +1,5 @@
+// This file is inserted as a shim for modules which we do not want to include into the distro.
+// This replacement is done in the "alias" plugin of the rollup config.
+// Use a ES dedicated file as Rollup assigns an object in the output
+// For example: "var KeySystemFormats = emptyEs.KeySystemFormats;"
+module.exports = {};


### PR DESCRIPTION
ESM build needs a special empty file that exports an object to prevent property access of "undefined"

### This PR will...

Fix `hls.light.mjs` script crash (`TypeError: Cannot read properties of undefined (reading 'KeySystemFormats')`

### Why is this Pull Request needed?

ESM bundle imports `empty` as an object. So we must export an empty object instead of `undefined` to prevent a crash.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
