### PR TITLE
feat: `fetchSetup` config support promise

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1722,7 +1722,7 @@ export type HlsConfig = {
     };
     fLoader?: FragmentLoaderConstructor;
     pLoader?: PlaylistLoaderConstructor;
-    fetchSetup?: (context: LoaderContext, initParams: any) => Request;
+    fetchSetup?: (context: LoaderContext, initParams: any) => Promise<Request> | Request;
     xhrSetup?: (xhr: XMLHttpRequest, url: string) => Promise<void> | void;
     audioStreamController?: typeof AudioStreamController;
     audioTrackController?: typeof AudioTrackController;

--- a/src/config.ts
+++ b/src/config.ts
@@ -276,7 +276,10 @@ export type HlsConfig = {
   loader: { new (confg: HlsConfig): Loader<LoaderContext> };
   fLoader?: FragmentLoaderConstructor;
   pLoader?: PlaylistLoaderConstructor;
-  fetchSetup?: (context: LoaderContext, initParams: any) => Request;
+  fetchSetup?: (
+    context: LoaderContext,
+    initParams: any,
+  ) => Promise<Request> | Request;
   xhrSetup?: (xhr: XMLHttpRequest, url: string) => Promise<void> | void;
 
   // Alt Audio

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types/loader';
 import { LoadStats } from '../loader/load-stats';
 import ChunkCache from '../demux/chunk-cache';
+import { isPromise } from '../demux/transmuxer';
 import { type HlsConfig } from '../config';
 
 export function fetchSupported() {
@@ -112,8 +113,11 @@ class FetchLoader implements Loader<LoaderContext> {
       callbacks.onTimeout(stats, context, this.response);
     }, config.timeout);
 
-    Promise.resolve(this.request)
-      .then(self.fetch)
+    const fetchPromise = isPromise(this.request)
+      ? this.request.then(self.fetch)
+      : self.fetch(this.request);
+
+    fetchPromise
       .then((response: Response): Promise<string | ArrayBuffer> => {
         this.response = this.loader = response;
 


### PR DESCRIPTION
### This PR will...

- support promise in `fetchSetup` config

```ts
const hls = new Hls({
  progressive: true,
  async fetchSetup (ctx, init) {
    const signature = await sign(ctx.url)
    init.headers = { ...init.headers, 'x-signature': signature }
    return new Request(ctx.url, init)
  }
})
```

### Why is this Pull Request needed?

This will be more friendly to users using `progressive` mode.
Currently only xhrSetup supports promises

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
