### PR TITLE
Force media capabilities check for HEVC to avoid failure on Windows

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3237,6 +3237,8 @@ export interface LevelLoadedData {
     // (undocumented)
     level: number;
     // (undocumented)
+    levelInfo: Level;
+    // (undocumented)
     networkDetails: any;
     // (undocumented)
     stats: LoaderStats;
@@ -3252,6 +3254,8 @@ export interface LevelLoadingData {
     id: number;
     // (undocumented)
     level: number;
+    // (undocumented)
+    levelInfo: Level;
     // (undocumented)
     pathwayId: string | undefined;
     // (undocumented)
@@ -4141,6 +4145,8 @@ export interface PlaylistLoaderContext extends LoaderContext {
     // (undocumented)
     levelDetails?: LevelDetails;
     // (undocumented)
+    levelOrTrack: Level | MediaPlaylist | null;
+    // (undocumented)
     pathwayId?: string;
     // (undocumented)
     type: PlaylistContextType;
@@ -4626,6 +4632,8 @@ export interface TrackLoadedData {
     networkDetails: any;
     // (undocumented)
     stats: LoaderStats;
+    // (undocumented)
+    track: MediaPlaylist;
 }
 
 // Warning: (ae-missing-release-tag) "TrackLoadingData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4638,6 +4646,8 @@ export interface TrackLoadingData {
     groupId: string;
     // (undocumented)
     id: number;
+    // (undocumented)
+    track: MediaPlaylist;
     // (undocumented)
     url: string;
 }

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -794,14 +794,15 @@ class AbrController extends Logger implements AbrComponentAPI {
           | undefined;
         if (
           typeof mediaCapabilities?.decodingInfo === 'function' &&
-          requiresMediaCapabilitiesDecodingInfo(
+          (requiresMediaCapabilitiesDecodingInfo(
             levelInfo,
             audioTracksByGroup,
             currentVideoRange,
             currentFrameRate,
             currentBw,
             audioPreference,
-          )
+          ) ||
+            levelInfo.videoCodec?.substring(0, 4) === 'hvc1') // Force media capabilities check for HEVC to avoid failure on Windows
         ) {
           levelInfo.supportedPromise = getMediaDecodingInfoPromise(
             levelInfo,
@@ -830,6 +831,9 @@ class AbrController extends Logger implements AbrComponentAPI {
               if (index > -1 && levels.length > 1) {
                 this.log(`Removing unsupported level ${index}`);
                 this.hls.removeLevel(index);
+                if (this.hls.loadLevel === -1) {
+                  this.hls.nextLoadLevel = 0;
+                }
               }
             }
           });

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -428,6 +428,7 @@ class AudioTrackController extends BasePlaylistController {
         id,
         groupId,
         deliveryDirectives: hlsUrlParameters || null,
+        track: audioTrack,
       });
     }
   }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -601,7 +601,7 @@ export default class LevelController extends BasePlaylistController {
 
   protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
     const { level, details } = data;
-    const curLevel = this._levels[level];
+    const curLevel = data.levelInfo;
 
     if (!curLevel) {
       this.warn(`Invalid level index ${level}`);
@@ -612,7 +612,7 @@ export default class LevelController extends BasePlaylistController {
     }
 
     // only process level loaded events matching with expected level
-    if (level === this.currentLevelIndex) {
+    if (curLevel === this.currentLevel) {
       // reset level load error counter on successful level loaded only if there is no issues with fragments
       if (curLevel.fragmentError === 0) {
         curLevel.loadError = 0;
@@ -665,6 +665,7 @@ export default class LevelController extends BasePlaylistController {
       this.hls.trigger(Events.LEVEL_LOADING, {
         url,
         level: currentLevelIndex,
+        levelInfo: currentLevel,
         pathwayId: currentLevel.attrs['PATHWAY-ID'],
         id: 0, // Deprecated Level urlId
         deliveryDirectives: hlsUrlParameters || null,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -639,7 +639,7 @@ export default class StreamController
     if (!levels || this.state !== State.IDLE) {
       return;
     }
-    const level = levels[data.level];
+    const level = data.levelInfo;
     if (
       !level.details ||
       (level.details.live && this.levelLastLoaded !== level) ||
@@ -667,7 +667,7 @@ export default class StreamController
       }, cc [${newDetails.startCC}, ${newDetails.endCC}] duration:${duration}`,
     );
 
-    const curLevel = levels[newLevelId];
+    const curLevel = data.levelInfo;
     const fragCurrent = this.fragCurrent;
     if (
       fragCurrent &&

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -453,6 +453,7 @@ class SubtitleTrackController extends BasePlaylistController {
         id,
         groupId,
         deliveryDirectives: hlsUrlParameters || null,
+        track: currentTrack,
       });
     }
   }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -188,6 +188,7 @@ export interface LevelSwitchedData {
 export interface TrackLoadingData {
   id: number;
   groupId: string;
+  track: MediaPlaylist;
   url: string;
   deliveryDirectives: HlsUrlParameters | null;
 }
@@ -195,6 +196,7 @@ export interface TrackLoadingData {
 export interface LevelLoadingData {
   id: number;
   level: number;
+  levelInfo: Level;
   pathwayId: string | undefined;
   url: string;
   deliveryDirectives: HlsUrlParameters | null;
@@ -207,12 +209,14 @@ export interface TrackLoadedData {
   networkDetails: any;
   stats: LoaderStats;
   deliveryDirectives: HlsUrlParameters | null;
+  track: MediaPlaylist;
 }
 
 export interface LevelLoadedData {
   details: LevelDetails;
   id: number;
   level: number;
+  levelInfo: Level;
   networkDetails: any;
   stats: LoaderStats;
   deliveryDirectives: HlsUrlParameters | null;

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -1,5 +1,6 @@
 import type { LoaderConfig } from '../config';
-import type { HlsUrlParameters } from './level';
+import type { HlsUrlParameters, Level } from './level';
+import type { MediaPlaylist } from './media-playlist';
 import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
 import type { KeyLoaderInfo } from '../loader/key-loader';
@@ -191,4 +192,6 @@ export interface PlaylistLoaderContext extends LoaderContext {
   levelDetails?: LevelDetails;
   // Blocking playlist request delivery directives (or null id none were added to playlist url
   deliveryDirectives: HlsUrlParameters | null;
+  // Reference to level or track object in hls.levels, hls.allAudioTracks, or hls.allSubtitleTracks (null when loading MVP)
+  levelOrTrack: Level | MediaPlaylist | null;
 }

--- a/tests/unit/controller/audio-stream-controller.ts
+++ b/tests/unit/controller/audio-stream-controller.ts
@@ -182,6 +182,7 @@ describe('AudioStreamController', function () {
           },
           targetduration: 100,
         } as unknown as LevelDetails,
+        track: {} as any,
       };
 
       audioStreamController.levels = tracks;

--- a/tests/unit/controller/audio-track-controller.ts
+++ b/tests/unit/controller/audio-track-controller.ts
@@ -283,6 +283,7 @@ describe('AudioTrackController', function () {
       networkDetails: null,
       stats: { loading: {} } as any,
       deliveryDirectives: null,
+      track: {} as any,
     });
     expect(audioTrackController.tracksInGroup[0], 'tracksInGroup[0]')
       .to.have.property('details')
@@ -299,6 +300,7 @@ describe('AudioTrackController', function () {
       networkDetails: null,
       stats: { loading: {} } as any,
       deliveryDirectives: null,
+      track: {} as any,
     });
     expect(audioTrackController.tracksInGroup[1], 'tracksInGroup[1]')
       .to.have.property('details')

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -129,6 +129,12 @@ describe('StreamController', function () {
         networkDetails: {},
         stats: new LoadStats(),
         deliveryDirectives: null,
+        levelInfo: new Level({
+          name: '',
+          url: '',
+          attrs,
+          bitrate: 500000,
+        }),
       });
       expect(streamController['startPosition']).to.equal(130.5);
       expect(streamController['nextLoadPosition']).to.equal(130.5);
@@ -174,6 +180,12 @@ describe('StreamController', function () {
         networkDetails: {},
         stats: new LoadStats(),
         deliveryDirectives: null,
+        levelInfo: new Level({
+          name: '',
+          url: '',
+          attrs,
+          bitrate: 500000,
+        }),
       });
       expect(streamController['startPosition']).to.equal(18);
       expect(streamController['nextLoadPosition']).to.equal(18);

--- a/tests/unit/controller/subtitle-track-controller.ts
+++ b/tests/unit/controller/subtitle-track-controller.ts
@@ -128,6 +128,7 @@ describe('SubtitleTrackController', function () {
         pathwayId: undefined,
         url: '',
         deliveryDirectives: null,
+        levelInfo: {} as any,
       });
     };
 
@@ -386,6 +387,7 @@ describe('SubtitleTrackController', function () {
           id: 1,
           groupId: 'default-text-group',
           deliveryDirectives: null,
+          track: subtitleTrackController.subtitleTracks[1],
         },
       );
     });
@@ -432,6 +434,7 @@ describe('SubtitleTrackController', function () {
           id: 2,
           groupId: 'default-text-group',
           deliveryDirectives: null,
+          track: subtitleTrackController.subtitleTracks[2],
         },
       );
     });
@@ -489,6 +492,7 @@ describe('SubtitleTrackController', function () {
         stats: new LoadStats(),
         networkDetails: {},
         deliveryDirectives: null,
+        track: {} as any,
       };
       hls.trigger(Events.SUBTITLE_TRACK_LOADED, mockLoadedEvent);
       expect((subtitleTrackController as any).timer).to.equal(-1);
@@ -521,6 +525,7 @@ describe('SubtitleTrackController', function () {
         stats: new LoadStats(),
         networkDetails: {},
         deliveryDirectives: null,
+        track: {} as any,
       };
 
       hls.subtitleTrack = -1;
@@ -544,6 +549,7 @@ describe('SubtitleTrackController', function () {
         stats: new LoadStats(),
         networkDetails: {},
         deliveryDirectives: null,
+        track: {} as any,
       });
       expect((subtitleTrackController as any).timer).to.equal(-1);
     });
@@ -560,6 +566,7 @@ describe('SubtitleTrackController', function () {
         stats: new LoadStats(),
         networkDetails: {},
         deliveryDirectives: null,
+        track: {} as any,
       });
       expect((subtitleTrackController as any).timer).to.exist;
     });
@@ -577,6 +584,7 @@ describe('SubtitleTrackController', function () {
         stats: new LoadStats(),
         networkDetails: {},
         deliveryDirectives: null,
+        track: {} as any,
       });
       expect((subtitleTrackController as any).timer).to.equal(-1);
     });


### PR DESCRIPTION
### This PR will...
Force media capabilities check for HEVC to decode errors from HEVC selection on Windows Firefox.

### Why is this Pull Request needed?
`MediaSource.isTypeSupported('')` reports true, but MediaCapabilities `decodingInfo` tests return false and appending media results in a decode error.

Failed test results: https://github.com/video-dev/hls.js/actions/runs/11844914912/job/33012913783?pr=6845

> `The video playback was aborted due to a corruption problem or because the video used features your browser did not support - NS_ERROR_DOM_MEDIA_NOT_SUPPORTED_ERR (0x806e0003) - Utility MF Media Engine CDM only support for media engine playback`

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
