### PR TITLE
Bugfix: Handle duplicate audio codec in CODECS

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -929,8 +929,11 @@ export default class BufferController implements ComponentAPI {
             `source buffer exists for track ${trackName}, however track does not`,
           );
         }
-        // use levelCodec as first priority
-        let codec = track.levelCodec || track.codec;
+        // use levelCodec as first priority unless it contains multiple comma-separated codec values
+        let codec =
+          track.levelCodec?.indexOf(',') === -1
+            ? track.levelCodec
+            : track.codec;
         if (codec) {
           if (trackName.slice(0, 5) === 'audio') {
             codec = getCodecCompatibleName(codec, this.appendSource);

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -193,7 +193,7 @@ export function pickMostCompleteCodecName(
   if (parsedCodec && parsedCodec !== 'mp4a') {
     return parsedCodec;
   }
-  return levelCodec;
+  return levelCodec ? levelCodec.split(',')[0] : levelCodec;
 }
 
 export function convertAVC1ToAVCOTI(codec: string) {


### PR DESCRIPTION
### This PR will...
Avoid using "levelCodec" to instantiate the audio SourceBuffer when multiple audio codec strings are present in the Multivariant Playlist CODECS attribute for muxed content (TS segment without alt-audio).

### Why is this Pull Request needed?
SourceBuffer creation fails with invalid mime-time.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6337

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
