### PR TITLE
Fix loading of audio media options with the same URI as the current level

### DIFF
--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -8,6 +8,7 @@ import {
   findClosestLevelWithAudioGroup,
   findMatchingOption,
   matchesOption,
+  useAlternateAudio,
 } from '../utils/rendition-helper';
 import type Hls from '../hls';
 import type {
@@ -401,11 +402,10 @@ class AudioTrackController extends BasePlaylistController {
     if (!this.shouldLoadPlaylist(audioTrack)) {
       return;
     }
-    if (audioTrack.url === this.hls.levels[this.hls.loadLevel]?.uri) {
-      // Do not load audio rendition with URI matching main variant URI
-      return;
+    // Do not load audio rendition with URI matching main variant URI
+    if (useAlternateAudio(audioTrack.url, this.hls)) {
+      this.scheduleLoading(audioTrack, hlsUrlParameters);
     }
-    this.scheduleLoading(audioTrack, hlsUrlParameters);
   }
 
   protected loadingPlaylist(

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1273,6 +1273,10 @@ MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
   }
 
   private onLevelUpdated(event: Events.LEVEL_UPDATED, data: LevelUpdatedData) {
+    if (data.level === -1) {
+      // level was removed
+      return;
+    }
     const main = this.hls.levels[data.level];
     const currentSelection = {
       ...(this.mediaSelection || this.altSelection),

--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -1,6 +1,7 @@
 import { codecsSetSelectionPreferenceValue } from './codecs';
 import { getVideoSelectionOptions } from './hdr';
 import { logger } from './logger';
+import type Hls from '../hls';
 import type { Level, VideoRange } from '../types/level';
 import type {
   AudioSelectionOption,
@@ -499,4 +500,8 @@ function searchDownAndUpList(
     }
   }
   return -1;
+}
+
+export function useAlternateAudio(audioTrackUrl: string, hls: Hls): boolean {
+  return !!audioTrackUrl && audioTrackUrl !== hls.levels[hls.loadLevel]?.uri;
 }


### PR DESCRIPTION
### This PR will...
Only load audio via the stream-controller (main playlist / active level) when the alternate audio rendition has the same URL.

### Why is this Pull Request needed?
The stream-controller was not loading audio for audio-only streams when there were alternate audio options. It assumed that the main variant was inactive or represented by another alternate. However, if the current alternate has a (redundant) URL matching that of the main variant, instead of opting to omit the URL attribute, that alternate should not handled by the the audio-track and audio-stream-controllers.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6859
Resolves #6783 (Fixed with #6785 but regressed with #6845)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
