### PR TITLE
Override media-capabilities result for HEVC support in Windows Firefox

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -8,6 +8,7 @@ import {
   requiresMediaCapabilitiesDecodingInfo,
   SUPPORTED_INFO_DEFAULT,
 } from '../utils/mediacapabilities-helper';
+import { isHEVC } from '../utils/mp4-tools';
 import {
   type AudioTracksByGroup,
   type CodecSetTier,
@@ -803,7 +804,7 @@ class AbrController extends Logger implements AbrComponentAPI {
             currentBw,
             audioPreference,
           ) ||
-            levelInfo.videoCodec?.substring(0, 4) === 'hvc1') // Force media capabilities check for HEVC to avoid failure on Windows
+            isHEVC(levelInfo.videoCodec)) // Force media capabilities check for HEVC to avoid failure on Windows
         ) {
           levelInfo.supportedPromise = getMediaDecodingInfoPromise(
             levelInfo,

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -797,6 +797,9 @@ class AudioStreamController
           this.state = State.IDLE;
         }
         break;
+      case ErrorDetails.BUFFER_ADD_CODEC_ERROR:
+        this.resetLoadingState();
+        break;
       case ErrorDetails.BUFFER_APPEND_ERROR:
       case ErrorDetails.BUFFER_FULL_ERROR:
         if (!data.parent || data.parent !== 'audio') {

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -798,15 +798,14 @@ class AudioStreamController
         }
         break;
       case ErrorDetails.BUFFER_ADD_CODEC_ERROR:
-        this.resetLoadingState();
-        break;
       case ErrorDetails.BUFFER_APPEND_ERROR:
-      case ErrorDetails.BUFFER_FULL_ERROR:
-        if (!data.parent || data.parent !== 'audio') {
+        if (data.parent !== 'audio') {
           return;
         }
-        if (data.details === ErrorDetails.BUFFER_APPEND_ERROR) {
-          this.resetLoadingState();
+        this.resetLoadingState();
+        break;
+      case ErrorDetails.BUFFER_FULL_ERROR:
+        if (data.parent !== 'audio') {
           return;
         }
         if (this.reduceLengthAndFlushBuffer(data)) {
@@ -957,7 +956,7 @@ class AudioStreamController
     }
     const track = tracks.audio;
 
-    track.id = 'audio';
+    track.id = PlaylistLevelType.AUDIO;
 
     const variantAudioCodecs = currentLevel.audioCodec;
     this.log(

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1409,6 +1409,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
           );
           // remove init segment from queue and delete track info
           this.shiftAndExecuteNext(type);
+          this.operationQueue?.removeBlockers();
           delete this.tracks[type];
           this.hls.trigger(Events.ERROR, {
             type: ErrorTypes.MEDIA_ERROR,
@@ -1417,6 +1418,7 @@ transfer tracks: ${JSON.stringify(transferredTracks, (key, value) => (key === 'i
             error,
             sourceBufferName: type,
             mimeType: mimeType,
+            parent: track.id as PlaylistLevelType,
           });
           return;
         }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1016,15 +1016,14 @@ export default class StreamController
         }
         break;
       case ErrorDetails.BUFFER_ADD_CODEC_ERROR:
-        this.resetLoadingState();
-        break;
       case ErrorDetails.BUFFER_APPEND_ERROR:
-      case ErrorDetails.BUFFER_FULL_ERROR:
-        if (!data.parent || data.parent !== 'main') {
+        if (data.parent !== 'main') {
           return;
         }
-        if (data.details === ErrorDetails.BUFFER_APPEND_ERROR) {
-          this.resetLoadingState();
+        this.resetLoadingState();
+        break;
+      case ErrorDetails.BUFFER_FULL_ERROR:
+        if (data.parent !== 'main') {
           return;
         }
         if (this.reduceLengthAndFlushBuffer(data)) {
@@ -1419,7 +1418,7 @@ export default class StreamController
         );
       }
       audio.levelCodec = audioCodec;
-      audio.id = 'main';
+      audio.id = PlaylistLevelType.MAIN;
       this.log(
         `Init audio buffer, container:${
           audio.container
@@ -1431,7 +1430,7 @@ export default class StreamController
     }
     if (video) {
       video.levelCodec = currentLevel.videoCodec;
-      video.id = 'main';
+      video.id = PlaylistLevelType.MAIN;
       const parsedVideoCodec = video.codec;
       if (parsedVideoCodec?.length === 4) {
         // Make up for passthrough-remuxer not being able to parse full codec

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1015,6 +1015,9 @@ export default class StreamController
           this.state = State.IDLE;
         }
         break;
+      case ErrorDetails.BUFFER_ADD_CODEC_ERROR:
+        this.resetLoadingState();
+        break;
       case ErrorDetails.BUFFER_APPEND_ERROR:
       case ErrorDetails.BUFFER_FULL_ERROR:
         if (!data.parent || data.parent !== 'main') {

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -1,5 +1,8 @@
 import { getMediaSource } from './mediasource-helper';
 
+const ua = navigator.userAgent;
+export const UA_HEVC_SUPPORT_INCORRECT = /\(windows;.+firefox/i.test(ua);
+
 // from http://mp4ra.org/codecs.html
 // values indicate codec selection preference (lower is higher priority)
 export const sampleEntryCodesISO = {
@@ -54,8 +57,8 @@ export const sampleEntryCodesISO = {
     dvh1: 0.7,
     dvhe: 0.7,
     encv: 1,
-    hev1: 0.75,
-    hvc1: 0.75,
+    hev1: UA_HEVC_SUPPORT_INCORRECT ? 9 : 0.75,
+    hvc1: UA_HEVC_SUPPORT_INCORRECT ? 9 : 0.75,
     mjp2: 1,
     mp4v: 1,
     mvc1: 1,
@@ -271,4 +274,8 @@ export function getM2TSSupportedAudioTypes(
       ? MediaSource.isTypeSupported('audio/mp4; codecs="ac-3"')
       : false,
   };
+}
+
+export function getCodecsForMimeType(mimeType: string): string {
+  return mimeType.replace(/^.+codecs=["']?([^"']+).*$/, '$1');
 }

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -2,7 +2,7 @@ import { getMediaSource } from './mediasource-helper';
 import { isHEVC } from './mp4-tools';
 
 export const userAgentHevcSupportIsInaccurate = () => {
-  return /\(windows;.+firefox/i.test(navigator.userAgent);
+  return /\(Windows.+Firefox\//i.test(navigator.userAgent);
 };
 
 // from http://mp4ra.org/codecs.html

--- a/src/utils/mediacapabilities-helper.ts
+++ b/src/utils/mediacapabilities-helper.ts
@@ -1,4 +1,9 @@
-import { fillInMissingAV01Params, mimeTypeForCodec } from './codecs';
+import {
+  fillInMissingAV01Params,
+  getCodecsForMimeType,
+  mimeTypeForCodec,
+  UA_HEVC_SUPPORT_INCORRECT,
+} from './codecs';
 import { isHEVC } from './mp4-tools';
 import type { AudioTracksByGroup } from './rendition-helper';
 import type { Level, VideoRange } from '../types/level';
@@ -120,7 +125,7 @@ export function getMediaDecodingInfoPromise(
     // Override Windows Firefox HEVC MediaCapabilities result (https://github.com/video-dev/hls.js/issues/7046)
     const ua = navigator.userAgent;
     if (
-      /\(windows;.+firefox/i.test(ua) &&
+      UA_HEVC_SUPPORT_INCORRECT &&
       videoCodecsArray.some((videoCodec) => isHEVC(videoCodec))
     ) {
       return Promise.resolve({
@@ -209,10 +214,7 @@ function getMediaDecodingInfoKey(config: MediaDecodingConfiguration): string {
   const { audio, video } = config;
   const mediaConfig = video || audio;
   if (mediaConfig) {
-    const codec = mediaConfig.contentType.replace(
-      /^.+codecs=["']?([^"']+).*$/,
-      '$1',
-    );
+    const codec = getCodecsForMimeType(mediaConfig.contentType);
     if (video) {
       return `r${video.height}x${video.width}f${Math.ceil(video.framerate)}${
         video.transferFunction || 'sd'

--- a/src/utils/mediacapabilities-helper.ts
+++ b/src/utils/mediacapabilities-helper.ts
@@ -2,7 +2,7 @@ import {
   fillInMissingAV01Params,
   getCodecsForMimeType,
   mimeTypeForCodec,
-  UA_HEVC_SUPPORT_INCORRECT,
+  userAgentHevcSupportIsInaccurate,
 } from './codecs';
 import { isHEVC } from './mp4-tools';
 import type { AudioTracksByGroup } from './rendition-helper';
@@ -125,8 +125,8 @@ export function getMediaDecodingInfoPromise(
     // Override Windows Firefox HEVC MediaCapabilities result (https://github.com/video-dev/hls.js/issues/7046)
     const ua = navigator.userAgent;
     if (
-      UA_HEVC_SUPPORT_INCORRECT &&
-      videoCodecsArray.some((videoCodec) => isHEVC(videoCodec))
+      videoCodecsArray.some((videoCodec) => isHEVC(videoCodec)) &&
+      userAgentHevcSupportIsInaccurate()
     ) {
       return Promise.resolve({
         supported: false,

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -1012,12 +1012,11 @@ export function parseSamples(
   return seiSamples;
 }
 
-function isHEVC(codec: string) {
+export function isHEVC(codec: string | undefined) {
   if (!codec) {
     return false;
   }
-  const delimit = codec.indexOf('.');
-  const baseCodec = delimit < 0 ? codec : codec.substring(0, delimit);
+  const baseCodec = codec.substring(0, 4);
   return (
     baseCodec === 'hvc1' ||
     baseCodec === 'hev1' ||

--- a/tests/index.js
+++ b/tests/index.js
@@ -43,6 +43,7 @@ import './unit/utils/codecs';
 import './unit/utils/error-helper';
 import './unit/utils/discontinuities';
 import './unit/utils/exp-golomb';
+import './unit/utils/mediacapabilities-helper';
 import './unit/utils/mock-media';
 import './unit/utils/output-filter';
 import './unit/utils/safe-json-stringify';

--- a/tests/unit/utils/mediacapabilities-helper.ts
+++ b/tests/unit/utils/mediacapabilities-helper.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { Level } from '../../../src/types/level';
+import { AttrList } from '../../../src/utils/attr-list';
+import {
+  getMediaDecodingInfoPromise,
+  SUPPORTED_INFO_CACHE,
+} from '../../../src/utils/mediacapabilities-helper';
+
+describe('getMediaDecodingInfoPromise', function () {
+  it('adds queries to cache', function () {
+    if (!navigator.mediaCapabilities) {
+      return;
+    }
+    const attrs = new AttrList(
+      'BANDWIDTH=5000000,CODECS="hvc1.2.20000000.L93.B0",FRAME-RATE=30,RESOLUTION=1920x1080',
+    );
+    const level = new Level({
+      attrs,
+      bitrate: attrs.decimalInteger('BANDWIDTH'),
+      videoCodec: 'hvc1.2.20000000.L93.B0',
+      ...attrs.decimalResolution('RESOLUTION'),
+      name: '',
+      url: '',
+    });
+    expect(level.codecSet).equals('hvc1');
+
+    const emptyAudioTracksByGroup = {
+      hasDefaultAudio: false,
+      hasAutoSelectAudio: false,
+      groups: {},
+    };
+    return getMediaDecodingInfoPromise(
+      level,
+      emptyAudioTracksByGroup,
+      navigator.mediaCapabilities,
+    ).then((mediaDecodingInfo) => {
+      const cachedKeys = Object.keys(SUPPORTED_INFO_CACHE);
+      expect(cachedKeys.length).to.be.gt(0);
+      expect(cachedKeys, JSON.stringify(SUPPORTED_INFO_CACHE)).to.include(
+        'r1080x1920f30sd_hvc1.2.20000000.L93.B0_50',
+      );
+      expect(mediaDecodingInfo).to.have.property('supported');
+      expect(mediaDecodingInfo).to.have.property('decodingInfoResults');
+    });
+  });
+});


### PR DESCRIPTION
### This PR will...

- Override selection preference and media-capabilities result for HEVC support in Windows Firefox
- Fix handling of BUFFER_ADD_CODEC_ERROR for switch error handling to work
- Fix incorrect caching of media-capabilities results (dev-only regression: codec undefined in `getMediaDecodingInfoKey`)

### Why is this Pull Request needed?
Functional tests fail for Windows Firefox with HEVC content:
https://github.com/video-dev/hls.js/actions/runs/13503192504/job/37727621627?pr=7045

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #7046

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
