### PR TITLE
Fix: Subtitles not loaded while buffering Interstitials

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -445,7 +445,8 @@ export default class BaseStreamController
     if (
       __USE_INTERSTITALS__ &&
       config.interstitialsController &&
-      config.enableInterstitialPlayback !== false
+      config.enableInterstitialPlayback !== false &&
+      frag.type !== PlaylistLevelType.SUBTITLE
     ) {
       // Do not load fragments outside the buffering schedule segment
       const interstitials = this.hls.interstitialsManager;


### PR DESCRIPTION
### This PR will...
Do not apply interstitial buffering bounds to subtitle fragments. Always allow subtitle fragments to be loaded while interstitials are buffering.

### Why is this Pull Request needed?
Buffer boundaries applied before loading fragments is only meant to apply to audio and video fragments.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6768

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
