### PR TITLE
Fix `reduceMaxBufferLength` with under-reported bitrate

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1029,12 +1029,13 @@ export default class BaseStreamController
   protected reduceMaxBufferLength(threshold: number, fragDuration: number) {
     const config = this.config;
     const minLength = Math.max(
-      Math.min(threshold, config.maxBufferLength),
+      Math.min(threshold - fragDuration, config.maxBufferLength),
       fragDuration,
     );
     const reducedLength = Math.max(
       threshold - fragDuration * 3,
       config.maxMaxBufferLength / 2,
+      minLength,
     );
     if (reducedLength >= minLength) {
       // reduce max buffer length as it might be too high. we do this to avoid loop flushing ...


### PR DESCRIPTION
### This PR will...
Make sure `reduceMaxBufferLength` can reach a min length of fragment duration resulting in buffer full error.

### Why is this Pull Request needed?
With under-reported bitrate the player may try to reload media that cannot be appended after reducing max buffer length close to but not all the way to the needed minimum.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6535


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
