### PR TITLE
Feature: support flush buffer manually

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1963,6 +1963,7 @@ class Hls implements HlsEventEmitter {
     get firstLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "firstLevel" must appear on the getter, not the setter.
     set firstLevel(newLevel: number);
+    flushBuffer(startOffset?: number, endOffset?: number): void;
     get forceStartLoad(): boolean;
     getMediaDecodingInfo(level: Level, audioTracks?: MediaPlaylist[]): Promise<MediaDecodingInfo>;
     static getMediaSource(): typeof MediaSource | undefined;
@@ -4302,7 +4303,7 @@ export class StreamController extends BaseStreamController implements NetworkCom
     // (undocumented)
     protected doTick(): void;
     // (undocumented)
-    protected flushMainBuffer(startOffset: number, endOffset: number): void;
+    flushMainBuffer(startOffset: number, endOffset: number): void;
     // (undocumented)
     get forceStartLoad(): boolean;
     // (undocumented)

--- a/docs/API.md
+++ b/docs/API.md
@@ -157,6 +157,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`hls.startPosition`](#hlsstartposition)
   - [`hls.pauseBuffering()`](#hlspausebuffering)
   - [`hls.resumeBuffering()`](#hlsresumebuffering)
+  - [`hls.flushBuffer()`](#hlsflushBuffer)
   - [`hls.bufferingEnabled`](#hlsbufferingenabled)
   - [`hls.bufferedToEnd`](#hlsbufferedtoend)
   - [`hls.url`](#hlsurl)
@@ -1865,6 +1866,10 @@ Pauses fragment buffering (used internally with ManagedMediaSource streaming eve
 ### `hls.resumeBuffering()`
 
 Resumes fragment buffering (used internally with ManagedMediaSource streaming events).
+
+### `hls.flushBuffer()`
+
+Flush loaded media buffer.
 
 ### `hls.bufferingEnabled`
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -505,7 +505,7 @@ export default class StreamController
     this.nextLoadPosition = this.getLoadPosition();
   }
 
-  protected flushMainBuffer(startOffset: number, endOffset: number) {
+  public flushMainBuffer(startOffset: number, endOffset: number) {
     super.flushMainBuffer(
       startOffset,
       endOffset,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -41,7 +41,7 @@ import type { HlsEventEmitter, HlsListeners } from './events';
 import type FragmentLoader from './loader/fragment-loader';
 import type { LevelDetails } from './loader/level-details';
 import type TaskLoop from './task-loop';
-import type { AttachMediaSourceData } from './types/buffer';
+import type { AttachMediaSourceData, SourceBufferName } from './types/buffer';
 import type {
   AbrComponentAPI,
   ComponentAPI,
@@ -573,6 +573,16 @@ export default class Hls implements HlsEventEmitter {
         }
       });
     }
+  }
+
+  /**
+   * Flush the loaded buffer
+   * @param startOffset - start offset
+   * @param endOffset - end offset
+   */
+  flushBuffer(startOffset: number = 0, endOffset: number = Number.POSITIVE_INFINITY) {
+    this.logger.log(`flush buffer, start: ${startOffset}, end: ${endOffset}`);
+    this.streamController.flushMainBuffer(startOffset, endOffset);
   }
 
   /**


### PR DESCRIPTION
### This PR will...
Add support to flush buffer manually

### Why is this Pull Request needed?
When I pauseBuffering and resumeBuffering after an interval, I want to watch the latest video content. But I must to watch the buffer stream and cannot skip it. SO, I need an api to flush the existed buffer.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
No

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
