### PR TITLE
Fix parsing of multiple video codecs when converting from AVC1 to AVCOTI

### DIFF
--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -206,16 +206,20 @@ export function pickMostCompleteCodecName(
 
 export function convertAVC1ToAVCOTI(codec: string) {
   // Convert avc1 codec string from RFC-4281 to RFC-6381 for MediaSource.isTypeSupported
-  const avcdata = codec.split('.');
-  if (avcdata.length > 2) {
-    let result = avcdata.shift() + '.';
-    result += parseInt(avcdata.shift() as string).toString(16);
-    result += ('000' + parseInt(avcdata.shift() as string).toString(16)).slice(
-      -4,
-    );
-    return result;
+  // Examples: avc1.66.30 to avc1.42001e and avc1.77.30,avc1.66.30 to avc1.4d001e,avc1.42001e.
+  const codecs = codec.split(',');
+  for (let i = 0; i < codecs.length; i++) {
+    const avcdata = codecs[i].split('.');
+    if (avcdata.length > 2) {
+      let result = avcdata.shift() + '.';
+      result += parseInt(avcdata.shift() as string).toString(16);
+      result += (
+        '000' + parseInt(avcdata.shift() as string).toString(16)
+      ).slice(-4);
+      codecs[i] = result;
+    }
   }
-  return codec;
+  return codecs.join(',');
 }
 
 export interface TypeSupported {

--- a/tests/index.js
+++ b/tests/index.js
@@ -37,6 +37,7 @@ import './unit/loader/playlist-loader';
 import './unit/utils/attr-list';
 import './unit/utils/binary-search';
 import './unit/utils/buffer-helper';
+import './unit/utils/codecs';
 import './unit/utils/error-helper';
 import './unit/utils/discontinuities';
 import './unit/utils/exp-golomb';

--- a/tests/unit/utils/codecs.ts
+++ b/tests/unit/utils/codecs.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { convertAVC1ToAVCOTI } from '../../../src/utils/codecs';
+
+describe('codecs', function () {
+  it('convert codec string from AVC1 to AVCOTI', function () {
+    expect(convertAVC1ToAVCOTI('avc1.66.30')).to.equal('avc1.42001e');
+  });
+
+  it('convert list of codecs string from AVC1 to AVCOTI', function () {
+    expect(convertAVC1ToAVCOTI('avc1.77.30,avc1.66.30')).to.equal(
+      'avc1.4d001e,avc1.42001e',
+    );
+  });
+
+  it('does not convert string if it is already converted', function () {
+    expect(convertAVC1ToAVCOTI('avc1.64001E')).to.equal('avc1.64001E');
+  });
+
+  it('does not convert list of codecs string if it is already converted', function () {
+    expect(convertAVC1ToAVCOTI('avc1.64001E,avc1.64001f')).to.equal(
+      'avc1.64001E,avc1.64001f',
+    );
+  });
+});


### PR DESCRIPTION
### This PR will...

Fix the parse of multiple value codecs (CODECS="avc1.64001E,avc1.64001f,mp4a.40.2") on `convertAVC1ToAVCOTI` function.

Before this MR, the codec value was converted from "avc1.64001E,avc1.64001f" to "avc1.fa01fa01" leading to the "no level with compatible codecs found in manifest" error.

Now, it is keeping the "avc1.64001E,avc1.64001f" value.

### Why is this Pull Request needed?

It fixes media with multiple video codecs broken on `1.5.x` hls.js versions.
Ex.: 
`#EXT-X-STREAM-INF:BANDWIDTH=1199000,RESOLUTION=854x480,CODECS="avc1.64001E,avc1.64001f,mp4a.40.2",AUDIO="audio",SUBTITLES="subs"`

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

Related to https://github.com/video-dev/hls.js/issues/5378

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
