### PR TITLE
Fix error handling for GAP tags in subtitles or audio

### DIFF
--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -381,7 +381,11 @@ export default class ErrorController implements NetworkComponentAPI {
         ) {
           const levelCandidate = levels[candidate];
           // Skip level switch if GAP tag is found in next level at same position
-          if (errorDetails === ErrorDetails.FRAG_GAP && data.frag) {
+          if (
+            errorDetails === ErrorDetails.FRAG_GAP &&
+            fragErrorType === PlaylistLevelType.MAIN &&
+            data.frag
+          ) {
             const levelDetails = levels[candidate].details;
             if (levelDetails) {
               const fragCandidate = findFragmentByPTS(

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -204,6 +204,10 @@ export class SubtitleStreamController
     const frag = data.frag;
 
     if (frag?.type === PlaylistLevelType.SUBTITLE) {
+      if (data.details === ErrorDetails.FRAG_GAP) {
+        this.fragmentTracker.fragBuffered(frag, true);
+        return;
+      }
       if (this.fragCurrent) {
         this.fragCurrent.abortRequests();
       }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -206,7 +206,6 @@ export class SubtitleStreamController
     if (frag?.type === PlaylistLevelType.SUBTITLE) {
       if (data.details === ErrorDetails.FRAG_GAP) {
         this.fragmentTracker.fragBuffered(frag, true);
-        return;
       }
       if (this.fragCurrent) {
         this.fragCurrent.abortRequests();


### PR DESCRIPTION
### This PR will...
Fix default error handling of GAP tags always treated as error in MAIN playlist.

### Why is this Pull Request needed?
`getLevelSwitchAction` ignores candidates with the same group ID, but this was being short-circuited by the `errorDetails === ErrorDetails.FRAG_GAP && data.frag` check.

### Are there any points in the code the reviewer needs to double check?

Adding the subtitle fragment with a gap to the fragment tracker prevents loop loading with repeated gap tag error events.

### Resolves issues:
Resolves #6475


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
