### PR TITLE
Update dependency update auto merge action and use GitHub auto merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,8 @@ jobs:
       group: 'automerge:run:${{ github.head_ref }}'
       cancel-in-progress: true
     steps:
-      - uses: tjenkinson/gh-action-auto-merge-dependency-updates@94a659f2eba4e787914b23e13ab2a28f46b5e1e6 # v1.3.5
+      - uses: tjenkinson/gh-action-auto-merge-dependency-updates@93fed7c1e20b34a68fa26f715772450bfb04602a # v1.4.0
         with:
           repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          use-auto-merge: true
           allowed-actors: renovate[bot]


### PR DESCRIPTION
### This PR will...

Update dependency update auto merge action and use GitHub auto merge.

### Why is this Pull Request needed?

Our CI user has been suspended and I think it may be automated due to the number of repeated merge calls the action was making. With these changes the action will now enable the native GitHub auto merge feature which should be much more efficient. 

Note the CI user is still disabled so this still won't actually work right now. I'm waiting to hear back from support.

## TODO

- [x] Make the status check required once merged
