### PR TITLE
Fix back buffer not being flushed when backBufferLength is set to 0 (#6781)

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1127,7 +1127,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
         ? config.liveBackBufferLength
         : config.backBufferLength;
 
-    if (Number.isFinite(backBufferLength) && backBufferLength > 0) {
+    if (Number.isFinite(backBufferLength) && backBufferLength >= 0) {
       const maxBackBufferLength = Math.max(backBufferLength, targetDuration);
       const targetBackBufferPosition =
         Math.floor(currentTime / targetDuration) * targetDuration -

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -617,6 +617,14 @@ describe('BufferController with attached media', function () {
         expect(triggerSpy).to.not.have.been.calledWith(Events.BUFFER_FLUSHING);
       });
 
+      it('should execute a remove operation if backBufferLength is set to 0', function () {
+        hls.config.backBufferLength = 0;
+        evokeTrimBuffers(hls);
+        expect(triggerSpy.withArgs(Events.BUFFER_FLUSHING)).to.have.callCount(
+          2,
+        );
+      });
+
       it('should execute a remove operation if flushing a valid backBuffer range', function () {
         evokeTrimBuffers(hls);
         expect(triggerSpy.withArgs(Events.BUFFER_FLUSHING)).to.have.callCount(


### PR DESCRIPTION
### This PR will...

Update `trimBuffers()` to flush the back buffer when `backBufferLength` is set to 0.

### Why is this Pull Request needed?

To be consistent with the documentation of the `backBufferLength` setting at https://github.com/video-dev/hls.js/blob/master/docs/API.md#backbufferlength , which states that this value can be set to 0 to keep the minimum amount.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

Resolves https://github.com/video-dev/hls.js/issues/6781

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
