### PR TITLE
Improve support of unknown CODECS

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1920,13 +1920,13 @@ class Hls implements HlsEventEmitter {
     constructor(userConfig?: Partial<HlsConfig>);
     // (undocumented)
     get abrEwmaDefaultEstimate(): number;
-    get allAudioTracks(): Array<MediaPlaylist>;
-    get allSubtitleTracks(): Array<MediaPlaylist>;
+    get allAudioTracks(): MediaPlaylist[];
+    get allSubtitleTracks(): MediaPlaylist[];
     attachMedia(data: HTMLMediaElement | MediaAttachingData): void;
     get audioTrack(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "audioTrack" must appear on the getter, not the setter.
     set audioTrack(audioTrackId: number);
-    get audioTracks(): Array<MediaPlaylist>;
+    get audioTracks(): MediaPlaylist[];
     get autoLevelCapping(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "autoLevelCapping" must appear on the getter, not the setter.
     set autoLevelCapping(newLevel: number);
@@ -1964,6 +1964,7 @@ class Hls implements HlsEventEmitter {
     // Warning: (ae-setter-with-docs) The doc comment for the property "firstLevel" must appear on the getter, not the setter.
     set firstLevel(newLevel: number);
     get forceStartLoad(): boolean;
+    getMediaDecodingInfo(level: Level, audioTracks?: MediaPlaylist[]): Promise<MediaDecodingInfo>;
     static getMediaSource(): typeof MediaSource | undefined;
     get hasEnoughToStart(): boolean;
     get interstitialsManager(): InterstitialsManager | null;
@@ -2043,7 +2044,7 @@ class Hls implements HlsEventEmitter {
     get subtitleTrack(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "subtitleTrack" must appear on the getter, not the setter.
     set subtitleTrack(subtitleTrackId: number);
-    get subtitleTracks(): Array<MediaPlaylist>;
+    get subtitleTracks(): MediaPlaylist[];
     swapAudioCodec(): void;
     get targetLatency(): number | null;
     set targetLatency(latency: number);

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -634,7 +634,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
         if (trackName.slice(0, 5) === 'audio') {
           trackCodec = getCodecCompatibleName(trackCodec, this.appendSource);
         }
-        this.log(`switching codec ${sbCodec} to ${codec}`);
+        this.log(`switching codec ${sbCodec} to ${trackCodec}`);
         if (trackCodec !== (track.pendingCodec || track.codec)) {
           track.pendingCodec = trackCodec;
         }
@@ -1431,7 +1431,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
   }
 
   private getTrackCodec(track: BaseTrack, trackName: SourceBufferName): string {
-    const codec = track.codec || track.levelCodec;
+    const codec = pickMostCompleteCodecName(track.codec, track.levelCodec);
     if (codec) {
       if (trackName.slice(0, 5) === 'audio') {
         return getCodecCompatibleName(codec, this.appendSource);

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -54,6 +54,11 @@ import type FragmentLoader from './loader/fragment-loader';
 import type { LevelDetails } from './loader/level-details';
 import type TaskLoop from './task-loop';
 import type TransmuxerInterface from './demux/transmuxer-interface';
+import { getAudioTracksByGroup } from './utils/rendition-helper';
+import {
+  getMediaDecodingInfoPromise,
+  MediaDecodingInfo,
+} from './utils/mediacapabilities-helper';
 
 /**
  * The `Hls` class is the core of the HLS.js library used to instantiate player instances.
@@ -951,7 +956,7 @@ export default class Hls implements HlsEventEmitter {
   /**
    * Get the complete list of audio tracks across all media groups
    */
-  get allAudioTracks(): Array<MediaPlaylist> {
+  get allAudioTracks(): MediaPlaylist[] {
     const audioTrackController = this.audioTrackController;
     return audioTrackController ? audioTrackController.allAudioTracks : [];
   }
@@ -959,7 +964,7 @@ export default class Hls implements HlsEventEmitter {
   /**
    * Get the list of selectable audio tracks
    */
-  get audioTracks(): Array<MediaPlaylist> {
+  get audioTracks(): MediaPlaylist[] {
     const audioTrackController = this.audioTrackController;
     return audioTrackController ? audioTrackController.audioTracks : [];
   }
@@ -985,7 +990,7 @@ export default class Hls implements HlsEventEmitter {
   /**
    * get the complete list of subtitle tracks across all media groups
    */
-  get allSubtitleTracks(): Array<MediaPlaylist> {
+  get allSubtitleTracks(): MediaPlaylist[] {
     const subtitleTrackController = this.subtitleTrackController;
     return subtitleTrackController
       ? subtitleTrackController.allSubtitleTracks
@@ -995,7 +1000,7 @@ export default class Hls implements HlsEventEmitter {
   /**
    * get alternate subtitle tracks list from playlist
    */
-  get subtitleTracks(): Array<MediaPlaylist> {
+  get subtitleTracks(): MediaPlaylist[] {
     const subtitleTrackController = this.subtitleTrackController;
     return subtitleTrackController
       ? subtitleTrackController.subtitleTracks
@@ -1131,6 +1136,21 @@ export default class Hls implements HlsEventEmitter {
    */
   get interstitialsManager(): InterstitialsManager | null {
     return this.interstitialsController?.interstitialsManager || null;
+  }
+
+  /**
+   * returns mediaCapabilities.decodingInfo for a variant/rendition
+   */
+  getMediaDecodingInfo(
+    level: Level,
+    audioTracks: MediaPlaylist[] = this.allAudioTracks,
+  ): Promise<MediaDecodingInfo> {
+    const audioTracksByGroup = getAudioTracksByGroup(audioTracks);
+    return getMediaDecodingInfoPromise(
+      level,
+      audioTracksByGroup,
+      navigator.mediaCapabilities,
+    );
   }
 }
 

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -32,7 +32,7 @@ import type {
 } from '../types/demuxer';
 import type { DecryptData } from '../loader/level-key';
 import type { TypeSupported } from '../utils/codecs';
-import type { ILogger } from '../utils/logger';
+import { logger, type ILogger } from '../utils/logger';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
 
 class PassThroughRemuxer implements Remuxer {
@@ -86,7 +86,7 @@ class PassThroughRemuxer implements Remuxer {
     }
     const initData = (this.initData = parseInitSegment(initSegment));
 
-    // Get codec from initSegment or fallback to default
+    // Get codec from initSegment
     if (initData.audio) {
       audioCodec = getParsedTrackCodec(
         initData.audio,
@@ -298,21 +298,13 @@ function getParsedTrackCodec(
       const preferManagedMediaSource = false;
       return getCodecCompatibleName(parsedCodec, preferManagedMediaSource);
     }
-    const result = 'mp4a.40.5';
-    this.logger.info(
-      `Parsed audio codec "${parsedCodec}" or audio object type not handled. Using "${result}"`,
-    );
-    return result;
+
+    logger.warn(`Unhandled audio codec "${parsedCodec}" in mp4 MAP`);
+    return parsedCodec || 'mp4a';
   }
   // Provide defaults based on codec type
   // This allows for some playback of some fmp4 playlists without CODECS defined in manifest
-  this.logger.warn(`Unhandled video codec "${parsedCodec}"`);
-  if (parsedCodec === 'hvc1' || parsedCodec === 'hev1') {
-    return 'hvc1.1.6.L120.90';
-  }
-  if (parsedCodec === 'av01') {
-    return 'av01.0.04M.08';
-  }
-  return 'avc1.42e01e';
+  logger.warn(`Unhandled video codec "${parsedCodec}" in mp4 MAP`);
+  return parsedCodec || 'avc1';
 }
 export default PassThroughRemuxer;

--- a/src/utils/mediacapabilities-helper.ts
+++ b/src/utils/mediacapabilities-helper.ts
@@ -1,4 +1,4 @@
-import { mimeTypeForCodec } from './codecs';
+import { fillInMissingAV01Params, mimeTypeForCodec } from './codecs';
 import type { Level, VideoRange } from '../types/level';
 import type { AudioSelectionOption } from '../types/media-playlist';
 import type { AudioTracksByGroup } from './rendition-helper';
@@ -96,33 +96,40 @@ export function getMediaDecodingInfoPromise(
 ): Promise<MediaDecodingInfo> {
   const videoCodecs = level.videoCodec;
   const audioCodecs = level.audioCodec;
-  if (!videoCodecs || !audioCodecs || !mediaCapabilities) {
+  if ((!videoCodecs && !audioCodecs) || !mediaCapabilities) {
     return Promise.resolve(SUPPORTED_INFO_DEFAULT);
   }
 
-  const baseVideoConfiguration: BaseVideoConfiguration = {
-    width: level.width,
-    height: level.height,
-    bitrate: Math.ceil(Math.max(level.bitrate * 0.9, level.averageBitrate)),
-    // Assume a framerate of 30fps since MediaCapabilities will not accept Level default of 0.
-    framerate: level.frameRate || 30,
-  };
+  const configurations: MediaDecodingConfiguration[] = [];
 
-  const videoRange = level.videoRange;
-  if (videoRange !== 'SDR') {
-    baseVideoConfiguration.transferFunction =
-      videoRange.toLowerCase() as TransferFunction;
+  if (videoCodecs) {
+    const baseVideoConfiguration: BaseVideoConfiguration = {
+      width: level.width,
+      height: level.height,
+      bitrate: Math.ceil(Math.max(level.bitrate * 0.9, level.averageBitrate)),
+      // Assume a framerate of 30fps since MediaCapabilities will not accept Level default of 0.
+      framerate: level.frameRate || 30,
+    };
+    const videoRange = level.videoRange;
+    if (videoRange !== 'SDR') {
+      baseVideoConfiguration.transferFunction =
+        videoRange.toLowerCase() as TransferFunction;
+    }
+
+    configurations.push.apply(
+      configurations,
+      videoCodecs.split(',').map((videoCodec) => ({
+        type: 'media-source',
+        video: {
+          ...baseVideoConfiguration,
+          contentType: mimeTypeForCodec(
+            fillInMissingAV01Params(videoCodec),
+            'video',
+          ),
+        },
+      })),
+    );
   }
-
-  const configurations: MediaDecodingConfiguration[] = videoCodecs
-    .split(',')
-    .map((videoCodec) => ({
-      type: 'media-source',
-      video: {
-        ...baseVideoConfiguration,
-        contentType: mimeTypeForCodec(videoCodec, 'video'),
-      },
-    }));
 
   if (audioCodecs && level.audioGroups) {
     level.audioGroups.forEach((audioGroupId) => {

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -152,12 +152,12 @@ function createMediaKeySystemConfigurations(
       drmSystemOptions.sessionType || 'temporary',
     ],
     audioCapabilities: audioCodecs.map((codec) => ({
-      contentType: `audio/mp4; codecs="${codec}"`,
+      contentType: `audio/mp4; codecs=${codec}`,
       robustness: drmSystemOptions.audioRobustness || '',
       encryptionScheme: drmSystemOptions.audioEncryptionScheme || null,
     })),
     videoCapabilities: videoCodecs.map((codec) => ({
-      contentType: `video/mp4; codecs="${codec}"`,
+      contentType: `video/mp4; codecs=${codec}`,
       robustness: drmSystemOptions.videoRobustness || '',
       encryptionScheme: drmSystemOptions.videoEncryptionScheme || null,
     })),

--- a/tests/unit/utils/codecs.ts
+++ b/tests/unit/utils/codecs.ts
@@ -1,24 +1,85 @@
 import { expect } from 'chai';
-import { convertAVC1ToAVCOTI } from '../../../src/utils/codecs';
+import {
+  convertAVC1ToAVCOTI,
+  fillInMissingAV01Params,
+} from '../../../src/utils/codecs';
 
 describe('codecs', function () {
-  it('convert codec string from AVC1 to AVCOTI', function () {
-    expect(convertAVC1ToAVCOTI('avc1.66.30')).to.equal('avc1.42001e');
+  describe('convertAVC1ToAVCOTI', function () {
+    it('convert codec string from AVC1 to AVCOTI', function () {
+      expect(convertAVC1ToAVCOTI('avc1.66.30')).to.equal('avc1.42001e');
+    });
+
+    it('convert list of codecs string from AVC1 to AVCOTI', function () {
+      expect(convertAVC1ToAVCOTI('avc1.77.30,avc1.66.30')).to.equal(
+        'avc1.4d001e,avc1.42001e',
+      );
+    });
+
+    it('does not convert string if it is already converted', function () {
+      expect(convertAVC1ToAVCOTI('avc1.64001E')).to.equal('avc1.64001E');
+    });
+
+    it('does not convert list of codecs string if it is already converted', function () {
+      expect(convertAVC1ToAVCOTI('avc1.64001E,avc1.64001f')).to.equal(
+        'avc1.64001E,avc1.64001f',
+      );
+    });
   });
 
-  it('convert list of codecs string from AVC1 to AVCOTI', function () {
-    expect(convertAVC1ToAVCOTI('avc1.77.30,avc1.66.30')).to.equal(
-      'avc1.4d001e,avc1.42001e',
-    );
-  });
+  describe('fillInMissingAV01Params', function () {
+    it('fills in incomplete AV1 CODECS strings 6-10', function () {
+      expect(fillInMissingAV01Params('av01.0.08M.10.0')).to.equal(
+        'av01.0.08M.10.0.111.01.01.01.0',
+      );
+    });
 
-  it('does not convert string if it is already converted', function () {
-    expect(convertAVC1ToAVCOTI('avc1.64001E')).to.equal('avc1.64001E');
-  });
+    it('fills in incomplete AV1 CODECS strings 7-10', function () {
+      expect(fillInMissingAV01Params('av01.0.08M.10.0.111')).to.equal(
+        'av01.0.08M.10.0.111.01.01.01.0',
+      );
+    });
 
-  it('does not convert list of codecs string if it is already converted', function () {
-    expect(convertAVC1ToAVCOTI('avc1.64001E,avc1.64001f')).to.equal(
-      'avc1.64001E,avc1.64001f',
-    );
+    it('fills in incomplete AV1 CODECS strings 8-10', function () {
+      expect(fillInMissingAV01Params('av01.0.08M.10.0.111.01')).to.equal(
+        'av01.0.08M.10.0.111.01.01.01.0',
+      );
+    });
+
+    it('fills in incomplete AV1 CODECS strings 9-10', function () {
+      expect(fillInMissingAV01Params('av01.0.08M.10.0.111.01.01')).to.equal(
+        'av01.0.08M.10.0.111.01.01.01.0',
+      );
+    });
+
+    it('fills in incomplete AV1 CODECS strings 10', function () {
+      expect(fillInMissingAV01Params('av01.0.08M.10.0.111.01.01.01')).to.equal(
+        'av01.0.08M.10.0.111.01.01.01.0',
+      );
+    });
+
+    it('does not modify four part AV1 CODECS', function () {
+      expect(fillInMissingAV01Params('av01.0.08M.10')).to.equal(
+        'av01.0.08M.10',
+      );
+    });
+
+    it('does not modify invalid AV1 CODECS with less than four parts', function () {
+      expect(fillInMissingAV01Params('av01.0.08M')).to.equal('av01.0.08M');
+    });
+
+    it('does not modify complete AV1 CODECS', function () {
+      expect(
+        fillInMissingAV01Params('av01.0.08M.10.0.112.09.09.09.0'),
+      ).to.equal('av01.0.08M.10.0.112.09.09.09.0');
+    });
+
+    it('does not modify other CODECS', function () {
+      expect(fillInMissingAV01Params('hvc1.2.20000000.L93.B0')).to.equal(
+        'hvc1.2.20000000.L93.B0',
+      );
+      expect(fillInMissingAV01Params('avc1.4d001e')).to.equal('avc1.4d001e');
+      expect(fillInMissingAV01Params('mp4a.40.2')).to.equal('mp4a.40.2');
+    });
   });
 });


### PR DESCRIPTION
### This PR will...
- Support unknown codec as video or audio with passing `isTypeSupported` checks
- Use multivariant playlist CODECS when mp4 parsed codec is incomplete
- Add `getMediaDecodingInfo` to public API (undocumented) and fix issues with video and audio only input
- Add codecs-helper to fill in AV1 codec string missing parameters required by MediaCapabilities decodingInfo checks

### Why is this Pull Request needed?
Adds support for playback of audio and video codecs not indexed in utils/codecs or not parsed completely from mp4 init segment so long as a supported CODECS value is provided.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
