### PR TITLE
Make latency-controllers getters safe to call after destroyed

### DIFF
--- a/tests/unit/controller/latency-controller.ts
+++ b/tests/unit/controller/latency-controller.ts
@@ -208,7 +208,7 @@ describe('LatencyController', function () {
       latencyController.targetLatency = 2;
       expect(latencyController['stallCount']).to.equal(0);
       expect(latencyController['config'].liveSyncDuration).to.equal(2);
-      expect(latencyController['hls'].userConfig.liveSyncDuration).to.be
+      expect(latencyController['hls']?.userConfig.liveSyncDuration).to.be
         .undefined;
       expect(latencyController.targetLatency).to.equal(2);
     });

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -267,9 +267,6 @@ describe('StreamController', function () {
       let fragPrevious;
 
       beforeEach(function () {
-        // onLevelUpdated updates  latencyController.levelDetails used to get live sync position
-        hls['latencyController']['levelDetails'] = levelDetails;
-
         fragPrevious = new Fragment(PlaylistLevelType.MAIN, '');
         // Fragment with PDT 1505502681523 in level 1 does not have the same sn as in level 2 where cc is 1
         fragPrevious.cc = 0;


### PR DESCRIPTION
### This PR will...
Make latency-controllers getters safe to call after destroyed

### Why is this Pull Request needed?
Prevents accessors like `hls.targetLatency` from throwing after `hls` instance is destroyed

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
