### PR TITLE
Bugfix: preferManagedMediaSource:false when MSE is not present 

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -104,10 +104,10 @@ export default class BufferController extends Logger implements ComponentAPI {
     super('buffer-controller', hls.logger);
     this.hls = hls;
     this.fragmentTracker = fragmentTracker;
-    this.appendSource =
-      hls.config.preferManagedMediaSource &&
-      typeof self !== 'undefined' &&
-      (self as any).ManagedMediaSource;
+    this.appendSource = isManagedMediaSource(
+      getMediaSource(hls.config.preferManagedMediaSource),
+    );
+
     this._initSourceBuffer();
     this.registerListeners();
   }
@@ -210,7 +210,6 @@ export default class BufferController extends Logger implements ComponentAPI {
   ) {
     const media = (this.media = data.media);
     const MediaSource = getMediaSource(this.appendSource);
-    this.appendSource ||= isManagedMediaSource(MediaSource);
 
     if (media && MediaSource) {
       const ms = (this.mediaSource = new MediaSource());

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -210,7 +210,7 @@ export default class BufferController extends Logger implements ComponentAPI {
   ) {
     const media = (this.media = data.media);
     const MediaSource = getMediaSource(this.appendSource);
-    this.appendSource = this.appendSource || isManagedMediaSource(MediaSource);
+    this.appendSource ||= isManagedMediaSource(MediaSource);
 
     if (media && MediaSource) {
       const ms = (this.mediaSource = new MediaSource());

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -6,7 +6,10 @@ import {
   getCodecCompatibleName,
   pickMostCompleteCodecName,
 } from '../utils/codecs';
-import { getMediaSource } from '../utils/mediasource-helper';
+import {
+  getMediaSource,
+  isManagedMediaSource,
+} from '../utils/mediasource-helper';
 import {
   ElementaryStreamTypes,
   type Part,
@@ -207,6 +210,8 @@ export default class BufferController extends Logger implements ComponentAPI {
   ) {
     const media = (this.media = data.media);
     const MediaSource = getMediaSource(this.appendSource);
+    this.appendSource = this.appendSource || isManagedMediaSource(MediaSource);
+
     if (media && MediaSource) {
       const ms = (this.mediaSource = new MediaSource());
       this.log(`created media source: ${ms.constructor?.name}`);

--- a/src/utils/mediasource-helper.ts
+++ b/src/utils/mediasource-helper.ts
@@ -15,3 +15,7 @@ export function getMediaSource(
     ((self as any).WebKitMediaSource as typeof MediaSource)
   );
 }
+
+export function isManagedMediaSource(source: typeof MediaSource | undefined) {
+  return source === (self as any).ManagedMediaSource;
+}

--- a/src/utils/mediasource-helper.ts
+++ b/src/utils/mediasource-helper.ts
@@ -17,5 +17,7 @@ export function getMediaSource(
 }
 
 export function isManagedMediaSource(source: typeof MediaSource | undefined) {
-  return source === (self as any).ManagedMediaSource;
+  return (
+    typeof self !== 'undefined' && source === (self as any).ManagedMediaSource
+  );
 }


### PR DESCRIPTION
### This PR will...
Flip the **BufferController.appendSource** flag, in cases where **_preferManagedMediaSource_** config is set to **_false_** but MSE is not present.

### Why is this Pull Request needed?

The API Docs state:
```
preferManagedMediaSource
...
Setting this to false will only use ManagedMediaSource when MediaSource is undefined.
```

This is indeed the case but the  **appendSource** flag is never updated to handle the scenario as it's only set within the constructor:
```
this.appendSource =
      hls.config.preferManagedMediaSource &&
      typeof self !== 'undefined' &&
      (self as any).ManagedMediaSource;
```
, thus blocks like:
```
      if (this.appendSource) {
        ms.addEventListener('startstreaming', this._onStartStreaming);
        ms.addEventListener('endstreaming', this._onEndStreaming);
      }
```
and 
```
if (this.appendSource) {
        try {
          media.removeAttribute('src');
          // ManagedMediaSource will not open without disableRemotePlayback set to false or source alternatives
          const MMS = (self as any).ManagedMediaSource;
          media.disableRemotePlayback =
            media.disableRemotePlayback || (MMS && ms instanceof MMS);
         ....
```
never get invoked.

What this PR aims to do is check if the elected MediaSource is MMS and ensure **appendSource** adequately represent the state of the world.

### Are there any points in the code the reviewer needs to double check?
Not to my knowledge

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
