### PR TITLE
fix: seek during startup on low power devices

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -733,7 +733,11 @@ export default class StreamController
       return;
     }
     const liveSyncPosition = this.hls.liveSyncPosition;
-    const currentTime = media.currentTime;
+    const mediaCurrentTime = media.currentTime;
+    const currentTime =
+      this.hasEnoughToStart || mediaCurrentTime > 0
+        ? mediaCurrentTime
+        : this.startPosition;
     const start = levelDetails.fragmentStart;
     const end = levelDetails.edge;
     const withinSlidingWindow =


### PR DESCRIPTION
### This PR will...
Fix an edge-case on webOS 5 (and possible other low power devices), where `synchronizeToLiveEdge()` could seek forward while the first segment was being appended to the buffer.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
https://github.com/video-dev/hls.js/issues/6998

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
