### PR TITLE
Emit FRAG_PARSING_ERROR on unsupported M2TS codec

### DIFF
--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -329,6 +329,7 @@ export default class TransmuxerInterface {
       type: ErrorTypes.MEDIA_ERROR,
       details: ErrorDetails.FRAG_PARSING_ERROR,
       chunkMeta,
+      frag: this.frag || undefined,
       fatal: false,
       error,
       err: error,

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -897,8 +897,7 @@ function parsePMT(
       case 0xc2: // SAMPLE-AES EC3
       /* falls through */
       case 0x87:
-        logger.warn('Unsupported EC-3 in M2TS found');
-        break;
+        throw new Error('Unsupported EC-3 in M2TS found');
 
       case 0x24: // ITU-T Rec. H.265 and ISO/IEC 23008-2 (HEVC)
         if (__USE_M2TS_ADVANCED_CODECS__) {
@@ -908,7 +907,7 @@ function parsePMT(
             logger.log('HEVC in M2TS found');
           }
         } else {
-          logger.warn('Unsupported HEVC in M2TS found');
+          throw new Error('Unsupported HEVC in M2TS found');
         }
         break;
 


### PR DESCRIPTION
### This PR will...
Emit FRAG_PARSING_ERROR on unsupported M2TS codec. Include `frag` reference in error event when `enableWorker` is `false`.

### Why is this Pull Request needed?
When EC-3 is encountered in MPEG-2 TS segments a warning is logged, but the result is handled like an empty segment (gap) rather than a standard FRAG_PARSING_ERROR error which calls for a variant or rendition change. 

Throwing from the demuxer is handled by emitting FRAG_PARSING_ERROR. The error is handled as an audio codec error provided the `frag` reference is present in the error event payload.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6445

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
