### PR TITLE
Fix audio segment loading when main segments loaded out of sequence

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -409,6 +409,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected loadFragment(frag: Fragment, level: Level, targetBufferTime: number): void;
     // (undocumented)
+    protected loadingParts: boolean;
+    // (undocumented)
     protected _loadInitSegment(frag: Fragment, level: Level): void;
     // (undocumented)
     mapToInitFragWhenRequired(frag: Fragment | null): typeof frag;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -101,7 +101,7 @@ export default class BaseStreamController
   protected decrypter: Decrypter;
   protected initPTS: RationalTimestamp[] = [];
   protected buffering: boolean = true;
-  private loadingParts: boolean = false;
+  protected loadingParts: boolean = false;
   private loopSn?: string | number;
 
   constructor(


### PR DESCRIPTION
### This PR will...
Fixes a shortcoming in #6491 that assumes the last fragment of the main playlist to be loaded is nearest to the end of the buffer.

### Why is this Pull Request needed?
Prevents audio from not loading up to a previously appended video buffer range after appended audio was ejected.

This was a regression in dev discovered while testing #6529.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
