### PR TITLE
Exclude AC3 and HEVC remuxing from light build

### DIFF
--- a/src/demux/audio/base-audio-demuxer.ts
+++ b/src/demux/audio/base-audio-demuxer.ts
@@ -18,8 +18,8 @@ import { dummyTrack } from '../dummy-demuxed-track';
 import type { RationalTimestamp } from '../../utils/timescale-conversion';
 
 class BaseAudioDemuxer implements Demuxer {
-  protected _audioTrack!: DemuxedAudioTrack;
-  protected _id3Track!: DemuxedMetadataTrack;
+  protected _audioTrack?: DemuxedAudioTrack;
+  protected _id3Track?: DemuxedMetadataTrack;
   protected frameIndex: number = 0;
   protected cachedData: Uint8Array | null = null;
   protected basePTS: number | null = null;
@@ -74,8 +74,8 @@ class BaseAudioDemuxer implements Demuxer {
     let id3Data: Uint8Array | undefined = getId3Data(data, 0);
     let offset = id3Data ? id3Data.length : 0;
     let lastDataIndex;
-    const track = this._audioTrack;
-    const id3Track = this._id3Track;
+    const track = this._audioTrack as DemuxedAudioTrack;
+    const id3Track = this._id3Track as DemuxedMetadataTrack;
     const timestamp = id3Data ? getId3Timestamp(id3Data) : undefined;
     const length = data.length;
 
@@ -167,9 +167,9 @@ class BaseAudioDemuxer implements Demuxer {
     }
 
     return {
-      audioTrack: this._audioTrack,
+      audioTrack: this._audioTrack as DemuxedAudioTrack,
       videoTrack: dummyTrack() as DemuxedVideoTrackBase,
-      id3Track: this._id3Track,
+      id3Track: this._id3Track as DemuxedMetadataTrack,
       textTrack: dummyTrack() as DemuxedUserdataTrack,
     };
   }

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -774,8 +774,8 @@ function parsePMT(
     audioPid: -1,
     videoPid: -1,
     id3Pid: -1,
-    segmentVideoCodec: 'avc',
-    segmentAudioCodec: 'aac',
+    segmentVideoCodec: 'avc' as 'avc' | 'hevc',
+    segmentAudioCodec: 'aac' as 'aac' | 'ac3' | 'mp3',
   };
   const sectionLength = ((data[offset + 1] & 0x0f) << 8) | data[offset + 2];
   const tableEnd = offset + 3 + sectionLength - 4;
@@ -822,7 +822,6 @@ function parsePMT(
         // logger.log('AVC PID:'  + pid);
         if (result.videoPid === -1) {
           result.videoPid = pid;
-          result.segmentVideoCodec = 'avc';
         }
 
         break;

--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -158,12 +158,7 @@ class HevcVideoParser extends BaseVideoParser {
               track.params[prop] = config.params[prop];
             }
           }
-          if (
-            (!track.vps && !track.sps.length) ||
-            (track.vps && track.vps[0] === this.initVPS)
-          ) {
-            track.sps.push(unit.data);
-          }
+          this.pushPPSorSPS(track.sps, unit.data, track.vps);
           if (!VideoSample) {
             VideoSample = this.VideoSample = this.createVideoSample(
               true,
@@ -185,12 +180,7 @@ class HevcVideoParser extends BaseVideoParser {
                 track.params[prop] = config[prop];
               }
             }
-            if (
-              (!track.vps && !track.pps.length) ||
-              (track.vps && track.vps[0] === this.initVPS)
-            ) {
-              track.pps.push(unit.data);
-            }
+            this.pushPPSorSPS(track.pps, unit.data, track.vps);
           }
           break;
 
@@ -224,6 +214,16 @@ class HevcVideoParser extends BaseVideoParser {
     if (endOfSegment && VideoSample) {
       this.pushAccessUnit(VideoSample, track);
       this.VideoSample = null;
+    }
+  }
+
+  private pushPPSorSPS(
+    ppsOrSps: Uint8Array[],
+    data: Uint8Array,
+    vps: Uint8Array[] | undefined,
+  ) {
+    if ((vps && vps[0] === this.initVPS) || (!vps && !ppsOrSps.length)) {
+      ppsOrSps.push(data);
     }
   }
 

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types/demuxer';
 import type {
   InitSegmentData,
+  Mp4Sample,
   RemuxedMetadata,
   RemuxedTrack,
   RemuxedUserdata,
@@ -36,6 +37,26 @@ const AC3_SAMPLES_PER_FRAME = 1536;
 let chromeVersion: number | null = null;
 let safariWebkitVersion: number | null = null;
 
+function createMp4Sample(
+  isKeyframe: boolean,
+  duration: number,
+  size: number,
+  cts: number,
+): Mp4Sample {
+  return {
+    duration,
+    size,
+    cts,
+    flags: {
+      isLeading: 0,
+      isDependedOn: 0,
+      hasRedundancy: 0,
+      degradPrio: 0,
+      dependsOn: isKeyframe ? 2 : 1,
+      isNonSync: isKeyframe ? 0 : 1,
+    },
+  };
+}
 export default class MP4Remuxer implements Remuxer {
   private readonly logger: ILogger;
   private readonly observer: HlsEventEmitter;
@@ -718,7 +739,7 @@ export default class MP4Remuxer implements Remuxer {
       maxPtsDelta = Math.max(maxPtsDelta, ptsDelta);
 
       outputSamples.push(
-        new Mp4Sample(
+        createMp4Sample(
           VideoSample.key,
           mp4SampleDuration,
           mp4SampleLength,
@@ -776,7 +797,7 @@ export default class MP4Remuxer implements Remuxer {
     const moof = MP4.moof(
       track.sequenceNumber++,
       firstDTS,
-      Object.assign({}, track, {
+      Object.assign(track, {
         samples: outputSamples,
       }),
     );
@@ -1027,7 +1048,7 @@ export default class MP4Remuxer implements Remuxer {
       // Default the sample's duration to the computed mp4SampleDuration, which will either be 1024 for AAC or 1152 for MPEG
       // In the case that we have 1 sample, this will be the duration. If we have more than one sample, the duration
       // becomes the PTS diff with the previous sample
-      outputSamples.push(new Mp4Sample(true, mp4SampleDuration, unitLen, 0));
+      outputSamples.push(createMp4Sample(true, mp4SampleDuration, unitLen, 0));
       lastPTS = pts;
     }
 
@@ -1166,39 +1187,4 @@ export function flushTextTrackUserdataCueSamples(
   return {
     samples,
   };
-}
-
-type Mp4SampleFlags = {
-  isLeading: 0;
-  isDependedOn: 0;
-  hasRedundancy: 0;
-  degradPrio: 0;
-  dependsOn: 1 | 2;
-  isNonSync: 0 | 1;
-};
-
-class Mp4Sample {
-  public size: number;
-  public duration: number;
-  public cts: number;
-  public flags: Mp4SampleFlags;
-
-  constructor(
-    isKeyframe: boolean,
-    duration: number,
-    size: number,
-    cts: number,
-  ) {
-    this.duration = duration;
-    this.size = size;
-    this.cts = cts;
-    this.flags = {
-      isLeading: 0,
-      isDependedOn: 0,
-      hasRedundancy: 0,
-      degradPrio: 0,
-      dependsOn: isKeyframe ? 2 : 1,
-      isNonSync: isKeyframe ? 0 : 1,
-    };
-  }
 }

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -59,14 +59,20 @@ export interface PassthroughTrack extends DemuxedTrack {
   codec: string;
 }
 export interface DemuxedAudioTrack extends DemuxedTrack {
+  type: 'audio';
+  segmentCodec: 'aac' | 'ac3' | 'mp3';
   config?: number[] | Uint8Array;
   samplerate?: number;
-  segmentCodec?: string;
   channelCount?: number;
   manifestCodec?: string;
   parsedCodec?: string;
   samples: AudioSample[];
 }
+
+export type DemuxedAC3 = DemuxedAudioTrack & {
+  segmentCodec: 'ac3';
+  config: Uint8Array;
+};
 
 export interface DemuxedVideoTrackBase extends DemuxedTrack {
   width?: number;
@@ -84,8 +90,42 @@ export interface DemuxedVideoTrackBase extends DemuxedTrack {
 }
 
 export interface DemuxedVideoTrack extends DemuxedVideoTrackBase {
+  type: 'video';
+  segmentCodec: 'avc' | 'hevc';
   samples: VideoSample[];
+  pixelRatio: [number, number];
+  width: number;
+  height: number;
 }
+
+export type DemuxedAVC1 = DemuxedVideoTrack & {
+  segmentCodec: 'avc';
+  pps: Uint8Array[];
+  sps: Uint8Array[];
+};
+
+export type DemuxedHEVC = DemuxedVideoTrack & {
+  segmentCodec: 'hevc';
+  params: {
+    general_profile_space: number;
+    general_tier_flag: number;
+    general_profile_idc: number;
+    general_profile_compatibility_flags: number[];
+    general_constraint_indicator_flags: number[];
+    general_level_idc: number;
+    min_spatial_segmentation_idc: number;
+    parallelismType: number;
+    chroma_format_idc: number;
+    bit_depth_luma_minus8: number;
+    bit_depth_chroma_minus8: number;
+    frame_rate: { fps: string; fixed: boolean };
+    temporal_id_nested: number;
+    num_temporal_layers: number;
+  };
+  pps: Uint8Array[];
+  sps: Uint8Array[];
+  vps: Uint8Array;
+};
 
 export interface DemuxedMetadataTrack extends DemuxedTrack {
   samples: MetadataSample[];

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -3,6 +3,7 @@ import type {
   DemuxedAudioTrack,
   DemuxedMetadataTrack,
   DemuxedUserdataTrack,
+  DemuxedVideoTrack,
   DemuxedVideoTrackBase,
   MetadataSample,
   UserdataSample,
@@ -60,6 +61,30 @@ export interface RemuxedMetadata {
 export interface RemuxedUserdata {
   samples: UserdataSample[];
 }
+
+export type Mp4SampleFlags = {
+  isLeading: 0;
+  isDependedOn: 0;
+  hasRedundancy: 0;
+  degradPrio: 0;
+  dependsOn: 1 | 2;
+  isNonSync: 0 | 1;
+};
+
+export type Mp4Sample = {
+  size: number;
+  duration: number;
+  cts: number;
+  flags: Mp4SampleFlags;
+};
+
+export type RemuxedAudioTrackSamples = DemuxedAudioTrack & {
+  samples: Mp4Sample[];
+};
+
+export type RemuxedVideoTrackSamples = DemuxedVideoTrack & {
+  samples: Mp4Sample[];
+};
 
 export interface RemuxerResult {
   audio?: RemuxedTrack;


### PR DESCRIPTION
### This PR will...

- Exclude AC3 and HEVC remuxing from light build
- Improve demux/remux types and type mp4-generator args

### Why is this Pull Request needed?

- Follow up to #6940

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
