### PR TITLE
Consider ManagedSourceBuffer in MSE support detection

### DIFF
--- a/src/is-supported.ts
+++ b/src/is-supported.ts
@@ -2,8 +2,13 @@ import { mimeTypeForCodec } from './utils/codecs';
 import { getMediaSource } from './utils/mediasource-helper';
 import type { ExtendedSourceBuffer } from './types/buffer';
 
-function getSourceBuffer(): typeof self.SourceBuffer {
-  return self.SourceBuffer || (self as any).WebKitSourceBuffer;
+function getSourceBuffer(
+  preferManagedSourceBuffer = true,
+): typeof self.SourceBuffer {
+  const msb =
+    (preferManagedSourceBuffer || !self.SourceBuffer) &&
+    ((self as any).ManagedSourceBuffer as undefined | typeof self.SourceBuffer);
+  return msb || self.SourceBuffer || (self as any).WebKitSourceBuffer;
 }
 
 export function isMSESupported(): boolean {


### PR DESCRIPTION
### This PR will...

Consider `ManagedSourceBuffer` as well when detecting MSE support.

### Why is this Pull Request needed?

On iOS Safari, `isMSESupported()`, and thus `isSupported()`, will currently always return `false` as the prototype checks on `SourceBuffer` fail, because `self.SourceBuffer` (and `self.WebKitSourceBuffer`) does not exist on iOS Safari.

### Are there any points in the code the reviewer needs to double check?

The change is rather simple, so no.

### Resolves issues:

No issue has been reported in this regard, but #6161 might be related.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable) => there were no tests for `isSupported()` to begin with
- [ ] API or design changes are documented in API.md => no API changes (`getSourceBuffer` is not exported)
