### PR TITLE
Workaround Safari "ended" event not firing when EoS is marked before seek on start

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -215,6 +215,10 @@ export default class BaseStreamController
     if (hasSecondBufferedRange) {
       return false;
     }
+    // Playhead is in unbuffered region. Marking EoS now could result in Safari failing to dispatch "ended" event following seek on start.
+    if (this.media.currentTime < bufferInfo.start) {
+      return false;
+    }
     const partList = levelDetails.partList;
     // Since the last part isn't guaranteed to correspond to the last playlist segment for Low-Latency HLS,
     // check instead if the last part is buffered.


### PR DESCRIPTION
### This PR will...

Delay `endOfStream` until playhead is in buffered region.

### Why is this Pull Request needed?

When `MediaSource.endOfStream()` is called before playback begins, and the SourceBuffer(s) buffered ranges start a little bit past 0 and HLS.js seeks on play to jump this gap, Safari does not emit "ended" event when reaching the end.

### Are there any points in the code the reviewer needs to double check?
Resolves #6890

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
