### PR TITLE
Make stream controllers wait for playlist updates before requesting segments from expired playlists

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -556,6 +556,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     protected unregisterListeners(): void;
     // (undocumented)
     protected waitForCdnTuneIn(details: LevelDetails): boolean | 0;
+    // (undocumented)
+    protected waitForLive(levelInfo: Level): boolean | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "BaseTrack" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3131,6 +3133,8 @@ export class LevelDetails {
     endCC: number;
     // (undocumented)
     endSN: number;
+    // (undocumented)
+    get expired(): boolean;
     // (undocumented)
     get fragmentEnd(): number;
     // (undocumented)

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -425,8 +425,17 @@ class AudioTrackController extends BasePlaylistController {
         }
       }
       // track not retrieved yet, or live playlist we need to (re)load it
+      const details = audioTrack.details;
+      const age = details?.age;
       this.log(
-        `loading audio-track playlist ${id} "${audioTrack.name}" lang:${audioTrack.lang} group:${groupId}`,
+        `Loading audio-track ${id} "${audioTrack.name}" lang:${audioTrack.lang} group:${groupId}${
+          hlsUrlParameters?.msn !== undefined
+            ? ' at sn ' +
+              hlsUrlParameters.msn +
+              ' part ' +
+              hlsUrlParameters.part
+            : ''
+        }${age && details.live ? ' age ' + age.toFixed(1) + (details.type ? ' ' + details.type || '' : '') : ''} ${url}`,
       );
       this.clearTimer();
       this.hls.trigger(Events.AUDIO_TRACK_LOADING, {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -648,6 +648,8 @@ export default class LevelController extends BasePlaylistController {
       }
 
       const pathwayId = currentLevel.attrs['PATHWAY-ID'];
+      const details = currentLevel.details;
+      const age = details?.age;
       this.log(
         `Loading level index ${currentLevelIndex}${
           hlsUrlParameters?.msn !== undefined
@@ -656,7 +658,7 @@ export default class LevelController extends BasePlaylistController {
               ' part ' +
               hlsUrlParameters.part
             : ''
-        } with${pathwayId ? ' Pathway ' + pathwayId : ''} ${url}`,
+        }${pathwayId ? ' Pathway ' + pathwayId : ''}${age && details.live ? ' age ' + age.toFixed(1) + (details.type ? ' ' + details.type || '' : '') : ''} ${url}`,
       );
 
       // console.log('Current audio track group ID:', this.hls.audioTracks[this.hls.audioTrack].groupId);

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -18,8 +18,8 @@ import {
 } from '../utils/encryption-methods-util';
 import { addSliding } from '../utils/level-helper';
 import { subtitleOptionsIdentical } from '../utils/media-option-attributes';
-import type Hls from '../hls';
 import type { FragmentTracker } from './fragment-tracker';
+import type Hls from '../hls';
 import type KeyLoader from '../loader/key-loader';
 import type { LevelDetails } from '../loader/level-details';
 import type { NetworkComponentAPI } from '../types/component-api';
@@ -423,6 +423,9 @@ export class SubtitleStreamController
       const { currentTrackId, levels } = this;
       const track = levels?.[currentTrackId];
       if (!track || !levels.length || !track.details) {
+        return;
+      }
+      if (this.waitForLive(track)) {
         return;
       }
       const { config } = this;

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -447,7 +447,18 @@ class SubtitleTrackController extends BasePlaylistController {
           );
         }
       }
-      this.log(`Loading subtitle playlist for id ${id}`);
+      const details = currentTrack.details;
+      const age = details?.age;
+      this.log(
+        `Loading subtitle ${id} "${currentTrack.name}" lang:${currentTrack.lang} group:${groupId}${
+          hlsUrlParameters?.msn !== undefined
+            ? ' at sn ' +
+              hlsUrlParameters.msn +
+              ' part ' +
+              hlsUrlParameters.part
+            : ''
+        }${age && details.live ? ' age ' + age.toFixed(1) + (details.type ? ' ' + details.type || '' : '') : ''} ${url}`,
+      );
       this.hls.trigger(Events.SUBTITLE_TRACK_LOADING, {
         url,
         id,

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -164,7 +164,11 @@ export class LevelDetails {
   get expired(): boolean {
     if (this.live && this.age) {
       const playlistWindowDuration = this.partEnd - this.fragmentStart;
-      return this.age > playlistWindowDuration + this.levelTargetDuration * 3;
+      return (
+        this.age >
+        Math.max(playlistWindowDuration, this.totalduration) +
+          this.levelTargetDuration
+      );
     }
     return false;
   }

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -160,4 +160,12 @@ export class LevelDetails {
     }
     return this.endSN;
   }
+
+  get expired(): boolean {
+    if (this.live && this.age) {
+      const playlistWindowDuration = this.partEnd - this.fragmentStart;
+      return this.age > playlistWindowDuration + this.levelTargetDuration * 3;
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
### This PR will...
Avoid requesting expired playlist segments when resuming live playback.

### Why is this Pull Request needed?
HLS.js should wait for live (not EVENT) playlists to refresh before loading segments if they have not been updated in enough time for the last segment to be older than three target duration past the start of the playlist.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6854

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
