### PR TITLE
Interstitials: Fix additional asset player creation between assets at start 

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -75,7 +75,9 @@ export type PlayheadTimes = {
 };
 
 function playWithCatch(media: HTMLMediaElement | null) {
-  media?.play().catch(/* no-op */);
+  media?.play().catch(() => {
+    /* no-op */
+  });
 }
 
 export default class InterstitialsController
@@ -1383,7 +1385,7 @@ MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
     const { playingItem } = this;
     if (
       playingItem &&
-      playingItem !== this.bufferingItem &&
+      !this.itemsMatch(playingItem, this.bufferingItem) &&
       !this.isInterstitial(playingItem)
     ) {
       const timelinePos = this.timelinePos;
@@ -1644,7 +1646,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     } else if (
       bufferIsEmpty &&
       playingItem &&
-      bufferingItem !== playingItem &&
+      !this.itemsMatch(playingItem, bufferingItem) &&
       bufferEndIndex === playingIndex
     ) {
       this.bufferedToItem(playingItem);


### PR DESCRIPTION
### This PR will...
- Fix additional asset player creation between assets at start 
- Update interstitial controller item references when the schedule is updated

### Why is this Pull Request needed?
Fixes cases where additional unexpected Interstitial events fire during playback. 

Ensures that the `bufferingItem` and `playingItem` in `hls.interstitialsManager` always match items in its `schedule`.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
