### PR TITLE
Make Fragment.stats enumerable

### DIFF
--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -50,6 +50,7 @@ export class BaseSegment {
       base = { url: base };
     }
     this.base = base;
+    makeEnumerable(this, 'stats');
   }
 
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
@@ -452,5 +453,30 @@ export class Part extends BaseSegment {
       elementaryStreams.video ||
       elementaryStreams.audiovideo
     );
+  }
+}
+
+function getOwnPropertyDescriptorFromPrototypeChain(
+  object: Object | undefined,
+  property: string,
+) {
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype) {
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(
+      prototype,
+      property,
+    );
+    if (propertyDescriptor) {
+      return propertyDescriptor;
+    }
+    return getOwnPropertyDescriptorFromPrototypeChain(prototype, property);
+  }
+}
+
+function makeEnumerable(object: Object, property: string) {
+  const d = getOwnPropertyDescriptorFromPrototypeChain(object, property);
+  if (d) {
+    d.enumerable = true;
+    Object.defineProperty(object, property, d);
   }
 }

--- a/tests/unit/utils/discontinuities.ts
+++ b/tests/unit/utils/discontinuities.ts
@@ -394,6 +394,7 @@ describe('discontinuities', function () {
           duration: 4,
           cc: 2,
           programDateTime: 1503892850000,
+          stats: details.fragments[0].stats,
         },
         {
           start: 74,
@@ -402,6 +403,7 @@ describe('discontinuities', function () {
           duration: 4,
           cc: 2,
           programDateTime: 1503892854000,
+          stats: details.fragments[1].stats,
         },
         {
           start: 78,
@@ -410,6 +412,7 @@ describe('discontinuities', function () {
           duration: 8,
           cc: 3,
           programDateTime: 1503892858000,
+          stats: details.fragments[2].stats,
         },
       ].map(objToFragment),
       PTSKnown: false,


### PR DESCRIPTION
### This PR will...
Make Fragment.stats enumerable.

### Why is this Pull Request needed?

Changing `stats` to a getter (#6811) made it non-enumerable. As a results `stats` are not copied by the spread operator or `Object.assign`. The demo app depends on this to display fragment loading progress.

### Are there any points in the code the reviewer needs to double check?

Fragment.stats were changed in favor of lazy instantiation (lower memory usage at playlist parse).

Using ES5 defineProperty after class instantiation expects es6>es5 transpiling. This should have no effect if running the ESM modules (need to verify).
 
### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
