### PR TITLE
Fix JS AES fallback when browserCrypto.subtle returns undefined (rath…

### DIFF
--- a/src/crypt/fast-aes-key.ts
+++ b/src/crypt/fast-aes-key.ts
@@ -1,11 +1,11 @@
 import { DecrypterAesMode } from './decrypter-aes-mode';
 
 export default class FastAESKey {
-  private subtle: any;
+  private subtle: SubtleCrypto;
   private key: ArrayBuffer;
   private aesMode: DecrypterAesMode;
 
-  constructor(subtle, key, aesMode: DecrypterAesMode) {
+  constructor(subtle: SubtleCrypto, key, aesMode: DecrypterAesMode) {
     this.subtle = subtle;
     this.key = key;
     this.aesMode = aesMode;


### PR DESCRIPTION
### This PR will...
Fix JS AES-128 fallback when `browserCrypto.subtle` returns `undefined`.

### Why is this Pull Request needed?
There was an assumption that `browserCrypto.subtle`  (or `webkitSubtle`)  would return `null`, but when hosting over http it returns `undefined`.

### Are there any points in the code the reviewer needs to double check?
Additional Typescript definitions and removal of outside variables used in callback function scope (`subtle`  ->`this.subtle`).

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
