### PR TITLE
fix: json stringify with circular dependencies

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -30,6 +30,7 @@ import { hash } from '../utils/hash';
 import { Logger } from '../utils/logger';
 import { isCompatibleTrackChange } from '../utils/mediasource-helper';
 import { getBasicSelectionOption } from '../utils/rendition-helper';
+import { stringify } from '../utils/safe-json-stringify';
 import type { HlsConfig } from '../config';
 import type Hls from '../hls';
 import type { LevelDetails } from '../loader/level-details';
@@ -692,7 +693,7 @@ export default class InterstitialsController
       }
       const attachMediaSourceData = player.transferMedia();
       this.log(
-        `transfer MediaSource from ${player} ${JSON.stringify(attachMediaSourceData)}`,
+        `transfer MediaSource from ${player} ${stringify(attachMediaSourceData)}`,
       );
       this.detachedData = attachMediaSourceData;
     } else if (toSegment && playerMedia) {
@@ -727,14 +728,14 @@ export default class InterstitialsController
     }
     this.log(
       `transferring to ${isAssetPlayer ? player : 'Primary'}
-MediaSource ${JSON.stringify(attachMediaSourceData)} from ${logFromSource}`,
+MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
     );
 
     if (!attachMediaSourceData) {
       if (detachedMediaSource) {
         attachMediaSourceData = this.detachedData;
         this.log(
-          `using detachedData: MediaSource ${JSON.stringify(attachMediaSourceData)}`,
+          `using detachedData: MediaSource ${stringify(attachMediaSourceData)}`,
         );
       } else if (!this.detachedData || this.hls.media === media) {
         // Media is attaching when `detachedData` and `hls.media` are populated. Detach to clear the MediaSource.

--- a/src/utils/safe-json-stringify.ts
+++ b/src/utils/safe-json-stringify.ts
@@ -1,0 +1,15 @@
+const replacer = () => {
+  const known = new WeakSet();
+  return (_, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (known.has(value)) {
+        return;
+      }
+      known.add(value);
+    }
+    return value;
+  };
+};
+
+export const stringify = <T>(object: T): string =>
+  JSON.stringify(object, replacer());

--- a/tests/index.js
+++ b/tests/index.js
@@ -45,6 +45,7 @@ import './unit/utils/discontinuities';
 import './unit/utils/exp-golomb';
 import './unit/utils/mock-media';
 import './unit/utils/output-filter';
+import './unit/utils/safe-json-stringify';
 import './unit/utils/texttrack-utils';
 import './unit/utils/vttparser';
 import './unit/utils/utf8';

--- a/tests/unit/utils/safe-json-stringify.js
+++ b/tests/unit/utils/safe-json-stringify.js
@@ -1,0 +1,14 @@
+import { stringify } from '../../../src/utils/safe-json-stringify';
+
+describe('Stringify', function () {
+  it('should safely stringify a circular object', function () {
+    const originalObject = { a: 'test' };
+
+    const circularObject = { ...originalObject };
+    circularObject.b = circularObject;
+
+    const stringified = stringify(circularObject);
+
+    expect(stringified).to.equal(JSON.stringify(originalObject));
+  });
+});


### PR DESCRIPTION
### This PR will...
- Fix JSON stringify errors caused by objects having circular references 

### Why is this Pull Request needed?
References can come from external objects like the media element that have additional properties on them. Eg; When a React reference is passed into `attachMedia`.

### Are there any points in the code the reviewer needs to double check?
A basic React app with interstitials turned on is currently breaking. With this fix it should not break anymore while logging still works.

### Resolves issues:
Broken interstitials.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
