### PR TITLE
Align live playlist updates to end of last when there is no overlap

### DIFF
--- a/src/utils/discontinuities.ts
+++ b/src/utils/discontinuities.ts
@@ -81,7 +81,7 @@ export function alignStream(
     // Try to align on sn so that we pick a better start fragment.
     // Do not perform this on playlists with delta updates as this is only to align levels on switch
     // and adjustSliding only adjusts fragments after skippedSegments.
-    adjustSliding(switchDetails, details);
+    adjustSliding(switchDetails, details, false);
   }
 }
 

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -407,14 +407,28 @@ export function mapFragmentIntersection(
 export function adjustSliding(
   oldDetails: LevelDetails,
   newDetails: LevelDetails,
+  matchingStableVariantOrRendition: boolean = true,
 ): void {
   const delta =
     newDetails.startSN + newDetails.skippedSegments - oldDetails.startSN;
   const oldFragments = oldDetails.fragments;
-  if (delta < 0 || delta >= oldFragments.length) {
+  if (delta < 0) {
     return;
   }
-  addSliding(newDetails, oldFragments[delta].start);
+  let sliding = 0;
+  if (delta < oldFragments.length) {
+    sliding = oldFragments[delta].start;
+  } else if (matchingStableVariantOrRendition) {
+    // align new start with old end (updated playlist start sequence is past end sequence of last update)
+    sliding = oldDetails.edge;
+  } else if (newDetails.fragments[0].start === 0) {
+    // align new start with old (playlist switch has a sequence with no overlap and should not be used for alignment)
+    sliding = oldDetails.fragments[0].start;
+  } else {
+    // new details already has a sliding offset
+    return;
+  }
+  addSliding(newDetails, sliding);
 }
 
 export function addSliding(details: LevelDetails, start: number) {

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -412,20 +412,21 @@ export function adjustSliding(
   const delta =
     newDetails.startSN + newDetails.skippedSegments - oldDetails.startSN;
   const oldFragments = oldDetails.fragments;
-  if (delta < 0) {
-    return;
-  }
+  const advancedOrStable = delta >= 0;
   let sliding = 0;
-  if (delta < oldFragments.length) {
+  if (advancedOrStable && delta < oldFragments.length) {
     sliding = oldFragments[delta].start;
-  } else if (matchingStableVariantOrRendition) {
+  } else if (advancedOrStable && matchingStableVariantOrRendition) {
     // align new start with old end (updated playlist start sequence is past end sequence of last update)
     sliding = oldDetails.edge;
-  } else if (newDetails.fragments[0].start === 0) {
+  } else if (
+    !newDetails.skippedSegments &&
+    newDetails.fragments[0].start === 0
+  ) {
     // align new start with old (playlist switch has a sequence with no overlap and should not be used for alignment)
     sliding = oldDetails.fragments[0].start;
   } else {
-    // new details already has a sliding offset
+    // new details already has a sliding offset or has skipped segments
     return;
   }
   addSliding(newDetails, sliding);

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -172,7 +172,7 @@ describe('LevelHelper Tests', function () {
       expect(actual).to.deep.equal([15, 20, 25]);
     });
 
-    it('does not extrapolate if the new playlist starts before the old', function () {
+    it('matches start when the new playlist starts before the old', function () {
       const oldPlaylist = generatePlaylist([3, 4, 5]);
       oldPlaylist.fragments.forEach((f) => {
         f.start += 10;
@@ -180,7 +180,7 @@ describe('LevelHelper Tests', function () {
       const newPlaylist = generatePlaylist([1, 2, 3]);
       mergeDetails(oldPlaylist, newPlaylist);
       const actual = newPlaylist.fragments.map((f) => f.start);
-      expect(actual).to.deep.equal([0, 5, 10]);
+      expect(actual).to.deep.equal([10, 15, 20]);
     });
 
     it('merges delta playlist updates', function () {

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -138,20 +138,20 @@ describe('LevelHelper Tests', function () {
       expect(actual).to.deep.equal([10, 15, 20]);
     });
 
-    it('does not apply sliding if no common segments exist', function () {
+    it('applies minimal sliding when no common segments exist', function () {
       const oldPlaylist = generatePlaylist([1, 2, 3]);
       const newPlaylist = generatePlaylist([5, 6, 7]);
       adjustSliding(oldPlaylist, newPlaylist);
       const actual = newPlaylist.fragments.map((f) => f.start);
-      expect(actual).to.deep.equal([0, 5, 10]);
+      expect(actual).to.deep.equal([15, 20, 25]);
     });
 
-    it('does not apply sliding when segments meet but do not overlap', function () {
+    it('applies minimal sliding when segments meet but do not overlap', function () {
       const oldPlaylist = generatePlaylist([1, 2, 3]);
       const newPlaylist = generatePlaylist([4, 5, 6]);
       adjustSliding(oldPlaylist, newPlaylist);
       const actual = newPlaylist.fragments.map((f) => f.start);
-      expect(actual).to.deep.equal([0, 5, 10]);
+      expect(actual).to.deep.equal([15, 20, 25]);
     });
   });
 
@@ -164,12 +164,12 @@ describe('LevelHelper Tests', function () {
       expect(actual).to.deep.equal([5, 10, 15, 20]);
     });
 
-    it('does not change start times when there is no segment overlap', function () {
+    it('applies minimal sliding when there is no segment overlap', function () {
       const oldPlaylist = generatePlaylist([1, 2, 3]);
       const newPlaylist = generatePlaylist([5, 6, 7]);
       mergeDetails(oldPlaylist, newPlaylist);
       const actual = newPlaylist.fragments.map((f) => f.start);
-      expect(actual).to.deep.equal([0, 5, 10]);
+      expect(actual).to.deep.equal([15, 20, 25]);
     });
 
     it('does not extrapolate if the new playlist starts before the old', function () {


### PR DESCRIPTION
### This PR will...
Align live playlist updates to end of last when there is no media-sequence overlap and no PDT.

### Why is this Pull Request needed?
When really short live playlists with sliding windows fail to update for longer than the duration of the sliding window, fragment times will slide back to 0 when there is no overlapping media-sequence, no overlapping discontinuity-sequence, and no program date time to sync on.

Keeping the sliding window moving forward, ahead of the playhead, ensures that streaming can continue and playback can resume when conditions are favorable and playback can resync with the live edge.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6685
(duplicate of #5282)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
