### PR TITLE
Separate the calculation of the next level into a protected method

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -30,6 +30,8 @@ export class AbrController extends Logger implements AbrComponentAPI {
     // (undocumented)
     clearTimer(): void;
     // (undocumented)
+    protected deriveNextAutoLevel(nextLevel: number): number;
+    // (undocumented)
     destroy(): void;
     // (undocumented)
     get firstAutoLevel(): number;

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -952,12 +952,16 @@ class AbrController extends Logger implements AbrComponentAPI {
   }
 
   public set nextAutoLevel(nextLevel: number) {
-    const { maxAutoLevel, minAutoLevel } = this.hls;
-    const value = Math.min(Math.max(nextLevel, minAutoLevel), maxAutoLevel);
+    const value = this.deriveNextAutoLevel(nextLevel);
     if (this._nextAutoLevel !== value) {
       this.nextAutoLevelKey = '';
       this._nextAutoLevel = value;
     }
+  }
+
+  protected deriveNextAutoLevel(nextLevel: number) {
+    const { maxAutoLevel, minAutoLevel } = this.hls;
+    return Math.min(Math.max(nextLevel, minAutoLevel), maxAutoLevel);
   }
 }
 


### PR DESCRIPTION
### This PR will...
Separate the calculation of `next level` into a protected method

### Why is this Pull Request needed?
I am trying to create a custom abrController by extending hls.js's abrController.

In `public set nextAutoLevel`, I want to calculate value using my own method and assign it to `this._nextAutoLevel`, but since `this._nextAutoLevel` is private, I cannot do that.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
It becomes easier for users to implement a custom abrController.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
