### PR TITLE
Add videoCodec field to videoPreference options

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3495,6 +3495,7 @@ export type VariableMap = Record<string, string>;
 export type VideoSelectionOption = {
     preferHDR?: boolean;
     allowedVideoRanges?: Array<VideoRange>;
+    videoCodec?: string;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -675,6 +675,7 @@ class AbrController extends Logger implements AbrComponentAPI {
     const audioTracksByGroup =
       this.audioTracksByGroup ||
       (this.audioTracksByGroup = getAudioTracksByGroup(allAudioTracks));
+    let minStartIndex = -1;
     if (firstSelection) {
       if (this.firstSelection !== -1) {
         return this.firstSelection;
@@ -694,8 +695,15 @@ class AbrController extends Logger implements AbrComponentAPI {
         audioPreference,
         videoPreference,
       );
-      const { codecSet, videoRanges, minFramerate, minBitrate, preferHDR } =
-        startTier;
+      const {
+        codecSet,
+        videoRanges,
+        minFramerate,
+        minBitrate,
+        minIndex,
+        preferHDR,
+      } = startTier;
+      minStartIndex = minIndex;
       currentCodecSet = codecSet;
       currentVideoRange = preferHDR
         ? videoRanges[videoRanges.length - 1]
@@ -789,8 +797,10 @@ class AbrController extends Logger implements AbrComponentAPI {
         (levelInfo.supportedResult &&
           !levelInfo.supportedResult.decodingInfoResults?.[0].smooth)
       ) {
-        levelsSkipped.push(i);
-        continue;
+        if (firstSelection && i !== minStartIndex) {
+          levelsSkipped.push(i);
+          continue;
+        }
       }
 
       const levelDetails = levelInfo.details;
@@ -869,7 +879,7 @@ class AbrController extends Logger implements AbrComponentAPI {
               1,
             )} fetchDuration:${fetchDuration.toFixed(
               1,
-            )} firstSelection:${firstSelection} codecSet:${currentCodecSet} videoRange:${currentVideoRange} hls.loadLevel:${loadLevel}`,
+            )} firstSelection:${firstSelection} codecSet:${level.codecSet} videoRange:${level.videoRange} hls.loadLevel:${loadLevel}`,
           );
         }
         if (firstSelection) {

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -813,7 +813,7 @@ export default class Hls implements HlsEventEmitter {
   public setAudioOption(
     audioOption: MediaPlaylist | AudioSelectionOption | undefined,
   ): MediaPlaylist | null {
-    return this.audioTrackController?.setAudioOption(audioOption);
+    return this.audioTrackController?.setAudioOption(audioOption) || null;
   }
   /**
    * Find and select the best matching subtitle track, making a level switch when a Group change is necessary.
@@ -822,8 +822,9 @@ export default class Hls implements HlsEventEmitter {
   public setSubtitleOption(
     subtitleOption: MediaPlaylist | SubtitleSelectionOption | undefined,
   ): MediaPlaylist | null {
-    this.subtitleTrackController?.setSubtitleOption(subtitleOption);
-    return null;
+    return (
+      this.subtitleTrackController?.setSubtitleOption(subtitleOption) || null
+    );
   }
 
   /**

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -1,6 +1,7 @@
 import type { AttrList } from '../utils/attr-list';
 import type { LevelDetails } from '../loader/level-details';
-import type { VideoRange } from './level';
+import type { Level, VideoRange } from './level';
+import type { PlaylistLevelType } from './loader';
 
 export type AudioPlaylistType = 'AUDIO';
 
@@ -10,9 +11,16 @@ export type SubtitlePlaylistType = 'SUBTITLES' | 'CLOSED-CAPTIONS';
 
 export type MediaPlaylistType = MainPlaylistType | SubtitlePlaylistType;
 
+export type MediaSelection = {
+  [PlaylistLevelType.MAIN]: Level;
+  [PlaylistLevelType.AUDIO]?: MediaPlaylist;
+  [PlaylistLevelType.SUBTITLE]?: MediaPlaylist;
+};
+
 export type VideoSelectionOption = {
   preferHDR?: boolean;
   allowedVideoRanges?: Array<VideoRange>;
+  videoCodec?: string;
 };
 
 export type AudioSelectionOption = {

--- a/src/utils/hdr.ts
+++ b/src/utils/hdr.ts
@@ -49,16 +49,13 @@ export function getVideoSelectionOptions(
   if (videoPreference) {
     allowedVideoRanges =
       videoPreference.allowedVideoRanges || VideoRangeValues.slice(0);
+    const allowAutoPreferHDR =
+      allowedVideoRanges.join('') !== 'SDR' && !videoPreference.videoCodec;
     preferHDR =
       videoPreference.preferHDR !== undefined
         ? videoPreference.preferHDR
-        : isHdrSupported();
-
-    if (preferHDR) {
-      allowedVideoRanges = allowedVideoRanges.filter(
-        (range: VideoRange) => range !== 'SDR',
-      );
-    } else {
+        : allowAutoPreferHDR && isHdrSupported();
+    if (!preferHDR) {
       allowedVideoRanges = ['SDR'];
     }
   }

--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -13,6 +13,7 @@ export type CodecSetTier = {
   minBitrate: number;
   minHeight: number;
   minFramerate: number;
+  minIndex: number;
   maxScore: number;
   videoRanges: Record<string, number>;
   channels: Record<string, number>;
@@ -32,6 +33,7 @@ type StartParameters = {
   preferHDR: boolean;
   minFramerate: number;
   minBitrate: number;
+  minIndex: number;
 };
 
 export function getStartCodecTier(
@@ -52,6 +54,7 @@ export function getStartCodecTier(
   let minHeight = Infinity;
   let minFramerate = Infinity;
   let minBitrate = Infinity;
+  let minIndex = Infinity;
   let selectedScore = 0;
   let videoRanges: Array<VideoRange> = [];
 
@@ -189,6 +192,7 @@ export function getStartCodecTier(
       ) {
         return selected;
       }
+      minIndex = candidateTier.minIndex;
       selectedScore = candidateTier.maxScore;
       return candidate;
     },
@@ -200,6 +204,7 @@ export function getStartCodecTier(
     preferHDR,
     minFramerate,
     minBitrate,
+    minIndex,
   };
 }
 
@@ -257,7 +262,7 @@ export function getCodecTiers(
 ): Record<string, CodecSetTier> {
   return levels
     .slice(minAutoLevel, maxAutoLevel + 1)
-    .reduce((tiers: Record<string, CodecSetTier>, level) => {
+    .reduce((tiers: Record<string, CodecSetTier>, level, index) => {
       if (!level.codecSet) {
         return tiers;
       }
@@ -268,6 +273,7 @@ export function getCodecTiers(
           minBitrate: Infinity,
           minHeight: Infinity,
           minFramerate: Infinity,
+          minIndex: index,
           maxScore: 0,
           videoRanges: { SDR: 0 },
           channels: { '2': 0 },
@@ -279,6 +285,7 @@ export function getCodecTiers(
       const lesserWidthOrHeight = Math.min(level.height, level.width);
       tier.minHeight = Math.min(tier.minHeight, lesserWidthOrHeight);
       tier.minFramerate = Math.min(tier.minFramerate, level.frameRate);
+      tier.minIndex = Math.min(tier.minIndex, index);
       tier.maxScore = Math.max(tier.maxScore, level.score);
       tier.fragmentError += level.fragmentError;
       tier.videoRanges[level.videoRange] =


### PR DESCRIPTION
### This PR will...
- Add `videoCodec` field to `config.videoPreference`
- Improve SDR/HDR initial selection results
  - Don't narrow allowed video-ranges to one that is not available
  - Pick lowest in start tier regardless of "skip candidate" rules as long as "can switch within tolerance" check passes
- Fix return value for `setSubtitleOption` and undefined->null type for `setAudioOption`

### Why is this Pull Request needed?
- #5730 with child player instances that match primary player SourceBuffer configuration

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
