### PR TITLE
Reset shouldPlay on manifest loading (#6839)

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1247,6 +1247,7 @@ MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
     this.schedule.reset();
     this.emptyPlayerQueue();
     this.clearScheduleState();
+    this.shouldPlay = false;
     this.bufferedPos = this.timelinePos = -1;
     this.mediaSelection =
       this.altSelection =


### PR DESCRIPTION
### This PR will...

Calling loadSource multiple times might start playback immediately as `shouldPlay` is not reset for each new playlist.

### Why is this Pull Request needed?

See https://github.com/video-dev/hls.js/issues/6839

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
