### PR TITLE
Reduce workers across instances

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -365,6 +365,10 @@ export default class BaseStreamController
 
   protected onHandlerDestroying() {
     this.stopLoad();
+    if (this.transmuxer) {
+      this.transmuxer.destroy();
+      this.transmuxer = null;
+    }
     super.onHandlerDestroying();
     // @ts-ignore
     this.hls = this.onMediaSeeking = this.onMediaEnded = null;
@@ -1931,10 +1935,7 @@ export default class BaseStreamController
   }
 
   protected resetTransmuxer() {
-    if (this.transmuxer) {
-      this.transmuxer.destroy();
-      this.transmuxer = null;
-    }
+    this.transmuxer?.reset();
   }
 
   protected recoverWorkerError(data: ErrorData) {

--- a/src/demux/audio/aacdemuxer.ts
+++ b/src/demux/audio/aacdemuxer.ts
@@ -4,16 +4,16 @@
 import BaseAudioDemuxer from './base-audio-demuxer';
 import * as ADTS from './adts';
 import * as MpegAudio from './mpegaudio';
-import { logger } from '../../utils/logger';
 import { getId3Data } from '@svta/common-media-library/id3/getId3Data';
 import type { HlsEventEmitter } from '../../events';
 import type { HlsConfig } from '../../config';
+import type { ILogger } from '../../utils/logger';
 
 class AACDemuxer extends BaseAudioDemuxer {
   private readonly observer: HlsEventEmitter;
   private readonly config: HlsConfig;
 
-  constructor(observer, config) {
+  constructor(observer: HlsEventEmitter, config) {
     super();
     this.observer = observer;
     this.config = config;
@@ -42,7 +42,7 @@ class AACDemuxer extends BaseAudioDemuxer {
   }
 
   // Source for probe info - https://wiki.multimedia.cx/index.php?title=ADTS
-  static probe(data: Uint8Array | undefined): boolean {
+  static probe(data: Uint8Array | undefined, logger: ILogger): boolean {
     if (!data) {
       return false;
     }

--- a/src/demux/audio/ac3-demuxer.ts
+++ b/src/demux/audio/ac3-demuxer.ts
@@ -8,7 +8,7 @@ import type { AudioFrame, DemuxedAudioTrack } from '../../types/demuxer';
 export class AC3Demuxer extends BaseAudioDemuxer {
   private readonly observer: HlsEventEmitter;
 
-  constructor(observer) {
+  constructor(observer: HlsEventEmitter) {
     super();
     this.observer = observer;
   }

--- a/src/demux/inject-worker.ts
+++ b/src/demux/inject-worker.ts
@@ -1,6 +1,9 @@
 // ensure the worker ends up in the bundle
 // If the worker should not be included this gets aliased to empty.js
 import './transmuxer-worker';
+import { version } from '../version';
+
+const workerStore: Record<string, WorkerContext> = {};
 
 export function hasUMDWorker(): boolean {
   return typeof __HLS_WORKER_BUNDLE__ === 'function';
@@ -10,9 +13,15 @@ export type WorkerContext = {
   worker: Worker;
   objectURL?: string;
   scriptURL?: string;
+  clientCount: number;
 };
 
 export function injectWorker(): WorkerContext {
+  const workerContext = workerStore[version];
+  if (workerContext) {
+    workerContext.clientCount++;
+    return workerContext;
+  }
   const blob = new self.Blob(
     [
       `var exports={};var module={exports:exports};function define(f){f()};define.amd=true;(${__HLS_WORKER_BUNDLE__.toString()})(true);`,
@@ -23,19 +32,44 @@ export function injectWorker(): WorkerContext {
   );
   const objectURL = self.URL.createObjectURL(blob);
   const worker = new self.Worker(objectURL);
-
-  return {
+  const result = {
     worker,
     objectURL,
+    clientCount: 1,
   };
+  workerStore[version] = result;
+  return result;
 }
 
 export function loadWorker(path: string): WorkerContext {
+  const workerContext = workerStore[path];
+  if (workerContext) {
+    workerContext.clientCount++;
+    return workerContext;
+  }
   const scriptURL = new self.URL(path, self.location.href).href;
   const worker = new self.Worker(scriptURL);
-
-  return {
+  const result = {
     worker,
     scriptURL,
+    clientCount: 1,
   };
+  workerStore[path] = result;
+  return result;
+}
+
+export function removeWorkerFromStore(path?: string | null) {
+  const workerContext = workerStore[path || version];
+  if (workerContext) {
+    const clientCount = workerContext.clientCount--;
+    if (clientCount === 1) {
+      const { worker, objectURL } = workerContext;
+      delete workerStore[path || version];
+      if (objectURL) {
+        // revoke the Object URL that was used to create transmuxer worker, so as not to leak it
+        self.URL.revokeObjectURL(objectURL);
+      }
+      worker.terminate();
+    }
+  }
 }

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -3,6 +3,7 @@ import {
   hasUMDWorker,
   injectWorker,
   loadWorker,
+  removeWorkerFromStore as removeWorkerClient,
 } from './inject-worker';
 import { Events } from '../events';
 import Transmuxer, {
@@ -10,29 +11,30 @@ import Transmuxer, {
   TransmuxState,
   isPromise,
 } from '../demux/transmuxer';
-import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { EventEmitter } from 'eventemitter3';
 import { MediaFragment, Part } from '../loader/fragment';
 import { getM2TSSupportedAudioTypes } from '../utils/codecs';
+
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import type Hls from '../hls';
 import type { HlsEventEmitter, HlsListeners } from '../events';
+import type { ErrorData, FragDecryptedData } from '../types/events';
 import type { PlaylistLevelType } from '../types/loader';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
+
+let transmuxerInstanceCount: number = 0;
 
 export default class TransmuxerInterface {
   public error: Error | null = null;
   private hls: Hls;
   private id: PlaylistLevelType;
+  private instanceNo: number = transmuxerInstanceCount++;
   private observer: HlsEventEmitter;
   private frag: MediaFragment | null = null;
   private part: Part | null = null;
   private useWorker: boolean;
   private workerContext: WorkerContext | null = null;
-  private onwmsg?: (
-    event: MessageEvent<{ event: string; data?: any } | null>,
-  ) => void;
   private transmuxer: Transmuxer | null = null;
   private onTransmuxComplete: (transmuxResult: TransmuxerResult) => void;
   private onFlush: (chunkMeta: ChunkMetadata) => void;
@@ -50,11 +52,16 @@ export default class TransmuxerInterface {
     this.onTransmuxComplete = onTransmuxComplete;
     this.onFlush = onFlush;
 
-    const forwardMessage = (ev, data) => {
+    const forwardMessage = (
+      ev: Events.ERROR | Events.FRAG_DECRYPTED,
+      data: ErrorData | FragDecryptedData,
+    ) => {
       data = data || {};
-      data.frag = this.frag;
-      data.id = this.id;
+      data.frag = this.frag || undefined;
       if (ev === Events.ERROR) {
+        data = data as ErrorData;
+        data.parent = this.id;
+        data.part = this.part;
         this.error = data.error;
       }
       this.hls.trigger(ev, data);
@@ -70,6 +77,7 @@ export default class TransmuxerInterface {
     );
 
     if (this.useWorker && typeof Worker !== 'undefined') {
+      const logger = this.hls.logger;
       const canCreateWorker = config.workerPath || hasUMDWorker();
       if (canCreateWorker) {
         try {
@@ -80,28 +88,14 @@ export default class TransmuxerInterface {
             logger.log(`injecting Web Worker for "${id}"`);
             this.workerContext = injectWorker();
           }
-          this.onwmsg = (event) => this.onWorkerMessage(event);
           const { worker } = this.workerContext;
-          worker.addEventListener('message', this.onwmsg);
-          worker.onerror = (event) => {
-            const error = new Error(
-              `${event.message}  (${event.filename}:${event.lineno})`,
-            );
-            config.enableWorker = false;
-            logger.warn(`Error in "${id}" Web Worker, fallback to inline`);
-            this.hls.trigger(Events.ERROR, {
-              type: ErrorTypes.OTHER_ERROR,
-              details: ErrorDetails.INTERNAL_EXCEPTION,
-              fatal: false,
-              event: 'demuxerWorker',
-              error,
-            });
-          };
+          worker.addEventListener('message', this.onWorkerMessage);
+          worker.addEventListener('error', this.onWorkerError);
           worker.postMessage({
+            instanceNo: this.instanceNo,
             cmd: 'init',
             typeSupported: m2tsTypeSupported,
-            vendor: '',
-            id: id,
+            id,
             config: JSON.stringify(config),
           });
         } catch (err) {
@@ -109,7 +103,7 @@ export default class TransmuxerInterface {
             `Error setting up "${id}" Web Worker, fallback to inline`,
             err,
           );
-          this.resetWorker();
+          this.terminateWorker();
           this.error = null;
           this.transmuxer = new Transmuxer(
             this.observer,
@@ -132,24 +126,42 @@ export default class TransmuxerInterface {
     );
   }
 
-  resetWorker() {
+  reset() {
+    this.frag = null;
+    this.part = null;
     if (this.workerContext) {
-      const { worker, objectURL } = this.workerContext;
-      if (objectURL) {
-        // revoke the Object URL that was used to create transmuxer worker, so as not to leak it
-        self.URL.revokeObjectURL(objectURL);
-      }
-      worker.removeEventListener('message', this.onwmsg as any);
-      worker.onerror = null;
-      worker.terminate();
+      const instanceNo = this.instanceNo;
+      this.instanceNo = transmuxerInstanceCount++;
+      const config = this.hls.config;
+      const m2tsTypeSupported = getM2TSSupportedAudioTypes(
+        config.preferManagedMediaSource,
+      );
+      this.workerContext.worker.postMessage({
+        instanceNo: this.instanceNo,
+        cmd: 'reset',
+        resetNo: instanceNo,
+        typeSupported: m2tsTypeSupported,
+        id: this.id,
+        config: JSON.stringify(config),
+      });
+    }
+  }
+
+  private terminateWorker() {
+    if (this.workerContext) {
+      const { worker } = this.workerContext;
       this.workerContext = null;
+      worker.removeEventListener('message', this.onWorkerMessage);
+      worker.removeEventListener('error', this.onWorkerError);
+      removeWorkerClient(this.hls.config.workerPath);
     }
   }
 
   destroy() {
     if (this.workerContext) {
-      this.resetWorker();
-      this.onwmsg = undefined;
+      this.terminateWorker();
+      // @ts-ignore
+      this.onWorkerMessage = this.onWorkerError = null;
     } else {
       const transmuxer = this.transmuxer;
       if (transmuxer) {
@@ -162,6 +174,7 @@ export default class TransmuxerInterface {
       observer.removeAllListeners();
     }
     this.frag = null;
+    this.part = null;
     // @ts-ignore
     this.observer = null;
     // @ts-ignore
@@ -181,7 +194,7 @@ export default class TransmuxerInterface {
     defaultInitPTS?: RationalTimestamp,
   ) {
     chunkMeta.transmuxing.start = self.performance.now();
-    const { transmuxer } = this;
+    const { instanceNo, transmuxer } = this;
     const timeOffset = part ? part.start : frag.start;
     // TODO: push "clear-lead" decrypt data for unencrypted fragments in streams with encrypted ones
     const decryptdata = frag.decryptdata;
@@ -219,7 +232,8 @@ export default class TransmuxerInterface {
       initSegmentChange,
     );
     if (!contiguous || discontinuity || initSegmentChange) {
-      logger.log(`[transmuxer-interface, ${frag.type}]: Starting new transmux session for sn: ${chunkMeta.sn} p: ${chunkMeta.part} level: ${chunkMeta.level} id: ${chunkMeta.id}
+      this.hls.logger
+        .log(`[transmuxer-interface, ${frag.type}]: Starting new transmux session for sn: ${chunkMeta.sn} p: ${chunkMeta.part} level: ${chunkMeta.level} id: ${chunkMeta.id}
         discontinuity: ${discontinuity}
         trackSwitch: ${trackSwitch}
         contiguous: ${contiguous}
@@ -244,6 +258,7 @@ export default class TransmuxerInterface {
       // post fragment payload as transferable objects for ArrayBuffer (no copy)
       this.workerContext.worker.postMessage(
         {
+          instanceNo,
           cmd: 'demux',
           data,
           decryptdata,
@@ -281,10 +296,11 @@ export default class TransmuxerInterface {
 
   flush(chunkMeta: ChunkMetadata) {
     chunkMeta.transmuxing.start = self.performance.now();
-    const { transmuxer } = this;
+    const { instanceNo, transmuxer } = this;
     if (this.workerContext) {
       1;
       this.workerContext.worker.postMessage({
+        instanceNo,
         cmd: 'flush',
         chunkMeta,
       });
@@ -329,6 +345,7 @@ export default class TransmuxerInterface {
       details: ErrorDetails.FRAG_PARSING_ERROR,
       chunkMeta,
       frag: this.frag || undefined,
+      part: this.part || undefined,
       fatal: false,
       error,
       err: error,
@@ -346,18 +363,16 @@ export default class TransmuxerInterface {
     this.onFlush(chunkMeta);
   }
 
-  private onWorkerMessage(
-    event: MessageEvent<{ event: string; data?: any } | null>,
-  ) {
+  private onWorkerMessage = (
+    event: MessageEvent<{
+      event: string;
+      data?: any;
+      instanceNo?: number;
+    } | null>,
+  ) => {
     const data = event.data;
-    if (!data?.event) {
-      logger.warn(
-        `worker message received with no ${data ? 'event name' : 'data'}`,
-      );
-      return;
-    }
     const hls = this.hls;
-    if (!this.hls) {
+    if (!hls || !data?.event || data.instanceNo !== this.instanceNo) {
       return;
     }
     switch (data.event) {
@@ -381,26 +396,49 @@ export default class TransmuxerInterface {
       }
 
       // pass logs from the worker thread to the main logger
-      case 'workerLog':
-        if (logger[data.data.logType]) {
-          logger[data.data.logType](data.data.message);
+      case 'workerLog': {
+        if (hls.logger[data.data.logType]) {
+          hls.logger[data.data.logType](data.data.message);
         }
         break;
+      }
 
       default: {
         data.data = data.data || {};
         data.data.frag = this.frag;
+        data.data.part = this.part;
         data.data.id = this.id;
         hls.trigger(data.event as keyof HlsListeners, data.data);
         break;
       }
     }
-  }
+  };
+
+  private onWorkerError = (event) => {
+    if (!this.hls) {
+      return;
+    }
+    const error = new Error(
+      `${event.message}  (${event.filename}:${event.lineno})`,
+    );
+    this.hls.config.enableWorker = false;
+    this.hls.logger.warn(
+      `Error in "${this.id}" Web Worker, fallback to inline`,
+    );
+    this.hls.trigger(Events.ERROR, {
+      type: ErrorTypes.OTHER_ERROR,
+      details: ErrorDetails.INTERNAL_EXCEPTION,
+      fatal: false,
+      event: 'demuxerWorker',
+      error,
+    });
+  };
 
   private configureTransmuxer(config: TransmuxConfig) {
-    const { transmuxer } = this;
+    const { instanceNo, transmuxer } = this;
     if (this.workerContext) {
       this.workerContext.worker.postMessage({
+        instanceNo,
         cmd: 'configure',
         config,
       });

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -111,6 +111,7 @@ export default class TransmuxerInterface {
             config,
             '',
             id,
+            hls.logger,
           );
         }
         return;
@@ -123,6 +124,7 @@ export default class TransmuxerInterface {
       config,
       '',
       id,
+      hls.logger,
     );
   }
 

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -275,7 +275,6 @@ export default class TransmuxerInterface {
         state,
       );
       if (isPromise(transmuxResult)) {
-        transmuxer.async = true;
         transmuxResult
           .then((data) => {
             this.handleTransmuxComplete(data);
@@ -288,7 +287,6 @@ export default class TransmuxerInterface {
             );
           });
       } else {
-        transmuxer.async = false;
         this.handleTransmuxComplete(transmuxResult as TransmuxerResult);
       }
     }
@@ -305,12 +303,8 @@ export default class TransmuxerInterface {
         chunkMeta,
       });
     } else if (transmuxer) {
-      let transmuxResult = transmuxer.flush(chunkMeta);
-      const asyncFlush = isPromise(transmuxResult);
-      if (asyncFlush || transmuxer.async) {
-        if (!isPromise(transmuxResult)) {
-          transmuxResult = Promise.resolve(transmuxResult);
-        }
+      const transmuxResult = transmuxer.flush(chunkMeta);
+      if (isPromise(transmuxResult)) {
         transmuxResult
           .then((data) => {
             this.handleFlushResult(data, chunkMeta);
@@ -323,10 +317,7 @@ export default class TransmuxerInterface {
             );
           });
       } else {
-        this.handleFlushResult(
-          transmuxResult as Array<TransmuxerResult>,
-          chunkMeta,
-        );
+        this.handleFlushResult(transmuxResult, chunkMeta);
       }
     }
   }

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -40,6 +40,7 @@ function startWorker() {
         config,
         '',
         data.id,
+        logger,
       );
       forwardMessage('init', null, instanceNo);
       return;

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -61,7 +61,6 @@ function startWorker() {
             data.state,
           );
         if (isPromise(transmuxResult)) {
-          transmuxer.async = true;
           transmuxResult
             .then((data) => {
               emitTransmuxComplete(self, data, instanceNo);
@@ -83,19 +82,14 @@ function startWorker() {
               );
             });
         } else {
-          transmuxer.async = false;
           emitTransmuxComplete(self, transmuxResult, instanceNo);
         }
         break;
       }
       case 'flush': {
         const chunkMeta = data.chunkMeta as ChunkMetadata;
-        let transmuxResult = transmuxer.flush(chunkMeta);
-        const asyncFlush = isPromise(transmuxResult);
-        if (asyncFlush || transmuxer.async) {
-          if (!isPromise(transmuxResult)) {
-            transmuxResult = Promise.resolve(transmuxResult);
-          }
+        const transmuxResult = transmuxer.flush(chunkMeta);
+        if (isPromise(transmuxResult)) {
           transmuxResult
             .then((results: Array<TransmuxerResult>) => {
               handleFlushResult(

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -6,114 +6,126 @@ import { ErrorDetails, ErrorTypes } from '../errors';
 import type { RemuxedTrack, RemuxerResult } from '../types/remuxer';
 import type { TransmuxerResult, ChunkMetadata } from '../types/transmuxer';
 
+const transmuxers: (Transmuxer | undefined)[] = [];
+
 if (typeof __IN_WORKER__ !== 'undefined' && __IN_WORKER__) {
-  startWorker(self);
+  startWorker();
 }
 
-function startWorker(self) {
-  const observer = new EventEmitter();
-  const forwardMessage = (ev, data) => {
-    self.postMessage({ event: ev, data: data });
-  };
-
-  // forward events to main thread
-  observer.on(Events.FRAG_DECRYPTED, forwardMessage);
-  observer.on(Events.ERROR, forwardMessage);
-
-  // forward logger events to main thread
-  const forwardWorkerLogs = (logger: ILogger) => {
-    for (const logFn in logger) {
-      const func: ILogFunction = (message?) => {
-        forwardMessage('workerLog', {
-          logType: logFn,
-          message,
-        });
-      };
-
-      logger[logFn] = func;
-    }
-  };
-
+function startWorker() {
   self.addEventListener('message', (ev) => {
     const data = ev.data;
-    switch (data.cmd) {
-      case 'init': {
-        const config = JSON.parse(data.config);
-        self.transmuxer = new Transmuxer(
-          observer,
-          data.typeSupported,
-          config,
-          '',
-          data.id,
-        );
-        const logger = enableLogs(config.debug, data.id);
-        forwardWorkerLogs(logger);
-        forwardMessage('init', null);
-        break;
+    const instanceNo = data.instanceNo;
+    if (instanceNo === undefined) {
+      return;
+    }
+    const transmuxer = transmuxers[instanceNo];
+    if (data.cmd === 'reset') {
+      delete transmuxers[data.resetNo];
+      if (transmuxer) {
+        transmuxer.destroy();
       }
+      data.cmd = 'init';
+    }
+    if (data.cmd === 'init') {
+      const config = JSON.parse(data.config);
+      const observer = new EventEmitter();
+      observer.on(Events.FRAG_DECRYPTED, forwardMessage);
+      observer.on(Events.ERROR, forwardMessage);
+      const logger = enableLogs(config.debug, data.id);
+      forwardWorkerLogs(logger, instanceNo);
+      transmuxers[instanceNo] = new Transmuxer(
+        observer,
+        data.typeSupported,
+        config,
+        '',
+        data.id,
+      );
+      forwardMessage('init', null, instanceNo);
+      return;
+    }
+    if (!transmuxer) {
+      return;
+    }
+    switch (data.cmd) {
       case 'configure': {
-        self.transmuxer.configure(data.config);
+        transmuxer.configure(data.config);
         break;
       }
       case 'demux': {
         const transmuxResult: TransmuxerResult | Promise<TransmuxerResult> =
-          self.transmuxer.push(
+          transmuxer.push(
             data.data,
             data.decryptdata,
             data.chunkMeta,
             data.state,
           );
         if (isPromise(transmuxResult)) {
-          self.transmuxer.async = true;
+          transmuxer.async = true;
           transmuxResult
             .then((data) => {
-              emitTransmuxComplete(self, data);
+              emitTransmuxComplete(self, data, instanceNo);
             })
             .catch((error) => {
-              forwardMessage(Events.ERROR, {
-                type: ErrorTypes.MEDIA_ERROR,
-                details: ErrorDetails.FRAG_PARSING_ERROR,
-                chunkMeta: data.chunkMeta,
-                fatal: false,
-                error,
-                err: error,
-                reason: `transmuxer-worker push error`,
-              });
+              forwardMessage(
+                Events.ERROR,
+                {
+                  instanceNo,
+                  type: ErrorTypes.MEDIA_ERROR,
+                  details: ErrorDetails.FRAG_PARSING_ERROR,
+                  chunkMeta: data.chunkMeta,
+                  fatal: false,
+                  error,
+                  err: error,
+                  reason: `transmuxer-worker push error`,
+                },
+                instanceNo,
+              );
             });
         } else {
-          self.transmuxer.async = false;
-          emitTransmuxComplete(self, transmuxResult);
+          transmuxer.async = false;
+          emitTransmuxComplete(self, transmuxResult, instanceNo);
         }
         break;
       }
       case 'flush': {
-        const id = data.chunkMeta;
-        let transmuxResult = self.transmuxer.flush(id);
+        const chunkMeta = data.chunkMeta as ChunkMetadata;
+        let transmuxResult = transmuxer.flush(chunkMeta);
         const asyncFlush = isPromise(transmuxResult);
-        if (asyncFlush || self.transmuxer.async) {
+        if (asyncFlush || transmuxer.async) {
           if (!isPromise(transmuxResult)) {
             transmuxResult = Promise.resolve(transmuxResult);
           }
           transmuxResult
             .then((results: Array<TransmuxerResult>) => {
-              handleFlushResult(self, results as Array<TransmuxerResult>, id);
+              handleFlushResult(
+                self,
+                results as Array<TransmuxerResult>,
+                chunkMeta,
+                instanceNo,
+              );
             })
             .catch((error) => {
-              forwardMessage(Events.ERROR, {
-                type: ErrorTypes.MEDIA_ERROR,
-                details: ErrorDetails.FRAG_PARSING_ERROR,
-                chunkMeta: data.chunkMeta,
-                fatal: false,
-                error,
-                err: error,
-                reason: `transmuxer-worker flush error`,
-              });
+              forwardMessage(
+                Events.ERROR,
+                {
+                  type: ErrorTypes.MEDIA_ERROR,
+                  details: ErrorDetails.FRAG_PARSING_ERROR,
+                  chunkMeta: data.chunkMeta,
+                  fatal: false,
+                  error,
+                  err: error,
+                  reason: `transmuxer-worker flush error`,
+                },
+                instanceNo,
+              );
             });
         } else {
           handleFlushResult(
             self,
             transmuxResult as Array<TransmuxerResult>,
-            id,
+            chunkMeta,
+            instanceNo,
           );
         }
         break;
@@ -127,6 +139,7 @@ function startWorker(self) {
 function emitTransmuxComplete(
   self: any,
   transmuxResult: TransmuxerResult,
+  instanceNo: number,
 ): boolean {
   if (isEmptyResult(transmuxResult.remuxResult)) {
     return false;
@@ -140,7 +153,7 @@ function emitTransmuxComplete(
     addToTransferable(transferable, video);
   }
   self.postMessage(
-    { event: 'transmuxComplete', data: transmuxResult },
+    { event: 'transmuxComplete', data: transmuxResult, instanceNo },
     transferable,
   );
   return true;
@@ -164,16 +177,42 @@ function handleFlushResult(
   self: any,
   results: Array<TransmuxerResult>,
   chunkMeta: ChunkMetadata,
+  instanceNo: number,
 ) {
   const parsed = results.reduce(
-    (parsed, result) => emitTransmuxComplete(self, result) || parsed,
+    (parsed, result) =>
+      emitTransmuxComplete(self, result, instanceNo) || parsed,
     false,
   );
   if (!parsed) {
     // Emit at least one "transmuxComplete" message even if media is not found to update stream-controller state to PARSING
-    self.postMessage({ event: 'transmuxComplete', data: results[0] });
+    self.postMessage({
+      event: 'transmuxComplete',
+      data: results[0],
+      instanceNo,
+    });
   }
-  self.postMessage({ event: 'flush', data: chunkMeta });
+  self.postMessage({ event: 'flush', data: chunkMeta, instanceNo });
+}
+
+function forwardMessage(event, data, instanceNo) {
+  self.postMessage({ event, data, instanceNo });
+}
+
+function forwardWorkerLogs(logger: ILogger, instanceNo: number) {
+  for (const logFn in logger) {
+    const func: ILogFunction = (message?) => {
+      forwardMessage(
+        'workerLog',
+        {
+          logType: logFn,
+          message,
+        },
+        instanceNo,
+      );
+    };
+    logger[logFn] = func;
+  }
 }
 
 function isEmptyResult(remuxResult: RemuxerResult) {

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -18,11 +18,11 @@ import HevcVideoParser from './video/hevc-video-parser';
 import SampleAesDecrypter from './sample-aes';
 import { Events } from '../events';
 import { appendUint8Array, RemuxerTrackIdConfig } from '../utils/mp4-tools';
-import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import type { HlsConfig } from '../config';
 import type { HlsEventEmitter } from '../events';
 import type { TypeSupported } from '../utils/codecs';
+import type { ILogger } from '../utils/logger';
 import {
   MetadataSchema,
   type DemuxedVideoTrack,
@@ -54,9 +54,10 @@ export type ParsedVideoSample = ParsedTimestamp &
 const PACKET_LENGTH = 188;
 
 class TSDemuxer implements Demuxer {
+  private readonly logger: ILogger;
   private readonly observer: HlsEventEmitter;
   private readonly config: HlsConfig;
-  private typeSupported: TypeSupported;
+  private readonly typeSupported: TypeSupported;
 
   private sampleAes: SampleAesDecrypter | null = null;
   private pmtParsed: boolean = false;
@@ -77,14 +78,16 @@ class TSDemuxer implements Demuxer {
     observer: HlsEventEmitter,
     config: HlsConfig,
     typeSupported: TypeSupported,
+    logger: ILogger,
   ) {
     this.observer = observer;
     this.config = config;
     this.typeSupported = typeSupported;
+    this.logger = logger;
     this.videoParser = null;
   }
 
-  static probe(data: Uint8Array) {
+  static probe(data: Uint8Array, logger: ILogger) {
     const syncOffset = TSDemuxer.syncOffset(data);
     if (syncOffset > 0) {
       logger.warn(
@@ -288,7 +291,7 @@ class TSDemuxer implements Demuxer {
         switch (pid) {
           case videoPid:
             if (stt) {
-              if (videoData && (pes = parsePES(videoData))) {
+              if (videoData && (pes = parsePES(videoData, this.logger))) {
                 if (this.videoParser === null) {
                   switch (videoTrack.segmentCodec) {
                     case 'avc':
@@ -321,7 +324,7 @@ class TSDemuxer implements Demuxer {
             break;
           case audioPid:
             if (stt) {
-              if (audioData && (pes = parsePES(audioData))) {
+              if (audioData && (pes = parsePES(audioData, this.logger))) {
                 switch (audioTrack.segmentCodec) {
                   case 'aac':
                     this.parseAACPES(audioTrack, pes);
@@ -345,7 +348,7 @@ class TSDemuxer implements Demuxer {
             break;
           case id3Pid:
             if (stt) {
-              if (id3Data && (pes = parsePES(id3Data))) {
+              if (id3Data && (pes = parsePES(id3Data, this.logger))) {
                 this.parseID3PES(id3Track, pes);
               }
 
@@ -362,7 +365,7 @@ class TSDemuxer implements Demuxer {
             }
 
             pmtId = this._pmtId = parsePAT(data, offset);
-            // logger.log('PMT PID:'  + this._pmtId);
+            // this.logger.log('PMT PID:'  + this._pmtId);
             break;
           case pmtId: {
             if (stt) {
@@ -375,6 +378,7 @@ class TSDemuxer implements Demuxer {
               this.typeSupported,
               isSampleAes,
               this.observer,
+              this.logger,
             );
 
             // only update track id if track PID found while parsing PMT
@@ -400,7 +404,7 @@ class TSDemuxer implements Demuxer {
             }
 
             if (unknownPID !== null && !pmtParsed) {
-              logger.warn(
+              this.logger.warn(
                 `MPEG-TS PMT found at ${start} after unknown PID '${unknownPID}'. Backtracking to sync byte @${syncOffset} to parse all TS packets.`,
               );
               unknownPID = null;
@@ -428,6 +432,8 @@ class TSDemuxer implements Demuxer {
         new Error(
           `Found ${tsPacketErrors} TS packet/s that do not start with 0x47`,
         ),
+        undefined,
+        this.logger,
       );
     }
 
@@ -477,7 +483,7 @@ class TSDemuxer implements Demuxer {
     const id3Data = id3Track.pesData;
     // try to parse last PES packets
     let pes: PES | null;
-    if (videoData && (pes = parsePES(videoData))) {
+    if (videoData && (pes = parsePES(videoData, this.logger))) {
       if (this.videoParser === null) {
         switch (videoTrack.segmentCodec) {
           case 'avc':
@@ -505,7 +511,7 @@ class TSDemuxer implements Demuxer {
       videoTrack.pesData = videoData;
     }
 
-    if (audioData && (pes = parsePES(audioData))) {
+    if (audioData && (pes = parsePES(audioData, this.logger))) {
       switch (audioTrack.segmentCodec) {
         case 'aac':
           this.parseAACPES(audioTrack, pes);
@@ -522,7 +528,7 @@ class TSDemuxer implements Demuxer {
       audioTrack.pesData = null;
     } else {
       if (audioData?.size) {
-        logger.log(
+        this.logger.log(
           'last AAC PES packet truncated,might overlap between fragments',
         );
       }
@@ -531,7 +537,7 @@ class TSDemuxer implements Demuxer {
       audioTrack.pesData = audioData;
     }
 
-    if (id3Data && (pes = parsePES(id3Data))) {
+    if (id3Data && (pes = parsePES(id3Data, this.logger))) {
       this.parseID3PES(id3Track, pes);
       id3Track.pesData = null;
     } else {
@@ -625,7 +631,12 @@ class TSDemuxer implements Demuxer {
       } else {
         reason = 'No ADTS header found in AAC PES';
       }
-      emitParsingError(this.observer, new Error(reason), recoverable);
+      emitParsingError(
+        this.observer,
+        new Error(reason),
+        recoverable,
+        this.logger,
+      );
       if (!recoverable) {
         return;
       }
@@ -648,7 +659,7 @@ class TSDemuxer implements Demuxer {
       const frameDuration = ADTS.getFrameDuration(track.samplerate as number);
       pts = aacOverFlow.sample.pts + frameDuration;
     } else {
-      logger.warn('[tsdemuxer]: AAC PES unknown PTS');
+      this.logger.warn('[tsdemuxer]: AAC PES unknown PTS');
       return;
     }
 
@@ -679,7 +690,7 @@ class TSDemuxer implements Demuxer {
     let offset = 0;
     const pts = pes.pts;
     if (pts === undefined) {
-      logger.warn('[tsdemuxer]: MPEG PES unknown PTS');
+      this.logger.warn('[tsdemuxer]: MPEG PES unknown PTS');
       return;
     }
 
@@ -711,7 +722,7 @@ class TSDemuxer implements Demuxer {
       const data = pes.data;
       const pts = pes.pts;
       if (pts === undefined) {
-        logger.warn('[tsdemuxer]: AC3 PES unknown PTS');
+        this.logger.warn('[tsdemuxer]: AC3 PES unknown PTS');
         return;
       }
       const length = data.length;
@@ -730,7 +741,7 @@ class TSDemuxer implements Demuxer {
 
   private parseID3PES(id3Track: DemuxedMetadataTrack, pes: PES) {
     if (pes.pts === undefined) {
-      logger.warn('[tsdemuxer]: ID3 PES unknown PTS');
+      this.logger.warn('[tsdemuxer]: ID3 PES unknown PTS');
       return;
     }
     const id3Sample = Object.assign({}, pes as Required<PES>, {
@@ -757,6 +768,7 @@ function parsePMT(
   typeSupported: TypeSupported,
   isSampleAes: boolean,
   observer: HlsEventEmitter,
+  logger: ILogger,
 ) {
   const result = {
     audioPid: -1,
@@ -779,7 +791,7 @@ function parsePMT(
     switch (data[offset]) {
       case 0xcf: // SAMPLE-AES AAC
         if (!isSampleAes) {
-          logEncryptedSamplesFoundInUnencryptedStream('ADTS AAC');
+          logEncryptedSamplesFoundInUnencryptedStream('ADTS AAC', this.logger);
           break;
         }
       /* falls through */
@@ -802,7 +814,7 @@ function parsePMT(
 
       case 0xdb: // SAMPLE-AES AVC
         if (!isSampleAes) {
-          logEncryptedSamplesFoundInUnencryptedStream('H.264');
+          logEncryptedSamplesFoundInUnencryptedStream('H.264', this.logger);
           break;
         }
       /* falls through */
@@ -830,7 +842,7 @@ function parsePMT(
 
       case 0xc1: // SAMPLE-AES AC3
         if (!isSampleAes) {
-          logEncryptedSamplesFoundInUnencryptedStream('AC-3');
+          logEncryptedSamplesFoundInUnencryptedStream('AC-3', this.logger);
           break;
         }
       /* falls through */
@@ -886,7 +898,12 @@ function parsePMT(
       case 0xc2: // SAMPLE-AES EC3
       /* falls through */
       case 0x87:
-        emitParsingError(observer, new Error('Unsupported EC-3 in M2TS found'));
+        emitParsingError(
+          observer,
+          new Error('Unsupported EC-3 in M2TS found'),
+          undefined,
+          this.logger,
+        );
         return result;
 
       case 0x24: // ITU-T Rec. H.265 and ISO/IEC 23008-2 (HEVC)
@@ -900,6 +917,8 @@ function parsePMT(
           emitParsingError(
             observer,
             new Error('Unsupported HEVC in M2TS found'),
+            undefined,
+            this.logger,
           );
           return result;
         }
@@ -919,7 +938,8 @@ function parsePMT(
 function emitParsingError(
   observer: HlsEventEmitter,
   error: Error,
-  levelRetry?: boolean,
+  levelRetry: boolean | undefined,
+  logger: ILogger,
 ) {
   logger.warn(`parsing error: ${error.message}`);
   observer.emit(Events.ERROR, Events.ERROR, {
@@ -932,11 +952,14 @@ function emitParsingError(
   });
 }
 
-function logEncryptedSamplesFoundInUnencryptedStream(type: string) {
+function logEncryptedSamplesFoundInUnencryptedStream(
+  type: string,
+  logger: ILogger,
+) {
   logger.log(`${type} with AES-128-CBC encryption found in unencrypted stream`);
 }
 
-function parsePES(stream: ElementaryStreamData): PES | null {
+function parsePES(stream: ElementaryStreamData, logger: ILogger): PES | null {
   let i = 0;
   let frag: Uint8Array;
   let pesLen: number;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -13,6 +13,7 @@ import { enableStreamingMode, hlsDefaultConfig, mergeConfig } from './config';
 import { EventEmitter } from 'eventemitter3';
 import { Events } from './events';
 import { ErrorTypes, ErrorDetails } from './errors';
+import { version } from './version';
 import { isHdcpLevel, type HdcpLevel, type Level } from './types/level';
 import type { HlsEventEmitter, HlsListeners } from './events';
 import type AudioTrackController from './controller/audio-track-controller';
@@ -87,7 +88,7 @@ export default class Hls implements HlsEventEmitter {
    * Get the video-dev/hls.js package version.
    */
   static get version(): string {
-    return __VERSION__;
+    return version;
   }
 
   /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const version = __VERSION__;

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -8,7 +8,6 @@ import Hls from '../../../src/hls';
 import sinon from 'sinon';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
-import { logger } from '../../../src/utils/logger';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -149,7 +148,7 @@ describe('TransmuxerInterface tests', function () {
     expect(
       firstCall,
       'Demux call 1: ' + JSON.stringify(firstCall, null, 2),
-    ).to.deep.equal({
+    ).to.deep.include({
       cmd: 'demux',
       data,
       decryptdata: currentFrag.decryptdata,
@@ -182,7 +181,7 @@ describe('TransmuxerInterface tests', function () {
     expect(
       secondCall,
       'Demux call 2: ' + JSON.stringify(secondCall, null, 2),
-    ).to.deep.equal({
+    ).to.deep.include({
       cmd: 'demux',
       data,
       decryptdata: newFrag.decryptdata,
@@ -282,6 +281,7 @@ describe('TransmuxerInterface tests', function () {
       data: {
         event: {},
         data: {},
+        instanceNo: transmuxerInterfacePrivates.instanceNo,
       },
     } as any;
 
@@ -304,6 +304,7 @@ describe('TransmuxerInterface tests', function () {
       data: {
         event: 'init',
         data: {},
+        instanceNo: transmuxerInterfacePrivates.instanceNo,
       },
     };
 
@@ -330,10 +331,11 @@ describe('TransmuxerInterface tests', function () {
           logType: 'log',
           message: 'testing logger',
         },
+        instanceNo: transmuxerInterfacePrivates.instanceNo,
       },
     };
 
-    const spy = sinon.spy(logger, 'log');
+    const spy = sinon.spy(hls.logger, 'log');
     transmuxerInterfacePrivates.onWorkerMessage(evt);
     expect(spy).to.have.been.calledWith(evt.data.data.message);
   });


### PR DESCRIPTION
### This PR will...
- Usa a single Web Worker by path and by player version across instances of transmux-interface and `Hls`
- Use the configured logger in remuxer and demuxer instances and static calls to probe

### Why is this Pull Request needed?
Creating and tearing down workers is costly. Avoiding this should improve performance and avoid leaks where `resetTransmuxer` is run in stream controllers.

### Are there any points in the code the reviewer needs to double check?
Workers are torn down only once all clients using them are destroyed. Worker load is fairly light so managing all transmuxers in a single worker should not have any negative impact on performance.

### Resolves issues:
- Resolves #5402
- Related to #2461

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
