### PR TITLE
Sync audio fragment loading with main discontinuity and time

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1429,7 +1429,7 @@ export class Fragment extends BaseSegment {
     // (undocumented)
     get end(): number;
     // (undocumented)
-    endDTS: number;
+    endDTS?: number;
     // (undocumented)
     endList?: boolean;
     // (undocumented)
@@ -1469,7 +1469,7 @@ export class Fragment extends BaseSegment {
     // (undocumented)
     start: number;
     // (undocumented)
-    startDTS: number;
+    startDTS?: number;
     // (undocumented)
     startPTS?: number;
     // (undocumented)
@@ -1976,7 +1976,7 @@ export interface InitPTSFoundData {
     // (undocumented)
     frag: MediaFragment;
     // (undocumented)
-    id: string;
+    id: PlaylistLevelType;
     // (undocumented)
     initPTS: number;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -353,7 +353,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected fragmentTracker: FragmentTracker;
     // (undocumented)
-    protected fragPrevious: Fragment | null;
+    protected fragPrevious: MediaFragment | null;
     // (undocumented)
     protected getAppendedFrag(position: number, playlistType?: PlaylistLevelType): Fragment | null;
     // (undocumented)

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -879,7 +879,7 @@ class AbrController extends Logger implements AbrComponentAPI {
               1,
             )} fetchDuration:${fetchDuration.toFixed(
               1,
-            )} firstSelection:${firstSelection} codecSet:${level.codecSet} videoRange:${level.videoRange} hls.loadLevel:${loadLevel}`,
+            )} firstSelection:${firstSelection} codecSet:${levelInfo.codecSet} videoRange:${levelInfo.videoRange} hls.loadLevel:${loadLevel}`,
           );
         }
         if (firstSelection) {

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -705,7 +705,7 @@ class AudioStreamController
       return;
     }
     if (frag.sn !== 'initSegment') {
-      this.fragPrevious = frag;
+      this.fragPrevious = frag as MediaFragment;
       const track = this.switchingTrack;
       if (track) {
         this.bufferedTrack = track;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -77,7 +77,7 @@ export default class BaseStreamController
 {
   protected hls: Hls;
 
-  protected fragPrevious: Fragment | null = null;
+  protected fragPrevious: MediaFragment | null = null;
   protected fragCurrent: Fragment | null = null;
   protected fragmentTracker: FragmentTracker;
   protected transmuxer: TransmuxerInterface | null = null;

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -13,7 +13,7 @@ import type Hls from '../hls';
 import type { RetryConfig } from '../config';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type { ErrorData } from '../types/events';
-import type { Fragment } from '../loader/fragment';
+import type { Fragment, MediaFragment } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 
 export const enum NetworkErrorAction {
@@ -384,7 +384,7 @@ export default class ErrorController
             const levelDetails = levels[candidate].details;
             if (levelDetails) {
               const fragCandidate = findFragmentByPTS(
-                data.frag,
+                data.frag as MediaFragment,
                 levelDetails.fragments,
                 data.frag.start,
               );

--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -55,7 +55,7 @@ export function findFragmentByPDT(
  * @returns a matching fragment or null
  */
 export function findFragmentByPTS(
-  fragPrevious: Fragment | null,
+  fragPrevious: MediaFragment | null,
   fragments: MediaFragment[],
   bufferEnd: number = 0,
   maxFragLookUpTolerance: number = 0,
@@ -63,12 +63,18 @@ export function findFragmentByPTS(
 ): MediaFragment | null {
   let fragNext: MediaFragment | null = null;
   if (fragPrevious) {
-    fragNext =
-      fragments[(fragPrevious.sn as number) - fragments[0].sn + 1] || null;
+    fragNext = fragments[1 + fragPrevious.sn - fragments[0].sn] || null;
     // check for buffer-end rounding error
     const bufferEdgeError = (fragPrevious.endDTS as number) - bufferEnd;
     if (bufferEdgeError > 0 && bufferEdgeError < 0.0000015) {
       bufferEnd += 0.0000015;
+    }
+    if (
+      fragNext &&
+      fragPrevious.level !== fragNext.level &&
+      fragNext.end <= fragPrevious.end
+    ) {
+      fragNext = fragments[2 + fragPrevious.sn - fragments[0].sn] || null;
     }
   } else if (bufferEnd === 0 && fragments[0].start === 0) {
     fragNext = fragments[0];

--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -1,5 +1,6 @@
 import BinarySearch from '../utils/binary-search';
 import type { Fragment, MediaFragment } from '../loader/fragment';
+import type { LevelDetails } from '../loader/level-details';
 
 /**
  * Returns first fragment whose endPdt value exceeds the given PDT, or null.
@@ -213,4 +214,27 @@ export function findFragWithCC(
       return 0;
     }
   });
+}
+
+export function findNearestWithCC(
+  details: LevelDetails | undefined,
+  cc: number,
+  fragment: MediaFragment,
+): MediaFragment | null {
+  if (details) {
+    if (details.startCC <= cc && details.endCC >= cc) {
+      const start = fragment.start;
+      const end = fragment.end;
+      return BinarySearch.search(details.fragments, (candidate) => {
+        if (candidate.cc < cc || candidate.end <= start) {
+          return 1;
+        } else if (candidate.cc > cc || candidate.start >= end) {
+          return -1;
+        } else {
+          return 0;
+        }
+      });
+    }
+  }
+  return null;
 }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -873,7 +873,7 @@ export default class StreamController
       (8 * stats.total) / (stats.buffering.end - stats.loading.first),
     );
     if (frag.sn !== 'initSegment') {
-      this.fragPrevious = frag;
+      this.fragPrevious = frag as MediaFragment;
     }
     this.fragBufferedComplete(frag, part);
   }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -124,7 +124,9 @@ export class SubtitleStreamController
     data: SubtitleFragProcessed,
   ) {
     const { frag, success } = data;
-    this.fragPrevious = frag;
+    if (frag.sn !== 'initSegment') {
+      this.fragPrevious = frag as MediaFragment;
+    }
     this.state = State.IDLE;
     if (!success) {
       return;

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -106,8 +106,8 @@ export class SubtitleStreamController
   }
 
   protected onManifestLoading() {
+    super.onManifestLoading();
     this.mainDetails = null;
-    this.fragmentTracker.removeAllFragments();
   }
 
   protected onMediaDetaching(): void {
@@ -491,11 +491,9 @@ export class SubtitleStreamController
     level: Level,
     targetBufferTime: number,
   ) {
-    this.fragCurrent = frag;
     if (frag.sn === 'initSegment') {
       this._loadInitSegment(frag, level);
     } else {
-      this.startFragRequested = true;
       super.loadFragment(frag, level, targetBufferTime);
     }
   }

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -192,7 +192,7 @@ export class TimelineController implements ComponentAPI {
     { frag, id, initPTS, timescale }: InitPTSFoundData,
   ) {
     const { unparsedVttFrags } = this;
-    if (id === 'main') {
+    if (id === PlaylistLevelType.MAIN) {
       this.initPTS[frag.cc] = { baseTime: initPTS, timescale };
     }
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -232,7 +232,7 @@ export default class Hls implements HlsEventEmitter {
         new AudioStreamControllerClass(this, fragmentTracker, keyLoader),
       );
     }
-    // subtitleTrackController must be defined before subtitleStreamController because the order of event handling is important
+    // Instantiate subtitleTrackController before SubtitleStreamController to receive level events first
     this.subtitleTrackController = this.createController(
       config.subtitleTrackController,
       networkControllers,

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -1,18 +1,17 @@
 import { ErrorTypes, ErrorDetails } from '../errors';
-import { Fragment } from './fragment';
-import type {
-  Loader,
-  LoaderConfiguration,
-  FragmentLoaderContext,
-} from '../types/loader';
 import { getLoaderConfigWithoutReties } from '../utils/error-helper';
 import type { HlsConfig } from '../config';
-import type { BaseSegment, Part } from './fragment';
+import type { BaseSegment, Fragment, Part } from './fragment';
 import type {
   ErrorData,
   FragLoadedData,
   PartsLoadedData,
 } from '../types/events';
+import type {
+  Loader,
+  LoaderConfiguration,
+  FragmentLoaderContext,
+} from '../types/loader';
 
 const MIN_CHUNK_SIZE = Math.pow(2, 17); // 128kb
 
@@ -77,13 +76,11 @@ export default class FragmentLoader {
           frag.gap = false;
         }
       }
-      const loader =
-        (this.loader =
-        frag.loader =
-          FragmentILoader
-            ? new FragmentILoader(config)
-            : (new DefaultILoader(config) as Loader<FragmentLoaderContext>));
+      const loader = (this.loader = FragmentILoader
+        ? new FragmentILoader(config)
+        : (new DefaultILoader(config) as Loader<FragmentLoaderContext>));
       const loaderContext = createLoaderContext(frag);
+      frag.loader = loader;
       const loadPolicy = getLoaderConfigWithoutReties(
         config.fragLoadPolicy.default,
       );
@@ -188,13 +185,11 @@ export default class FragmentLoader {
         reject(createGapLoadError(frag, part));
         return;
       }
-      const loader =
-        (this.loader =
-        frag.loader =
-          FragmentILoader
-            ? new FragmentILoader(config)
-            : (new DefaultILoader(config) as Loader<FragmentLoaderContext>));
+      const loader = (this.loader = FragmentILoader
+        ? new FragmentILoader(config)
+        : (new DefaultILoader(config) as Loader<FragmentLoaderContext>));
       const loaderContext = createLoaderContext(frag, part);
+      frag.loader = loader;
       // Should we define another load policy for parts?
       const loadPolicy = getLoaderConfigWithoutReties(
         config.fragLoadPolicy.default,

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -127,9 +127,9 @@ export class Fragment extends BaseSegment {
   // The ending Presentation Time Stamp (PTS) of the fragment. Set after transmux complete.
   public endPTS?: number;
   // The starting Decode Time Stamp (DTS) of the fragment. Set after transmux complete.
-  public startDTS!: number;
+  public startDTS?: number;
   // The ending Decode Time Stamp (DTS) of the fragment. Set after transmux complete.
-  public endDTS!: number;
+  public endDTS?: number;
   // The start time of the fragment, as listed in the manifest. Updated after transmux complete.
   public start: number = 0;
   // Set by `updateFragPTSDTS` in level-helper

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -1,6 +1,5 @@
-import type { Part } from './fragment';
+import type { Fragment, MediaFragment, Part } from './fragment';
 import type { DateRange } from './date-range';
-import type { Fragment, MediaFragment } from './fragment';
 import type { AttrList } from '../utils/attr-list';
 import type { VariableMap } from '../types/level';
 

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -452,7 +452,6 @@ class PlaylistLoader implements NetworkComponentAPI {
     const { id, level, type } = context;
 
     const url = getResponseUrl(response, context);
-    const levelUrlId = 0;
     const levelId = Number.isFinite(level as number)
       ? (level as number)
       : Number.isFinite(id as number)
@@ -464,7 +463,7 @@ class PlaylistLoader implements NetworkComponentAPI {
       url,
       levelId,
       levelType,
-      levelUrlId,
+      0,
       this.variableList,
     );
 

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -160,15 +160,18 @@ export default class MP4Remuxer implements Remuxer {
       if (this.ISGenerated) {
         const config = this.videoTrackConfig;
         if (
-          config &&
-          (videoTrack.width !== config.width ||
-            videoTrack.height !== config.height ||
-            videoTrack.pixelRatio?.[0] !== config.pixelRatio?.[0] ||
-            videoTrack.pixelRatio?.[1] !== config.pixelRatio?.[1])
+          (config &&
+            (videoTrack.width !== config.width ||
+              videoTrack.height !== config.height ||
+              videoTrack.pixelRatio?.[0] !== config.pixelRatio?.[0] ||
+              videoTrack.pixelRatio?.[1] !== config.pixelRatio?.[1])) ||
+          (!config && enoughVideoSamples) ||
+          (this.nextAudioPts === null && enoughAudioSamples)
         ) {
           this.resetInitSegment();
         }
-      } else {
+      }
+      if (!this.ISGenerated) {
         initSegment = this.generateIS(
           audioTrack,
           videoTrack,
@@ -1085,8 +1088,9 @@ export default class MP4Remuxer implements Remuxer {
     const startDTS: number =
       (nextAudioPts !== null
         ? nextAudioPts
-        : videoData.startDTS * inputTimeScale) + init90kHz;
-    const endDTS: number = videoData.endDTS * inputTimeScale + init90kHz;
+        : (videoData.startDTS as number) * inputTimeScale) + init90kHz;
+    const endDTS: number =
+      (videoData.endDTS as number) * inputTimeScale + init90kHz;
     // one sample's duration value
     const frameDuration: number = scaleFactor * AAC_SAMPLES_PER_FRAME;
     // samples count of this segment's duration

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -178,7 +178,7 @@ class PassThroughRemuxer implements Remuxer {
       initSegment.initPTS = decodeTime - timeOffset;
       if (initPTS && initPTS.timescale === 1) {
         logger.warn(
-          `Adjusting initPTS by ${initSegment.initPTS - initPTS.baseTime}`,
+          `Adjusting initPTS @${timeOffset} from ${initPTS.baseTime / initPTS.timescale} to ${initSegment.initPTS}`,
         );
       }
       this.initPTS = initPTS = {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -192,6 +192,18 @@ export interface LevelUpdatedData {
   level: number;
 }
 
+export interface AudioTrackUpdatedData {
+  details: LevelDetails;
+  id: number;
+  groupId: string;
+}
+
+export interface SubtitleTrackUpdatedData {
+  details: LevelDetails;
+  id: number;
+  groupId: string;
+}
+
 export interface LevelPTSUpdatedData {
   details: LevelDetails;
   level: Level;
@@ -317,7 +329,7 @@ export interface NonNativeTextTracksData {
 }
 
 export interface InitPTSFoundData {
-  id: string;
+  id: PlaylistLevelType;
   frag: MediaFragment;
   initPTS: number;
   timescale: number;

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -461,11 +461,10 @@ export function computeReloadInterval(
 }
 
 export function getFragmentWithSN(
-  level: Level,
+  details: LevelDetails | undefined,
   sn: number,
   fragCurrent: Fragment | null,
 ): MediaFragment | null {
-  const details = level?.details;
   if (!details) {
     return null;
   }
@@ -485,14 +484,14 @@ export function getFragmentWithSN(
 }
 
 export function getPartWith(
-  level: Level,
+  details: LevelDetails | undefined,
   sn: number,
   partIndex: number,
 ): Part | null {
-  if (!level?.details) {
+  if (!details) {
     return null;
   }
-  return findPart(level.details?.partList, sn, partIndex);
+  return findPart(details.partList, sn, partIndex);
 }
 
 export function findPart(

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -8,7 +8,7 @@ import {
 import StreamController from '../../../src/controller/stream-controller';
 import { State } from '../../../src/controller/base-stream-controller';
 import { mockFragments } from '../../mocks/data';
-import { Fragment } from '../../../src/loader/fragment';
+import { Fragment, MediaFragment } from '../../../src/loader/fragment';
 import { LevelDetails } from '../../../src/loader/level-details';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
 import { LoadStats } from '../../../src/loader/load-stats';
@@ -183,7 +183,10 @@ describe('StreamController', function () {
   });
 
   describe('SN Searching', function () {
-    const fragPrevious = new Fragment(PlaylistLevelType.MAIN, '');
+    const fragPrevious = new Fragment(
+      PlaylistLevelType.MAIN,
+      '',
+    ) as MediaFragment;
     fragPrevious.programDateTime = 1505502671523;
     fragPrevious.duration = 5.0;
     fragPrevious.level = 1;
@@ -464,7 +467,10 @@ describe('StreamController', function () {
     });
 
     it('should seek to start pos when data is first loaded', function () {
-      const firstFrag = new Fragment(PlaylistLevelType.MAIN, '');
+      const firstFrag = new Fragment(
+        PlaylistLevelType.MAIN,
+        '',
+      ) as MediaFragment;
       firstFrag.duration = 5.0;
       firstFrag.level = 1;
       firstFrag.start = 0;


### PR DESCRIPTION
### This PR will...
Ensure that audio-stream-controller loads segments from the same discontinuity domain (`cc`) as the main stream-controller.

Sync max audio buffer target with main playlist loading fragment (rather than video SourceBuffer end).

Properties defined in the base stream controller class are now set and reset there where possible.

### Why is this Pull Request needed?
This PR improves Live start and VOD resume at offset by selecting audio segments that align with selected video segments.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
