### PR TITLE
Fix backtracking when an appended segment has no buffered timerange

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -447,7 +447,7 @@ export default class BaseStreamController
     const { fragmentTracker } = this;
     const fragState = fragmentTracker.getState(frag);
     if (fragState === FragmentState.APPENDING) {
-      // Lower the buffer size and try again
+      // Lower the max buffer length and try again
       const playlistType = frag.type as PlaylistLevelType;
       const bufferedInfo = this.getFwdBufferInfo(
         this.mediaBuffer,
@@ -457,7 +457,17 @@ export default class BaseStreamController
         frag.duration,
         bufferedInfo ? bufferedInfo.len : this.config.maxBufferLength,
       );
-      if (this.reduceMaxBufferLength(minForwardBufferLength)) {
+      // If backtracking, always remove from the tracker without reducing max buffer length
+      const backtrackFragment = (this as any).backtrackFragment as
+        | Fragment
+        | undefined;
+      const backtracked = backtrackFragment
+        ? (frag.sn as number) - (backtrackFragment.sn as number)
+        : 0;
+      if (
+        backtracked === 1 ||
+        this.reduceMaxBufferLength(minForwardBufferLength)
+      ) {
         fragmentTracker.removeFragment(frag);
       }
     } else if (this.mediaBuffer?.buffered.length === 0) {
@@ -1134,10 +1144,11 @@ export default class BaseStreamController
   protected reduceMaxBufferLength(threshold: number) {
     const config = this.config;
     const minLength = threshold || config.maxBufferLength;
-    if (config.maxMaxBufferLength >= minLength) {
+    const reducedLength = config.maxMaxBufferLength / 2;
+    if (reducedLength >= minLength) {
       // reduce max buffer length as it might be too high. we do this to avoid loop flushing ...
-      config.maxMaxBufferLength /= 2;
-      this.warn(`Reduce max buffer length to ${config.maxMaxBufferLength}s`);
+      config.maxMaxBufferLength = reducedLength;
+      this.warn(`Reduce max buffer length to ${reducedLength}s`);
       return true;
     }
     return false;


### PR DESCRIPTION
### This PR will...
Clear backtracking fragments stuck in "APPENDING" state without reducing max buffer length.

### Why is this Pull Request needed?

Reducing the max buffer length and skipping fragment tracker removal is done to address BUFFER_FULL errors (#5354).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6428

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
