### PR TITLE
Reset asset lists after Interstitial has played

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -932,13 +932,6 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
     // Check if playback has entered the next asset
     const playingAsset = this.playingAsset;
     if (!playingAsset) {
-      if (
-        !this.isInterstitial(playingItem) &&
-        this.media &&
-        !this.media.seeking
-      ) {
-        //interstitial.reset()
-      }
       return;
     }
     const end = playingAsset.timelineStart + (playingAsset.duration || 0);
@@ -2212,8 +2205,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     interstitial.assetList.forEach((asset) => {
       this.clearAssetPlayer(asset.identifier, toSegment);
     });
-    interstitial.appendInPlaceStarted = false;
-    interstitial.assetListResponse = null;
     // Remove asset list and resolved duration
     interstitial.reset();
   }

--- a/src/controller/interstitials-schedule.ts
+++ b/src/controller/interstitials-schedule.ts
@@ -91,6 +91,22 @@ export class InterstitialsSchedule extends Logger {
     this.events = this.items = null;
   }
 
+  public resetErrorsInRange(start: number, end: number): number {
+    if (this.events) {
+      return this.events.reduce((count, interstitial) => {
+        if (
+          start <= interstitial.startOffset &&
+          end > interstitial.startOffset
+        ) {
+          delete interstitial.error;
+          return count + 1;
+        }
+        return count;
+      }, 0);
+    }
+    return 0;
+  }
+
   get duration(): number {
     const items = this.items;
     return items ? items[items.length - 1].end : 0;

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -106,6 +106,9 @@ export class InterstitialEvent {
   public reset() {
     this.assetListLoader?.destroy();
     this.assetListLoader = this.error = undefined;
+    this.assetListResponse = null;
+    this.assetList.length = 0;
+    this._duration = null;
   }
 
   public isAssetPastPlayoutLimit(assetIndex: number): boolean {

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -104,11 +104,14 @@ export class InterstitialEvent {
   }
 
   public reset() {
+    this.appendInPlaceStarted = false;
     this.assetListLoader?.destroy();
     this.assetListLoader = this.error = undefined;
-    this.assetListResponse = null;
-    this.assetList.length = 0;
-    this._duration = null;
+    if (!this.supplementsPrimary) {
+      this.assetListResponse = null;
+      this.assetList = [];
+      this._duration = null;
+    }
   }
 
   public isAssetPastPlayoutLimit(assetIndex: number): boolean {

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -106,12 +106,14 @@ export class InterstitialEvent {
   public reset() {
     this.appendInPlaceStarted = false;
     this.assetListLoader?.destroy();
-    this.assetListLoader = this.error = undefined;
+    this.assetListLoader = undefined;
     if (!this.supplementsPrimary) {
       this.assetListResponse = null;
       this.assetList = [];
       this._duration = null;
     }
+    // `error?` is reset when seeking back over interstitial `startOffset`
+    //  using `schedule.resetErrorsInRange(start, end)`.
   }
 
   public isAssetPastPlayoutLimit(assetIndex: number): boolean {

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1570,7 +1570,7 @@ fileSequence6.mp4
         ).to.be.an('object');
       };
       const logIm = (context: string) =>
-        console.log(
+        hls.logger.info(
           `primary.currentTime ${im.primary.currentTime | 0} intg.currentTime ${im.integrated.currentTime | 0} pi: ${im.playingIndex} bi: ${im.bufferingIndex} @${context}`,
         );
 


### PR DESCRIPTION
### This PR will...
- Reset asset lists after Interstitial has played, unless the interstitial supplements primary.
- Reset errors when seeking back over interstitial start
- Fix gaps in interstital-controller `bufferedPos` and interstitial manager timeline `bufferedEnd` alignment with playback position
- Fix seeking to primary from appendInPlace interstitial when media is help by primary

### Why is this Pull Request needed?
Asset lists should always be reloaded for late binding.

Interstitial errors are handled by unscheduling the interstitial and falling back to primary. The `error` state on each interstitial is therefor not removed until seeking back 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
