### PR TITLE
Bugfix: Handle irregular white-space in segment URIs

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -47,7 +47,7 @@ const IS_MEDIA_PLAYLIST = /^#EXT(?:INF|-X-TARGETDURATION):/m; // Handle empty Me
 const LEVEL_PLAYLIST_REGEX_FAST = new RegExp(
   [
     /#EXTINF:\s*(\d*(?:\.\d+)?)(?:,(.*)\s+)?/.source, // duration (#EXTINF:<duration>,<title>), group 1 => duration, group 2 => title
-    /(?!#) *(\S[\S ]*)/.source, // segment URI, group 3 => the URI (note newline is not eaten)
+    /(?!#) *(\S[^\r\n]*)/.source, // segment URI, group 3 => the URI (note newline is not eaten)
     /#EXT-X-BYTERANGE:*(.+)/.source, // next segment's byterange, group 4 => range spec (x@y)
     /#EXT-X-PROGRAM-DATE-TIME:(.+)/.source, // next segment's program date/time group 5 => the datetime spec
     /#.*/.source, // All other non-segment oriented tags will match with all groups empty

--- a/tests/unit/loader/playlist-loader.ts
+++ b/tests/unit/loader/playlist-loader.ts
@@ -427,6 +427,30 @@ http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/
     expect(result.fragments[1].relurl).to.equal('1');
   });
 
+  it('parse level with unicode white-space in fragment URI', function () {
+    const uriWithIrregularWs0 = 'sample-mp4-file\u3000_240p_00000.ts';
+    const uriWithIrregularWs1 = 'sample-mp4-file\u3000_another\u3000_00001.ts';
+    const level = `#EXTM3U
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-TARGETDURATION:2
+#EXTINF:2,
+${uriWithIrregularWs0}
+#EXTINF:2,
+${uriWithIrregularWs1}
+#EXT-X-ENDLIST`;
+    const result = M3U8Parser.parseLevelPlaylist(
+      level,
+      'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',
+      0,
+      PlaylistLevelType.MAIN,
+      0,
+      null,
+    );
+    expect(result.fragments).to.have.lengthOf(2);
+    expect(result.fragments[0].relurl).to.equal(uriWithIrregularWs0);
+    expect(result.fragments[1].relurl).to.equal(uriWithIrregularWs1);
+  });
+
   it('parse level with EXTINF line without comma', function () {
     const level = `#EXTM3U
 #EXT-X-VERSION:3


### PR DESCRIPTION
### This PR will...
- Update parser pattern to not terminate segment URIs on irregular white-space
- Add test for unicode (\u3000) white-space in segment URIs

### Why is this Pull Request needed?
Someone put \u3000 chars in their segment URIs and the regular expression to match segment URIs ends on any white-space character instead of only newline or return like the pattern used for media playlist URIs.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6381

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
