### PR TITLE
fix: assumptions in multi-drm cases where only playready is available for playback.

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -554,7 +554,11 @@ class EMEController extends Logger implements ComponentAPI {
       let keyId: Uint8Array | null | undefined;
       let keySystemDomain: KeySystems | undefined;
 
-      if (initDataType === 'sinf' && keySystem === KeySystems.FAIRPLAY) {
+      if (initDataType === 'sinf') {
+        if (keySystem !== KeySystems.FAIRPLAY) {
+          this.log(`Ignoring "${event.type}" event with init data type: "${initDataType}" for selected key-system ${keySystem}`);
+          return;
+        }
         // Match sinf keyId to playlist skd://keyId=
         const json = bin2str(new Uint8Array(initData));
         try {
@@ -651,7 +655,11 @@ class EMEController extends Logger implements ComponentAPI {
         }
       }
 
-      if (!keySessionContextPromise && keySystemDomain === keySystem) {
+      if (!keySessionContextPromise) {
+        if (keySystemDomain !== keySystem) {
+          this.log(`Ignoring "${event.type}" event with ${keySystemDomain} init data for selected key-system ${keySystem}`);
+          return;
+        }
         // "Clear-lead" (misc key not encountered in playlist)
         keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
           this.getKeySystemSelectionPromise([keySystemDomain]).then(

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -597,8 +597,8 @@ class EMEController extends Logger implements ComponentAPI {
         );
 
         if (psshInfos.length) {
-          this.log(
-            `${logMessage} contains multiple pssh boxes for selected key-system ${keySystem}. Using first found.`,
+          this.warn(
+            `${logMessage} Using first of ${psshInfos.length} pssh found for selected key-system ${keySystem}`,
           );
         }
 

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -525,7 +525,7 @@ class EMEController extends Logger implements ComponentAPI {
     return this.attemptKeySystemAccess(keySystemsToAttempt);
   }
 
-  private onMediaEncrypted = (event: MediaEncryptedEvent) => {
+  private onMediaEncrypted = async (event: MediaEncryptedEvent) => {
     const { initDataType, initData } = event;
     const logMessage = `"${event.type}" event: init data type: "${initDataType}"`;
     this.debug(logMessage);
@@ -535,146 +535,212 @@ class EMEController extends Logger implements ComponentAPI {
       return;
     }
 
-    let keyId: Uint8Array | null | undefined;
-    let keySystemDomain: KeySystems | undefined;
+    type KeyIdInfo = { keyId: Uint8Array; keySystemDomain: KeySystems };
 
-    if (
-      initDataType === 'sinf' &&
-      this.getLicenseServerUrl(KeySystems.FAIRPLAY)
-    ) {
-      // Match sinf keyId to playlist skd://keyId=
-      const json = bin2str(new Uint8Array(initData));
-      try {
-        const sinf = base64Decode(JSON.parse(json).sinf);
-        const tenc = parseSinf(sinf);
-        if (!tenc) {
-          throw new Error(
-            `'schm' box missing or not cbcs/cenc with schi > tenc`,
-          );
+    // Ideally this would be a pure function...
+    // This function yields an array of candidate key id + corresponding key system pairs
+    // to use for playback based on:
+    // - the init data type + init data payload (sinf for Fairplay, pssh for PlayReady, Widevine, or both)
+    // - available DRM server configurations via config
+    // NOTE: We cannot (yet) presume a single key system, as one of the key systems may still fail
+    // based on device + browser availability and/or client/server key requests/responses.
+    const getKeyIdInfos = (): KeyIdInfo[] => {
+      if (initDataType === 'sinf') {
+        const fairplayLicenseServerUrl = this.getLicenseServerUrl(
+          KeySystems.FAIRPLAY,
+        );
+        // FairPlay and only FairPlay uses sinf boxes for EME signaling, so
+        // if we don't have a FairPlay license server URL available, we can't
+        // use the sinf for EME.
+        if (!fairplayLicenseServerUrl) return [];
+
+        // Match sinf keyId to playlist skd://keyId=
+        const json = bin2str(new Uint8Array(initData));
+        try {
+          const sinf = base64Decode(JSON.parse(json).sinf);
+          const tenc = parseSinf(sinf);
+          if (!tenc) {
+            throw new Error(
+              `'schm' box missing or not cbcs/cenc with schi > tenc`,
+            );
+          }
+          const keyId = tenc.subarray(8, 24);
+          const keySystemDomain = KeySystems.FAIRPLAY;
+          return [{ keyId, keySystemDomain }];
+        } catch (error) {
+          this.warn(`${logMessage} Failed to parse sinf: ${error}`);
         }
-        keyId = tenc.subarray(8, 24);
-        keySystemDomain = KeySystems.FAIRPLAY;
-      } catch (error) {
-        this.warn(`${logMessage} Failed to parse sinf: ${error}`);
-        return;
+        return [];
       }
-    } else if (this.getLicenseServerUrl(KeySystems.WIDEVINE)) {
-      // Support Widevine clear-lead key-session creation (otherwise depend on playlist keys)
-      const psshResults = parseMultiPssh(initData);
 
-      // TODO: If using keySystemAccessPromises we might want to wait until one is resolved
+      // We can assume pssh boxes otherwise. Both PlayReady and Widevine use
+      // pssh, and pssh data may include info for either or both.
+      const KeySystemLicenseURL = {
+        [KeySystems.WIDEVINE]: this.getLicenseServerUrl(KeySystems.WIDEVINE),
+        [KeySystems.PLAYREADY]: this.getLicenseServerUrl(KeySystems.PLAYREADY),
+      };
+
+      if (
+        !(
+          KeySystemLicenseURL[KeySystems.WIDEVINE] ||
+          KeySystemLicenseURL[KeySystems.PLAYREADY]
+        )
+      )
+        return [];
+
+      // Shouldn't we not attempt key system access if we don't have a URL for the key system?
       let keySystems = Object.keys(
         this.keySystemAccessPromises,
       ) as KeySystems[];
+
       if (!keySystems.length) {
+        // getKeySystemsForConfig() does not filter out drmSystems that have no URL value
         keySystems = getKeySystemsForConfig(this.config);
       }
 
-      const psshInfo = psshResults.filter((pssh): pssh is PsshData => {
+      // Only try key systems if we actually have URLs for them via config
+      keySystems = keySystems.filter(
+        (keySystem) => !!KeySystemLicenseURL[keySystem],
+      );
+
+      if (!keySystems.length) return [];
+
+      // Support Widevine clear-lead key-session creation (otherwise depend on playlist keys)
+      const psshResults = parseMultiPssh(initData);
+      const psshInfos = psshResults.filter((pssh): pssh is PsshData => {
+        // If there's no systemId, assume it's an invalid PSSH (PsshInvalidResult)
+        if (!pssh.systemId) return false;
+        // If the parsed PSSHInfo is for a key system that is not available via config,
+        // filter it out so we don't attempt to use it.
         const keySystem = pssh.systemId
           ? keySystemIdToKeySystemDomain(pssh.systemId)
           : null;
-        return keySystem ? keySystems.indexOf(keySystem) > -1 : false;
-      })[0];
+        return !!keySystem && keySystems.indexOf(keySystem) > -1;
+      });
 
-      if (!psshInfo) {
-        if (
-          psshResults.length === 0 ||
-          psshResults.some((pssh): pssh is PsshInvalidResult => !pssh.systemId)
-        ) {
-          this.warn(`${logMessage} contains incomplete or invalid pssh data`);
-        } else {
-          this.log(
-            `ignoring ${logMessage} for ${(psshResults as PsshData[])
-              .map((pssh) => keySystemIdToKeySystemDomain(pssh.systemId))
-              .join(',')} pssh data in favor of playlist keys`,
+      if (!psshInfos.length) {
+        this.warn(`${logMessage} contains incomplete or invalid pssh data`);
+        return [];
+      }
+
+      const keyInfos = psshInfos
+        .filter((psshInfo) => {
+          return (
+            psshInfo.version === 0 &&
+            !!psshInfo.data &&
+            !!keySystemIdToKeySystemDomain(psshInfo.systemId)
           );
+        })
+        .map((psshInfo) => {
+          const keySystemDomain = keySystemIdToKeySystemDomain(
+            psshInfo.systemId,
+          ) as KeySystems;
+          const psshInfoData = psshInfo.data as Uint8Array;
+          const keyId =
+            keySystemDomain === KeySystems.PLAYREADY
+              ? (parsePlayReadyWRM(
+                  psshInfoData,
+                ) as Uint8Array) /** @TODO Confirm this is accurate under these conditions */
+              : psshInfoData.subarray(
+                  psshInfoData.length - 22,
+                  psshInfoData.length - 22 + 16,
+                );
+          return { keySystemDomain, keyId };
+        });
+
+      return keyInfos;
+    };
+
+    const keyIdInfos: KeyIdInfo[] = getKeyIdInfos();
+
+    /** @TODO errors? */
+    if (!keyIdInfos.length) return;
+
+    const errors: (EMEKeyError | Error)[] = [];
+    for (const { keyId, keySystemDomain } of keyIdInfos) {
+      const keyIdHex = Hex.hexDump(keyId);
+      const { keyIdToKeySessionPromise, mediaKeySessions } = this;
+
+      let keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex];
+      for (let i = 0; i < mediaKeySessions.length; i++) {
+        // Match playlist key
+        const keyContext = mediaKeySessions[i];
+        const decryptdata = keyContext.decryptdata;
+        if (!decryptdata.keyId) {
+          continue;
         }
-        return;
-      }
-
-      keySystemDomain = keySystemIdToKeySystemDomain(psshInfo.systemId);
-      if (psshInfo.version === 0 && psshInfo.data) {
-        if (keySystemDomain === KeySystems.WIDEVINE) {
-          const offset = psshInfo.data.length - 22;
-          keyId = psshInfo.data.subarray(offset, offset + 16);
-        } else if (keySystemDomain === KeySystems.PLAYREADY) {
-          keyId = parsePlayReadyWRM(psshInfo.data);
-        }
-      }
-    }
-
-    if (!keySystemDomain || !keyId) {
-      return;
-    }
-
-    const keyIdHex = Hex.hexDump(keyId);
-    const { keyIdToKeySessionPromise, mediaKeySessions } = this;
-
-    let keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex];
-    for (let i = 0; i < mediaKeySessions.length; i++) {
-      // Match playlist key
-      const keyContext = mediaKeySessions[i];
-      const decryptdata = keyContext.decryptdata;
-      if (!decryptdata.keyId) {
-        continue;
-      }
-      const oldKeyIdHex = Hex.hexDump(decryptdata.keyId);
-      if (
-        keyIdHex === oldKeyIdHex ||
-        decryptdata.uri.replace(/-/g, '').indexOf(keyIdHex) !== -1
-      ) {
-        keySessionContextPromise = keyIdToKeySessionPromise[oldKeyIdHex];
-        if (decryptdata.pssh) {
-          break;
-        }
-        delete keyIdToKeySessionPromise[oldKeyIdHex];
-        decryptdata.pssh = new Uint8Array(initData);
-        decryptdata.keyId = keyId;
-        keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
-          keySessionContextPromise.then(() => {
-            return this.generateRequestWithPreferredKeySession(
-              keyContext,
-              initDataType,
-              initData,
-              'encrypted-event-key-match',
-            );
-          });
-        keySessionContextPromise.catch((error) => this.handleError(error));
-        break;
-      }
-    }
-
-    if (!keySessionContextPromise) {
-      // Clear-lead key (not encountered in playlist)
-      keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
-        this.getKeySystemSelectionPromise([keySystemDomain]).then(
-          ({ keySystem, mediaKeys }) => {
-            this.throwIfDestroyed();
-            const decryptdata = new LevelKey(
-              'ISO-23001-7',
-              keyIdHex,
-              keySystemToKeySystemFormat(keySystem) ?? '',
-            );
-            decryptdata.pssh = new Uint8Array(initData);
-            decryptdata.keyId = keyId as Uint8Array;
-            return this.attemptSetMediaKeys(keySystem, mediaKeys).then(() => {
-              this.throwIfDestroyed();
-              const keySessionContext = this.createMediaKeySessionContext({
-                decryptdata,
-                keySystem,
-                mediaKeys,
-              });
+        const oldKeyIdHex = Hex.hexDump(decryptdata.keyId);
+        if (
+          keyIdHex === oldKeyIdHex ||
+          decryptdata.uri.replace(/-/g, '').indexOf(keyIdHex) !== -1
+        ) {
+          keySessionContextPromise = keyIdToKeySessionPromise[oldKeyIdHex];
+          if (decryptdata.pssh) {
+            break;
+          }
+          delete keyIdToKeySessionPromise[oldKeyIdHex];
+          decryptdata.pssh = new Uint8Array(initData);
+          decryptdata.keyId = keyId;
+          keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
+            keySessionContextPromise.then(() => {
               return this.generateRequestWithPreferredKeySession(
-                keySessionContext,
+                keyContext,
                 initDataType,
                 initData,
-                'encrypted-event-no-match',
+                'encrypted-event-key-match',
               );
             });
-          },
-        );
-      keySessionContextPromise.catch((error) => this.handleError(error));
+          break;
+        }
+      }
+
+      if (!keySessionContextPromise) {
+        // keySystemDomain = KeySystems.PLAYREADY;
+        // Clear-lead key (not encountered in playlist)
+        keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
+          this.getKeySystemSelectionPromise([keySystemDomain]).then(
+            ({ keySystem, mediaKeys }) => {
+              this.throwIfDestroyed();
+              const decryptdata = new LevelKey(
+                'ISO-23001-7',
+                keyIdHex,
+                keySystemToKeySystemFormat(keySystem) ?? '',
+              );
+              decryptdata.pssh = new Uint8Array(initData);
+              decryptdata.keyId = keyId as Uint8Array;
+              return this.attemptSetMediaKeys(keySystem, mediaKeys).then(() => {
+                this.throwIfDestroyed();
+                const keySessionContext = this.createMediaKeySessionContext({
+                  decryptdata,
+                  keySystem,
+                  mediaKeys,
+                });
+                return this.generateRequestWithPreferredKeySession(
+                  keySessionContext,
+                  initDataType,
+                  initData,
+                  'encrypted-event-no-match',
+                );
+              });
+            },
+          );
+
+        try {
+          // Use the first successful key session context promise.
+          await keySessionContextPromise;
+          break;
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+    }
+
+    // If we have errors for all candidate key infos, this means we failed
+    // to get any key for playback. In this case, handle these errors
+    // NOTE: Currently, we will not signal failed key requests if at least
+    // one succeeds, since this *can* happen and be valid in multi-drm scenarios.
+    if (errors.length >= keyIdInfos.length) {
+      errors.forEach((error) => this.handleError(error));
     }
   };
 

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -112,7 +112,12 @@ export default class KeyLoader implements ComponentAPI {
   }
 
   load(frag: Fragment): Promise<KeyLoadedData> {
-    if (!frag.decryptdata && frag.encrypted && this.emeController) {
+    if (
+      !frag.decryptdata &&
+      frag.encrypted &&
+      this.emeController &&
+      this.config.emeEnabled
+    ) {
       // Multiple keys, but none selected, resolve in eme-controller
       return this.emeController
         .selectKeySystemFormat(frag)


### PR DESCRIPTION
### This PR will...

Clean up some assumptions on key request logic in multi-drm scenarios, particularly around PlayReady usage.

### Why is this Pull Request needed?

There were

### Are there any points in the code the reviewer needs to double check?

Everything was localized to `EmeController::onMediaEncrypted()` and much of the core logic stayed the same, but definitely want some attention while reviewing the implementation decisions, particularly the callout questions/comments (including in github comments) before 👍.

Smoke tested multi-drm case (on demand stream with FairPlay, Widevine, and PlayReady advertised via `EXT-X-KEY` tags and `sinf`/`pssh` mp4 boxes) on:
1. macOS
    1. Safari (for FairPlay usage regression testing)
    2. Chrome (for Widevine usage regression testing)
3. Windows
    1. Edge ("Edgium") with Widevine Enabled and Widevine Disabled (See: https://learn.microsoft.com/en-us/legal/microsoft-edge/privacy#digital-rights-management-and-media-licenses for disabling flag)

Also tested using both the repo-provided demo application* and local linking to Mux Elements ("Mux Player") using the repo-provided next.js application.

**NOTE:** For my testing, where my dev machine is macOS but I needed to test on a Windows machine on my LAN, this required updating the `server` script (`http-server`) to use `https` (based on security constraints). If needed for review, see https://www.npmjs.com/package/http-server#tlsssl or reach out to me directly.

**NOTE:** I do not have any publicly-shareable test assets + corresponding service requests, _**however,**_ if needed for review, reach out to me directly and I can provide one out of band.

### Resolves issues:

fixes #6947

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable) **(N/A from what I could tell with existing unit tests)**
- [ ] API or design changes are documented in API.md **(N/A)**
