### PR TITLE
Re-align audio playlist with main when there is no overlap between audio playlist updates

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -521,12 +521,16 @@ class AudioStreamController
     event: Events.AUDIO_TRACK_LOADED,
     data: TrackLoadedData,
   ) {
-    if (this.mainDetails == null) {
+    const { levels } = this;
+    const { details: newDetails, id: trackId } = data;
+    if (
+      this.mainDetails == null ||
+      this.mainDetails.expired ||
+      newDetails.endCC > this.mainDetails.endCC
+    ) {
       this.cachedTrackLoadedData = data;
       return;
     }
-    const { levels } = this;
-    const { details: newDetails, id: trackId } = data;
     if (!levels) {
       this.warn(`Audio tracks were reset while loading level ${trackId}`);
       return;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -566,8 +566,8 @@ class AudioStreamController
         );
       }
       if (!newDetails.alignedSliding) {
-        // Make sure our audio rendition is aligned with the "main" rendition, using
-        // pdt as our reference times.
+        // Align audio rendition with the "main" playlist on discontinuity change
+        // or program-date-time (PDT)
         alignDiscontinuities(newDetails, mainDetails);
         if (!newDetails.alignedSliding) {
           alignMediaPlaylistByPDT(newDetails, mainDetails);

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -260,7 +260,7 @@ class AudioStreamController
             this.nextLoadPosition = this.findSyncFrag(videoAnchor).start;
             this.clearWaitingFragment();
           }
-        } else if (this.state !== State.STOPPED) {
+        } else {
           this.state = State.IDLE;
         }
       }
@@ -511,9 +511,10 @@ class AudioStreamController
 
   private onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
     this.mainDetails = data.details;
-    if (this.cachedTrackLoadedData !== null) {
-      this.hls.trigger(Events.AUDIO_TRACK_LOADED, this.cachedTrackLoadedData);
+    const cachedTrackLoadedData = this.cachedTrackLoadedData;
+    if (cachedTrackLoadedData) {
       this.cachedTrackLoadedData = null;
+      this.hls.trigger(Events.AUDIO_TRACK_LOADED, cachedTrackLoadedData);
     }
   }
 
@@ -529,6 +530,9 @@ class AudioStreamController
       newDetails.endCC > this.mainDetails.endCC
     ) {
       this.cachedTrackLoadedData = data;
+      if (this.state !== State.STOPPED) {
+        this.state = State.WAITING_TRACK;
+      }
       return;
     }
     if (!levels) {
@@ -673,7 +677,9 @@ class AudioStreamController
         complete: false,
       });
       cache.push(new Uint8Array(payload));
-      this.state = State.WAITING_INIT_PTS;
+      if (this.state !== State.STOPPED) {
+        this.state = State.WAITING_INIT_PTS;
+      }
     }
   }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1593,15 +1593,12 @@ export default class BaseStreamController
     const firstLevelLoad = !previousDetails;
     const aligned = details.alignedSliding && Number.isFinite(slidingStart);
     if (firstLevelLoad || (!aligned && !slidingStart)) {
-      const { fragPrevious } = this;
-      alignStream(fragPrevious, switchDetails, details);
+      alignStream(switchDetails, details);
       const alignedSlidingStart = details.fragmentStart;
       this.log(
         `Live playlist sliding: ${alignedSlidingStart.toFixed(2)} start-sn: ${
           previousDetails ? previousDetails.startSN : 'na'
-        }->${details.startSN} prev-sn: ${
-          fragPrevious ? fragPrevious.sn : 'na'
-        } fragments: ${length}`,
+        }->${details.startSN} fragments: ${length}`,
       );
       return alignedSlidingStart;
     }

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -526,7 +526,7 @@ export default class M3U8Parser {
           }
 
           case 'DISCONTINUITY-SEQUENCE':
-            discontinuityCounter = parseInt(value1);
+            level.startCC = discontinuityCounter = parseInt(value1);
             break;
           case 'KEY': {
             const levelKey = parseKey(value1, baseurl, level);
@@ -671,7 +671,7 @@ export default class M3U8Parser {
       if (!level.live) {
         lastFragment.endList = true;
       }
-      if (firstFragment) {
+      if (firstFragment && !level.startCC) {
         level.startCC = firstFragment.cc;
       }
       /**

--- a/src/utils/discontinuities.ts
+++ b/src/utils/discontinuities.ts
@@ -57,12 +57,10 @@ export function adjustSlidingStart(sliding: number, details: LevelDetails) {
  * The PTS of a fragment lets Hls.js know where it fits into a stream - by knowing every PTS, we know which fragment to
  * download at any given time. PTS is normally computed when the fragment is demuxed, so taking this step saves us time
  * and an extra download.
- * @param lastFrag
  * @param lastLevel
  * @param details
  */
 export function alignStream(
-  lastFrag: Fragment | null,
   switchDetails: LevelDetails | undefined,
   details: LevelDetails,
 ) {

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -229,7 +229,9 @@ export function mergeDetails(
         newDetails.fragments.shift();
       }
       newDetails.startSN = newDetails.fragments[0].sn;
-      newDetails.startCC = newDetails.fragments[0].cc;
+      if (!newDetails.startCC) {
+        newDetails.startCC = newDetails.fragments[0].cc;
+      }
     } else {
       if (newDetails.canSkipDateRanges) {
         newDetails.dateRanges = mergeDateRanges(

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -698,7 +698,7 @@ audio_5441.m4s`;
 
     beforeEach(function () {
       hls = new Hls({
-        debug: true,
+        // debug: true,
       }) as unknown as HlsTestable;
       for (let i = hls.networkControllers.length; i--; ) {
         const component = hls.networkControllers[i];


### PR DESCRIPTION
### This PR will...

- Attempt to realign audio with main when `alignPlaylists` finds no overlap in live playlist updates.
- Wait for audio rendition playlist update when ending discontinuity is not matched in main playlist.
- `startCC` of LevelDetails will be set to DISCONTINUITY-SEQUENCE when playlists begin with a DISCONTINUITY tag instead of the sequence number of the first fragment (starting sequence +1), allowing alignment on first segment with new discontinuity.  
- Prevent audio-stream-controller state changes to "WAITING..." when loading is stopped.

### Why is this Pull Request needed?

- Realigns live main and audio playlists after media sequence sync is lost.
- Prioritizes discontinuity sequence alignment over program date time.
- Prevents audio segment fetching of new discontinuity until main discontinuity sequence is avaiable.

### Are there any points in the code the reviewer needs to double check?

Audio playlists aligned with main on program date time at start can have negative start times.

### Resolves issues:

Resolves #6823

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
