### PR TITLE
Fix decode error escape in dev

### DIFF
--- a/src/demux/video/avc-video-parser.ts
+++ b/src/demux/video/avc-video-parser.ts
@@ -14,10 +14,10 @@ class AvcVideoParser extends BaseVideoParser {
     track: DemuxedVideoTrack,
     textTrack: DemuxedUserdataTrack,
     pes: PES,
-    last: boolean,
+    endOfSegment: boolean,
     duration: number,
   ) {
-    const units = this.parseNALu(track, pes.data, last);
+    const units = this.parseNALu(track, pes.data, endOfSegment);
     const debug = false;
     let VideoSample = this.VideoSample;
     let push: boolean;
@@ -206,7 +206,7 @@ class AvcVideoParser extends BaseVideoParser {
       }
     });
     // if last PES packet, push samples
-    if (last && VideoSample) {
+    if (endOfSegment && VideoSample) {
       this.pushAccessUnit(VideoSample, track);
       this.VideoSample = null;
     }

--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -16,10 +16,10 @@ class HevcVideoParser extends BaseVideoParser {
     track: DemuxedVideoTrack,
     textTrack: DemuxedUserdataTrack,
     pes: PES,
-    last: boolean,
+    endOfSegment: boolean,
     duration: number,
   ) {
-    const units = this.parseNALu(track, pes.data, last);
+    const units = this.parseNALu(track, pes.data, endOfSegment);
     const debug = false;
     let VideoSample = this.VideoSample;
     let push: boolean;
@@ -244,7 +244,7 @@ class HevcVideoParser extends BaseVideoParser {
       }
     });
     // if last PES packet, push samples
-    if (last && VideoSample) {
+    if (endOfSegment && VideoSample) {
       this.pushAccessUnit(VideoSample, track);
       this.VideoSample = null;
     }

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -77,7 +77,6 @@ export interface DemuxedVideoTrackBase extends DemuxedTrack {
   pps?: Uint8Array[];
   sps?: Uint8Array[];
   naluState?: number;
-  lastNalu?: VideoSampleUnit | null;
   segmentCodec?: string;
   manifestCodec?: string;
   samples: VideoSample[] | Uint8Array;


### PR DESCRIPTION
### This PR will...
Revert NALu overflow handling change introduced in #6268 that results in a decode error at 30s w/ https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/media/b2962000-video.m3u8 

`PIPELINE_ERROR_DECODE: Error Domain=NSOSStatusErrorDomain Code=-12909 "(null)" (-12909): VTDecompressionOutputCallback`

### Why is this Pull Request needed?
The above asset produces a decode error when playback reaches 29-30s in Chrome using the latest from dev:

https://hlsjs-dev.video-dev.org/demo/?src=https%3A%2F%2Fbitmovin-a.akamaihd.net%2Fcontent%2Fdataset%2Fmulti-codec%2Fhevc%2Fv720p_ts.m3u8&demoConfig=eyJlbmFibGVTdHJlYW1pbmciOnRydWUsImF1dG9SZWNvdmVyRXJyb3IiOmZhbHNlLCJzdG9wT25TdGFsbCI6ZmFsc2UsImR1bXBmTVA0Ijp0cnVlLCJsZXZlbENhcHBpbmciOi0xLCJsaW1pdE1ldHJpY3MiOi0xfQ==

The escape can be tracked back to #6268.

### Are there any points in the code the reviewer needs to double check?
This PR removes the offending changes without removing the test asset added. I don't see how the change makes the test asset play any better - all the segment durations and timestamps show overlap. The change only prevents SEI parsing error logs that have no impact on playback. It doesn't seem like the change was correct - it may have only been adding padding that suppressed those error logs.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
