### PR TITLE
Fallback to primary when Interstitial DateRange is removed while playing

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3646,8 +3646,6 @@ export interface ManifestLoadedData {
     // (undocumented)
     contentSteering: ContentSteeringOptions | null;
     // (undocumented)
-    isMediaPlaylist?: boolean;
-    // (undocumented)
     levels: LevelParsed[];
     // (undocumented)
     networkDetails: any;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -138,7 +138,6 @@ export interface ManifestLoadedData {
   subtitles?: MediaPlaylist[];
   url: string;
   variableList: VariableMap | null;
-  isMediaPlaylist?: boolean;
 }
 
 export interface ManifestParsedData {


### PR DESCRIPTION
### This PR will...
- Fallback to primary when Interstitial DateRange is removed while playing
- Resolve regression in dev starting live interstitials from media playlist (revert autostart load after playlist populated when no multivariant playlist is provided)

### Why is this Pull Request needed?
Prevents playback from stalling when the Interstitial DateRange of the currently playing Interstitial is removed in a live playlist update. Removal of active events should terminate event playback and resume primary (#6765).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6765
Resolves regression in dev starting live interstitials from media playlist (no multivariant playlist loaded startup sequence changed)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
