### PR TITLE
Fix reset of "ended" state after main muxed audio flush

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1192,10 +1192,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
             this.hls.trigger(Events.LIVE_BACK_BUFFER_REACHED, {
               bufferEnd: targetBackBufferPosition,
             });
-          } else if (
-            track?.ended &&
-            buffered.end(buffered.length - 1) - currentTime < targetDuration * 2
-          ) {
+          } else if (track?.ended) {
             this.log(
               `Cannot flush ${type} back buffer while SourceBuffer is in ended state`,
             );
@@ -1227,20 +1224,11 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
         }
         const bufferStart = buffered.start(numBufferedRanges - 1);
         const bufferEnd = buffered.end(numBufferedRanges - 1);
-        const track = this.tracks[type];
         // No flush if we can tolerate the current buffer length or the current buffer range we would flush is contiguous with current position
         if (
           targetFrontBufferPosition > bufferStart ||
           (currentTime >= bufferStart && currentTime <= bufferEnd)
         ) {
-          return;
-        } else if (
-          track?.ended &&
-          currentTime - bufferEnd < 2 * targetDuration
-        ) {
-          this.log(
-            `Cannot flush ${type} front buffer while SourceBuffer is in ended state`,
-          );
           return;
         }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1076,10 +1076,7 @@ export default class StreamController
     event: Events.BUFFER_FLUSHED,
     { type }: BufferFlushedData,
   ) {
-    if (
-      type !== ElementaryStreamTypes.AUDIO ||
-      (this.audioOnly && !this.altAudio)
-    ) {
+    if (type !== ElementaryStreamTypes.AUDIO || !this.altAudio) {
       const mediaBuffer =
         (type === ElementaryStreamTypes.VIDEO
           ? this.videoBuffer


### PR DESCRIPTION
### This PR will...
- Run `afterBufferFlushed` on stream-controller when main audio is flushed
  - Resolves  #6919 by allowing the stream-controller to re-enter "ENDED" state when only audio back-buffer is flushed by HLS.js (because video was already auto-ejected on append)
- Ignore back buffer removal requests in ended state and remove front buffer removal ended check

Fixes https://github.com/video-dev/hls.js/issues/6919

### Why is this Pull Request needed?

Fixes a case where EOS is removed by HLS.js back-buffer removal logic flush operation, and never reset. Preventing the removal in ended state will make ending more reliable. There is no need to do so for front-buffer removal.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6919

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
