### PR TITLE
Parse multiple pssh from "encrypted" init data and fix Widevine key I…

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -21,7 +21,13 @@ import { strToUtf8array } from '../utils/utf8-utils';
 import { base64Decode } from '../utils/numeric-encoding-utils';
 import { DecryptData, LevelKey } from '../loader/level-key';
 import Hex from '../utils/hex';
-import { bin2str, parseMultiPssh, parseSinf } from '../utils/mp4-tools';
+import {
+  bin2str,
+  parseMultiPssh,
+  parseSinf,
+  PsshData,
+  PsshInvalidResult,
+} from '../utils/mp4-tools';
 import { EventEmitter } from 'eventemitter3';
 import type Hls from '../hls';
 import type { ComponentAPI } from '../types/component-api';
@@ -510,7 +516,8 @@ class EMEController extends Logger implements ComponentAPI {
 
   private onMediaEncrypted = (event: MediaEncryptedEvent) => {
     const { initDataType, initData } = event;
-    this.debug(`"${event.type}" event: init data type: "${initDataType}"`);
+    const logMessage = `"${event.type}" event: init data type: "${initDataType}"`;
+    this.debug(logMessage);
 
     // Ignore event when initData is null
     if (initData === null) {
@@ -530,31 +537,39 @@ class EMEController extends Logger implements ComponentAPI {
         const sinf = base64Decode(JSON.parse(json).sinf);
         const tenc = parseSinf(new Uint8Array(sinf));
         if (!tenc) {
-          return;
+          throw new Error(
+            `'schm' box missing or not cbcs/cenc with schi > tenc`,
+          );
         }
         keyId = tenc.subarray(8, 24);
         keySystemDomain = KeySystems.FAIRPLAY;
       } catch (error) {
-        this.warn('Failed to parse sinf "encrypted" event message initData');
+        this.warn(`${logMessage} Failed to parse sinf: ${error}`);
         return;
       }
     } else {
-      // Support clear-lead key-session creation (otherwise depend on playlist keys)
-      const psshInfos = parseMultiPssh(initData);
-      const psshInfo = psshInfos.filter(
-        (pssh) => pssh.systemId === KeySystemIds.WIDEVINE,
+      // Support Widevine clear-lead key-session creation (otherwise depend on playlist keys)
+      const psshResults = parseMultiPssh(initData);
+      const psshInfo = psshResults.filter(
+        (pssh): pssh is PsshData => pssh.systemId === KeySystemIds.WIDEVINE,
       )[0];
       if (!psshInfo) {
+        if (
+          psshResults.length === 0 ||
+          psshResults.some((pssh): pssh is PsshInvalidResult => !pssh.systemId)
+        ) {
+          this.warn(`${logMessage} contains incomplete or invalid pssh data`);
+        } else {
+          this.log(
+            `ignoring ${logMessage} for ${(psshResults as PsshData[])
+              .map((pssh) => keySystemIdToKeySystemDomain(pssh.systemId))
+              .join(',')} pssh data in favor of playlist keys`,
+          );
+        }
         return;
       }
-      keySystemDomain = keySystemIdToKeySystemDomain(
-        psshInfo.systemId as KeySystemIds,
-      );
-      if (
-        psshInfo.version === 0 &&
-        psshInfo.data &&
-        psshInfo.data.length >= 30
-      ) {
+      keySystemDomain = keySystemIdToKeySystemDomain(psshInfo.systemId);
+      if (psshInfo.version === 0 && psshInfo.data) {
         const offset = psshInfo.data.length - 22;
         keyId = psshInfo.data.subarray(offset, offset + 16);
       }

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -36,10 +36,10 @@ export function keySystemFormatToKeySystemDomain(
 
 // System IDs for which we can extract a key ID from "encrypted" event PSSH
 export const enum KeySystemIds {
-  // CENC = '1077efecc0b24d02ace33c1e52e2fb4b'
-  // CLEARKEY = 'e2719d58a985b3c9781ab030af78d30e',
-  // FAIRPLAY = '94ce86fb07ff4f43adb893d2fa968ca2',
-  // PLAYREADY = '9a04f07998404286ab92e65be0885f95',
+  CENC = '1077efecc0b24d02ace33c1e52e2fb4b',
+  CLEARKEY = 'e2719d58a985b3c9781ab030af78d30e',
+  FAIRPLAY = '94ce86fb07ff4f43adb893d2fa968ca2',
+  PLAYREADY = '9a04f07998404286ab92e65be0885f95',
   WIDEVINE = 'edef8ba979d64acea3c827dcd51d21ed',
 }
 
@@ -48,10 +48,13 @@ export function keySystemIdToKeySystemDomain(
 ): KeySystems | undefined {
   if (systemId === KeySystemIds.WIDEVINE) {
     return KeySystems.WIDEVINE;
-    // } else if (systemId === KeySystemIds.PLAYREADY) {
-    //   return KeySystems.PLAYREADY;
-    // } else if (systemId === KeySystemIds.CENC || systemId === KeySystemIds.CLEARKEY) {
-    //   return KeySystems.CLEARKEY;
+  } else if (systemId === KeySystemIds.PLAYREADY) {
+    return KeySystems.PLAYREADY;
+  } else if (
+    systemId === KeySystemIds.CENC ||
+    systemId === KeySystemIds.CLEARKEY
+  ) {
+    return KeySystems.CLEARKEY;
   }
 }
 

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -1409,7 +1409,7 @@ function parsePssh(view: DataView): PsshData | PsshInvalidResult {
   let kids: null | Uint8Array[] = null;
   let data: null | Uint8Array = null;
   if (version === 0) {
-    if (size - 32 < dataSizeOrKidCount || dataSizeOrKidCount < 30) {
+    if (size - 32 < dataSizeOrKidCount || dataSizeOrKidCount < 22) {
       return { offset, size };
     }
     data = new Uint8Array(buffer, offset + 32, dataSizeOrKidCount);

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -295,7 +295,10 @@ describe('EMEController', function () {
 
     media.emit('encrypted', badData);
 
-    expect(emeController.keyIdToKeySessionPromise).to.deep.equal({});
+    expect(emeController.keyIdToKeySessionPromise).to.deep.equal(
+      {},
+      '`keyIdToKeySessionPromise` should be an empty dictionary when no key IDs are found',
+    );
   });
 
   it('should fetch the server certificate and set it into the session', function () {

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -295,18 +295,7 @@ describe('EMEController', function () {
 
     media.emit('encrypted', badData);
 
-    expect(emeController.keyIdToKeySessionPromise.f000ba00).to.be.a('Promise');
-    if (!emeController.keyIdToKeySessionPromise.f000ba00) {
-      return;
-    }
-    return emeController.keyIdToKeySessionPromise.f000ba00
-      .catch(() => {})
-      .finally(() => {
-        expect(emeController.hls.trigger).callCount(1);
-        expect(emeController.hls.trigger.args[0][1].details).to.equal(
-          ErrorDetails.KEY_SYSTEM_NO_SESSION,
-        );
-      });
+    expect(emeController.keyIdToKeySessionPromise).to.deep.equal({});
   });
 
   it('should fetch the server certificate and set it into the session', function () {


### PR DESCRIPTION
### This PR will...
Parse multiple pssh from "encrypted" init data and fix Widevine key ID extraction for playlist match

### Why is this Pull Request needed?
With Widevine, HLS.js generates key sessions and license requests using key IDs from pssh data found in playlist KEY URIs or "encrypted" events - whichever it encounters first. The parsing of pssh data in "encrypted" event init data did not parse all payloads for all key-systems present. It also did not pull the key ID for the correct offset and as a result was not matching the playlist key which could result in a second session and set of license requests being made when the first payload was a Widevine PSSH. If it was for another key-system then the "encrypted" event was ignored.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6636

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
