### PR TITLE
Trigger `ATTACH_MEDIA_ERROR` when calling `attachMedia` with falsey `media` argument

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1055,6 +1055,8 @@ export interface ErrorData {
 // @public (undocumented)
 export enum ErrorDetails {
     // (undocumented)
+    ATTACH_MEDIA_ERROR = "attachMediaError",
+    // (undocumented)
     AUDIO_TRACK_LOAD_ERROR = "audioTrackLoadError",
     // (undocumented)
     AUDIO_TRACK_LOAD_TIMEOUT = "audioTrackLoadTimeOut",

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1941,7 +1941,10 @@ export default class BaseStreamController
   protected recoverWorkerError(data: ErrorData) {
     if (data.event === 'demuxerWorker') {
       this.fragmentTracker.removeAllFragments();
-      this.resetTransmuxer();
+      if (this.transmuxer) {
+        this.transmuxer.destroy();
+        this.transmuxer = null;
+      }
       this.resetStartWhenNotLoaded(this.levelLastLoaded);
       this.resetLoadingState();
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -85,6 +85,8 @@ export enum ErrorDetails {
   INTERNAL_EXCEPTION = 'internalException',
   // Identifier for an internal call to abort a loader
   INTERNAL_ABORTED = 'aborted',
+  // Triggered when attachMedia fails
+  ATTACH_MEDIA_ERROR = 'attachMediaError',
   // Uncategorized error
   UNKNOWN = 'unknown',
 }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -395,7 +395,6 @@ export default class Hls implements HlsEventEmitter {
         type: ErrorTypes.OTHER_ERROR,
         details: ErrorDetails.ATTACH_MEDIA_ERROR,
         fatal: true,
-        reason: 'attachMedia failed: media element is null',
         error,
       });
       return;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -389,7 +389,7 @@ export default class Hls implements HlsEventEmitter {
    * Attaches Hls.js to a media element
    */
   attachMedia(media: HTMLMediaElement) {
-    if (media === null) {
+    if (!media) {
       const error = new Error('attachMedia failed: media element is null');
       this.trigger(Events.ERROR, {
         type: ErrorTypes.OTHER_ERROR,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -390,7 +390,7 @@ export default class Hls implements HlsEventEmitter {
    */
   attachMedia(media: HTMLMediaElement) {
     if (!media) {
-      const error = new Error('attachMedia failed: media argument is ${media}');
+      const error = new Error(`attachMedia failed: media argument is ${media}`);
       this.trigger(Events.ERROR, {
         type: ErrorTypes.OTHER_ERROR,
         details: ErrorDetails.ATTACH_MEDIA_ERROR,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -389,6 +389,18 @@ export default class Hls implements HlsEventEmitter {
    * Attaches Hls.js to a media element
    */
   attachMedia(media: HTMLMediaElement) {
+    if (media === null) {
+      const error = new Error('attachMedia failed: media element is null');
+      this.trigger(Events.ERROR, {
+        type: ErrorTypes.OTHER_ERROR,
+        details: ErrorDetails.ATTACH_MEDIA_ERROR,
+        fatal: true,
+        reason: 'attachMedia failed: media element is null',
+        error,
+      });
+      return;
+    }
+
     this.logger.log('attachMedia');
     this._media = media;
     this.trigger(Events.MEDIA_ATTACHING, { media: media });

--- a/tests/unit/hls.ts
+++ b/tests/unit/hls.ts
@@ -4,6 +4,7 @@ import { Events } from '../../src/events';
 
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -51,7 +52,8 @@ describe('Hls', function () {
         );
       });
     }
-    it('should add and remove refrences to the "media" element immediately', function () {
+
+    it('should add and remove references to the "media" element immediately', function () {
       const hls = new Hls({ capLevelOnFPSDrop: true });
       expect(hls.media).to.equal(null);
       const media = document.createElement('video');
@@ -62,7 +64,7 @@ describe('Hls', function () {
       hls.destroy();
     });
 
-    it('should add and remove refrences to the "media" element after attached', function () {
+    it('should add and remove references to the "media" element after attached', function () {
       const hls = new Hls({
         capLevelOnFPSDrop: true,
         emeEnabled: true,
@@ -77,14 +79,27 @@ describe('Hls', function () {
       detachTest(hls, media, 12);
       hls.destroy();
     });
+
+    it('should trigger an error event when attachMedia is called with null', function () {
+      const hls = new Hls();
+      const triggerSpy = sinon.spy(hls, 'trigger');
+
+      hls.on(Events.ERROR, function (_event, _data) {});
+      (hls as any).attachMedia(null);
+      expect(triggerSpy.calledWith(Events.ERROR)).to.be.true;
+
+      triggerSpy.restore();
+      hls.destroy();
+    });
   });
 
   describe('loadSource and url', function () {
-    it('url should initally be null', function () {
+    it('url should initially be null', function () {
       const hls = new Hls();
       expect(hls.url).to.equal(null);
       hls.destroy();
     });
+
     it('should return given url after load', function () {
       const hls = new Hls();
       hls.loadSource(
@@ -95,6 +110,7 @@ describe('Hls', function () {
       );
       hls.destroy();
     });
+
     it('should make relative url absolute', function () {
       const hls = new Hls();
       hls.loadSource('/streams/x36xhzz/x36xhzz.m3u8');

--- a/tests/unit/hls.ts
+++ b/tests/unit/hls.ts
@@ -1,6 +1,7 @@
 import Hls from '../../src/hls';
 import { hlsDefaultConfig } from '../../src/config';
 import { Events } from '../../src/events';
+import { ErrorTypes, ErrorDetails } from '../../src/errors';
 
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
@@ -86,7 +87,25 @@ describe('Hls', function () {
 
       hls.on(Events.ERROR, function (_event, _data) {});
       (hls as any).attachMedia(null);
-      expect(triggerSpy.calledWith(Events.ERROR)).to.be.true;
+
+      const expectedEvent = {
+        type: ErrorTypes.OTHER_ERROR,
+        details: ErrorDetails.ATTACH_MEDIA_ERROR,
+        fatal: true,
+        error: sinon.match
+          .instanceOf(Error)
+          .and(
+            sinon.match.has(
+              'message',
+              'attachMedia failed: media argument is null',
+            ),
+          ),
+      };
+
+      expect(triggerSpy).to.be.calledWith(
+        Events.ERROR,
+        sinon.match(expectedEvent),
+      );
 
       triggerSpy.restore();
       hls.destroy();


### PR DESCRIPTION
### This PR will...
Improves error handling in `hls.attachMedia(media)` when `null` is passed as a parameter. 

### Why is this Pull Request needed?
Logging error to the console will benefit users when when attachMedia is called with a null parameter and this feedback will also help avoid potential confusion.

### Resolves issues:
https://github.com/video-dev/hls.js/issues/6463

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
