### PR TITLE
Flush MSE rendering pipeline when crossing video buffer holes with audio

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -551,8 +551,6 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected transmuxer: TransmuxerInterface | null;
     // (undocumented)
-    protected triggerEnded(): void;
-    // (undocumented)
     protected unregisterListeners(): void;
     // (undocumented)
     protected waitForCdnTuneIn(details: LevelDetails): boolean | 0;
@@ -650,47 +648,15 @@ export interface BufferCodecsData {
 export class BufferController extends Logger implements ComponentAPI {
     constructor(hls: Hls, fragmentTracker: FragmentTracker);
     // (undocumented)
-    protected appendChangeType(type: SourceBufferName, container: string, codec: string): void;
-    // (undocumented)
     get bufferedToEnd(): boolean;
-    // (undocumented)
-    protected checkPendingTracks(): void;
     // (undocumented)
     destroy(): void;
     // (undocumented)
     hasSourceTypes(): boolean;
     // (undocumented)
-    media: HTMLMediaElement | null;
-    // (undocumented)
-    mediaSource: MediaSource | null;
-    // (undocumented)
-    protected onBufferAppending(event: Events.BUFFER_APPENDING, eventData: BufferAppendingData): void;
-    // (undocumented)
-    protected onBufferCodecs(event: Events.BUFFER_CODECS, data: BufferCodecsData): void;
-    // (undocumented)
-    protected onBufferEos(event: Events.BUFFER_EOS, data: BufferEOSData): void;
-    // (undocumented)
-    protected onBufferFlushing(event: Events.BUFFER_FLUSHING, data: BufferFlushingData): void;
-    // (undocumented)
-    protected onBufferReset(): void;
-    // (undocumented)
-    protected onFragParsed(event: Events.FRAG_PARSED, data: FragParsedData): void;
-    // (undocumented)
-    protected onLevelUpdated(event: Events.LEVEL_UPDATED, { details }: LevelUpdatedData): void;
-    // (undocumented)
-    protected onManifestParsed(event: Events.MANIFEST_PARSED, data: ManifestParsedData): void;
-    // (undocumented)
-    protected onMediaAttaching(event: Events.MEDIA_ATTACHING, data: MediaAttachingData): void;
-    // (undocumented)
-    protected onMediaDetaching(event: Events.MEDIA_DETACHING, data: MediaDetachingData): void;
-    // (undocumented)
-    protected registerListeners(): void;
-    // (undocumented)
     get sourceBufferTracks(): BaseTrackSet;
     // (undocumented)
     transferMedia(): AttachMediaSourceData | null;
-    // (undocumented)
-    protected unregisterListeners(): void;
 }
 
 // Warning: (ae-missing-release-tag) "BufferControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -764,6 +730,7 @@ export type BufferInfo = {
     end: number;
     nextStart?: number;
     buffered?: BufferTimeRange[];
+    bufferedIndex: number;
 };
 
 // Warning: (ae-missing-release-tag) "BufferTimeRange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1958,6 +1925,17 @@ export interface FragParsingUserdataData {
     samples: UserdataSample[];
 }
 
+// Warning: (ae-missing-release-tag) "GapControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type GapControllerConfig = {
+    detectStallWithCurrentTimeMs: number;
+    highBufferWatchdogPeriod: number;
+    nudgeOffset: number;
+    nudgeMaxRetry: number;
+    nudgeOnVideoHole: boolean;
+};
+
 // Warning: (ae-missing-release-tag) "HdcpLevel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2219,8 +2197,7 @@ export type HlsConfig = {
     progressive: boolean;
     lowLatencyMode: boolean;
     primarySessionId?: string;
-    detectStallWithCurrentTimeMs: number;
-} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & LevelControllerConfig & MP4RemuxerConfig & StreamControllerConfig & SelectionPreferences & LatencyControllerConfig & MetadataControllerConfig & TimelineControllerConfig & TSDemuxerConfig & HlsLoadPolicies & FragmentLoaderConfig & PlaylistLoaderConfig;
+} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & GapControllerConfig & LevelControllerConfig & MP4RemuxerConfig & StreamControllerConfig & SelectionPreferences & LatencyControllerConfig & MetadataControllerConfig & TimelineControllerConfig & TSDemuxerConfig & HlsLoadPolicies & FragmentLoaderConfig & PlaylistLoaderConfig;
 
 // Warning: (ae-missing-release-tag) "HlsEventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -4416,8 +4393,6 @@ export class StreamController extends BaseStreamController implements NetworkCom
     // (undocumented)
     swapAudioCodec(): void;
     // (undocumented)
-    protected triggerEnded(): void;
-    // (undocumented)
     protected unregisterListeners(): void;
 }
 
@@ -4432,9 +4407,6 @@ export type StreamControllerConfig = {
     maxBufferLength: number;
     maxBufferSize: number;
     maxBufferHole: number;
-    highBufferWatchdogPeriod: number;
-    nudgeOffset: number;
-    nudgeMaxRetry: number;
     maxFragLookUpTolerance: number;
     maxMaxBufferLength: number;
     startFragPrefetch: boolean;

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -450,6 +450,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected hls: Hls;
     // (undocumented)
+    get inFlightFrag(): InFlightData;
+    // (undocumented)
     protected initPTS: RationalTimestamp[];
     // (undocumented)
     protected isLoopLoading(frag: Fragment, targetBufferTime: number): boolean;
@@ -539,11 +541,11 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     get startPositionValue(): number;
     // (undocumented)
     protected startTimeOffset: number | null;
-    set state(nextState: string);
+    set state(nextState: (typeof State)[keyof typeof State]);
     // (undocumented)
-    get state(): string;
+    get state(): (typeof State)[keyof typeof State];
     // (undocumented)
-    protected _state: string;
+    protected _state: (typeof State)[keyof typeof State];
     // (undocumented)
     stopLoad(): void;
     // (undocumented)
@@ -1998,6 +2000,8 @@ class Hls implements HlsEventEmitter {
     getMediaDecodingInfo(level: Level, audioTracks?: MediaPlaylist[]): Promise<MediaDecodingInfo>;
     static getMediaSource(): typeof MediaSource | undefined;
     get hasEnoughToStart(): boolean;
+    // (undocumented)
+    get inFlightFragments(): InFlightFragments;
     get interstitialsManager(): InterstitialsManager | null;
     static isMSESupported(): boolean;
     static isSupported(): boolean;
@@ -2469,6 +2473,23 @@ export interface ILogger {
     // (undocumented)
     warn: ILogFunction;
 }
+
+// Warning: (ae-missing-release-tag) "InFlightData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type InFlightData = {
+    frag: Fragment | null;
+    state: (typeof State)[keyof typeof State];
+};
+
+// Warning: (ae-missing-release-tag) "InFlightFragments" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type InFlightFragments = {
+    [PlaylistLevelType.MAIN]: InFlightData;
+    [PlaylistLevelType.AUDIO]?: InFlightData;
+    [PlaylistLevelType.SUBTITLE]?: InFlightData;
+};
 
 // Warning: (ae-missing-release-tag) "InitPTSFoundData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -4315,6 +4336,24 @@ export interface SourceBufferTrack extends BaseTrack {
 //
 // @public (undocumented)
 export type SourceBufferTrackSet = Partial<Record<SourceBufferName, SourceBufferTrack>>;
+
+// Warning: (ae-missing-release-tag) "State" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const State: {
+    STOPPED: string;
+    IDLE: string;
+    KEY_LOADING: string;
+    FRAG_LOADING: string;
+    FRAG_LOADING_WAITING_RETRY: string;
+    WAITING_TRACK: string;
+    PARSING: string;
+    PARSED: string;
+    ENDED: string;
+    ERROR: string;
+    WAITING_INIT_PTS: string;
+    WAITING_LEVEL: string;
+};
 
 // Warning: (ae-missing-release-tag) "SteeringManifest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/docs/API.md
+++ b/docs/API.md
@@ -162,6 +162,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`hls.resumeBuffering()`](#hlsresumebuffering)
   - [`hls.bufferingEnabled`](#hlsbufferingenabled)
   - [`hls.bufferedToEnd`](#hlsbufferedtoend)
+  - [`hls.inFlightFragments`](#hlsinflightfragments)
   - [`hls.url`](#hlsurl)
 - [Audio Tracks Control API](#audio-tracks-control-api)
   - [`hls.setAudioOption(audioOption)`](#hlssetaudiooptionaudiooption)
@@ -1887,6 +1888,29 @@ get : Returns a boolean indicating whether fragment loading has been toggled wit
 ### `hls.bufferedToEnd`
 
 get : Returns a boolean indicating if EOS has been appended (media is buffered from currentTime to end of stream).
+
+### `hls.inFlightFragments`
+
+get: Returns an object with each streaming controller's state and in-flight fragment (or null).
+
+Example:
+
+```js
+{
+  main: {
+    frag: <Fragment Object>,
+    state: "FRAG_LOADING"
+  },
+  audio: {
+    frag: <Fragment Object>,
+    state: "PARSED"
+  },
+  subtitle: {
+    frag: null,
+    state: "IDLE"
+  }
+}
+```
 
 ### `hls.url`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # HLS.js v1 API
 
-See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete list of interfaces available in the hls.js package.
+See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete list of interfaces available in the "hls.js" package.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -35,9 +35,11 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`maxStarvationDelay`](#maxstarvationdelay)
   - [`maxLoadingDelay`](#maxloadingdelay)
   - [`lowBufferWatchdogPeriod` (deprecated)](#lowbufferwatchdogperiod-deprecated)
+  - [`detectStallWithCurrentTimeMs`](#detectstallwithcurrenttimems)
   - [`highBufferWatchdogPeriod`](#highbufferwatchdogperiod)
   - [`nudgeOffset`](#nudgeoffset)
   - [`nudgeMaxRetry`](#nudgemaxretry)
+  - [`nudgeOnVideoHole`](#nudgeonvideohole)
   - [`maxFragLookUpTolerance`](#maxfraglookuptolerance)
   - [`maxMaxBufferLength`](#maxmaxbufferlength)
   - [`liveSyncDurationCount`](#livesyncdurationcount)
@@ -319,7 +321,7 @@ Each error is categorized by an error type, error details, and whether or not is
 - Error Details:
   - refer to [Errors details](#Errors)
 - Error is `fatal`:
-  - `false` if error is not fatal, hls.js will try to recover.
+  - `false` if error is not fatal, HLS.js will try to recover.
   - `true` if error is fatal, all attempts to recover have been performed. See [LoadPolicies](#fragloadpolicy--keyloadpolicy--certloadpolicy--playlistloadpolicy--manifestloadpolicy--steeringmanifestloadpolicy--interstitialAssetListLoadPolicy) details on how to configure retries.
 
 Full details are described [below](#Errors)
@@ -344,11 +346,11 @@ hls.on(Hls.Events.ERROR, function (event, data) {
 
 #### Fatal Error Recovery
 
-hls.js provides means to 'try to' recover fatal media errors, through these methods:
+HLS.js provides several methods for attempting playback recover in the event of a decoding error in the HTMLMediaElement:
 
 ##### `hls.recoverMediaError()`
 
-Should be invoked to recover media error.
+Resets the MediaSource and restarts streaming from the last known playhead position.
 
 ###### Error recovery sample code
 
@@ -378,13 +380,9 @@ hls.on(Hls.Events.ERROR, function (event, data) {
 
 ##### `hls.swapAudioCodec()`
 
-If media error are still raised after calling `hls.recoverMediaError()`,
-calling this method, could be useful to workaround audio codec mismatch.
-the workflow should be:
+`hls.swapAudioCodec()` can be used in the place of `hls.recoverMediaError()` when dealing with user agents that have issues handling HE-AAC and AAC audio (mp4a.40.5 and mp4a.40.2) codecs and media.
 
-on First Media Error : call `hls.recoverMediaError()`
-
-if another Media Error is raised 'quickly' after this first Media Error : first call `hls.swapAudioCodec()`, then call `hls.recoverMediaError()`.
+This should no longer be required and is not recommended. If you find a case where it is, please [file a bug](https://github.com/video-dev/hls.js/issues/new?template=bug.yaml) with steps to reproduce.
 
 ### Final step: destroying, switching between streams
 
@@ -392,7 +390,7 @@ if another Media Error is raised 'quickly' after this first Media Error : first 
 
 ## Fine Tuning
 
-Configuration parameters could be provided to hls.js upon instantiation of `Hls` object.
+Configuration parameters could be provided to HLS.js upon instantiation of `Hls` object.
 
 ```js
 var config = {
@@ -559,13 +557,11 @@ A logger object could also be provided for custom logging: `config.debug = custo
 
 (default: `undefined`)
 
-If audio codec is not signaled in variant manifest, or if only a stream manifest is provided, hls.js tries to guess audio codec by parsing audio sampling rate in ADTS header.
-If sampling rate is less or equal than 22050 Hz, then hls.js assumes it is HE-AAC, otherwise it assumes it is AAC-LC. This could result in bad guess, leading to audio decode error, ending up in media error.
-It is possible to hint default audiocodec to hls.js by configuring this value as below:
+Use this to override the multi-variant playlist audio codec, or provide one if loading only a media playlist.
 
-- `mp4a.40.2` (AAC-LC) or
-- `mp4a.40.5` (HE-AAC) or
-- `undefined` (guess based on sampling rate)
+HLS.js parses track codecs from mp4 stsd or ADTS object type in the case of AAC in MPEG-TS. If there is an error using the value it finds in the segments, it will fallback to codec found in the multi-variant playlist or `defaultAudioCodec`.
+
+This should no longer be required and is not recommended. If you find a case where it is, please [file a bug](https://github.com/video-dev/hls.js/issues/new?template=bug.yaml) with steps to reproduce.
 
 ### `initialLiveManifestSize`
 
@@ -578,13 +574,13 @@ number of segments needed to start a playback of Live stream. Buffering will beg
 (default: `30` seconds)
 
 Maximum buffer length in seconds. If buffer length is/become less than this value, a new fragment will be loaded.
-This is the guaranteed buffer length hls.js will try to reach, regardless of maxBufferSize.
+This is the guaranteed buffer length HLS.js will try to reach, regardless of maxBufferSize.
 
 ### `backBufferLength`
 
 (default: `Infinity`)
 
-The maximum duration of buffered media to keep once it has been played, in seconds. Any video buffered past this duration will be evicted. `Infinity` means no restriction on back buffer length; `0` keeps the minimum amount. The minimum amount is equal to the target duration of a segment to ensure that current playback is not interrupted. Keep in mind, the browser can and does evict media from the buffer on its own, so with the `Infinity` setting, hls.js will let the browser do what it needs to do. (Ref: the MSE spec under [coded frame eviction](https://www.w3.org/TR/media-source-2/#sourcebuffer-coded-frame-eviction)).
+The maximum duration of buffered media to keep once it has been played, in seconds. Any video buffered past this duration will be evicted. `Infinity` means no restriction on back buffer length; `0` keeps the minimum amount. The minimum amount is equal to the target duration of a segment to ensure that current playback is not interrupted. Keep in mind, the browser can and does evict media from the buffer on its own, so with the `Infinity` setting, HLS.js will let the browser do what it needs to do. (Ref: the MSE spec under [coded frame eviction](https://www.w3.org/TR/media-source-2/#sourcebuffer-coded-frame-eviction)).
 
 ### `frontBufferFlushThreshold`
 
@@ -602,7 +598,7 @@ The maximum duration of buffered media, in seconds, from the play position to ke
 
 (default: `0.1` seconds)
 
-'Maximum' inter-fragment buffer hole tolerance that hls.js can cope with when searching for the next fragment to load.
+'Maximum' inter-fragment buffer hole tolerance that HLS.js can cope with when searching for the next fragment to load.
 When switching between quality level, fragments might not be perfectly aligned.
 This could result in small overlapping or hole in media buffer. This tolerance factor helps cope with this.
 
@@ -626,24 +622,36 @@ max video loading delay used in automatic start level selection : in that mode A
 
 `lowBufferWatchdogPeriod` has been deprecated. Use `highBufferWatchdogPeriod` instead.
 
+### `detectStallWithCurrentTimeMs`
+
+(default: `1250` milliseconds)
+
+The amount of time that playback can progress without `currentTime` advancing before HLS.js will report a stall. Note that stalls are detected immediately when the attached HTMLMediaElement dispatched the "waiting" event outside of startup and seeking. `detectStallWithCurrentTimeMs` is used when "waiting" is not dispatched and `currentTime` fails to advance without a reasonable interval.
+
 ### `highBufferWatchdogPeriod`
 
 (default 3s)
 
-if media element is expected to play and if currentTime has not moved for more than `highBufferWatchdogPeriod` and if there are more than `maxBufferHole` seconds buffered upfront, hls.js will jump buffer gaps, or try to nudge playhead to recover playback
+if media element is expected to play and if currentTime has not moved for more than `highBufferWatchdogPeriod` and if there are more than `maxBufferHole` seconds buffered upfront, HLS.js will jump buffer gaps, or try to nudge playhead to recover playback
 
 ### `nudgeOffset`
 
-(default 0.1s)
+(default: `0.1` seconds)
 
 In case playback continues to stall after first playhead nudging, currentTime will be nudged evenmore following nudgeOffset to try to restore playback.
-media.currentTime += (nb nudge retry -1)\*nudgeOffset
+`media.currentTime += <number of nudge retries> * nudgeOffset`
 
 ### `nudgeMaxRetry`
 
-(default 3)
+(default: `3`)
 
-Max nb of nudge retries before hls.js raise a fatal BUFFER_STALLED_ERROR
+Max number of playhead (`currentTime`) nudges before HLS.js raise a fatal BUFFER_STALLED_ERROR
+
+### `nudgeOnVideoHole`
+
+(default: `true`)
+
+Whether or not HLS.js should perform a seek nudge to flush the rendering pipeline upon traversing a gap or hole in video SourceBuffer buffered time ranges. This is only performed when audio is buffered at the point where the hole is detected. For more information see `nudgeOnVideoHole` in gap-controller and issues https://issues.chromium.org/issues/40280613#comment10 and https://github.com/video-dev/hls.js/issues/5631.
 
 ### `maxFragLookUpTolerance`
 
@@ -675,12 +683,12 @@ This time, `buffered.end` is within `frag[1]` range, and `frag[1]` will be the n
 
 (default 600s)
 
-Maximum buffer length in seconds. Hls.js will never exceed this value, even if `maxBufferSize` is not reached yet.
+Maximum buffer length in seconds. HLS.js will never exceed this value, even if `maxBufferSize` is not reached yet.
 
-hls.js tries to buffer up to a maximum number of bytes (60 MB by default) rather than to buffer up to a maximum nb of seconds.
+HLS.js tries to buffer up to a maximum number of bytes (60 MB by default) rather than to buffer up to a maximum nb of seconds.
 this is to mimic the browser behaviour (the buffer eviction algorithm is starting after the browser detects that video buffer size reaches a limit in bytes)
 
-`maxBufferLength` is the minimum guaranteed buffer length that hls.js will try to achieve, even if that value exceeds the amount of bytes 60 MB of memory.
+`maxBufferLength` is the minimum guaranteed buffer length that HLS.js will try to achieve, even if that value exceeds the amount of bytes 60 MB of memory.
 `maxMaxBufferLength` acts as a capping value, as if bitrate is really low, you could need more than one hour of buffer to fill 60 MB.
 
 ### `liveSyncDurationCount`
@@ -1005,7 +1013,7 @@ Start prefetching start fragment although media not attached yet.
 
 (default: `true`)
 
-You must also set `startLevel = -1` for this to have any impact. Otherwise, hls.js will load the first level in the manifest and start playback from there. If you do set `startLevel = -1`, a fragment of the lowest level will be downloaded to establish a bandwidth estimate before selecting the first auto-level.
+You must also set `startLevel = -1` for this to have any impact. Otherwise, HLS.js will load the first level in the manifest and start playback from there. If you do set `startLevel = -1`, a fragment of the lowest level will be downloaded to establish a bandwidth estimate before selecting the first auto-level.
 Disable this test if you'd like to provide your own estimate or use the default `abrEwmaDefaultEstimate`.
 
 ### `progressive`
@@ -1441,11 +1449,11 @@ parameter should be a boolean
 Browsers are really strict about audio frames timings.
 They usually play audio frames one after the other, regardless of the timestamps advertised in the fmp4.
 If audio timestamps are not consistent (consecutive audio frames too close or too far from each other), audio will easily drift.
-hls.js is restamping audio frames so that the distance between consecutive audio frame remains constant.
-if the distance is larger than the max allowed drift, hls.js will either
+HLS.js is restamping audio frames so that the distance between consecutive audio frame remains constant.
+if the distance is larger than the max allowed drift, HLS.js will either:
 
-- drop the next audio frame if distance is too small (if next audio frame timestamp is smaller than expected time stamp - max allowed drift)
-- insert silent frames if distance is too big (next audio frame timestamp is bigger than expected timestamp + max allowed drift)
+1. drop the next audio frame if distance is too small (if next audio frame timestamp is smaller than expected time stamp - max allowed drift)
+2. (AAC only) insert silent frames if distance is too big (next audio frame timestamp is bigger than expected timestamp + max allowed drift)
 
 parameter should be an integer representing the max number of audio frames allowed to drift.
 keep in mind that one audio frame is 1024 audio samples (if using AAC), at 44.1 kHz, it gives 1024/44100 = 23ms
@@ -1831,8 +1839,7 @@ set: Reset `EwmaBandWidthEstimator` using the value set as the new default estim
 ### `hls.removeLevel(levelIndex)`
 
 Remove a level from the list of loaded levels.
-This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user
-or hls.js can choose from.
+This can be used to remove a rendition or playlist url that errors frequently from the list of levels that a user or HLS.js can choose from.
 
 Modifying the levels this way will result in a `Hls.Events.LEVELS_UPDATED` event being triggered.
 
@@ -1840,11 +1847,11 @@ Modifying the levels this way will result in a `Hls.Events.LEVELS_UPDATED` event
 
 ### `Hls.version`
 
-Static getter: return hls.js dist version number.
+Static getter: return the hls.js@version string (dist build version or src **VERSION** build const).
 
 ## Network Loading Control API
 
-By default, hls.js will automatically start loading quality level playlists, and fragments after `Hls.Events.MANIFEST_PARSED` event has been triggered.
+By default, HLS.js will automatically start loading quality level playlists, and fragments after `Hls.Events.MANIFEST_PARSED` event has been triggered.
 
 However, if `config.autoStartLoad` is set to `false`, then `hls.startLoad()` needs to be called to manually start playlist and fragments loading.
 
@@ -1855,7 +1862,7 @@ Start/restart playlist/fragment loading. This is only effective if MANIFEST_PARS
 startPosition is the initial position in the playlist.
 If startPosition is not set to -1, it allows to override default startPosition to the one you want (it will bypass hls.config.liveSync\* config params for Live for example, so that user can start playback from whatever position).
 
-Once media is appended hls.js will seek to the start position. Passing in a `skipSeekToStartPosition` of `true` allows loading to begin at the start position without seeking on append. This is used when multiple players contribute to buffering media to the same source for Interstitials that overlap primary content.
+Once media is appended HLS.js will seek to the start position. Passing in a `skipSeekToStartPosition` of `true` allows loading to begin at the start position without seeking on append. This is used when multiple players contribute to buffering media to the same source for Interstitials that overlap primary content.
 
 ### `hls.stopLoad()`
 
@@ -1932,7 +1939,7 @@ get/set : if set to true the active subtitle track mode will be set to `showing`
 ### `hls.liveSyncPosition`
 
 get : position of live sync point (ie edge of live position minus safety delay defined by `hls.config.liveSyncDuration`).
-If playback stalls outside the sliding window, or latency exceeds `liveMaxLatencyDuration` hls.js will seek ahead to
+If playback stalls outside the sliding window, or latency exceeds `liveMaxLatencyDuration`, HLS.js will seek ahead to
 `liveSyncPosition` to get back in sync with the stream stream.
 
 ### `hls.latency`

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,13 +214,18 @@ export type StreamControllerConfig = {
   maxBufferLength: number;
   maxBufferSize: number;
   maxBufferHole: number;
-  highBufferWatchdogPeriod: number;
-  nudgeOffset: number;
-  nudgeMaxRetry: number;
   maxFragLookUpTolerance: number;
   maxMaxBufferLength: number;
   startFragPrefetch: boolean;
   testBandwidth: boolean;
+};
+
+export type GapControllerConfig = {
+  detectStallWithCurrentTimeMs: number;
+  highBufferWatchdogPeriod: number;
+  nudgeOffset: number;
+  nudgeMaxRetry: number;
+  nudgeOnVideoHole: boolean;
 };
 
 export type SelectionPreferences = {
@@ -319,12 +324,12 @@ export type HlsConfig = {
   progressive: boolean;
   lowLatencyMode: boolean;
   primarySessionId?: string;
-  detectStallWithCurrentTimeMs: number;
 } & ABRControllerConfig &
   BufferControllerConfig &
   CapLevelControllerConfig &
   EMEControllerConfig &
   FPSControllerConfig &
+  GapControllerConfig &
   LevelControllerConfig &
   MP4RemuxerConfig &
   StreamControllerConfig &
@@ -365,11 +370,13 @@ export const hlsDefaultConfig: HlsConfig = {
   backBufferLength: Infinity, // used by buffer-controller
   frontBufferFlushThreshold: Infinity,
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
-  maxBufferHole: 0.1, // used by stream-controller
-  highBufferWatchdogPeriod: 2, // used by stream-controller
-  nudgeOffset: 0.1, // used by stream-controller
-  nudgeMaxRetry: 3, // used by stream-controller
   maxFragLookUpTolerance: 0.25, // used by stream-controller
+  maxBufferHole: 0.1, // used by stream-controller and gap-controller
+  detectStallWithCurrentTimeMs: 1250, // used by gap-controller
+  highBufferWatchdogPeriod: 2, // used by gap-controller
+  nudgeOffset: 0.1, // used by gap-controller
+  nudgeMaxRetry: 3, // used by gap-controller
+  nudgeOnVideoHole: true, // used by gap-controller
   liveSyncDurationCount: 3, // used by latency-controller
   liveSyncOnStallIncrease: 1, // used by latency-controller
   liveMaxLatencyDurationCount: Infinity, // used by latency-controller
@@ -428,7 +435,6 @@ export const hlsDefaultConfig: HlsConfig = {
   progressive: false,
   lowLatencyMode: true,
   cmcd: undefined,
-  detectStallWithCurrentTimeMs: 1250,
   enableDateRangeMetadataCues: true,
   enableEmsgMetadataCues: true,
   enableEmsgKLVMetadata: false,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -391,12 +391,7 @@ export default class BaseStreamController
     // reset startPosition and lastCurrentTime to restart playback @ stream beginning
     this.log(`setting startPosition to 0 because media ended`);
     this.startPosition = this.lastCurrentTime = 0;
-    this.triggerEnded();
   };
-
-  protected triggerEnded() {
-    /* overridden in stream-controller */
-  }
 
   protected onManifestLoaded(
     event: Events.MANIFEST_LOADED,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -79,6 +79,11 @@ export const State = {
   WAITING_LEVEL: 'WAITING_LEVEL',
 };
 
+export type InFlightData = {
+  frag: Fragment | null;
+  state: (typeof State)[keyof typeof State];
+};
+
 export default class BaseStreamController
   extends TaskLoop
   implements NetworkComponentAPI
@@ -89,7 +94,7 @@ export default class BaseStreamController
   protected fragCurrent: Fragment | null = null;
   protected fragmentTracker: FragmentTracker;
   protected transmuxer: TransmuxerInterface | null = null;
-  protected _state: string = State.STOPPED;
+  protected _state: (typeof State)[keyof typeof State] = State.STOPPED;
   protected playlistType: PlaylistLevelType;
   protected media: HTMLMediaElement | null = null;
   protected mediaBuffer: Bufferable | null = null;
@@ -192,6 +197,10 @@ export default class BaseStreamController
 
   public resumeBuffering() {
     this.buffering = true;
+  }
+
+  public get inFlightFrag(): InFlightData {
+    return { frag: this.fragCurrent, state: this.state };
   }
 
   protected _streamEnded(
@@ -2014,7 +2023,7 @@ export default class BaseStreamController
     }
   }
 
-  set state(nextState) {
+  set state(nextState: (typeof State)[keyof typeof State]) {
     const previousState = this._state;
     if (previousState !== nextState) {
       this._state = nextState;
@@ -2022,7 +2031,7 @@ export default class BaseStreamController
     }
   }
 
-  get state() {
+  get state(): (typeof State)[keyof typeof State] {
     return this._state;
   }
 }

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -461,7 +461,8 @@ export default class GapController extends TaskLoop {
         bufferInfo.len > config.maxBufferHole) ||
         (bufferInfo.nextStart &&
           bufferInfo.nextStart - currentTime < config.maxBufferHole)) &&
-      stalledDurationMs > config.highBufferWatchdogPeriod * 1000
+      (stalledDurationMs > config.highBufferWatchdogPeriod * 1000 ||
+        this.waiting)
     ) {
       this.warn('Trying to nudge playhead over buffer-hole');
       // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -22,6 +22,10 @@ import {
   TimelineOccupancy,
 } from '../loader/interstitial-event';
 import { BufferHelper } from '../utils/buffer-helper';
+import {
+  addEventListener,
+  removeEventListener,
+} from '../utils/event-listener-helper';
 import { hash } from '../utils/hash';
 import { Logger } from '../utils/logger';
 import { isCompatibleTrackChange } from '../utils/mediasource-helper';
@@ -226,17 +230,17 @@ export default class InterstitialsController
   }
 
   private onDestroying() {
-    const media = this.primaryMedia;
+    const media = this.primaryMedia || this.media;
     if (media) {
       this.removeMediaListeners(media);
     }
   }
 
   private removeMediaListeners(media: HTMLMediaElement) {
-    media.removeEventListener('play', this.onPlay);
-    media.removeEventListener('pause', this.onPause);
-    media.removeEventListener('seeking', this.onSeeking);
-    media.removeEventListener('timeupdate', this.onTimeupdate);
+    removeEventListener(media, 'play', this.onPlay);
+    removeEventListener(media, 'pause', this.onPause);
+    removeEventListener(media, 'seeking', this.onSeeking);
+    removeEventListener(media, 'timeupdate', this.onTimeupdate);
   }
 
   private onMediaAttaching(
@@ -244,11 +248,10 @@ export default class InterstitialsController
     data: MediaAttachingData,
   ) {
     const media = (this.media = data.media);
-    this.removeMediaListeners(media);
-    media.addEventListener('seeking', this.onSeeking);
-    media.addEventListener('timeupdate', this.onTimeupdate);
-    media.addEventListener('play', this.onPlay);
-    media.addEventListener('pause', this.onPause);
+    addEventListener(media, 'seeking', this.onSeeking);
+    addEventListener(media, 'timeupdate', this.onTimeupdate);
+    addEventListener(media, 'play', this.onPlay);
+    addEventListener(media, 'pause', this.onPause);
   }
 
   private onMediaAttached(

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'eventemitter3';
 import { buildAbsoluteURL } from 'url-toolkit';
 import { enableStreamingMode, hlsDefaultConfig, mergeConfig } from './config';
 import { FragmentTracker } from './controller/fragment-tracker';
+import GapController from './controller/gap-controller';
 import ID3TrackController from './controller/id3-track-controller';
 import LatencyController from './controller/latency-controller';
 import LevelController from './controller/level-controller';
@@ -94,6 +95,7 @@ export default class Hls implements HlsEventEmitter {
   private audioTrackController?: AudioTrackController;
   private subtitleTrackController?: SubtitleTrackController;
   private interstitialsController?: InterstitialsController;
+  private gapController: GapController;
   private emeController?: EMEController;
   private cmcdController?: CMCDController;
   private _media: HTMLMediaElement | null = null;
@@ -229,6 +231,12 @@ export default class Hls implements HlsEventEmitter {
       keyLoader,
     ));
 
+    const gapController = (this.gapController = new GapController(
+      this,
+      fragmentTracker,
+      streamController,
+    ));
+
     // Cap level controller uses streamController to flush the buffer
     capLevelController.setStreamController(streamController);
     // fpsController uses streamController to switch when frames are being dropped
@@ -250,6 +258,7 @@ export default class Hls implements HlsEventEmitter {
     const coreComponents: ComponentAPI[] = [
       abrController,
       bufferController,
+      gapController,
       capLevelController,
       fpsController,
       id3TrackController,
@@ -1232,6 +1241,7 @@ export type {
   FPSControllerConfig,
   FragmentLoaderConfig,
   FragmentLoaderConstructor,
+  GapControllerConfig,
   HlsLoadPolicies,
   LevelControllerConfig,
   LoaderConfig,

--- a/src/utils/event-listener-helper.ts
+++ b/src/utils/event-listener-helper.ts
@@ -1,0 +1,16 @@
+export function addEventListener(
+  el: HTMLElement,
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+) {
+  removeEventListener(el, type, listener);
+  el.addEventListener(type, listener);
+}
+
+export function removeEventListener(
+  el: HTMLElement,
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+) {
+  el.removeEventListener(type, listener);
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -43,6 +43,7 @@ import './unit/utils/codecs';
 import './unit/utils/error-helper';
 import './unit/utils/discontinuities';
 import './unit/utils/exp-golomb';
+import './unit/utils/mock-media';
 import './unit/utils/output-filter';
 import './unit/utils/texttrack-utils';
 import './unit/utils/vttparser';

--- a/tests/unit/controller/base-stream-controller.ts
+++ b/tests/unit/controller/base-stream-controller.ts
@@ -49,6 +49,8 @@ describe('BaseStreamController', function () {
       nextStart: 0,
       start: 0,
       end: 1,
+      bufferedIndex: 0,
+      buffered: [{ start: 0, end: 1 }],
     };
     media = {
       duration: 0,

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -806,9 +806,9 @@ describe('BufferController with attached media', function () {
     it('sets media duration when attaching after level update', function () {
       (bufferController as any).resetBuffer('audio');
       (bufferController as any).resetBuffer('video');
-      const media = bufferController.media;
+      const media = (bufferController as any).media;
       // media is null prior to attaching
-      bufferController.media = null;
+      (bufferController as any).media = null;
       expect(mockMediaSource.duration, 'mediaSource.duration').to.equal(
         Infinity,
       );
@@ -817,7 +817,7 @@ describe('BufferController with attached media', function () {
         Infinity,
       );
       // simulate attach and open source buffers
-      bufferController.media = media;
+      (bufferController as any).media = media;
       (bufferController as any)._onMediaSourceOpen();
       expect(mockMediaSource.duration, 'mediaSource.duration').to.equal(10);
     });

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -10,6 +10,7 @@ import { ElementaryStreamTypes, Fragment } from '../../../src/loader/fragment';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
+import { MockMediaElement, MockMediaSource } from '../utils/mock-media';
 import type BufferOperationQueue from '../../../src/controller/buffer-operation-queue';
 import type {
   BufferOperation,
@@ -22,6 +23,7 @@ import type {
   NetworkComponentAPI,
 } from '../../../src/types/component-api';
 import type { BufferAppendingData } from '../../../src/types/events';
+import type { MockSourceBuffer } from '../utils/mock-media';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -31,119 +33,6 @@ type HlsTestable = Omit<Hls, 'networkControllers' | 'coreComponents'> & {
   coreComponents: ComponentAPI[];
   networkControllers: NetworkComponentAPI[];
 };
-
-export class MockMediaSource extends EventTarget {
-  public readyState: string = 'open';
-  public duration: number = Infinity;
-  private _sourceBuffers: MockSourceBuffer[] = [];
-
-  get sourceBuffers(): MockSourceBuffer[] {
-    return this._sourceBuffers;
-  }
-  addSourceBuffer(): MockSourceBuffer {
-    const sb = new MockSourceBuffer();
-    this._sourceBuffers.push(sb);
-    return sb;
-  }
-
-  removeSourceBuffer(sb: MockSourceBuffer) {
-    const index = this._sourceBuffers.indexOf(sb);
-    if (index !== -1) {
-      this._sourceBuffers.splice(index, 1);
-    }
-  }
-
-  addEventListener() {}
-
-  removeEventListener() {}
-
-  endOfStream() {}
-}
-
-type TimeRange = { start: number; end: number };
-
-class MockBufferedRanges {
-  public _ranges: Array<TimeRange> = [];
-  start(index: number) {
-    if (index < 0 || index >= this._ranges.length) {
-      throw new Error(
-        `Index out of bounds: index=${index} but buffered.length=${this._ranges.length}`,
-      );
-    }
-    return this._ranges[index].start;
-  }
-
-  end(index: number) {
-    if (index < 0 || index >= this._ranges.length) {
-      throw new Error(
-        `Index out of bounds: index=${index} but buffered.length=${this._ranges.length}`,
-      );
-    }
-    return this._ranges[index].end;
-  }
-
-  get length() {
-    return this._ranges.length;
-  }
-
-  add(range: TimeRange) {
-    // Empty
-    if (this._ranges.length === 0) {
-      this._ranges.push(range);
-      return;
-    }
-
-    // No overlap from beginning
-    if (range.end < this.start(0)) {
-      this._ranges.unshift(range);
-      return;
-    }
-
-    // No overlap from end
-    if (range.start > this.end(this.length - 1)) {
-      this._ranges.push(range);
-      return;
-    }
-
-    const result = [this._ranges[0]];
-    this._ranges.push(range);
-    this._ranges.sort((a, b) => a.start - b.start);
-
-    let j = 0;
-    // Find and merge overlapping range
-    for (let i = 1; i < this._ranges.length; i++) {
-      const curRange = result[j];
-      const nextRange = this._ranges[i];
-      if (curRange.end >= nextRange.start) {
-        curRange.end = Math.max(curRange.end, nextRange.end);
-      } else {
-        result.push(nextRange);
-        j++;
-      }
-    }
-
-    this._ranges = result;
-  }
-}
-
-class MockSourceBuffer extends EventTarget {
-  public updating: boolean = false;
-  public appendBuffer = sandbox.stub();
-  public remove = sandbox.stub();
-  public buffered: MockBufferedRanges = new MockBufferedRanges();
-
-  setBuffered(start: number, end: number) {
-    this.buffered.add({ start, end });
-  }
-}
-
-export class MockMediaElement {
-  public currentTime: number = 0;
-  public duration: number = Infinity;
-  public textTracks: any[] = [];
-  addEventListener() {}
-  removeEventListener() {}
-}
 
 const queueNames: Array<SourceBufferName> = ['audio', 'video'];
 

--- a/tests/unit/controller/buffer-controller.ts
+++ b/tests/unit/controller/buffer-controller.ts
@@ -1,14 +1,11 @@
 import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import {
-  MockMediaElement,
-  MockMediaSource,
-} from './buffer-controller-operations';
 import BufferController from '../../../src/controller/buffer-controller';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
+import { MockMediaElement, MockMediaSource } from '../utils/mock-media';
 import type BufferOperationQueue from '../../../src/controller/buffer-operation-queue';
 import type {
   ExtendedSourceBuffer,
@@ -313,11 +310,9 @@ describe('BufferController', function () {
 
     it('creates the expected amount of sourceBuffers given the standard event flow', function () {
       bufferController.tracks = {};
-      bufferController.mediaSource = {
-        readyState: 'open',
-        removeEventListener: sandbox.stub(),
-      } as unknown as MediaSource;
-
+      bufferController.mediaSource =
+        new MockMediaSource() as unknown as MediaSource;
+      sandbox.stub(bufferController.mediaSource, 'removeEventListener');
       hls.trigger(Events.MANIFEST_PARSED, {
         altAudio: true,
       } as any);

--- a/tests/unit/controller/gap-controller.ts
+++ b/tests/unit/controller/gap-controller.ts
@@ -14,6 +14,7 @@ import {
   type BufferInfo,
 } from '../../../src/utils/buffer-helper';
 import type { HlsConfig } from '../../../src/config';
+import type StreamController from '../../../src/controller/stream-controller';
 import type { Fragment } from '../../../src/loader/fragment';
 
 chai.use(sinonChai);
@@ -35,6 +36,7 @@ type GapControllerTestable = Omit<GapController, ''> & {
 
 describe('GapController', function () {
   let hls: Hls;
+  let streamController: StreamController;
   let config: HlsConfig;
   let gapController: GapControllerTestable;
   let media;
@@ -45,18 +47,26 @@ describe('GapController', function () {
     hls = new Hls({});
     config = hls.config;
     const hlsTestable: any = hls;
-    hlsTestable.networkControllers.forEach((component) => component.destroy());
-    hlsTestable.networkControllers.length = 0;
+    for (let i = hlsTestable.networkControllers.length; i--; ) {
+      const component = hlsTestable.networkControllers[i];
+      if (component !== (hls as any).streamController) {
+        component.destroy();
+        hlsTestable.networkControllers.splice(i, 1);
+      }
+    }
     hlsTestable.coreComponents.forEach((component) => component.destroy());
     hlsTestable.coreComponents.length = 0;
     media = {
       currentTime: 0,
     };
+    streamController = (hls as any).streamController;
+    streamController.state = State.IDLE;
     gapController = new GapController(
-      media,
-      new FragmentTracker(hls as Hls),
       hls,
+      new FragmentTracker(hls as Hls),
+      streamController,
     ) as unknown as GapControllerTestable;
+    hls.trigger(Events.MEDIA_ATTACHING, { media });
     triggerSpy = sinon.spy(hls, 'trigger');
   });
 
@@ -99,6 +109,7 @@ describe('GapController', function () {
       config.nudgeMaxRetry = 0;
       gapController._tryNudgeBuffer(bufferInfo);
       expect(media.currentTime).to.equal(0);
+      expect(triggerSpy).to.have.been.called;
       expect(triggerSpy).to.have.been.calledWith(Events.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_STALLED_ERROR,
@@ -263,7 +274,7 @@ describe('GapController', function () {
         mockMedia.currentTime += incrementSec;
         gapController.waiting = 0;
       }
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
     }
 
     function setStalling() {
@@ -287,13 +298,13 @@ describe('GapController', function () {
     it('should try to fix a stall if expected to be playing', function () {
       const fixStallStub = sandbox.stub(gapController, '_tryFixBufferStall');
       setStalling();
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
 
       // The first poll call made while stalling just sets stall flags
       expect(gapController.stalled).to.be.a('number');
       expect(gapController.stallReported).to.be.false;
 
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
       expect(fixStallStub).to.have.been.calledOnce;
     });
 
@@ -303,7 +314,7 @@ describe('GapController', function () {
       gapController.nudgeRetry = 1;
       gapController.stalled = 4200;
       const fixStallStub = sandbox.stub(gapController, '_tryFixBufferStall');
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
 
       expect(gapController.stalled).to.not.exist;
       expect(gapController.nudgeRetry).to.equal(0);
@@ -345,7 +356,7 @@ describe('GapController', function () {
     it('should not detect stalls when loading an earlier fragment while seeking', function () {
       wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
       mockMedia.currentTime += 0.1;
-      gapController.poll(0, null, undefined, State.IDLE);
+      gapController.poll(0, mockMedia.currentTime);
       expect(gapController.stalled).to.equal(null, 'buffered start');
 
       wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
@@ -353,23 +364,15 @@ describe('GapController', function () {
       mockMedia.seeking = true;
       mockTimeRangesData.length = 1;
       mockTimeRangesData[0] = [5.5, 10];
-      gapController.poll(
-        mockMedia.currentTime - 5,
-        null,
-        undefined,
-        State.IDLE,
-      );
+      gapController.poll(mockMedia.currentTime - 5, mockMedia.currentTime);
       expect(gapController.stalled).to.equal(null, 'new seek position');
 
       wallClock.tick(2 * STALL_HANDLING_RETRY_PERIOD_MS);
-      gapController.poll(
-        mockMedia.currentTime,
-        {
-          start: 5,
-        } as unknown as Fragment,
-        undefined,
-        State.IDLE,
-      );
+      streamController.state = State.FRAG_LOADING;
+      (streamController as any).fragCurrent = {
+        start: 5,
+      } as unknown as Fragment;
+      gapController.poll(mockMedia.currentTime, mockMedia.currentTime);
       expect(gapController.stalled).to.equal(
         null,
         'seeking while loading fragment',
@@ -380,10 +383,10 @@ describe('GapController', function () {
       setStalling();
       wallClock.tick(250);
       gapController.stalled = 1;
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
       expect(reportStallSpy).to.not.have.been.called;
       wallClock.tick(config.detectStallWithCurrentTimeMs + 1);
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
       expect(reportStallSpy).to.have.been.calledOnce;
     });
 
@@ -391,11 +394,11 @@ describe('GapController', function () {
       setStalling();
       wallClock.tick(250);
       gapController.stalled = 1;
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
       expect(reportStallSpy).to.not.have.been.called;
       gapController.waiting = 250;
       wallClock.tick(1);
-      gapController.poll(lastCurrentTime, null, undefined, State.IDLE);
+      gapController.poll(lastCurrentTime, mockMedia.currentTime);
       expect(reportStallSpy).to.have.been.calledOnce;
     });
 
@@ -444,8 +447,8 @@ describe('GapController', function () {
     it('should skip any initial gap when not having played yet on second poll', function () {
       mockMedia.currentTime = 0;
       mockTimeRangesData = [[0.9, 10]];
-      gapController.poll(0, null, undefined, State.IDLE);
-      gapController.poll(0, null, undefined, State.IDLE);
+      gapController.poll(0, mockMedia.currentTime);
+      gapController.poll(0, mockMedia.currentTime);
       expect(mockMedia.currentTime).to.equal(0.9 + SKIP_BUFFER_RANGE_START);
     });
   });

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -453,7 +453,7 @@ describe('StreamController', function () {
     });
   });
 
-  describe('checkBuffer', function () {
+  describe('seekToStartPos', function () {
     const sandbox = sinon.createSandbox();
     const bufStart = 5;
 
@@ -480,11 +480,6 @@ describe('StreamController', function () {
     });
     afterEach(function () {
       sandbox.restore();
-    });
-
-    it('should not throw when media is undefined', function () {
-      streamController['media'] = null;
-      streamController['checkBuffer']();
     });
 
     it('should seek to start pos when data is first loaded', function () {
@@ -514,21 +509,6 @@ describe('StreamController', function () {
         id: 'main',
       });
       expect(seekStub).to.have.been.calledOnce;
-    });
-
-    it('should not seek to start pos when metadata has been loaded', function () {
-      // @ts-ignore
-      const seekStub = sandbox.stub(streamController, 'seekToStartPos');
-      streamController['checkBuffer']();
-      expect(seekStub).to.have.not.been.called;
-    });
-
-    it('should not seek to start pos when nothing has been buffered', function () {
-      // @ts-ignore
-      const seekStub = sandbox.stub(streamController, 'seekToStartPos');
-      (streamController['media']!.buffered as any).length = 0;
-      streamController['checkBuffer']();
-      expect(seekStub).to.have.not.been.called;
     });
 
     describe('seekToStartPos', function () {

--- a/tests/unit/hls.ts
+++ b/tests/unit/hls.ts
@@ -60,7 +60,7 @@ describe('Hls', function () {
       expect(media || null).to.not.equal(null);
       hls.attachMedia(media);
       expect(hls.media).to.equal(media);
-      detachTest(hls, media, 7);
+      detachTest(hls, media, 6);
       hls.destroy();
     });
 

--- a/tests/unit/hls.ts
+++ b/tests/unit/hls.ts
@@ -60,7 +60,7 @@ describe('Hls', function () {
       expect(media || null).to.not.equal(null);
       hls.attachMedia(media);
       expect(hls.media).to.equal(media);
-      detachTest(hls, media, 6);
+      detachTest(hls, media, 7);
       hls.destroy();
     });
 
@@ -76,7 +76,7 @@ describe('Hls', function () {
       hls.attachMedia(media);
       expect(hls.media).to.equal(media);
       hls.trigger(Events.MEDIA_ATTACHED, { media });
-      detachTest(hls, media, 13);
+      detachTest(hls, media, 14);
       hls.destroy();
     });
 

--- a/tests/unit/utils/buffer-helper.js
+++ b/tests/unit/utils/buffer-helper.js
@@ -79,13 +79,14 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        bufferedIndex: 0,
         buffered: [
           { start: 0, end: 0.5 },
           { start: 1, end: 2 },
         ],
       });
     });
-    it('should return empty buffer info if media does not exist', function () {
+    it('should return empty buffer info when media.buffered throws', function () {
       const invalidMedia = {
         get buffered() {
           throw new Error('InvalidStateError');
@@ -98,6 +99,7 @@ describe('BufferHelper', function () {
         len: 0,
         start: 0,
         end: 0,
+        bufferedIndex: -1,
       });
     });
     it('should return empty buffer info if media does not exist', function () {
@@ -106,6 +108,7 @@ describe('BufferHelper', function () {
         len: 0,
         start: 0,
         end: 0,
+        bufferedIndex: -1,
       });
     });
   });
@@ -132,6 +135,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        bufferedIndex: 0,
         buffered,
       });
       expect(
@@ -141,6 +145,7 @@ describe('BufferHelper', function () {
         start: 0.5,
         end: 0.5,
         nextStart: 1,
+        bufferedIndex: 0,
         buffered,
       });
       expect(
@@ -150,6 +155,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        bufferedIndex: 1,
         buffered,
       });
       expect(
@@ -159,6 +165,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        bufferedIndex: 1,
         buffered,
       });
     });
@@ -183,6 +190,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        bufferedIndex: 0,
         buffered,
       });
       // M: maxHoleDuration: 0.5
@@ -195,6 +203,7 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        bufferedIndex: 0, // input pos (-0.5 intersects first time range which is ignored by `maxHoleDuration`)
         buffered,
       });
       expect(
@@ -204,15 +213,18 @@ describe('BufferHelper', function () {
         start: 1,
         end: 2,
         nextStart: undefined,
+        bufferedIndex: 1,
         buffered,
       });
       expect(
         BufferHelper.bufferedInfo(buffered, 2, maxHoleDuration),
+        JSON.stringify(BufferHelper.bufferedInfo(buffered, 2, maxHoleDuration)),
       ).to.deep.equal({
         len: 0,
         start: 2,
         end: 2,
         nextStart: undefined,
+        bufferedIndex: 1,
         buffered,
       });
     });
@@ -237,6 +249,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 0.5,
         nextStart: 1,
+        bufferedIndex: 0,
         buffered,
       });
     });
@@ -261,6 +274,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 2,
         nextStart: undefined,
+        bufferedIndex: 0,
         buffered,
       });
     });
@@ -286,6 +300,7 @@ describe('BufferHelper', function () {
         start: 0,
         end: 1,
         nextStart: undefined,
+        bufferedIndex: 1,
         buffered,
       });
     });
@@ -308,6 +323,7 @@ describe('BufferHelper', function () {
         start: 5,
         end: 5,
         nextStart: undefined,
+        bufferedIndex: -1,
         buffered,
       });
     });

--- a/tests/unit/utils/mock-media.ts
+++ b/tests/unit/utils/mock-media.ts
@@ -1,0 +1,114 @@
+import sinon from 'sinon';
+
+export class MockMediaSource extends EventTarget {
+  public readyState: string = 'open';
+  public duration: number = Infinity;
+  private _sourceBuffers: MockSourceBuffer[] = [];
+
+  get sourceBuffers(): MockSourceBuffer[] {
+    return this._sourceBuffers;
+  }
+  addSourceBuffer(): MockSourceBuffer {
+    const sb = new MockSourceBuffer();
+    this._sourceBuffers.push(sb);
+    return sb;
+  }
+
+  removeSourceBuffer(sb: MockSourceBuffer) {
+    const index = this._sourceBuffers.indexOf(sb);
+    if (index !== -1) {
+      this._sourceBuffers.splice(index, 1);
+    }
+  }
+
+  addEventListener() {}
+
+  removeEventListener() {}
+
+  endOfStream() {}
+}
+
+type TimeRange = { start: number; end: number };
+
+class MockBufferedRanges {
+  public _ranges: Array<TimeRange> = [];
+  start(index: number) {
+    if (index < 0 || index >= this._ranges.length) {
+      throw new Error(
+        `Index out of bounds: index=${index} but buffered.length=${this._ranges.length}`,
+      );
+    }
+    return this._ranges[index].start;
+  }
+
+  end(index: number) {
+    if (index < 0 || index >= this._ranges.length) {
+      throw new Error(
+        `Index out of bounds: index=${index} but buffered.length=${this._ranges.length}`,
+      );
+    }
+    return this._ranges[index].end;
+  }
+
+  get length() {
+    return this._ranges.length;
+  }
+
+  add(range: TimeRange) {
+    // Empty
+    if (this._ranges.length === 0) {
+      this._ranges.push(range);
+      return;
+    }
+
+    // No overlap from beginning
+    if (range.end < this.start(0)) {
+      this._ranges.unshift(range);
+      return;
+    }
+
+    // No overlap from end
+    if (range.start > this.end(this.length - 1)) {
+      this._ranges.push(range);
+      return;
+    }
+
+    const result = [this._ranges[0]];
+    this._ranges.push(range);
+    this._ranges.sort((a, b) => a.start - b.start);
+
+    let j = 0;
+    // Find and merge overlapping range
+    for (let i = 1; i < this._ranges.length; i++) {
+      const curRange = result[j];
+      const nextRange = this._ranges[i];
+      if (curRange.end >= nextRange.start) {
+        curRange.end = Math.max(curRange.end, nextRange.end);
+      } else {
+        result.push(nextRange);
+        j++;
+      }
+    }
+
+    this._ranges = result;
+  }
+}
+
+export class MockSourceBuffer extends EventTarget {
+  public updating: boolean = false;
+  public appendBuffer = sinon.stub();
+  public remove = sinon.stub();
+  public buffered: MockBufferedRanges = new MockBufferedRanges();
+
+  setBuffered(start: number, end: number) {
+    this.buffered.add({ start, end });
+  }
+}
+
+export class MockMediaElement {
+  public currentTime: number = 0;
+  public duration: number = Infinity;
+  public textTracks: any[] = [];
+  addEventListener() {}
+  removeEventListener() {}
+}


### PR DESCRIPTION
### This PR will...

Flush MSE rendering pipeline when crossing video buffer holes with audio.

### Why is this Pull Request needed?

Chrome will play past a hole in the video buffer when there is audio, but video will not render and playback will stall one second past the hole. https://issues.chromium.org/issues/40280613#comment10

These changes detect playback traversal of such a gap and issue a seek to flush the pipeline render. This prevents the stall and results in video frames being rendered that would not have otherwise (#5631).

The improvement in stall detection and immediate triggering of "bufferNudgeOnStall" when the media element is "waiting" addresses stalls on audio buffer gaps (#6169).

### Are there any points in the code the reviewer needs to double check?

Are other gap-controller labelled issues addressed?
https://github.com/video-dev/hls.js/issues?q=is%3Aopen+is%3Aissue+label%3Agap-controller

The gap-controller now resembles other hls.js controllers in that it uses hls.js and media element events as well as a task interval to perform work. There are still a couple of places where it is dependent on the stream-controller that could be improved. For the most part this removes shared responsibility between the stream-controller and gap-controller.
Ex: all responsibility for emitting MEDIA_ENDED is contained in the gap-controller now.


### Resolves issues:
- #5631
- #6169

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
