### PR TITLE
Maintain startup event order with autoStartLoad

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3646,6 +3646,8 @@ export interface ManifestLoadedData {
     // (undocumented)
     contentSteering: ContentSteeringOptions | null;
     // (undocumented)
+    isMediaPlaylist?: boolean;
+    // (undocumented)
     levels: LevelParsed[];
     // (undocumented)
     networkDetails: any;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -300,6 +300,12 @@ export default class Hls implements HlsEventEmitter {
     if (typeof onErrorOut === 'function') {
       this.on(Events.ERROR, onErrorOut, errorController);
     }
+    // Autostart load handler
+    this.on(
+      Events.MANIFEST_LOADED,
+      playListLoader.onManifestLoaded,
+      playListLoader,
+    );
   }
 
   createController(ControllerClass, components) {

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -19,6 +19,7 @@ import type {
   ErrorData,
   LevelLoadingData,
   LevelsUpdatedData,
+  ManifestLoadedData,
   ManifestLoadingData,
   TrackLoadingData,
 } from '../types/events';
@@ -495,8 +496,12 @@ class PlaylistLoader implements NetworkComponentAPI {
       startTimeOffset,
       variableList,
     });
+  }
 
-    this.checkAutostartLoad();
+  onManifestLoaded(event: Events.MANIFEST_LOADED, data: ManifestLoadedData) {
+    if (!data.isMediaPlaylist) {
+      this.checkAutostartLoad();
+    }
   }
 
   private handleTrackOrLevelPlaylist(
@@ -549,6 +554,7 @@ class PlaylistLoader implements NetworkComponentAPI {
         contentSteering: null,
         startTimeOffset: null,
         variableList: null,
+        isMediaPlaylist: true,
       });
     }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,8 +7,6 @@ import type {
   SourceBufferName,
   SourceBufferTrackSet,
 } from './buffer';
-import type { ChunkMetadata } from './transmuxer';
-import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { MetadataSample, UserdataSample } from './demuxer';
 import type {
   HdcpLevel,
@@ -27,6 +25,7 @@ import type {
   PlaylistLoaderContext,
 } from './loader';
 import type { MediaPlaylist, MediaPlaylistType } from './media-playlist';
+import type { ChunkMetadata } from './transmuxer';
 import type { SteeringManifest } from '../controller/content-steering-controller';
 import type { IErrorAction } from '../controller/error-controller';
 import type { HlsAssetPlayer } from '../controller/interstitial-player';
@@ -34,6 +33,7 @@ import type {
   InterstitialScheduleDurations,
   InterstitialScheduleItem,
 } from '../controller/interstitials-schedule';
+import type { ErrorDetails, ErrorTypes } from '../errors';
 import type { HlsListeners } from '../events';
 import type { Fragment, MediaFragment, Part } from '../loader/fragment';
 import type {
@@ -138,6 +138,7 @@ export interface ManifestLoadedData {
   subtitles?: MediaPlaylist[];
   url: string;
   variableList: VariableMap | null;
+  isMediaPlaylist?: boolean;
 }
 
 export interface ManifestParsedData {


### PR DESCRIPTION
### This PR will...
Maintain startup event order using autoStartLoad for expected level and audioTrack getter results on MANIFEST_LOADING

### Why is this Pull Request needed?
Moving the `startLoad()` call evoked when `autoStartLoad` is `true` in MANIFEST_LOADING to after MANIFEST_LOADING caused loadLevel and hls.audioTracks to not be populated in app callback to the MANIFEST_LOADING event - because level switching and associated media selection is not performed until loading is started.

Fixes a regression in dev in apps that expect these getters to be populated rather that using events associated with track updates and level selection (caused by #6879).

### Are there any points in the code the reviewer needs to double check?


### Resolves issues:
Resolves #6891

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
