### PR TITLE
chore: update all type imports to explicitly use the type keyword.

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -1,8 +1,13 @@
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
-import { getSkipValue, HlsSkip, HlsUrlParameters, Level } from '../types/level';
+import {
+  getSkipValue,
+  HlsSkip,
+  HlsUrlParameters,
+  type Level,
+} from '../types/level';
 import { computeReloadInterval, mergeDetails } from '../utils/level-helper';
-import { ErrorData } from '../types/events';
+import type { ErrorData } from '../types/events';
 import { getRetryDelay, isTimeoutError } from '../utils/error-helper';
 import { NetworkErrorAction } from './error-controller';
 import { Logger } from '../utils/logger';

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -1,5 +1,5 @@
 import { Events } from '../events';
-import Hls from '../hls';
+import type Hls from '../hls';
 import { Cmcd } from '@svta/common-media-library/cmcd/Cmcd';
 import { CmcdObjectType } from '@svta/common-media-library/cmcd/CmcdObjectType';
 import { CmcdStreamingFormat } from '@svta/common-media-library/cmcd/CmcdStreamingFormat';

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ManifestLoadedData,
   ManifestParsedData,
   LevelLoadedData,

--- a/src/demux/audio/base-audio-demuxer.ts
+++ b/src/demux/audio/base-audio-demuxer.ts
@@ -1,13 +1,13 @@
 import * as ID3 from '../id3';
 import {
-  DemuxerResult,
-  Demuxer,
-  DemuxedAudioTrack,
-  AudioFrame,
-  DemuxedMetadataTrack,
-  DemuxedVideoTrackBase,
-  DemuxedUserdataTrack,
-  KeyData,
+  type DemuxerResult,
+  type Demuxer,
+  type DemuxedAudioTrack,
+  type AudioFrame,
+  type DemuxedMetadataTrack,
+  type DemuxedVideoTrackBase,
+  type DemuxedUserdataTrack,
+  type KeyData,
   MetadataSchema,
 } from '../../types/demuxer';
 import { dummyTrack } from '../dummy-demuxed-track';

--- a/src/demux/audio/mpegaudio.ts
+++ b/src/demux/audio/mpegaudio.ts
@@ -1,7 +1,7 @@
 /**
  *  MPEG parser helper
  */
-import { DemuxedAudioTrack } from '../../types/demuxer';
+import type { DemuxedAudioTrack } from '../../types/demuxer';
 
 let chromeVersion: number | null = null;
 

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -2,13 +2,13 @@
  * MP4 demuxer
  */
 import {
-  Demuxer,
-  DemuxerResult,
-  PassthroughTrack,
-  DemuxedAudioTrack,
-  DemuxedUserdataTrack,
-  DemuxedMetadataTrack,
-  KeyData,
+  type Demuxer,
+  type DemuxerResult,
+  type PassthroughTrack,
+  type DemuxedAudioTrack,
+  type DemuxedUserdataTrack,
+  type DemuxedMetadataTrack,
+  type KeyData,
   MetadataSchema,
 } from '../types/demuxer';
 import {

--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -1,5 +1,8 @@
 import BaseVideoParser from './base-video-parser';
-import { DemuxedVideoTrack, DemuxedUserdataTrack } from '../../types/demuxer';
+import type {
+  DemuxedVideoTrack,
+  DemuxedUserdataTrack,
+} from '../../types/demuxer';
 import { parseSEIMessageFromNALu } from '../../utils/mp4-tools';
 
 import type { PES } from '../tsdemuxer';

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ManifestLoadedData,
   ManifestLoadingData,
   MediaAttachedData,

--- a/src/exports-named.ts
+++ b/src/exports-named.ts
@@ -1,7 +1,7 @@
 import Hls from './hls';
 import { Events } from './events';
 import { ErrorTypes, ErrorDetails } from './errors';
-import { Level } from './types/level';
+import type { Level } from './types/level';
 import AbrController from './controller/abr-controller';
 import AudioTrackController from './controller/audio-track-controller';
 import AudioStreamController from './controller/audio-stream-controller';

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -1,6 +1,6 @@
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { Fragment } from './fragment';
-import {
+import type {
   Loader,
   LoaderConfiguration,
   FragmentLoaderContext,

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -1,5 +1,5 @@
 import { ErrorTypes, ErrorDetails } from '../errors';
-import {
+import type {
   LoaderStats,
   LoaderResponse,
   LoaderConfiguration,

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -4,7 +4,7 @@ import type { HlsEventEmitter } from '../events';
 import { Events } from '../events';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
-import {
+import type {
   InitSegmentData,
   Remuxer,
   RemuxerResult,

--- a/src/types/component-api.ts
+++ b/src/types/component-api.ts
@@ -1,4 +1,4 @@
-import EwmaBandWidthEstimator from '../utils/ewma-bandwidth-estimator';
+import type EwmaBandWidthEstimator from '../utils/ewma-bandwidth-estimator';
 
 export interface ComponentAPI {
   destroy(): void;

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -1,5 +1,5 @@
 import type { TrackSet } from './track';
-import {
+import type {
   DemuxedAudioTrack,
   DemuxedMetadataTrack,
   DemuxedUserdataTrack,

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   LoaderCallbacks,
   LoaderContext,
   Loader,


### PR DESCRIPTION
### This PR will...

Refactor TypeScript type imports to consistently only use `type` keyword with the imports.

### Why is this Pull Request needed?

Improves tooling identification of type vs. non-type imports.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable) (N/A)
- [x] API or design changes are documented in API.md (N/A)
