### PR TITLE
fix: media buffer is not empty but video element buffer is empty

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -659,13 +659,13 @@ export default class BaseStreamController
       }
     }
     this.state = State.IDLE;
-    if (!media) {
+    if (!media || !this.media) {
       return;
     }
     if (
       !this.loadedmetadata &&
       frag.type == PlaylistLevelType.MAIN &&
-      media.buffered.length &&
+      this.media.buffered.length &&
       this.fragCurrent?.sn === this.fragPrevious?.sn
     ) {
       this.loadedmetadata = true;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -631,13 +631,14 @@ export default class BaseStreamController
   }
 
   protected fragBufferedComplete(frag: Fragment, part: Part | null) {
-    const media = this.mediaBuffer ? this.mediaBuffer : this.media;
+    const mediaBuffer = this.mediaBuffer ? this.mediaBuffer : this.media;
+    const media = this.media;
     this.log(
       `Buffered ${frag.type} sn: ${frag.sn}${
         part ? ' part: ' + part.index : ''
       } of ${this.fragInfo(frag)} > buffer:${
-        media
-          ? TimeRanges.toString(BufferHelper.getBuffered(media))
+        mediaBuffer
+          ? TimeRanges.toString(BufferHelper.getBuffered(mediaBuffer))
           : '(detached)'
       })`,
     );
@@ -659,13 +660,13 @@ export default class BaseStreamController
       }
     }
     this.state = State.IDLE;
-    if (!media || !this.media) {
+    if (!media || !mediaBuffer) {
       return;
     }
     if (
       !this.loadedmetadata &&
       frag.type == PlaylistLevelType.MAIN &&
-      this.media.buffered.length &&
+      media.buffered.length &&
       this.fragCurrent?.sn === this.fragPrevious?.sn
     ) {
       this.loadedmetadata = true;


### PR DESCRIPTION
### This PR will

It will solve one edge case: the `mediaBuffer` is not empty, but the video element `buffered` is empty, so the `seekToStartPosition` can be executed.

### Why is this Pull Request needed?

The video will freeze if we can not seek the correct position in the special case:

``` bash
the audio buffer [12, 17]
the video buffer [8, 11.9]
the video element buffer []
```
<img width="763" alt="image" src="https://github.com/user-attachments/assets/6b44ddc8-88fc-45a2-a45f-40d5ab4a4be8">

Then it will not increase the gap delta position because the `bufferStart` is 0.

![WX20240723-170700@2x](https://github.com/user-attachments/assets/342aa2c2-7bb0-4940-a4e5-751c3387846d)


### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
