### PR TITLE
fix: drop fragment when currentLevel is undefined

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -700,7 +700,7 @@ export default class StreamController
       return;
     }
     const currentLevel = levels[frag.level];
-    const details = currentLevel.details;
+    const details = currentLevel?.details;
     if (!details) {
       this.warn(
         `Dropping fragment ${frag.sn} of level ${frag.level} after level details were reset`,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -700,7 +700,11 @@ export default class StreamController
       return;
     }
     const currentLevel = levels[frag.level];
-    const details = currentLevel?.details;
+    if (!currentLevel) {
+      this.warn(`Level ${frag.level} not found on progress`);
+      return;
+    }
+    const details = currentLevel.details;
     if (!details) {
       this.warn(
         `Dropping fragment ${frag.sn} of level ${frag.level} after level details were reset`,


### PR DESCRIPTION
### This PR will...

It will iron logic for dropping a level fragment after resetting the details.

### Why is this Pull Request needed?

It fixes TypeError: Cannot read properties of undefined (reading 'details') which sometimes happens on mobile devices.
Especially on Android 10. 

### Are there any points in the code the reviewer needs to double check?

No idea.

### Resolves issues:

I don't think someone reported an issue.

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
