### PR TITLE
feat: pathways getter

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2058,6 +2058,7 @@ class Hls implements HlsEventEmitter {
     once<E extends keyof HlsListeners, Context = undefined>(event: E, listener: HlsListeners[E], context?: Context): void;
     get pathwayPriority(): string[] | null;
     set pathwayPriority(pathwayPriority: string[]);
+    get pathways(): string[];
     pauseBuffering(): void;
     get playingDate(): Date | null;
     recoverMediaError(): void;

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -529,6 +529,14 @@ export default class LevelController extends BasePlaylistController {
     this._startLevel = newLevel;
   }
 
+  get pathways(): string[] {
+    if (this.steering) {
+      return this.steering.pathways();
+    }
+
+    return [];
+  }
+
   get pathwayPriority(): string[] | null {
     if (this.steering) {
       return this.steering.pathwayPriority;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1187,6 +1187,13 @@ export default class Hls implements HlsEventEmitter {
   }
 
   /**
+   * ContentSteering pathways getter
+   */
+  get pathways(): string[] {
+    return this.levelController.pathways;
+  }
+
+  /**
    * ContentSteering pathwayPriority getter/setter
    */
   get pathwayPriority(): string[] | null {


### PR DESCRIPTION
### This PR will...
Provide a public API to get the list of `pathways`.

### Why is this Pull Request needed?
1.6.0 introduces a `pathwayPriority` API, but there is no public API to get the list of `pathways` making `pathwayPriority` hard to use. (This is currently only possible with a private `hls.levelController.steering.pathways()` call)

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
https://github.com/video-dev/hls.js/issues/6996

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
