### PR TITLE
Only use selected key-system in EME "mediaencrypted" event handler

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -554,7 +554,11 @@ class EMEController extends Logger implements ComponentAPI {
       let keyId: Uint8Array | null | undefined;
       let keySystemDomain: KeySystems | undefined;
 
-      if (initDataType === 'sinf' && keySystem === KeySystems.FAIRPLAY) {
+      if (initDataType === 'sinf') {
+        if (keySystem !== KeySystems.FAIRPLAY) {
+          this.log(`Ignoring "${event.type}" event with init data type: "${initDataType}" for selected key-system ${keySystem}`);
+          return;
+        }
         // Match sinf keyId to playlist skd://keyId=
         const json = bin2str(new Uint8Array(initData));
         try {
@@ -651,7 +655,11 @@ class EMEController extends Logger implements ComponentAPI {
         }
       }
 
-      if (!keySessionContextPromise && keySystemDomain === keySystem) {
+      if (!keySessionContextPromise) {
+        if (keySystemDomain !== keySystem) {
+          this.log(`Ignoring "${event.type}" event with ${keySystemDomain} init data for selected key-system ${keySystem}`);
+          return;
+        }
         // "Clear-lead" (misc key not encountered in playlist)
         keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
           this.getKeySystemSelectionPromise([keySystemDomain]).then(

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -112,7 +112,12 @@ export default class KeyLoader implements ComponentAPI {
   }
 
   load(frag: Fragment): Promise<KeyLoadedData> {
-    if (!frag.decryptdata && frag.encrypted && this.emeController) {
+    if (
+      !frag.decryptdata &&
+      frag.encrypted &&
+      this.emeController &&
+      this.config.emeEnabled
+    ) {
       // Multiple keys, but none selected, resolve in eme-controller
       return this.emeController
         .selectKeySystemFormat(frag)


### PR DESCRIPTION
Resolves #6947 / Suggested changes for #6946

- #6947
- #6946

CC @cjpillsbury. Thanks for reporting #6947 and submitting #6946. I was able to reproduce the issue. The only issue with the PR was that adding async/await functions introduces regenerator-runtime boilerplate (about 300 lines) to hls.js. To avoid this I wanted to see if we could simplify the fix. Resolving the selected key-system up front (as it always should be based on playlist keys/config) simplifies the rest.