### PR TITLE
Prevent overlapping appends on start not present in v1.4.x

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1278,7 +1278,7 @@ export default class BaseStreamController
     let { fragPrevious } = this;
     let { fragments, endSN } = levelDetails;
     const { fragmentHint } = levelDetails;
-    const tolerance = config.maxFragLookUpTolerance;
+    const { maxFragLookUpTolerance } = config;
     const partList = levelDetails.partList;
 
     const loadingParts = !!(
@@ -1294,7 +1294,8 @@ export default class BaseStreamController
 
     let frag;
     if (bufferEnd < end) {
-      const lookupTolerance = bufferEnd > end - tolerance ? 0 : tolerance;
+      const lookupTolerance =
+        bufferEnd > end - maxFragLookUpTolerance ? 0 : maxFragLookUpTolerance;
       // Remove the tolerance if it would put the bufferEnd past the actual end of stream
       // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
       frag = findFragmentByPTS(


### PR DESCRIPTION


### This PR will...
Don't append over first fragment when next fragment aligns with playlist within 1/200s tolerance.

### Why is this Pull Request needed?
Fixes edge-case starting in v1.5 that causes #6441

### Are there any points in the code the reviewer needs to double check?
The 1/200s magic number is a temporary workaround. We may make this configurable in future releases, but it can be masked completely by `maxFragLookupTolerance`.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
