### PR TITLE
Gap controller fixes

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -763,6 +763,15 @@ export type BufferInfo = {
     start: number;
     end: number;
     nextStart?: number;
+    buffered?: BufferTimeRange[];
+};
+
+// Warning: (ae-missing-release-tag) "BufferTimeRange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type BufferTimeRange = {
+    start: number;
+    end: number;
 };
 
 // Warning: (ae-missing-release-tag) "CapLevelController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1209,6 +1218,8 @@ export interface ErrorData {
     // (undocumented)
     buffer?: number;
     // (undocumented)
+    bufferInfo?: BufferInfo;
+    // (undocumented)
     bytes?: number;
     // (undocumented)
     chunkMeta?: ChunkMetadata;
@@ -1252,6 +1263,10 @@ export interface ErrorData {
     response?: LoaderResponse;
     // (undocumented)
     sourceBufferName?: SourceBufferName;
+    // (undocumented)
+    stalled?: {
+        start: number;
+    };
     // (undocumented)
     stats?: LoaderStats;
     // (undocumented)
@@ -1516,6 +1531,8 @@ export enum Events {
     NON_NATIVE_TEXT_TRACKS_FOUND = "hlsNonNativeTextTracksFound",
     // (undocumented)
     PLAYOUT_LIMIT_REACHED = "hlsPlayoutLimitReached",
+    // (undocumented)
+    STALL_RESOLVED = "hlsStallResolved",
     // (undocumented)
     STEERING_MANIFEST_LOADED = "hlsSteeringManifestLoaded",
     // (undocumented)
@@ -2202,6 +2219,7 @@ export type HlsConfig = {
     progressive: boolean;
     lowLatencyMode: boolean;
     primarySessionId?: string;
+    detectStallWithCurrentTimeMs: number;
 } & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & LevelControllerConfig & MP4RemuxerConfig & StreamControllerConfig & SelectionPreferences & LatencyControllerConfig & MetadataControllerConfig & TimelineControllerConfig & TSDemuxerConfig & HlsLoadPolicies & FragmentLoaderConfig & PlaylistLoaderConfig;
 
 // Warning: (ae-missing-release-tag) "HlsEventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2358,6 +2376,8 @@ export interface HlsListeners {
     [Events.NON_NATIVE_TEXT_TRACKS_FOUND]: (event: Events.NON_NATIVE_TEXT_TRACKS_FOUND, data: NonNativeTextTracksData) => void;
     // (undocumented)
     [Events.PLAYOUT_LIMIT_REACHED]: (event: Events.PLAYOUT_LIMIT_REACHED, data: {}) => void;
+    // (undocumented)
+    [Events.STALL_RESOLVED]: (event: Events.STALL_RESOLVED, data: {}) => void;
     // (undocumented)
     [Events.STEERING_MANIFEST_LOADED]: (event: Events.STEERING_MANIFEST_LOADED, data: SteeringManifestLoadedData) => void;
     // (undocumented)

--- a/src/config.ts
+++ b/src/config.ts
@@ -319,6 +319,7 @@ export type HlsConfig = {
   progressive: boolean;
   lowLatencyMode: boolean;
   primarySessionId?: string;
+  detectStallWithCurrentTimeMs: number;
 } & ABRControllerConfig &
   BufferControllerConfig &
   CapLevelControllerConfig &
@@ -427,6 +428,7 @@ export const hlsDefaultConfig: HlsConfig = {
   progressive: false,
   lowLatencyMode: true,
   cmcd: undefined,
+  detectStallWithCurrentTimeMs: 1250,
   enableDateRangeMetadataCues: true,
   enableEmsgMetadataCues: true,
   enableEmsgKLVMetadata: false,

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -4,47 +4,41 @@ import { Events } from '../events';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper } from '../utils/buffer-helper';
 import { Logger } from '../utils/logger';
-import type { HlsConfig } from '../config';
 import type Hls from '../hls';
 import type { FragmentTracker } from './fragment-tracker';
 import type { Fragment } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 import type { BufferInfo } from '../utils/buffer-helper';
 
-export const STALL_MINIMUM_DURATION_MS = 250;
 export const MAX_START_GAP_JUMP = 2.0;
 export const SKIP_BUFFER_HOLE_STEP_SECONDS = 0.1;
 export const SKIP_BUFFER_RANGE_START = 0.05;
 
 export default class GapController extends Logger {
-  private config: HlsConfig;
   private media: HTMLMediaElement | null = null;
-  private fragmentTracker: FragmentTracker;
-  private hls: Hls;
+  private fragmentTracker: FragmentTracker | null = null;
+  private hls: Hls | null = null;
   private nudgeRetry: number = 0;
   private stallReported: boolean = false;
   private stalled: number | null = null;
   private moved: boolean = false;
   private seeking: boolean = false;
   public ended: number = 0;
+  public waiting: number = 0;
 
   constructor(
-    config: HlsConfig,
     media: HTMLMediaElement,
     fragmentTracker: FragmentTracker,
     hls: Hls,
   ) {
     super('gap-controller', hls.logger);
-    this.config = config;
     this.media = media;
     this.fragmentTracker = fragmentTracker;
     this.hls = hls;
   }
 
   public destroy() {
-    this.media = null;
-    // @ts-ignore
-    this.hls = this.fragmentTracker = null;
+    this.media = this.hls = this.fragmentTracker = null;
   }
 
   /**
@@ -59,8 +53,9 @@ export default class GapController extends Logger {
     levelDetails: LevelDetails | undefined,
     state: string,
   ) {
-    const { config, media, stalled } = this;
-    if (media === null) {
+    const { media, stalled } = this;
+
+    if (!media) {
       return;
     }
     const { currentTime, seeking } = media;
@@ -78,50 +73,44 @@ export default class GapController extends Logger {
       if (!seeking) {
         this.nudgeRetry = 0;
       }
-      if (stalled !== null) {
-        // The playhead is now moving, but was previously stalled
-        if (this.stallReported) {
-          const stalledDuration = self.performance.now() - stalled;
-          this.warn(
-            `playback not stuck anymore @${currentTime}, after ${Math.round(
-              stalledDuration,
-            )}ms`,
-          );
-          this.stallReported = false;
-        }
-        this.stalled = null;
+      if (this.waiting === 0) {
+        this.stallResolved(currentTime);
       }
       return;
     }
 
     // Clear stalled state when beginning or finishing seeking so that we don't report stalls coming out of a seek
     if (beginSeek || seeked) {
-      this.stalled = null;
+      if (seeked) {
+        this.stallResolved(currentTime);
+      }
       return;
     }
 
     // The playhead should not be moving
-    if (
-      (media.paused && !seeking) ||
-      media.ended ||
-      media.playbackRate === 0 ||
-      !BufferHelper.getBuffered(media).length
-    ) {
+    if ((media.paused && !seeking) || media.ended || media.playbackRate === 0) {
+      this.nudgeRetry = 0;
+      this.stallResolved(currentTime);
       // Fire MEDIA_ENDED to workaround event not being dispatched by browser
-      if (!this.ended && media.ended) {
+      if (!this.ended && media.ended && this.hls) {
         this.ended = currentTime || 1;
         this.hls.trigger(Events.MEDIA_ENDED, {
           stalled: false,
         });
       }
+      return;
+    }
+
+    if (!BufferHelper.getBuffered(media).length) {
       this.nudgeRetry = 0;
       return;
     }
 
     const bufferInfo = BufferHelper.bufferInfo(media, currentTime, 0);
     const nextStart = bufferInfo.nextStart || 0;
+    const fragmentTracker = this.fragmentTracker;
 
-    if (seeking) {
+    if (seeking && fragmentTracker) {
       // Waiting for seeking in a buffered range to complete
       const hasEnoughBuffer = bufferInfo.len > MAX_START_GAP_JUMP;
       // Next buffered range is too far ahead to jump to while still seeking
@@ -129,7 +118,7 @@ export default class GapController extends Logger {
         !nextStart ||
         (activeFrag && activeFrag.start <= currentTime) ||
         (nextStart - currentTime > MAX_START_GAP_JUMP &&
-          !this.fragmentTracker.getPartialFragment(currentTime));
+          !fragmentTracker.getPartialFragment(currentTime));
       if (hasEnoughBuffer || noBufferGap) {
         return;
       }
@@ -139,7 +128,7 @@ export default class GapController extends Logger {
 
     // Skip start gaps if we haven't played, but the last poll detected the start of a stall
     // The addition poll gives the browser a chance to jump the gap for us
-    if (!this.moved && this.stalled !== null) {
+    if (!this.moved && this.stalled !== null && fragmentTracker) {
       // There is no playable buffer (seeked, waiting for buffer)
       const isBuffered = bufferInfo.len > 0;
       if (!isBuffered && !nextStart) {
@@ -156,7 +145,7 @@ export default class GapController extends Logger {
       const maxStartGapJump = isLive
         ? levelDetails!.targetduration * 2
         : MAX_START_GAP_JUMP;
-      const partialOrGap = this.fragmentTracker.getPartialFragment(currentTime);
+      const partialOrGap = fragmentTracker.getPartialFragment(currentTime);
       if (startJump > 0 && (startJump <= maxStartGapJump || partialOrGap)) {
         if (!media.paused) {
           this._trySkipBufferHole(partialOrGap);
@@ -166,21 +155,36 @@ export default class GapController extends Logger {
     }
 
     // Start tracking stall time
+    const config = this.hls?.config;
+    if (!config) {
+      return;
+    }
+    const detectStallWithCurrentTimeMs = config.detectStallWithCurrentTimeMs;
     const tnow = self.performance.now();
+    const tWaiting = this.waiting;
     if (stalled === null) {
-      this.stalled = tnow;
+      // Use time of recent "waiting" event
+      if (tWaiting > 0 && tnow - tWaiting < detectStallWithCurrentTimeMs) {
+        this.stalled = tWaiting;
+      } else {
+        this.stalled = tnow;
+      }
       return;
     }
 
     const stalledDuration = tnow - stalled;
-    if (!seeking && stalledDuration >= STALL_MINIMUM_DURATION_MS) {
+    if (
+      !seeking &&
+      (stalledDuration >= detectStallWithCurrentTimeMs || tWaiting) &&
+      this.hls
+    ) {
       // Dispatch MEDIA_ENDED when media.ended/ended event is not signalled at end of stream
       if (
         state === State.ENDED &&
         !levelDetails?.live &&
         Math.abs(currentTime - (levelDetails?.edge || 0)) < 1
       ) {
-        if (stalledDuration < 1000 || this.ended) {
+        if (this.ended) {
           return;
         }
         this.ended = currentTime || 1;
@@ -191,7 +195,7 @@ export default class GapController extends Logger {
       }
       // Report stalling after trying to fix
       this._reportStall(bufferInfo);
-      if (!this.media) {
+      if (!this.media || !this.hls) {
         return;
       }
     }
@@ -204,6 +208,25 @@ export default class GapController extends Logger {
     this._tryFixBufferStall(bufferedWithHoles, stalledDuration);
   }
 
+  private stallResolved(currentTime: number) {
+    const stalled = this.stalled;
+    if (stalled && this.hls) {
+      this.stalled = null;
+      // The playhead is now moving, but was previously stalled
+      if (this.stallReported) {
+        const stalledDuration = self.performance.now() - stalled;
+        this.warn(
+          `playback not stuck anymore @${currentTime}, after ${Math.round(
+            stalledDuration,
+          )}ms`,
+        );
+        this.stallReported = false;
+        this.waiting = 0;
+        this.hls.trigger(Events.STALL_RESOLVED, {});
+      }
+    }
+  }
+
   /**
    * Detects and attempts to fix known buffer stalling issues.
    * @param bufferInfo - The properties of the current buffer.
@@ -214,10 +237,12 @@ export default class GapController extends Logger {
     bufferInfo: BufferInfo,
     stalledDurationMs: number,
   ) {
-    const { config, fragmentTracker, media } = this;
-    if (media === null) {
+    const { fragmentTracker, media } = this;
+    const config = this.hls?.config;
+    if (!media || !fragmentTracker || !config) {
       return;
     }
+
     const currentTime = media.currentTime;
 
     const partial = fragmentTracker.getPartialFragment(currentTime);
@@ -236,8 +261,11 @@ export default class GapController extends Logger {
     // we may just have to "nudge" the playlist as the browser decoding/rendering engine
     // needs to cross some sort of threshold covering all source-buffers content
     // to start playing properly.
+    const bufferedRanges = bufferInfo.buffered;
     if (
-      (bufferInfo.len > config.maxBufferHole ||
+      ((bufferedRanges &&
+        bufferedRanges.length > 1 &&
+        bufferInfo.len > config.maxBufferHole) ||
         (bufferInfo.nextStart &&
           bufferInfo.nextStart - currentTime < config.maxBufferHole)) &&
       stalledDurationMs > config.highBufferWatchdogPeriod * 1000
@@ -245,9 +273,7 @@ export default class GapController extends Logger {
       this.warn('Trying to nudge playhead over buffer-hole');
       // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds
       // We only try to jump the hole if it's under the configured size
-      // Reset stalled so to rearm watchdog timer
-      this.stalled = null;
-      this._tryNudgeBuffer();
+      this._tryNudgeBuffer(bufferInfo);
     }
   }
 
@@ -257,8 +283,8 @@ export default class GapController extends Logger {
    * @private
    */
   private _reportStall(bufferInfo: BufferInfo) {
-    const { hls, media, stallReported } = this;
-    if (!stallReported && media) {
+    const { hls, media, stallReported, stalled } = this;
+    if (!stallReported && stalled !== null && media && hls) {
       // Report stalled error once
       this.stallReported = true;
       const error = new Error(
@@ -273,6 +299,8 @@ export default class GapController extends Logger {
         fatal: false,
         error,
         buffer: bufferInfo.len,
+        bufferInfo,
+        stalled: { start: stalled },
       });
     }
   }
@@ -283,8 +311,9 @@ export default class GapController extends Logger {
    * @private
    */
   private _trySkipBufferHole(partial: Fragment | null): number {
-    const { config, hls, media } = this;
-    if (media === null) {
+    const { fragmentTracker, media } = this;
+    const config = this.hls?.config;
+    if (!media || !fragmentTracker || !config) {
       return 0;
     }
 
@@ -301,7 +330,6 @@ export default class GapController extends Logger {
       if (gapLength > 0 && (bufferStarved || waiting)) {
         // Only allow large gaps to be skipped if it is a start gap, or all fragments in skip range are partial
         if (gapLength > config.maxBufferHole) {
-          const { fragmentTracker } = this;
           let startGap = false;
           if (currentTime === 0) {
             const startFrag = fragmentTracker.getAppendedFrag(
@@ -345,19 +373,20 @@ export default class GapController extends Logger {
           `skipping hole, adjusting currentTime from ${currentTime} to ${targetTime}`,
         );
         this.moved = true;
-        this.stalled = null;
         media.currentTime = targetTime;
-        if (partial && !partial.gap) {
+        if (partial && !partial.gap && this.hls) {
           const error = new Error(
             `fragment loaded with buffer holes, seeking from ${currentTime} to ${targetTime}`,
           );
-          hls.trigger(Events.ERROR, {
+          this.hls.trigger(Events.ERROR, {
             type: ErrorTypes.MEDIA_ERROR,
             details: ErrorDetails.BUFFER_SEEK_OVER_HOLE,
             fatal: false,
             error,
             reason: error.message,
             frag: partial,
+            buffer: bufferInfo.len,
+            bufferInfo,
           });
         }
         return targetTime;
@@ -370,10 +399,11 @@ export default class GapController extends Logger {
    * Attempts to fix buffer stalls by advancing the mediaElement's current time by a small amount.
    * @private
    */
-  private _tryNudgeBuffer() {
-    const { config, hls, media, nudgeRetry } = this;
-    if (media === null) {
-      return;
+  private _tryNudgeBuffer(bufferInfo: BufferInfo) {
+    const { hls, media, nudgeRetry } = this;
+    const config = hls?.config;
+    if (!media || !config) {
+      return 0;
     }
     const currentTime = media.currentTime;
     this.nudgeRetry++;
@@ -391,6 +421,8 @@ export default class GapController extends Logger {
         details: ErrorDetails.BUFFER_NUDGE_ON_STALL,
         error,
         fatal: false,
+        buffer: bufferInfo.len,
+        bufferInfo,
       });
     } else {
       const error = new Error(
@@ -402,6 +434,8 @@ export default class GapController extends Logger {
         details: ErrorDetails.BUFFER_STALLED_ERROR,
         error,
         fatal: true,
+        buffer: bufferInfo.len,
+        bufferInfo,
       });
     }
   }

--- a/src/events.ts
+++ b/src/events.ts
@@ -78,6 +78,8 @@ export enum Events {
   MEDIA_DETACHED = 'hlsMediaDetached',
   // Fired when HTMLMediaElement dispatches "ended" event, or stalls at end of VOD program
   MEDIA_ENDED = 'hlsMediaEnded',
+  // Fired after playback stall is resolved with playing, seeked, or ended event following BUFFER_STALLED_ERROR
+  STALL_RESOLVED = 'hlsStallResolved',
   // Fired when the buffer is going to be reset
   BUFFER_RESET = 'hlsBufferReset',
   // Fired when we know about the codecs that we need buffers for to push into - data: {tracks : { container, codec, levelCodec, initSegment, metadata }}
@@ -244,6 +246,7 @@ export interface HlsListeners {
     event: Events.MEDIA_ENDED,
     data: MediaEndedData,
   ) => void;
+  [Events.STALL_RESOLVED]: (event: Events.STALL_RESOLVED, data: {}) => void;
   [Events.BUFFER_RESET]: (event: Events.BUFFER_RESET) => void;
   [Events.BUFFER_CODECS]: (
     event: Events.BUFFER_CODECS,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -54,7 +54,7 @@ import type {
   SubtitleSelectionOption,
   VideoSelectionOption,
 } from './types/media-playlist';
-import type { BufferInfo } from './utils/buffer-helper';
+import type { BufferInfo, BufferTimeRange } from './utils/buffer-helper';
 import type EwmaBandWidthEstimator from './utils/ewma-bandwidth-estimator';
 import type { MediaDecodingInfo } from './utils/mediacapabilities-helper';
 
@@ -1195,6 +1195,7 @@ export type {
   HlsEventEmitter,
   HlsConfig,
   BufferInfo,
+  BufferTimeRange,
   HdcpLevel,
   AbrController,
   AudioStreamController,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -47,6 +47,7 @@ import type { LevelDetails } from '../loader/level-details';
 import type { LevelKey } from '../loader/level-key';
 import type { LoadStats } from '../loader/load-stats';
 import type { AttrList } from '../utils/attr-list';
+import type { BufferInfo } from '../utils/buffer-helper';
 
 export interface MediaAttachingData {
   media: HTMLMediaElement;
@@ -313,6 +314,7 @@ export interface ErrorData {
   fatal: boolean;
   errorAction?: IErrorAction;
   buffer?: number;
+  bufferInfo?: BufferInfo;
   bytes?: number;
   chunkMeta?: ChunkMetadata;
   context?: PlaylistLoaderContext;
@@ -323,6 +325,7 @@ export interface ErrorData {
   levelRetry?: boolean;
   loader?: Loader<LoaderContext>;
   networkDetails?: any;
+  stalled?: { start: number };
   stats?: LoaderStats;
   mimeType?: string;
   reason?: string;

--- a/src/utils/buffer-helper.ts
+++ b/src/utils/buffer-helper.ts
@@ -8,7 +8,7 @@
 
 import { logger } from './logger';
 
-type BufferTimeRange = {
+export type BufferTimeRange = {
   start: number;
   end: number;
 };
@@ -22,6 +22,7 @@ export type BufferInfo = {
   start: number;
   end: number;
   nextStart?: number;
+  buffered?: BufferTimeRange[];
 };
 
 const noopBuffered: TimeRanges = {
@@ -61,19 +62,14 @@ export class BufferHelper {
         return BufferHelper.bufferedInfo(buffered, pos, maxHoleDuration);
       }
     }
-    return { len: 0, start: pos, end: pos, nextStart: undefined };
+    return { len: 0, start: pos, end: pos };
   }
 
   static bufferedInfo(
     buffered: BufferTimeRange[],
     pos: number,
     maxHoleDuration: number,
-  ): {
-    len: number;
-    start: number;
-    end: number;
-    nextStart?: number;
-  } {
+  ): BufferInfo {
     pos = Math.max(0, pos);
     // sort on buffer.start/smaller end (IE does not always return sorted buffered range)
     buffered.sort((a, b) => a.start - b.start || b.end - a.end);
@@ -136,6 +132,7 @@ export class BufferHelper {
       start: bufferStart || 0,
       end: bufferEnd || 0,
       nextStart: bufferStartNext,
+      buffered,
     };
   }
 

--- a/tests/unit/utils/buffer-helper.js
+++ b/tests/unit/utils/buffer-helper.js
@@ -79,6 +79,10 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        buffered: [
+          { start: 0, end: 0.5 },
+          { start: 1, end: 2 },
+        ],
       });
     });
     it('should return empty buffer info if media does not exist', function () {
@@ -94,7 +98,6 @@ describe('BufferHelper', function () {
         len: 0,
         start: 0,
         end: 0,
-        nextStart: undefined,
       });
     });
     it('should return empty buffer info if media does not exist', function () {
@@ -103,7 +106,6 @@ describe('BufferHelper', function () {
         len: 0,
         start: 0,
         end: 0,
-        nextStart: undefined,
       });
     });
   });
@@ -130,6 +132,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        buffered,
       });
       expect(
         BufferHelper.bufferedInfo(buffered, 0.5, maxHoleDuration),
@@ -138,6 +141,7 @@ describe('BufferHelper', function () {
         start: 0.5,
         end: 0.5,
         nextStart: 1,
+        buffered,
       });
       expect(
         BufferHelper.bufferedInfo(buffered, 1, maxHoleDuration),
@@ -146,6 +150,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        buffered,
       });
       expect(
         BufferHelper.bufferedInfo(buffered, 1.5, maxHoleDuration),
@@ -154,6 +159,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        buffered,
       });
     });
     it('should return found buffer info when maxHoleDuration is 0.5', function () {
@@ -177,6 +183,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        buffered,
       });
       // M: maxHoleDuration: 0.5
       // |////////|________|////////////////|
@@ -188,6 +195,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        buffered,
       });
       expect(
         BufferHelper.bufferedInfo(buffered, 1, maxHoleDuration),
@@ -196,6 +204,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        buffered,
       });
       expect(
         BufferHelper.bufferedInfo(buffered, 2, maxHoleDuration),
@@ -204,6 +213,7 @@ describe('BufferHelper', function () {
         start: 2,
         end: 2,
         nextStart: undefined,
+        buffered,
       });
     });
     it('should be able to handle unordered buffered', function () {
@@ -227,6 +237,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        buffered,
       });
     });
     it('should be able to merge adjacent time ranges with a small hole', function () {
@@ -250,6 +261,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 2,
         nextStart: undefined,
+        buffered,
       });
     });
     it('should be able to merge overlapping time ranges', function () {
@@ -274,6 +286,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 1,
         nextStart: undefined,
+        buffered,
       });
     });
     it('should return empty buffered if pos is out of range', function () {
@@ -295,18 +308,21 @@ describe('BufferHelper', function () {
         start: 5,
         end: 5,
         nextStart: undefined,
+        buffered,
       });
     });
     it('should return empty buffered if buffered is empty', function () {
       const buffered = [];
       const maxHoleDuration = 0;
+
       expect(
         BufferHelper.bufferedInfo(buffered, 5, maxHoleDuration),
-      ).to.deep.equal({
+      ).to.include({
+        // `buffered` empty array fails deep.equal
         len: 0,
         start: 5,
         end: 5,
-        nextStart: undefined,
+        buffered,
       });
     });
   });


### PR DESCRIPTION
### This PR will...
- Improve stall detection and reporting using "waiting" event timing
- Add `config.detectStallWithCurrentTimeMs` with a default of 1250 to configure stall detection when currentTime does not advance while playing without a "waiting" event
- Implement STALL_RESOLVED event - fires after "playing", "seeked", or "ended" event following BUFFER_STALLED_ERROR (Resolves #4273)
- Add BufferInfo to stall-related errors (BUFFER_STALLED_ERROR, BUFFER_NUDGE_ON_STALL, BUFFER_SEEK_OVER_HOLE)
- Add `stalled.start` performance timing to BUFFER_STALLED_ERROR
- Add `buffered` time range array to BufferInfo
- Only perform BUFFER_NUDGE_ON_STALL when needed (multiple buffered time ranges)
- Fix seek on start without play() request (regression in dev)

### Why is this Pull Request needed?
Stall reporting and resolution requires these enhancements. Stalls should be reported quickly and accurately. Seeking should only be performed when absolutely necessary to begin or restore playback (including flushing the rendering pipeline after passing over a gap).

### Are there any points in the code the reviewer needs to double check?

Revisit these issues to see if they can be addressed with additional changes:
- #5631
- #6169
- #6814
- [ ] nudge when "waiting" is emitted over a video or audio gap without a playback/currentTime stall

### Resolves issues:

- Resolves #4273

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
