### PR TITLE
Fix duplicate subtitle/captions with same NAME edge-case

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -215,6 +215,8 @@ export class TimelineController implements ComponentAPI {
           canReuseVttTextTrack(textTrack, {
             name: label,
             lang: language,
+            characteristics:
+              'transcribes-spoken-dialog,describes-music-and-sound',
             attrs: {} as any,
           })
         ) {


### PR DESCRIPTION
### This PR will...
Do not allow subtitles TextTracks with labels matching captions options names to be reused by timeline-controller.

### Why is this Pull Request needed?
Handles edge case where subtitle and captions media options are assigned the same NAME attribute value.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6392

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
