### PR TITLE
ensure fragment start before synchronize to live edge

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -681,7 +681,8 @@ export default class StreamController
 
     if (!this.startFragRequested) {
       this.setStartPosition(newDetails, sliding);
-    } else if (newDetails.live) {
+    } else if (newDetails.live && newDetails.PTSKnown) {
+      // Ensure Fragments have correct starts
       this.synchronizeToLiveEdge(newDetails);
     }
 


### PR DESCRIPTION
### This PR will...
ensure fragment start before synchronize to live edge

### Why is this Pull Request needed?
player synchronized to 0.00 with bad internet conditions. which live stream level list has short fragment and small length of fragments list.

### Are there any points in the code the reviewer needs to double check?
Not have any other function change

### Resolves issues:
#6685 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
