### PR TITLE
feat: `maxDevicePixelRatio` limits the browser's value

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2132,6 +2132,7 @@ export type HlsConfig = {
     enableSoftwareAES: boolean;
     minAutoBitrate: number;
     ignoreDevicePixelRatio: boolean;
+    maxDevicePixelRatio: number;
     preferManagedMediaSource: boolean;
     timelineOffset?: number;
     loader: {

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`capLevelToPlayerSize`](#capleveltoplayersize)
   - [`capLevelOnFPSDrop`](#caplevelonfpsdrop)
   - [`ignoreDevicePixelRatio`](#ignoredevicepixelratio)
+  - [`maxDevicePixelRatio`](#maxdevicepixelratio)
   - [`debug`](#debug)
   - [`autoStartLoad`](#autostartload)
   - [`startPosition`](#startposition)
@@ -525,6 +526,12 @@ This configuration will be applied by default to all instances.
 
 - when set to true, calculations related to player size will ignore browser `devicePixelRatio`.
 - when set to false, calculations related to player size will respect browser `devicePixelRatio`.
+
+### `maxDevicePixelRatio`
+
+(default: `Number.POSITIVE_INFINITY`)
+
+- when set, calculations related to player size will limit the browser's `devicePixelRatio` to this specified value.
 
 ### `debug`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -272,6 +272,7 @@ export type HlsConfig = {
   enableSoftwareAES: boolean;
   minAutoBitrate: number;
   ignoreDevicePixelRatio: boolean;
+  maxDevicePixelRatio: number;
   preferManagedMediaSource: boolean;
   timelineOffset?: number;
   loader: { new (confg: HlsConfig): Loader<LoaderContext> };
@@ -356,6 +357,7 @@ export const hlsDefaultConfig: HlsConfig = {
   capLevelOnFPSDrop: false, // used by fps-controller
   capLevelToPlayerSize: false, // used by cap-level-controller
   ignoreDevicePixelRatio: false, // used by cap-level-controller
+  maxDevicePixelRatio: Number.POSITIVE_INFINITY, // used by cap-level-controller
   preferManagedMediaSource: true,
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller

--- a/src/controller/cap-level-controller.ts
+++ b/src/controller/cap-level-controller.ts
@@ -258,7 +258,7 @@ class CapLevelController implements ComponentAPI {
       }
     }
 
-    return pixelRatio;
+    return Math.min(pixelRatio, this.hls.config.maxDevicePixelRatio);
   }
 
   private isLevelAllowed(level: Level): boolean {


### PR DESCRIPTION
### This PR will limit the browser's `devicePixelRatio` for calculations related to player size.

### Why is this Pull Request needed?
We have more and more devices with high `devicePixelRatio` values. For example, a new iPhone today has a `devicePixelRatio` of 3. If a high-density browser (usually mobile phones) requests the video, a level with high resolution is requested. In the past, to avoid this, `ignoreDevicePixelRatio` was implemented. However, this results in videos that are sometimes visually detectably low-res. This option provides a granular value to adjust this.

For example, if a video on an iPhone loaded before with `{ capLevelToPlayerSize: true }` 10 MB, it would now take about 4.5 MB with `{ capLevelToPlayerSize: true, maxDevicePixelRatio: 2 }` (10 MB ÷ (3 × 3) * (2 × 2)) with almost no visual degradation (assuming, of course, the levels are available).

### Are there any points in the code the reviewer needs to double check?
no

### Resolves issues:
use case with hight density devices.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
