### PR TITLE
Fix TSDemuxer parsing error handling in sync path

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -397,7 +397,7 @@ export default class BaseStreamController
         if (this.state === State.STOPPED || this.state === State.ERROR) {
           return;
         }
-        this.warn(reason);
+        this.warn(`Frag error: ${reason?.message || reason}`);
         this.resetFragmentLoading(frag);
       });
   }

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -43,7 +43,7 @@ function startWorker(self) {
           observer,
           data.typeSupported,
           config,
-          data.vendor,
+          '',
           data.id,
         );
         enableLogs(config.debug, data.id);


### PR DESCRIPTION
### This PR will...
- Emit FRAG_PARSING_ERROR rather than throw in TSDemuxer
- Add type safety to worker message handling
- Warn with error message when available

### Why is this Pull Request needed?
Throwing in transmuxers was handled correctly in worker and async (WebCrypto Promise wrapped) execution paths, but not in sync paths (transmuxer-interface `handleTransmuxComplete`, `handleFlushResult`).

### Are there any points in the code the reviewer needs to double check?
This is only an issue when delivering codecs unsupported in TS. 

### Resolves issues:
Resolves #6445

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
