### PR TITLE
Fragment 4xx network error handling improvements

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -5,7 +5,7 @@ import ChunkCache from '../demux/chunk-cache';
 import TransmuxerInterface from '../demux/transmuxer-interface';
 import { ErrorDetails } from '../errors';
 import { Events } from '../events';
-import { ElementaryStreamTypes } from '../loader/fragment';
+import { ElementaryStreamTypes, isMediaFragment } from '../loader/fragment';
 import { Level } from '../types/level';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import { ChunkMetadata } from '../types/transmuxer';
@@ -409,8 +409,8 @@ class AudioStreamController
     if (
       this.startFragRequested &&
       mainFragLoading &&
-      mainFragLoading.sn !== 'initSegment' &&
-      frag.sn !== 'initSegment' &&
+      isMediaFragment(mainFragLoading) &&
+      isMediaFragment(frag) &&
       !frag.endList &&
       (!trackDetails.live ||
         (!this.loadingParts && targetBufferTime < this.hls.liveSyncPosition!))
@@ -694,7 +694,7 @@ class AudioStreamController
   private onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData) {
     if (
       data.frag.type === PlaylistLevelType.MAIN &&
-      data.frag.sn !== 'initSegment'
+      isMediaFragment(data.frag)
     ) {
       this.mainFragLoading = data;
       if (this.state === State.IDLE) {
@@ -722,8 +722,8 @@ class AudioStreamController
       );
       return;
     }
-    if (frag.sn !== 'initSegment') {
-      this.fragPrevious = frag as MediaFragment;
+    if (isMediaFragment(frag)) {
+      this.fragPrevious = frag;
       const track = this.switchingTrack;
       if (track) {
         this.bufferedTrack = track;
@@ -962,7 +962,7 @@ class AudioStreamController
       fragState === FragmentState.NOT_LOADED ||
       fragState === FragmentState.PARTIAL
     ) {
-      if (frag.sn === 'initSegment') {
+      if (!isMediaFragment(frag)) {
         this._loadInitSegment(frag, track);
       } else if (track.details?.live && !this.initPTS[frag.cc]) {
         this.log(

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -6,7 +6,7 @@ import TransmuxerInterface from '../demux/transmuxer-interface';
 import { ErrorDetails } from '../errors';
 import { Events } from '../events';
 import { changeTypeSupported } from '../is-supported';
-import { ElementaryStreamTypes } from '../loader/fragment';
+import { ElementaryStreamTypes, isMediaFragment } from '../loader/fragment';
 import { PlaylistContextType, PlaylistLevelType } from '../types/loader';
 import { ChunkMetadata } from '../types/transmuxer';
 import { BufferHelper } from '../utils/buffer-helper';
@@ -319,7 +319,7 @@ export default class StreamController
       this.couldBacktrack &&
       !this.fragPrevious &&
       frag &&
-      frag.sn !== 'initSegment' &&
+      isMediaFragment(frag) &&
       this.fragmentTracker.getState(frag) !== FragmentState.OK
     ) {
       const backtrackSn = (this.backtrackFragment ?? frag).sn as number;
@@ -378,7 +378,7 @@ export default class StreamController
       fragState === FragmentState.NOT_LOADED ||
       fragState === FragmentState.PARTIAL
     ) {
-      if (frag.sn === 'initSegment') {
+      if (!isMediaFragment(frag)) {
         this._loadInitSegment(frag, level);
       } else if (this.bitrateTest) {
         this.log(
@@ -963,8 +963,8 @@ export default class StreamController
       this.fragLastKbps = Math.round(
         (8 * stats.total) / (stats.buffering.end - stats.loading.first),
       );
-      if (frag.sn !== 'initSegment') {
-        this.fragPrevious = frag as MediaFragment;
+      if (isMediaFragment(frag)) {
+        this.fragPrevious = frag;
       }
       this.fragBufferedComplete(frag, part);
     }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -3,6 +3,11 @@ import { findFragmentByPTS } from './fragment-finders';
 import { FragmentState } from './fragment-tracker';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
+import {
+  type Fragment,
+  isMediaFragment,
+  type MediaFragment,
+} from '../loader/fragment';
 import { Level } from '../types/level';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper } from '../utils/buffer-helper';
@@ -15,7 +20,6 @@ import { addSliding } from '../utils/level-helper';
 import { subtitleOptionsIdentical } from '../utils/media-option-attributes';
 import type Hls from '../hls';
 import type { FragmentTracker } from './fragment-tracker';
-import type { Fragment, MediaFragment } from '../loader/fragment';
 import type KeyLoader from '../loader/key-loader';
 import type { LevelDetails } from '../loader/level-details';
 import type { NetworkComponentAPI } from '../types/component-api';
@@ -126,8 +130,8 @@ export class SubtitleStreamController
     data: SubtitleFragProcessed,
   ) {
     const { frag, success } = data;
-    if (frag.sn !== 'initSegment') {
-      this.fragPrevious = frag as MediaFragment;
+    if (isMediaFragment(frag)) {
+      this.fragPrevious = frag;
     }
     this.state = State.IDLE;
     if (!success) {
@@ -466,7 +470,7 @@ export class SubtitleStreamController
         return;
       }
       foundFrag = this.mapToInitFragWhenRequired(foundFrag) as Fragment;
-      if (foundFrag.sn !== 'initSegment') {
+      if (isMediaFragment(foundFrag)) {
         // Load earlier fragment in same discontinuity to make up for misaligned playlists and cues that extend beyond end of segment
         const curSNIdx = foundFrag.sn - trackDetails.startSN;
         const prevFrag = fragments[curSNIdx - 1];
@@ -492,7 +496,7 @@ export class SubtitleStreamController
     level: Level,
     targetBufferTime: number,
   ) {
-    if (frag.sn === 'initSegment') {
+    if (!isMediaFragment(frag)) {
       this._loadInitSegment(frag, level);
     } else {
       super.loadFragment(frag, level, targetBufferTime);

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -152,6 +152,10 @@ export type MediaFragmentRef = {
   programDateTime: number | null;
 };
 
+export function isMediaFragment(frag: Fragment): frag is MediaFragment {
+  return frag.sn !== 'initSegment';
+}
+
 /**
  * Object representing parsed data from an HLS Segment. Found in {@link hls.js#LevelDetails.fragments}.
  */
@@ -323,7 +327,7 @@ export class Fragment extends BaseSegment {
   }
 
   get ref(): MediaFragmentRef | null {
-    if (this.sn === 'initSegment') {
+    if (!isMediaFragment(this)) {
       return null;
     }
     if (!this._ref) {


### PR DESCRIPTION
### This PR will...

- Skip errored fragments with no alternate
- Fix fragment retry delay when there are no alternates

### Why is this Pull Request needed?

Error handling of fragment 4xx errors skips retry, expecting a switch to an alternate selection or pathway. When there is none, the error was reset, but then the stream controller would request the fragment again on next IDLE tick.

This change skips fragments that 4xx when there are no alternate pathways or media options, treating them as gaps, unless the segment is the last segment in a VOD playlist (#5153, #6171). An init segment or the last segment in a playlist will be retried using retry rules even if the network error is a 4xx (#5647, #6741).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

- Resolves #6741
- Resolves #5647
- Resolves #5153
- Closes/Replaces #6171

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
