### PR TITLE
Live reload throttling per level details schedule

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -305,6 +305,8 @@ export type BaseData = {
 export class BasePlaylistController extends Logger implements NetworkComponentAPI {
     constructor(hls: Hls, logPrefix: string);
     // (undocumented)
+    protected canLoad: boolean;
+    // (undocumented)
     protected checkRetry(errorEvent: ErrorData): boolean;
     // (undocumented)
     destroy(): void;
@@ -319,7 +321,7 @@ export class BasePlaylistController extends Logger implements NetworkComponentAP
     // (undocumented)
     protected playlistLoaded(index: number, data: LevelLoadedData | AudioTrackLoadedData | TrackLoadedData, previousDetails?: LevelDetails): void;
     // (undocumented)
-    protected scheduleLoading(levelOrTrack: Level | MediaPlaylist, deliveryDirectives?: HlsUrlParameters): void;
+    protected scheduleLoading(levelOrTrack: Level | MediaPlaylist, deliveryDirectives?: HlsUrlParameters, updatedDetails?: LevelDetails): void;
     // (undocumented)
     protected shouldLoadPlaylist(playlist: Level | MediaPlaylist | null | undefined): playlist is Level | MediaPlaylist;
     // (undocumented)
@@ -2012,6 +2014,7 @@ class Hls implements HlsEventEmitter {
     // (undocumented)
     listeners<E extends keyof HlsListeners>(event: E): HlsListeners[E][];
     get liveSyncPosition(): number | null;
+    get loadingEnabled(): boolean;
     get loadLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "loadLevel" must appear on the getter, not the setter.
     set loadLevel(newLevel: number);
@@ -3158,6 +3161,8 @@ export class LevelDetails {
     // (undocumented)
     m3u8: string;
     // (undocumented)
+    get maxPartIndex(): number;
+    // (undocumented)
     misses: number;
     // (undocumented)
     get partEnd(): number;
@@ -3258,6 +3263,8 @@ export interface LevelLoadedData {
     networkDetails: any;
     // (undocumented)
     stats: LoaderStats;
+    // (undocumented)
+    withoutMultiVariant?: boolean;
 }
 
 // Warning: (ae-missing-release-tag) "LevelLoadingData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -522,7 +522,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected resetTransmuxer(): void;
     // (undocumented)
-    protected resetWhenMissingContext(chunkMeta: ChunkMetadata): void;
+    protected resetWhenMissingContext(chunkMeta: ChunkMetadata | Fragment): void;
     // (undocumented)
     resumeBuffering(): void;
     // (undocumented)

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -718,7 +718,7 @@ class AbrController extends Logger implements AbrComponentAPI {
     if (levels.length === 1) {
       return 0;
     }
-    const level: Level | undefined = levels[selectionBaseLevel];
+    const level = levels[selectionBaseLevel] as Level | undefined;
     const live = !!this.hls.latestLevelDetails?.live;
     const firstSelection = loadLevel === -1 || lastLoadedFragLevel === -1;
     let currentCodecSet: string | undefined;
@@ -920,7 +920,7 @@ class AbrController extends Logger implements AbrComponentAPI {
               )} of ${maxAutoLevel} max with CODECS and VIDEO-RANGE:"${
                 levels[levelsSkipped[0]].codecs
               }" ${levels[levelsSkipped[0]].videoRange}; not compatible with "${
-                level.codecs
+                currentCodecSet
               }" ${currentVideoRange}`,
             );
           }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1871,7 +1871,7 @@ export default class BaseStreamController
     }
   }
 
-  protected resetWhenMissingContext(chunkMeta: ChunkMetadata) {
+  protected resetWhenMissingContext(chunkMeta: ChunkMetadata | Fragment) {
     this.warn(
       `The loading context changed while buffering fragment ${chunkMeta.sn} of ${this.playlistLabel()} ${chunkMeta.level}. This chunk will not be buffered.`,
     );

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -664,6 +664,9 @@ export default class LevelController extends BasePlaylistController {
   }
 
   removeLevel(levelIndex: number) {
+    if (this._levels.length === 1) {
+      return;
+    }
     const levels = this._levels.filter((level, index) => {
       if (index !== levelIndex) {
         return true;
@@ -684,6 +687,14 @@ export default class LevelController extends BasePlaylistController {
     this._levels = levels;
     if (this.currentLevelIndex > -1 && this.currentLevel?.details) {
       this.currentLevelIndex = this.currentLevel.details.fragments[0].level;
+    }
+    if (this.manualLevelIndex > -1) {
+      this.manualLevelIndex = this.currentLevelIndex;
+    }
+    const maxLevel = levels.length - 1;
+    this._firstLevel = Math.min(this._firstLevel, maxLevel);
+    if (this._startLevel) {
+      this._startLevel = Math.min(this._startLevel, maxLevel);
     }
     this.hls.trigger(Events.LEVELS_UPDATED, { levels });
   }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -380,18 +380,6 @@ export default class LevelController extends BasePlaylistController {
       altAudio: !audioOnly && audioTracks.some((t) => !!t.url),
     };
     this.hls.trigger(Events.MANIFEST_PARSED, edata);
-
-    // Initiate loading after all controllers have received MANIFEST_PARSED
-    const {
-      config: { autoStartLoad, startPosition },
-      forceStartLoad,
-    } = this.hls;
-    if (autoStartLoad || forceStartLoad) {
-      this.log(
-        `${autoStartLoad ? 'auto' : 'force'} startLoad with configured startPosition ${startPosition}`,
-      );
-      this.hls.startLoad(startPosition);
-    }
   }
 
   get levels(): Level[] | null {
@@ -606,8 +594,8 @@ export default class LevelController extends BasePlaylistController {
       return;
     }
 
-    // only process level loaded events matching with expected level
-    if (curLevel === this.currentLevel) {
+    // only process level loaded events matching with expected level or prior to switch when media playlist is loaded directly
+    if (curLevel === this.currentLevel || data.withoutMultiVariant) {
       // reset level load error counter on successful level loaded only if there is no issues with fragments
       if (curLevel.fragmentError === 0) {
         curLevel.loadError = 0;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1095,6 +1095,9 @@ export default class StreamController
   ) {
     if (this.level > -1 && this.fragCurrent) {
       this.level = this.fragCurrent.level;
+      if (this.level === -1) {
+        this.resetWhenMissingContext(this.fragCurrent);
+      }
     }
     this.levels = data.levels;
   }

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -544,6 +544,13 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
+   * Returns whether loading, toggled with `startLoad()` and `stopLoad()`, is active or not`.
+   */
+  get loadingEnabled(): boolean {
+    return this.streamController.hasInterval();
+  }
+
+  /**
    * Returns state of fragment loading toggled by calling `pauseBuffering()` and `resumeBuffering()`.
    */
   get bufferingEnabled(): boolean {

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -155,6 +155,22 @@ export class LevelDetails {
     return -1;
   }
 
+  get maxPartIndex(): number {
+    const partList = this.partList;
+    if (partList) {
+      const lastIndex = this.lastPartIndex;
+      if (lastIndex !== -1) {
+        for (let i = partList.length; i--; ) {
+          if (partList[i].index > lastIndex) {
+            return partList[i].index;
+          }
+        }
+        return lastIndex;
+      }
+    }
+    return 0;
+  }
+
   get lastPartSn(): number {
     if (this.partList?.length) {
       return this.partList[this.partList.length - 1].fragment.sn;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -220,6 +220,7 @@ export interface LevelLoadedData {
   networkDetails: any;
   stats: LoaderStats;
   deliveryDirectives: HlsUrlParameters | null;
+  withoutMultiVariant?: boolean;
 }
 
 export interface LevelUpdatedData {

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -538,10 +538,13 @@ export function findPart(
 
 export function reassignFragmentLevelIndexes(levels: Level[]) {
   levels.forEach((level, index) => {
-    const { details } = level;
-    if (details?.fragments) {
-      details.fragments.forEach((fragment) => {
+    const fragments = level.details?.fragments;
+    if (fragments) {
+      fragments.forEach((fragment) => {
         fragment.level = index;
+        if (fragment.initSegment) {
+          fragment.initSegment.level = index;
+        }
       });
     }
   });

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -266,7 +266,9 @@ describe('ErrorController Integration Tests', function () {
       hls.loadSource('noSegmentsVod.m3u8');
       hls.stopLoad.should.have.been.calledOnce;
       return new Promise((resolve, reject) => {
-        hls.on(Events.ERROR, (event, data) => resolve(data));
+        hls.on(Events.ERROR, (event, data) =>
+          Promise.resolve().then(() => resolve(data)),
+        );
         hls.on(Events.LEVEL_LOADED, () =>
           reject(
             new Error(

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -221,14 +221,11 @@ fileSequence4.ts
         },
       ]);
       expect(interstitialEvent).to.equal(schedule[1].event);
-      expect(hls.trigger).to.have.callCount(4);
+      expect(hls.trigger).to.have.callCount(3);
       expect(hls.trigger).to.have.been.calledWith(Events.LEVEL_UPDATED);
       expect(hls.trigger).to.have.been.calledWith(Events.INTERSTITIALS_UPDATED);
       expect(hls.trigger).to.have.been.calledWith(
         Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
-      );
-      expect(hls.trigger).to.have.been.calledWith(
-        Events.INTERSTITIALS_PRIMARY_RESUMED,
       );
     });
 

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -49,7 +49,10 @@ describe('StreamController', function () {
   });
 
   const assertStreamControllerStarted = (streamController) => {
-    expect(streamController.hasInterval()).to.be.true;
+    expect(
+      streamController.hasInterval(),
+      `StreamController should be ticking. State: ${streamController.state}`,
+    ).to.be.true;
     expect(streamController.state).to.equal(
       State.IDLE,
       "StreamController's state should not be STOPPED",
@@ -57,7 +60,10 @@ describe('StreamController', function () {
   };
 
   const assertStreamControllerStopped = (streamController) => {
-    expect(streamController.hasInterval()).to.be.false;
+    expect(
+      streamController.hasInterval(),
+      `StreamController should be stopped. State: ${streamController.state}`,
+    ).to.be.false;
     expect(streamController.state).to.equal(
       State.STOPPED,
       "StreamController's state should be STOPPED",
@@ -89,6 +95,8 @@ describe('StreamController', function () {
       startTimeOffset,
       variableList,
     });
+    const playlistLoader = (hls as any).networkControllers[0];
+    (playlistLoader as any).checkAutostartLoad();
     return result;
   };
 


### PR DESCRIPTION
### This PR will...

- Improve live reload scheduling (and fix a regression in dev)
- Improve blocking requests with parts and low-latency mode disabled
- Defer autostart until after manifest loasded and level loaded when media playlist is source
- Added `hls.loadingEnabled` getter
- Prevent Interstitial controller from calling startLoad when stopped and do not resume primary on first item 

### Why is this Pull Request needed?
Prevents redundant playlist request on startup and fixes autostart behavior in development.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
- Fixes #6858
- Fixes #6839

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
