### PR TITLE
Improve handling of empty ASSETS array in X-ASSET-LIST response

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2629,6 +2629,8 @@ export class InterstitialEvent {
     // (undocumented)
     assetList: InterstitialAssetItem[];
     // (undocumented)
+    get assetListLoaded(): boolean;
+    // (undocumented)
     assetListLoader?: Loader<LoaderContext>;
     // (undocumented)
     assetListResponse: AssetListJSON | null;

--- a/src/controller/interstitials-schedule.ts
+++ b/src/controller/interstitials-schedule.ts
@@ -635,6 +635,9 @@ export class InterstitialsSchedule extends Logger {
   }
 
   private updateAssetDurations(interstitial: InterstitialEvent) {
+    if (!interstitial.assetListLoaded) {
+      return;
+    }
     const eventStart = interstitial.timelineStart;
     let sumDuration = 0;
     let hasUnknownDuration = false;

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -208,6 +208,9 @@ export class InterstitialEvent {
   get duration(): number {
     const playoutLimit = this.playoutLimit;
     let duration: number;
+    if (this.assetListResponse && this.assetList.length === 0) {
+      return 0;
+    }
     if (this._duration) {
       duration = this._duration;
     } else if (this.dateRange.duration) {

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -208,10 +208,7 @@ export class InterstitialEvent {
   get duration(): number {
     const playoutLimit = this.playoutLimit;
     let duration: number;
-    if (this.assetListResponse && this.assetList.length === 0) {
-      return 0;
-    }
-    if (this._duration) {
+    if (this._duration !== null) {
       duration = this._duration;
     } else if (this.dateRange.duration) {
       duration = this.dateRange.duration;
@@ -257,6 +254,10 @@ export class InterstitialEvent {
 
   get baseUrl(): string {
     return this.base.url;
+  }
+
+  get assetListLoaded(): boolean {
+    return this.assetList.length > 0 || this.assetListResponse !== null;
   }
 
   toString(): string {

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1148,7 +1148,7 @@ fileSequence5.mp4`;
       });
     });
 
-    it('should handle empty asset-lists', function () {
+    it('should handle empty asset-lists with resume offset', function () {
       const playlist = `#EXTM3U
 #EXT-X-TARGETDURATION:10
 #EXT-X-VERSION:7
@@ -1206,6 +1206,7 @@ fileSequence3.mp4
       expect(callsAfterAttach).to.deep.equal(
         [
           Events.ASSET_LIST_LOADED,
+          Events.INTERSTITIALS_UPDATED,
           Events.INTERSTITIAL_ENDED,
           Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
           Events.INTERSTITIALS_PRIMARY_RESUMED,
@@ -1215,6 +1216,79 @@ fileSequence3.mp4
       expect(insterstitials.bufferingIndex).to.equal(1, 'bufferingIndex b');
       expect(insterstitials.playingIndex).to.equal(1, 'playingIndex b');
       expect(insterstitials.primary.currentTime).to.equal(5, 'timelinePos b');
+    });
+
+    it('should handle empty asset-lists without resume offset, ignoring date range tag duration', function () {
+      const playlist = `#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-VERSION:7
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-PROGRAM-DATE-TIME:2024-02-23T15:00:00.000Z
+#EXT-X-DATERANGE:ID="start",CLASS="com.apple.hls.interstitial",START-DATE="2024-02-23T15:00:00.000Z",DURATION=5,X-ASSET-LIST="https://example.com/empty.json"
+#EXT-X-MAP:URI="fileSequence0.mp4"
+#EXTINF:5,
+fileSequence1.mp4
+#EXTINF:5,
+fileSequence2.mp4
+#EXTINF:5,
+fileSequence3.mp4
+#EXT-X-ENDLIST`;
+      attachMediaToHls();
+
+      setLoadedLevelDetails(playlist);
+      const insterstitials = interstitialsController.interstitialsManager;
+      if (!insterstitials) {
+        expect(insterstitials, 'interstitialsManager').to.be.an('object');
+        return;
+      }
+      expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
+      expect(insterstitials.schedule).is.an('array').which.has.lengthOf(2);
+      if (!insterstitials.events || !insterstitials.schedule) {
+        return;
+      }
+      const callsBeforeAttach = getTriggerCalls();
+      expect(callsBeforeAttach).to.deep.equal(
+        [
+          Events.MEDIA_ATTACHING,
+          Events.MEDIA_ATTACHED,
+          Events.LEVEL_UPDATED,
+          Events.INTERSTITIALS_UPDATED,
+          Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
+          Events.ASSET_LIST_LOADING,
+          Events.INTERSTITIAL_STARTED,
+        ],
+        `Actual events before asset-list: ${callsBeforeAttach.join(', ')}`,
+      );
+      hls.trigger.resetHistory();
+      expect(insterstitials.bufferingIndex).to.equal(0, 'bufferingIndex a');
+      expect(insterstitials.playingIndex).to.equal(0, 'playingIndex a');
+      expect(insterstitials.primary.currentTime).to.equal(0, 'timelinePos a');
+
+      // Load empty asset-list
+      const interstitial = insterstitials.events[0];
+      interstitial.assetListResponse = { ASSETS: [] };
+      hls.trigger(Events.ASSET_LIST_LOADED, {
+        event: interstitial,
+        assetListResponse: interstitial.assetListResponse,
+        networkDetails: {},
+      });
+      const callsAfterAttach = getTriggerCalls();
+      expect(callsAfterAttach).to.deep.equal(
+        [
+          Events.ASSET_LIST_LOADED,
+          Events.INTERSTITIALS_UPDATED,
+          Events.INTERSTITIAL_ENDED,
+          Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
+          Events.INTERSTITIALS_PRIMARY_RESUMED,
+        ],
+        `Actual events after asset-list: ${callsAfterAttach.join(', ')}`,
+      );
+      expect(insterstitials.bufferingIndex).to.equal(1, 'bufferingIndex b');
+      expect(insterstitials.playingIndex).to.equal(1, 'playingIndex b');
+      expect(insterstitials.primary.currentTime).to.equal(
+        0,
+        'playback should resume primary at 0 because no interstitial played',
+      );
     });
 
     it('should resume at start plus resumption-offset (start + duration and attach after level updated)', function () {


### PR DESCRIPTION
### This PR will...

- Resume primary with a resumption offset of 0 when asset list is empty and no X-RESUME-OFFSET is present
- Avoid aborting in-flight primary segment requests with `startLoad()` when passing over Interstitial with empty asset list
- Clear asset list response before reloading asset-list
- Do not update interstitial duration before assets are resolved

### Why is this Pull Request needed?

Prior to this change the resumption offset was based on the date range tag DURATION even though there was no interstitial played.

Asset lists that return empty ASSETS are re-requested when media is rebuffered to interstitial start boundary. `assetListResponse` should be set to null prior to requesting the list again.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
