### PR TITLE
Paused and backward seeking enhancement

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -367,8 +367,6 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected getFwdBufferInfo(bufferable: Bufferable | null, type: PlaylistLevelType): BufferInfo | null;
     // (undocumented)
-    protected getFwdBufferInfoAtPos(bufferable: Bufferable | null, pos: number, type: PlaylistLevelType): BufferInfo | null;
-    // (undocumented)
     protected getInitialLiveFragment(levelDetails: LevelDetails, fragments: MediaFragment[]): MediaFragment | null;
     // (undocumented)
     protected getLevelDetails(): LevelDetails | undefined;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -314,7 +314,12 @@ export default class BaseStreamController
         true,
       );
 
-      this.lastCurrentTime = currentTime;
+      // Don't set lastCurrentTime with backward seeks (allows for frag selection with strict tolerances)
+      const lastCurrentTime = this.lastCurrentTime;
+      if (currentTime > lastCurrentTime) {
+        this.lastCurrentTime = currentTime;
+      }
+
       if (!this.loadingParts) {
         const bufferEnd = Math.max(bufferInfo.end, currentTime);
         const shouldLoadParts = this.shouldLoadParts(
@@ -1109,17 +1114,18 @@ export default class BaseStreamController
     if (!Number.isFinite(pos)) {
       return null;
     }
-    return this.getFwdBufferInfoAtPos(bufferable, pos, type);
+    const backwardSeek = this.lastCurrentTime > pos;
+    const maxBufferHole =
+      backwardSeek || this.media?.paused ? 0 : this.config.maxBufferHole;
+    return this.getFwdBufferInfoAtPos(bufferable, pos, type, maxBufferHole);
   }
 
-  protected getFwdBufferInfoAtPos(
+  private getFwdBufferInfoAtPos(
     bufferable: Bufferable | null,
     pos: number,
     type: PlaylistLevelType,
+    maxBufferHole: number,
   ): BufferInfo | null {
-    const {
-      config: { maxBufferHole },
-    } = this;
     const bufferInfo = BufferHelper.bufferInfo(bufferable, pos, maxBufferHole);
     // Workaround flaw in getting forward buffer when maxBufferHole is smaller than gap at current pos
     if (bufferInfo.len === 0 && bufferInfo.nextStart !== undefined) {
@@ -1264,6 +1270,7 @@ export default class BaseStreamController
           this.mediaBuffer ? this.mediaBuffer : this.media,
           bufferInfo.nextStart,
           playlistType,
+          0,
         );
         if (
           nextbufferInfo !== null &&
@@ -1425,8 +1432,13 @@ export default class BaseStreamController
 
     let frag: MediaFragment | null;
     if (bufferEnd < end) {
+      const backwardSeek = bufferEnd < this.lastCurrentTime;
       const lookupTolerance =
-        bufferEnd > end - maxFragLookUpTolerance ? 0 : maxFragLookUpTolerance;
+        backwardSeek ||
+        bufferEnd > end - maxFragLookUpTolerance ||
+        this.media?.paused
+          ? 0
+          : maxFragLookUpTolerance;
       // Remove the tolerance if it would put the bufferEnd past the actual end of stream
       // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
       frag = findFragmentByPTS(


### PR DESCRIPTION
### This PR will...
Use strict tolerance when picking fragments when paused and seeking backward.

### Why is this Pull Request needed?
Support seeking back step-by-step without requiring additional configuration that sacrifices performance when seeking forward while playing.

### Are there any points in the code the reviewer needs to double check?
This cannot address rendering of buffered media near an unbuffered playhead or rendering subsequently buffered media while paused. I consider these MSE flaws that HLS.js cannot or should not workaround (at least not with this change). For more detail see https://github.com/video-dev/hls.js/issues/6511#issuecomment-2191450440.

Does anyone question whether this enhancement should only apply when media is paused (and not when seeking backwards)? When not paused the _max frag lookup and buffer hole_ tolerances allow skipping loading of a whole segment that would only contribute to playback for a small fraction of time. In those cases this could cause more stalls when seeking back near a segment boundary. External pausing and unpausing while seeking could also impact performance in similar ways, so voice you concern if you'd like additional settings to fine-tune this behavior.

### Resolves issues:
Resolves #6511 #6331 #4905
Closes #4884

- #6511
- #6331
- #4905
- #4884 (can't reproduce)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
