### PR TITLE
Clarify capLevelToPlayerSize docs in API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -485,6 +485,8 @@ This configuration will be applied by default to all instances.
 
 - if set to true, the adaptive algorithm with limit levels usable in auto-quality by the HTML video element dimensions (width and height).
   If dimensions between multiple levels are equal, the cap is chosen as the level with the greatest bandwidth.
+  In some devices, the video element dimensions will be multiplied by the device pixel ratio.
+  Use `ignoreDevicePixelRatio` for a strict level limitation based on the size of the video element.
 - if set to false, levels will not be limited. All available levels could be used in auto-quality mode taking only bandwidth into consideration.
 
 ### `capLevelOnFPSDrop`


### PR DESCRIPTION
### This PR will...

Adjust the API documentation for property capLevelToPlayerSize.

### Why is this Pull Request needed?

Without this clarification anyone using a modern high resolution display will have to figure out the additionally required config themselves.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

- https://github.com/video-dev/hls.js/issues/5594

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
