### PR TITLE
Worker message type safety

### DIFF
--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -43,7 +43,7 @@ function startWorker(self) {
           observer,
           data.typeSupported,
           config,
-          data.vendor,
+          '',
           data.id,
         );
         const logger = enableLogs(config.debug, data.id);


### PR DESCRIPTION
### This PR will...
Add type safety to worker message handler and replace deprecated vendor field with empty string.

### Why is this Pull Request needed?
Prevent `onWorkerMessage` from throwing from an unexpected message missing data, or from emitting an event with an undefined `event` name.

[`navigator.vendor`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor) is deprecated and not used in any significant way. The transmuxer and remuxer arguments may be removed in a future change.

### Are there any points in the code the reviewer needs to double check?
Root cause of an empty worker message has not been determined (#6445). Throwing on an async callback shouldn't interfere with other operations. If this is related to worker failure, a necessary followup would be to reset the worker and fallback to inline transmuxing.

### Resolves issues:
Related to #6445

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
