### PR TITLE
Fix live duration override by interstitials

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1254,8 +1254,6 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
     }
     const playlistEnd = details.edge;
     if (details.live && this.hls.config.liveDurationInfinity) {
-      // Override duration to Infinity
-      mediaSource.duration = Infinity;
       const len = details.fragments.length;
       if (len && details.live && !!mediaSource.setLiveSeekableRange) {
         const start = Math.max(0, details.fragmentStart);
@@ -1267,6 +1265,9 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
     }
     const overrideDuration = this.overrides?.duration;
     if (overrideDuration) {
+      if (!Number.isFinite(overrideDuration)) {
+        return null;
+      }
       return { duration: overrideDuration };
     }
     const mediaDuration = this.media.duration;


### PR DESCRIPTION
### This PR will...

Ignore non-finite MediaSource duration overrides.

Do not set duration to Infinity in `getDurationAndRange` as this can throw when SourceBuffers are updating.

### Why is this Pull Request needed?

Prevents Interstitial asset players from resetting duration on transferred MediaSource when the schedule duration is `Infinity` for a live primary asset and `liveDurationInfinity` is false.

Duration is already set in `updateMediaSource` between blocking operations and should never be set in `getDurationAndRange`. 

### Are there any points in the code the reviewer needs to double check?

Only applies to live playback with Interstitials with default `liveDurationInfinity` of `false` (set to `true` to workaround this issue).

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
