### PR TITLE
Fix access of mediaSrc value

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1197,5 +1197,5 @@ function addSource(media: HTMLMediaElement, url: string) {
 }
 
 function getSourceChild(media: HTMLMediaElement): HTMLSourceElement | null {
-  return media.querySelector('source');
+  return media.querySelector?.('source');
 }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1026,9 +1026,8 @@ export default class BufferController implements ComponentAPI {
   };
 
   private get mediaSrc(): string | undefined {
-    if (!this.media) return undefined;
-    const media = getSourceChild(this.media) || this.media;
-    return media.src;
+    const media = this.media?.querySelector?.('source') || this.media;
+    return media?.src;
   }
 
   private _onSBUpdateStart(type: SourceBufferName) {
@@ -1194,8 +1193,4 @@ function addSource(media: HTMLMediaElement, url: string) {
   source.type = 'video/mp4';
   source.src = url;
   media.appendChild(source);
-}
-
-function getSourceChild(media: HTMLMediaElement): HTMLSourceElement | null {
-  return media.querySelector?.('source');
 }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1026,9 +1026,9 @@ export default class BufferController implements ComponentAPI {
   };
 
   private get mediaSrc(): string | undefined {
-    const media =
-      (this.media?.firstChild as HTMLSourceElement | null) || this.media;
-    return media?.src;
+    if (!this.media) return undefined;
+    const media = getSourceChild(this.media) || this.media;
+    return media.src;
   }
 
   private _onSBUpdateStart(type: SourceBufferName) {
@@ -1194,4 +1194,8 @@ function addSource(media: HTMLMediaElement, url: string) {
   source.type = 'video/mp4';
   source.src = url;
   media.appendChild(source);
+}
+
+function getSourceChild(media: HTMLMediaElement): HTMLSourceElement | null {
+  return media.querySelector('source');
 }


### PR DESCRIPTION
### This PR will...

Fix the access to retrieve the `src` value from current media.

The problem happens when there is a video element child which is not a `source` element. Other children could be `track` or any other element.

Now, instead of retrieving the `src` from `firstChild`, it is retrieved from the `source` element if it exists.

### Why is this Pull Request needed?

The cleanup when detaching media is being skipped and an error is wrongly logged due to this problem.

<img width="753" alt="Screenshot 2024-08-03 at 16 29 56" src="https://github.com/user-attachments/assets/51e04c37-3618-4716-90b4-e621fca6bd63">


### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
