### PR TITLE
Fix seeking into and over multiple EXT-X-GAP segments

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1866,7 +1866,7 @@ export class FragmentTracker implements ComponentAPI {
     getBufferedFrag(position: number, levelType: PlaylistLevelType): MediaFragment | null;
     // (undocumented)
     getFragAtPos(position: number, levelType: PlaylistLevelType, buffered?: boolean): MediaFragment | null;
-    getPartialFragment(time: number): Fragment | null;
+    getPartialFragment(time: number): MediaFragment | null;
     // (undocumented)
     getState(fragment: Fragment): FragmentState;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2019,6 +2019,8 @@ class Hls implements HlsEventEmitter {
     get loadLevel(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "loadLevel" must appear on the getter, not the setter.
     set loadLevel(newLevel: number);
+    // (undocumented)
+    get loadLevelObj(): Level | null;
     loadSource(url: string): void;
     readonly logger: ILogger;
     get lowLatencyMode(): boolean;

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,6 +190,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [Interstitial Objects and Classes](#interstitial-objects-and-classes)
 - [Additional data](#additional-data)
   - [`hls.latestLevelDetails`](#hlslatestleveldetails)
+  - [`hjs.loadLevelObj`](#hjsloadlevelobj)
   - [`hls.sessionId`](#hlssessionid)
 - [Runtime Events](#runtime-events)
 - [Creating a Custom Loader](#creating-a-custom-loader)
@@ -2145,7 +2146,11 @@ type InterstitialAssetErrorData = {
 
 ### `hls.latestLevelDetails`
 
-- get: Returns the LevelDetails of the most up-to-date HLS variant playlist data.
+- get: Returns the `LevelDetails` of last loaded level (variant) or `null` prior to loading a media playlist.
+
+### `hjs.loadLevelObj`
+
+- get: Returns the `Level` object of the selected level (variant) or `null` prior to selecting a level or once the level is removed.
 
 ### `hls.sessionId`
 

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -672,8 +672,8 @@ class AbrController extends Logger implements AbrComponentAPI {
     }
     // If no matching level found, see if min auto level would be a better option
     const minLevel = hls.levels[minAutoLevel];
-    const autoLevel = hls.levels[hls.loadLevel];
-    if (minLevel?.bitrate < autoLevel?.bitrate) {
+    const autoLevel = hls.loadLevelObj;
+    if (autoLevel && minLevel?.bitrate < autoLevel.bitrate) {
       return minAutoLevel;
     }
     // or if bitrate is not lower, continue to use loadLevel

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1215,11 +1215,11 @@ export default class BaseStreamController
         bufferedFragAtPos &&
         (bufferInfo.nextStart <= bufferedFragAtPos.end || bufferedFragAtPos.gap)
       ) {
-        return BufferHelper.bufferInfo(
-          bufferable,
-          pos,
-          Math.max(bufferInfo.nextStart, maxBufferHole),
+        const gapDuration = Math.max(
+          Math.min(bufferInfo.nextStart, bufferedFragAtPos.end) - pos,
+          maxBufferHole,
         );
+        return BufferHelper.bufferInfo(bufferable, pos, gapDuration);
       }
     }
     return bufferInfo;

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -176,7 +176,7 @@ export default class ErrorController
       case ErrorDetails.SUBTITLE_LOAD_ERROR:
       case ErrorDetails.SUBTITLE_TRACK_LOAD_TIMEOUT:
         if (context) {
-          const level = hls.levels[hls.loadLevel];
+          const level = hls.loadLevelObj;
           if (
             level &&
             ((context.type === PlaylistContextType.AUDIO_TRACK &&
@@ -200,7 +200,7 @@ export default class ErrorController
         return;
       case ErrorDetails.KEY_SYSTEM_STATUS_OUTPUT_RESTRICTED:
         {
-          const level = hls.levels[hls.loadLevel];
+          const level = hls.loadLevelObj;
           const restrictedHdcpLevel = level?.attrs['HDCP-LEVEL'];
           if (restrictedHdcpLevel) {
             data.errorAction = {

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -321,7 +321,7 @@ export class FragmentTracker implements ComponentAPI {
   /**
    * Gets the partial fragment for a certain time
    */
-  public getPartialFragment(time: number): Fragment | null {
+  public getPartialFragment(time: number): MediaFragment | null {
     let bestFragment: Fragment | null = null;
     let timePadding: number;
     let startTime: number;

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -541,11 +541,11 @@ export default class GapController extends TaskLoop {
                 PlaylistLevelType.MAIN,
               );
             if (startProvisioned) {
-              // Do not seek when switching variants
-              if (!this.hls.levels[this.hls.loadLevel]?.details) {
+              // Do not seek when selected variant playlist is unloaded
+              if (!this.hls.loadLevelObj?.details) {
                 return 0;
               }
-              // Do not seek when loading frags
+              // Do not seek when required fragments are inflight or appending
               const inFlightDependency = getInFlightDependency(
                 this.hls.inFlightFragments,
                 startTime,

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1921,7 +1921,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     const userConfig = primary.userConfig;
     let videoPreference = userConfig.videoPreference;
     const currentLevel =
-      primary.levels[primary.loadLevel] || primary.levels[primary.currentLevel];
+      primary.loadLevelObj || primary.levels[primary.currentLevel];
     if (videoPreference || currentLevel) {
       videoPreference = Object.assign({}, videoPreference);
       if (currentLevel.videoCodec) {

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -389,6 +389,10 @@ export default class LevelController extends BasePlaylistController {
     return this._levels;
   }
 
+  get loadLevelObj(): Level | null {
+    return this.currentLevel;
+  }
+
   get level(): number {
     return this.currentLevelIndex;
   }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -237,7 +237,7 @@ export default class StreamController
 
   protected onTickEnd() {
     super.onTickEnd();
-    if (this.media?.readyState) {
+    if (this.media?.readyState && this.media.seeking === false) {
       this.lastCurrentTime = this.media.currentTime;
     }
     this.checkFragmentChanged();

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -690,8 +690,18 @@ export default class Hls implements HlsEventEmitter {
     return levels ? levels : [];
   }
 
+  /**
+   * @returns LevelDetails of last loaded level (variant) or `null` prior to loading a media playlist.
+   */
   get latestLevelDetails(): LevelDetails | null {
     return this.streamController.getLevelDetails() || null;
+  }
+
+  /**
+   * @returns Level object of selected level (variant) or `null` prior to selecting a level or once the level is removed.
+   */
+  get loadLevelObj(): Level | null {
+    return this.levelController.loadLevelObj;
   }
 
   /**

--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -502,5 +502,5 @@ export function useAlternateAudio(
   audioTrackUrl: string | undefined,
   hls: Hls,
 ): boolean {
-  return !!audioTrackUrl && audioTrackUrl !== hls.levels[hls.loadLevel]?.uri;
+  return !!audioTrackUrl && audioTrackUrl !== hls.loadLevelObj?.uri;
 }

--- a/tests/unit/controller/gap-controller.ts
+++ b/tests/unit/controller/gap-controller.ts
@@ -16,7 +16,7 @@ import {
 import { MockMediaElement, MockMediaSource } from '../utils/mock-media';
 import type { HlsConfig } from '../../../src/config';
 import type StreamController from '../../../src/controller/stream-controller';
-import type { Fragment } from '../../../src/loader/fragment';
+import type { Fragment, MediaFragment } from '../../../src/loader/fragment';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -202,7 +202,7 @@ describe('GapController', function () {
       const bufferInfo = BufferHelper.bufferedInfo([], 0, 0);
       sandbox
         .stub(gapController.fragmentTracker, 'getPartialFragment')
-        .returns({} as unknown as Fragment);
+        .returns({} as unknown as MediaFragment);
       const skipHoleStub = sandbox.stub(gapController, '_trySkipBufferHole');
       gapController._tryFixBufferStall(bufferInfo, 100);
       expect(skipHoleStub).to.have.been.calledOnce;


### PR DESCRIPTION
### This PR will...
- Fix an issue where the gap-controller would not skip over buffer holes produced by EXT-X-GAP segments.
- Add `hls.loadLevelObj` to API - replaces internal use of `hls.levels[hls.loadLevel]`

### Why is this Pull Request needed?
`getFwdBufferInfoAtPos` was not properly stepping over EXT-X-GAP segments which prevented them from being re-added to the fragment tracker. `_trySkipBufferHole` in gap-controller depends on being able to step through gap segments in the tracker to skip over large buffer holes.

### Are there any points in the code the reviewer needs to double check?
Additional changes will prevent skipping over a hole when an earlier audio or main segment is being loaded or a variant playlist is being loaded.

### Resolves issues:
Fixes #6814

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
