### PR TITLE
<#6316> Patch for light player exception with audio groups

### DIFF
--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -269,12 +269,15 @@ export function getCodecTiers(
       tier.fragmentError += level.fragmentError;
       tier.videoRanges[level.videoRange] =
         (tier.videoRanges[level.videoRange] || 0) + 1;
-      if (audioGroups) {
+      if (__USE_ALT_AUDIO__ && audioGroups) {
         audioGroups.forEach((audioGroupId) => {
           if (!audioGroupId) {
             return;
           }
           const audioGroup = audioTracksByGroup.groups[audioGroupId];
+          if (!audioGroup) {
+            return;
+          }
           // Default audio is any group with DEFAULT=YES, or if missing then any group with AUTOSELECT=YES, or all variants
           tier.hasDefaultAudio =
             tier.hasDefaultAudio || audioTracksByGroup.hasDefaultAudio

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -619,7 +619,7 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
 
   const entries = Object.entries(streams);
   if (HlsjsLightBuild) {
-    entries.length = 10;
+    entries.length = 12;
   }
 
   const isSafari = browserConfig.name === 'safari';


### PR DESCRIPTION
Don't look through audio groups if environment __USE_ALT_AUDIO__ is false

setup.js: Update entries 10 -> 12 to add tests to light build

### This PR will...
Don't look through audio groups if environment USE_ALT_AUDIO is false


### Why is this Pull Request needed?
Fix light build as described in https://github.com/video-dev/hls.js/issues/6316

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
