### PR TITLE
Fix unregister listener typo in audio-stream-controller

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -118,7 +118,7 @@ class AudioStreamController
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
     hls.off(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.off(Events.INIT_PTS_FOUND, this.onInitPtsFound, this);
-    hls.on(Events.FRAG_LOADING, this.onFragLoading, this);
+    hls.off(Events.FRAG_LOADING, this.onFragLoading, this);
     hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
   }
 


### PR DESCRIPTION
### This PR will...
Fix unregister listener typo in audio-stream-controller

### Why is this Pull Request needed?
`onFragLoading` should be removed not added again in `unregisterListeners`.

### Are there any points in the code the reviewer needs to double check?
Regression introduced in dev and 1.6.0-beta.1 only. Listeners are still removed on destroy with removeAllListeners.

### Resolves issues:
Resolves #6773

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
