### PR TITLE
Fix HE-AACv1 and v2 in fMP4 on iOS

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1272,7 +1272,13 @@ export default class StreamController
         // In the case that AAC and HE-AAC audio codecs are signalled in manifest,
         // force HE-AAC, as it seems that most browsers prefers it.
         // don't force HE-AAC if mono stream, or in Firefox
-        if (audio.metadata.channelCount !== 1 && ua.indexOf('firefox') === -1) {
+        const audioMetadata = audio.metadata;
+        if (
+          audioMetadata &&
+          'channelCount' in audioMetadata &&
+          (audioMetadata.channelCount || 1) !== 1 &&
+          ua.indexOf('firefox') === -1
+        ) {
           audioCodec = 'mp4a.40.5';
         }
       }


### PR DESCRIPTION
### This PR will...
Fix exception reading metadata.channelCount with HE-AAC when changeType is not supported.

### Why is this Pull Request needed?
`audio.metadata` is undefined after parsing mp4 init segments.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6470

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
