### PR TITLE
Fix primary resume time when advancing after interstitial with CUE="ONCE"

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -889,7 +889,7 @@ MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
   private checkStart() {
     const schedule = this.schedule;
     const interstitialEvents = schedule.events;
-    if (!interstitialEvents || this.playbackDisabled) {
+    if (!interstitialEvents || this.playbackDisabled || !this.media) {
       return;
     }
     // Check buffered to pre-roll
@@ -939,6 +939,10 @@ MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
         if (nextIndex >= scheduleLength) {
           this.setSchedulePosition(-1);
           return;
+        }
+        const resumptionTime = interstitial.resumeTime;
+        if (this.timelinePos < resumptionTime) {
+          this.timelinePos = resumptionTime;
         }
         this.setSchedulePosition(nextIndex);
       }
@@ -1078,10 +1082,8 @@ MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
       }
       // Ensure Interstitial is enqueued
       const waitingItem = this.waitingItem;
+      this.setBufferingItem(scheduledItem);
       let player = this.preloadAssets(interstitial, assetListIndex);
-      if (!player) {
-        this.setBufferingItem(scheduledItem);
-      }
       if (!this.eventItemsMatch(scheduledItem, currentItem || waitingItem)) {
         this.waitingItem = scheduledItem;
         this.log(


### PR DESCRIPTION
### This PR will...
- Advance interstitials-controller timeline position before advancing at the end of an interstitial (#6983)
- Trigger INTERSTITIALS_BUFFERED_TO_BOUNDARY before other interstitial events when program begins
- Do not start interstitials program until media is attached

### Why is this Pull Request needed?
> Advance interstitials-controller timeline position before advancing at the end of an interstitial (#6983)

Ensures correct resumption time of primary when interstitial uses CUE="ONCE"; Normally when resuming from an interstitial, the primary schedule item start and end time are used update the last known timeline position for the primary player. This wasn't working with interstitials with CUE="ONCE" because the interstitial item is removed from the schedule before resuming, merging the the adjacent primary schedule items into one, and loosing the start of the latter which is the resumption time.

> Trigger INTERSTITIALS_BUFFERED_TO_BOUNDARY before other interstitial events when program begins

Makes event event order more rational when the buffered item is set on start and seek.

> Do not start interstitials program until media is attached

Prevent Interstitial started events from firing until media is attached. This also prevents INTERSTITIALS_BUFFERED_TO_BOUNDARY until attached. It is better to avoid asset loading and interstitial event tracking until media is attached. This will help prevent false starts, but it also impedes some preloading from taking place. Please file enhancements if you want preloading of interstitial assets before playback can begin with attached media.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6983

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
