### PR TITLE
Prevent loading of audio media options with the same URI as the current level

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -404,11 +404,17 @@ class AudioTrackController extends BasePlaylistController {
 
   protected loadPlaylist(hlsUrlParameters?: HlsUrlParameters): void {
     const audioTrack = this.currentTrack;
-    if (this.shouldLoadPlaylist(audioTrack) && audioTrack) {
+    if (!audioTrack) {
+      return;
+    }
+    let url = audioTrack.url;
+    if (
+      this.shouldLoadPlaylist(audioTrack) &&
+      url !== this.hls.levels[this.hls.loadLevel]?.uri
+    ) {
       super.loadPlaylist();
       const id = audioTrack.id;
       const groupId = audioTrack.groupId as string;
-      let url = audioTrack.url;
       if (hlsUrlParameters) {
         try {
           url = hlsUrlParameters.addDirectives(url);


### PR DESCRIPTION
### This PR will...
Prevent loading of audio media options with the same URI as the current level.

### Resolves issues:
Resolves #6783

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
