### PR TITLE
Check-in on abandon rules check and abort in-flight frag when stuck on playlist loading

### DIFF
--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -439,11 +439,12 @@ export default class LevelController extends BasePlaylistController {
 
     if (
       lastLevelIndex === newLevel &&
-      level.details &&
       lastLevel &&
       lastPathwayId === pathwayId
     ) {
-      return;
+      if (level.details || this.requestScheduled !== -1) {
+        return;
+      }
     }
 
     this.log(
@@ -571,7 +572,10 @@ export default class LevelController extends BasePlaylistController {
       data.context.type === PlaylistContextType.LEVEL &&
       data.context.level === this.level
     ) {
-      this.checkRetry(data);
+      const retry = this.checkRetry(data);
+      if (!retry) {
+        this.requestScheduled = -1;
+      }
     }
   }
 


### PR DESCRIPTION
### This PR will...
Check-in on abandon rules check and abort in-flight frag when stuck on playlist loading

### Why is this Pull Request needed?
Switches down to a variant that should load at line speed when the higher bitrate in-flight fragment is late. If the playlist of the lower variant still hasn't arrived by the time estimated, and the original in-flight fragment is still active, abort it and switch down further if needed.

### Are there any points in the code the reviewer needs to double check?

Fixes redundant switching level / level loading events that occur for VOD when playlist loading is significantly delays. These events cancel the fallback abandon rules check playlist timeout.

### Resolves issues:
Resolves #6689 (provided throttled requests do not timeout)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
