### PR TITLE
Replace JSON.stringify with safe stringify module

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ import { TimelineController } from './controller/timeline-controller';
 import Cues from './utils/cues';
 import FetchLoader, { fetchSupported } from './utils/fetch-loader';
 import { requestMediaKeySystemAccess } from './utils/mediakeys-helper';
+import { stringify } from './utils/safe-json-stringify';
 import XhrLoader from './utils/xhr-loader';
 import type { MediaKeySessionContext } from './controller/eme-controller';
 import type Hls from './hls';
@@ -688,7 +689,7 @@ export function mergeConfig(
       logger.warn(
         `hls.js config: "${report.join(
           '", "',
-        )}" setting(s) are deprecated, use "${policyName}": ${JSON.stringify(
+        )}" setting(s) are deprecated, use "${policyName}": ${stringify(
           userConfig[policyName],
         )}`,
       );

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -15,6 +15,7 @@ import {
   getCodecTiers,
   getStartCodecTier,
 } from '../utils/rendition-helper';
+import { stringify } from '../utils/safe-json-stringify';
 import type Hls from '../hls';
 import type { Fragment } from '../loader/fragment';
 import type { Part } from '../loader/fragment';
@@ -764,7 +765,7 @@ class AbrController extends Logger implements AbrComponentAPI {
         : videoRanges[0];
       currentFrameRate = minFramerate;
       currentBw = Math.max(currentBw, minBitrate);
-      this.log(`picked start tier ${JSON.stringify(startTier)}`);
+      this.log(`picked start tier ${stringify(startTier)}`);
     } else {
       currentCodecSet = level?.codecSet;
       currentVideoRange = level?.videoRange;
@@ -821,11 +822,11 @@ class AbrController extends Logger implements AbrComponentAPI {
               this.warn(
                 `MediaCapabilities decodingInfo error: "${
                   decodingInfo.error
-                }" for level ${index} ${JSON.stringify(decodingInfo)}`,
+                }" for level ${index} ${stringify(decodingInfo)}`,
               );
             } else if (!decodingInfo.supported) {
               this.warn(
-                `Unsupported MediaCapabilities decodingInfo result for level ${index} ${JSON.stringify(
+                `Unsupported MediaCapabilities decodingInfo result for level ${index} ${stringify(
                   decodingInfo,
                 )}`,
               );

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -15,6 +15,7 @@ import {
   isCompatibleTrackChange,
   isManagedMediaSource,
 } from '../utils/mediasource-helper';
+import { stringify } from '../utils/safe-json-stringify';
 import type { FragmentTracker } from './fragment-tracker';
 import type { HlsConfig } from '../config';
 import type Hls from '../hls';
@@ -353,8 +354,8 @@ export default class BufferController extends Logger implements ComponentAPI {
       }
       this
         .log(`attachTransferred: (bufferCodecEventsTotal ${this.bufferCodecEventsTotal})
-required tracks: ${JSON.stringify(requiredTracks, (key, value) => (key === 'initSegment' ? undefined : value))};
-transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'initSegment' ? undefined : value))}}`);
+required tracks: ${stringify(requiredTracks, (key, value) => (key === 'initSegment' ? undefined : value))};
+transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSegment' ? undefined : value))}}`);
       if (!isCompatibleTrackChange(transferredTracks, requiredTracks)) {
         // destroy attaching media source
         data.mediaSource = null;
@@ -1322,7 +1323,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
   private checkPendingTracks() {
     const { bufferCodecEventsTotal, pendingTrackCount, tracks } = this;
     this.log(
-      `checkPendingTracks (pending: ${pendingTrackCount} codec events expected: ${bufferCodecEventsTotal}) ${JSON.stringify(tracks)}`,
+      `checkPendingTracks (pending: ${pendingTrackCount} codec events expected: ${bufferCodecEventsTotal}) ${stringify(tracks)}`,
     );
     // Check if we've received all of the expected bufferCodec events. When none remain, create all the sourceBuffers at once.
     // This is important because the MSE spec allows implementations to throw QuotaExceededErrors if creating new sourceBuffers after
@@ -1391,7 +1392,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
         const mimeType = `${track.container};codecs=${codec}`;
         track.codec = codec;
         this.log(
-          `creating sourceBuffer(${mimeType})${this.currentOp(type) ? ' Queued' : ''} ${JSON.stringify(track)}`,
+          `creating sourceBuffer(${mimeType})${this.currentOp(type) ? ' Queued' : ''} ${stringify(track)}`,
         );
         try {
           const sb = mediaSource.addSourceBuffer(

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -13,6 +13,7 @@ import {
 import { AttrList } from '../utils/attr-list';
 import { reassignFragmentLevelIndexes } from '../utils/level-helper';
 import { Logger } from '../utils/logger';
+import { stringify } from '../utils/safe-json-stringify';
 import type { RetryConfig } from '../config';
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
@@ -221,9 +222,9 @@ export default class ContentSteeringController
             data.error.message
           }") with content-steering for Pathway: ${errorPathway} levels: ${
             levels ? levels.length : levels
-          } priorities: ${JSON.stringify(
+          } priorities: ${stringify(
             pathwayPriority,
-          )} penalized: ${JSON.stringify(this.penalizedPathways)}`,
+          )} penalized: ${stringify(this.penalizedPathways)}`,
         );
       }
     }

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -27,6 +27,7 @@ import {
   type PsshInvalidResult,
 } from '../utils/mp4-tools';
 import { base64Decode } from '../utils/numeric-encoding-utils';
+import { stringify } from '../utils/safe-json-stringify';
 import { strToUtf8array } from '../utils/utf8-utils';
 import type { EMEControllerConfig, HlsConfig, LoadPolicy } from '../config';
 import type Hls from '../hls';
@@ -254,7 +255,7 @@ class EMEController extends Logger implements ComponentAPI {
     let keySystemAccess = keySystemAccessPromises?.keySystemAccess;
     if (!keySystemAccess) {
       this.log(
-        `Requesting encrypted media "${keySystem}" key-system access with config: ${JSON.stringify(
+        `Requesting encrypted media "${keySystem}" key-system access with config: ${stringify(
           mediaKeySystemConfigs,
         )}`,
       );
@@ -519,7 +520,7 @@ class EMEController extends Logger implements ComponentAPI {
           details: ErrorDetails.KEY_SYSTEM_NO_CONFIGURED_LICENSE,
           fatal: true,
         },
-        `Missing key-system license configuration options ${JSON.stringify({
+        `Missing key-system license configuration options ${stringify({
           drmSystems: this.config.drmSystems,
         })}`,
       );

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -8,6 +8,7 @@ import {
   addEventListener,
   removeEventListener,
 } from '../utils/event-listener-helper';
+import { stringify } from '../utils/safe-json-stringify';
 import type { InFlightData } from './base-stream-controller';
 import type { InFlightFragments } from '../hls';
 import type Hls from '../hls';
@@ -486,7 +487,7 @@ export default class GapController extends TaskLoop {
       const error = new Error(
         `Playback stalling at @${
           media.currentTime
-        } due to low buffer (${JSON.stringify(bufferInfo)})`,
+        } due to low buffer (${stringify(bufferInfo)})`,
       );
       this.warn(error.message);
       hls.trigger(Events.ERROR, {

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -6,6 +6,7 @@ import {
   isSCTE35Attribute,
 } from '../loader/date-range';
 import { MetadataSchema } from '../types/demuxer';
+import { stringify } from '../utils/safe-json-stringify';
 import {
   clearCurrentCues,
   removeCuesInRange,
@@ -54,7 +55,7 @@ function createCueWithDataFields(
     cue = new Cue(
       startTime,
       endTime,
-      JSON.stringify(type ? { type, ...data } : data),
+      stringify(type ? { type, ...data } : data),
     );
   }
   return cue;

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -12,6 +12,7 @@ import {
   videoCodecPreferenceValue,
 } from '../utils/codecs';
 import { reassignFragmentLevelIndexes } from '../utils/level-helper';
+import { stringify } from '../utils/safe-json-stringify';
 import type ContentSteeringController from './content-steering-controller';
 import type Hls from '../hls';
 import type {
@@ -248,7 +249,7 @@ export default class LevelController extends BasePlaylistController {
         if (this.hls) {
           if (data.levels.length) {
             this.warn(
-              `One or more CODECS in variant not supported: ${JSON.stringify(
+              `One or more CODECS in variant not supported: ${stringify(
                 data.levels[0].attrs,
               )}`,
             );

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -14,6 +14,7 @@ import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
 import { PlaylistLevelType } from '../types/loader';
 import { getM2TSSupportedAudioTypes } from '../utils/codecs';
+import { stringify } from '../utils/safe-json-stringify';
 import type { WorkerContext } from './inject-worker';
 import type { HlsEventEmitter, HlsListeners } from '../events';
 import type Hls from '../hls';
@@ -95,7 +96,7 @@ export default class TransmuxerInterface {
             cmd: 'init',
             typeSupported: m2tsTypeSupported,
             id,
-            config: JSON.stringify(config),
+            config: stringify(config),
           });
         } catch (err) {
           logger.warn(
@@ -143,7 +144,7 @@ export default class TransmuxerInterface {
         resetNo: instanceNo,
         typeSupported: m2tsTypeSupported,
         id: this.id,
-        config: JSON.stringify(config),
+        config: stringify(config),
       });
     }
   }

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -1,3 +1,4 @@
+import { stringify } from './safe-json-stringify';
 import { logger } from '../utils/logger';
 import type OutputFilter from './output-filter';
 
@@ -593,10 +594,7 @@ export class CaptionScreen {
   }
 
   setPAC(pacData: PACData) {
-    this.logger.log(
-      VerboseLevel.INFO,
-      () => 'pacData = ' + JSON.stringify(pacData),
-    );
+    this.logger.log(VerboseLevel.INFO, () => 'pacData = ' + stringify(pacData));
     let newRow = pacData.row - 1;
     if (this.nrRollUpRows && newRow < this.nrRollUpRows - 1) {
       newRow = this.nrRollUpRows - 1;
@@ -650,10 +648,7 @@ export class CaptionScreen {
    * Set background/extra foreground, but first do back_space, and then insert space (backwards compatibility).
    */
   setBkgData(bkgData: Partial<PenStyles>) {
-    this.logger.log(
-      VerboseLevel.INFO,
-      () => 'bkgData = ' + JSON.stringify(bkgData),
-    );
+    this.logger.log(VerboseLevel.INFO, () => 'bkgData = ' + stringify(bkgData));
     this.backSpace();
     this.setPen(bkgData);
     this.insertChar(0x20); // Space
@@ -951,7 +946,7 @@ class Cea608Channel {
     } else {
       styles.foreground = 'white';
     }
-    this.logger.log(VerboseLevel.INFO, 'MIDROW: ' + JSON.stringify(styles));
+    this.logger.log(VerboseLevel.INFO, 'MIDROW: ' + stringify(styles));
     this.writeScreen.setPen(styles);
   }
 

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -3,6 +3,7 @@
  */
 
 import { logger } from './logger';
+import { stringify } from './safe-json-stringify';
 import { DateRange } from '../loader/date-range';
 import { assignProgramDateTime, mapDateRanges } from '../loader/m3u8-parser';
 import type { Fragment, MediaFragment, Part } from '../loader/fragment';
@@ -344,7 +345,7 @@ function mergeDateRanges(
         }
       } else {
         logger.warn(
-          `Ignoring invalid Playlist Delta Update DATERANGE tag: "${JSON.stringify(
+          `Ignoring invalid Playlist Delta Update DATERANGE tag: "${stringify(
             deltaDateRanges[id].attr,
           )}"`,
         );

--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -1,6 +1,7 @@
 import { codecsSetSelectionPreferenceValue } from './codecs';
 import { getVideoSelectionOptions } from './hdr';
 import { logger } from './logger';
+import { stringify } from './safe-json-stringify';
 import type Hls from '../hls';
 import type { Level, VideoRange } from '../types/level';
 import type {
@@ -165,9 +166,7 @@ export function getStartCodecTier(
         ) {
           logStartCodecCandidateIgnored(
             candidate,
-            `no variants with VIDEO-RANGE of ${JSON.stringify(
-              videoRanges,
-            )} found`,
+            `no variants with VIDEO-RANGE of ${stringify(videoRanges)} found`,
           );
           return selected;
         }

--- a/src/utils/safe-json-stringify.ts
+++ b/src/utils/safe-json-stringify.ts
@@ -1,6 +1,11 @@
-const replacer = () => {
+const omitCircularRefsReplacer = (
+  replacer: ((this: any, key: string, value: any) => any) | undefined,
+) => {
   const known = new WeakSet();
   return (_, value) => {
+    if (replacer) {
+      value = replacer(_, value);
+    }
     if (typeof value === 'object' && value !== null) {
       if (known.has(value)) {
         return;
@@ -11,5 +16,7 @@ const replacer = () => {
   };
 };
 
-export const stringify = <T>(object: T): string =>
-  JSON.stringify(object, replacer());
+export const stringify = <T>(
+  object: T,
+  replacer?: (this: any, key: string, value: any) => any,
+): string => JSON.stringify(object, omitCircularRefsReplacer(replacer));

--- a/tests/unit/utils/safe-json-stringify.js
+++ b/tests/unit/utils/safe-json-stringify.js
@@ -11,4 +11,64 @@ describe('Stringify', function () {
 
     expect(stringified).to.equal(JSON.stringify(originalObject));
   });
+
+  it('should use the optional custom replacer', function () {
+    const stringified = stringify(
+      {
+        a: '1',
+        b: { c: 2 },
+      },
+      (k, v) => (k === 'b' ? '2' : v),
+    );
+
+    expect(stringified).to.equal(
+      JSON.stringify({
+        a: '1',
+        b: '2',
+      }),
+    );
+  });
+
+  it('uses the optional custom replacer before checking for cyclical references', function () {
+    const originalObject = { a: 'test' };
+
+    const circularObject = { ...originalObject };
+    circularObject.b = circularObject;
+
+    const stringified = stringify(circularObject, (k, v) =>
+      k === 'b' ? 'replaced' : v,
+    );
+
+    expect(stringified).to.equal(
+      JSON.stringify({
+        a: 'test',
+        b: 'replaced',
+      }),
+    );
+  });
+
+  it('cyclical references added by the custom replacer are removed', function () {
+    const originalObject = { a: 'test' };
+
+    const circularObject = { ...originalObject };
+    circularObject.b = {};
+    circularObject.d = 'replace-with-circular-object';
+
+    const stringified = stringify(circularObject, (k, v) => {
+      if (k === 'b') {
+        v.b = circularObject;
+        v.c = 'test';
+      } else if (v === 'replace-with-circular-object') {
+        v = circularObject;
+      }
+      return v;
+    });
+
+    expect(stringified).to.equal(
+      JSON.stringify({
+        a: 'test',
+        b: { c: 'test' },
+      }),
+    );
+  });
 });


### PR DESCRIPTION
### This PR will...
Prevent exceptions when circular references are added externally to objects HLS.js serializes or logs using `JSON.stringify`.

### Are there any points in the code the reviewer needs to double check?
Added support for custom replacers since we use on in buffer-controller. I had to choose if the replacer should run before or after the cyclical reference check. I chose before.

### Resolves issues:
Resolves #7036 (Follow up to #7037)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
