### PR TITLE
Bugfix: Low-Latency false starts when part selection does not match fragment

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -466,7 +466,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected loadingParts: boolean;
     // (undocumented)
-    protected _loadInitSegment(frag: Fragment, level: Level): void;
+    protected _loadInitSegment(fragment: Fragment, level: Level): void;
     // (undocumented)
     mapToInitFragWhenRequired(frag: Fragment | null): typeof frag;
     // (undocumented)

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1151,11 +1151,12 @@ export default class StreamController
     return audioCodec;
   }
 
-  private _loadBitrateTestFrag(frag: Fragment, level: Level) {
-    frag.bitrateTest = true;
-    this._doFragLoad(frag, level).then((data) => {
+  private _loadBitrateTestFrag(fragment: Fragment, level: Level) {
+    fragment.bitrateTest = true;
+    this._doFragLoad(fragment, level).then((data) => {
       const { hls } = this;
-      if (!data || this.fragContextChanged(frag)) {
+      const frag = data?.frag;
+      if (!frag || this.fragContextChanged(frag)) {
         return;
       }
       level.fragmentError = 0;

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -12,13 +12,13 @@ import Transmuxer, {
 } from '../demux/transmuxer';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
+import { PlaylistLevelType } from '../types/loader';
 import { getM2TSSupportedAudioTypes } from '../utils/codecs';
 import type { WorkerContext } from './inject-worker';
 import type { HlsEventEmitter, HlsListeners } from '../events';
 import type Hls from '../hls';
 import type { MediaFragment, Part } from '../loader/fragment';
 import type { ErrorData, FragDecryptedData } from '../types/events';
-import type { PlaylistLevelType } from '../types/loader';
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
 
@@ -234,7 +234,9 @@ export default class TransmuxerInterface {
     );
     if (!contiguous || discontinuity || initSegmentChange) {
       this.hls.logger
-        .log(`[transmuxer-interface, ${frag.type}]: Starting new transmux session for sn: ${chunkMeta.sn} p: ${chunkMeta.part} level: ${chunkMeta.level} id: ${chunkMeta.id}
+        .log(`[transmuxer-interface]: Starting new transmux session for ${frag.type} sn: ${chunkMeta.sn}${
+        chunkMeta.part > -1 ? ' part: ' + chunkMeta.part : ''
+      } ${this.id === PlaylistLevelType.MAIN ? 'level' : 'track'}: ${chunkMeta.level} id: ${chunkMeta.id}
         discontinuity: ${discontinuity}
         trackSwitch: ${trackSwitch}
         contiguous: ${contiguous}

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -290,7 +290,7 @@ export default class Transmuxer {
     const { accurateTimeOffset, timeOffset } = this.currentTransmuxState;
     this.logger.log(
       `[transmuxer.ts]: Flushed ${this.id} sn: ${chunkMeta.sn}${
-        chunkMeta.part > -1 ? ' p: ' + chunkMeta.part : ''
+        chunkMeta.part > -1 ? ' part: ' + chunkMeta.part : ''
       } of ${this.id === PlaylistLevelType.MAIN ? 'level' : 'track'} ${chunkMeta.level}`,
     );
     const remuxResult = this.remuxer!.remux(


### PR DESCRIPTION
### This PR will...
Fix unused part loading when selected frag passed to `_doFragLoad` is not used by part selection.

### Why is this Pull Request needed?
There was an expectation that `_doFragLoad(frag)` will resolve with the frag or a part from that frag being loaded. The result of `_doFragLoad` is ignored if `streamController.currentFrag` no longer matches `frag`. 

This PR fixes the case where  `_doFragLoad(frag)` resolves with a different fragment because of part selection needing to use `fragmentHint` or an independent part in the part list belonging to another fragment:

```
    if (this.loadingParts && frag.sn !== 'initSegment') {
      const partList = details.partList;
      if (partList && progressCallback) {
        if (targetBufferTime > frag.end && details.fragmentHint) {
          frag = details.fragmentHint;
        }
        const partIndex = this.getNextPart(partList, frag, targetBufferTime);
        if (partIndex > -1) {
```
### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
