### PR TITLE
Improve Live start with slow conditions

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -207,14 +207,16 @@ class AbrController extends Logger implements AbrComponentAPI {
     isSwitch: boolean,
   ): number {
     const fragLoadSec = timeToFirstByteSec + fragSizeBits / bandwidth;
-    const playlistLoadSec = isSwitch ? this.lastLevelLoadSec : 0;
+    const playlistLoadSec = isSwitch
+      ? timeToFirstByteSec + this.lastLevelLoadSec
+      : 0;
     return fragLoadSec + playlistLoadSec;
   }
 
   protected onLevelLoaded(event: Events.LEVEL_LOADED, data: LevelLoadedData) {
     const config = this.hls.config;
     const { loading } = data.stats;
-    const timeLoadingMs = loading.end - loading.start;
+    const timeLoadingMs = loading.end - loading.first;
     if (Number.isFinite(timeLoadingMs)) {
       this.lastLevelLoadSec = timeLoadingMs / 1000;
     }
@@ -224,7 +226,7 @@ class AbrController extends Logger implements AbrComponentAPI {
       this.bwEstimator.update(config.abrEwmaSlowVoD, config.abrEwmaFastVoD);
     }
     if (this.timer > -1) {
-      this._abandonRulesCheck(true);
+      this._abandonRulesCheck(data.levelInfo);
     }
   }
 
@@ -232,7 +234,7 @@ class AbrController extends Logger implements AbrComponentAPI {
       This method monitors the download rate of the current fragment, and will downswitch if that fragment will not load
       quickly enough to prevent underbuffering
     */
-  private _abandonRulesCheck = (levelLoaded?: boolean) => {
+  private _abandonRulesCheck = (levelLoaded?: Level) => {
     const { fragCurrent: frag, partCurrent: part, hls } = this;
     const { autoLevelEnabled, media } = hls;
     if (!frag || !media) {
@@ -244,11 +246,13 @@ class AbrController extends Logger implements AbrComponentAPI {
     const duration = part ? part.duration : frag.duration;
     const timeLoading = now - stats.loading.start;
     const minAutoLevel = hls.minAutoLevel;
+    const loadingFragForLevel = frag.level;
+    const currentAutoLevel = this._nextAutoLevel;
     // If frag loading is aborted, complete, or from lowest level, stop timer and return
     if (
       stats.aborted ||
       (stats.loaded && stats.loaded === stats.total) ||
-      frag.level <= minAutoLevel
+      loadingFragForLevel <= minAutoLevel
     ) {
       this.clearTimer();
       // reset forced auto level value so that next level will be selected
@@ -256,17 +260,24 @@ class AbrController extends Logger implements AbrComponentAPI {
       return;
     }
 
-    // This check only runs if we're in ABR mode and actually playing
+    // This check only runs if we're in ABR mode
+    if (!autoLevelEnabled) {
+      return;
+    }
+
+    // Must be loading/loaded a new level or be in a playing state
+    const fragBlockingSwitch =
+      currentAutoLevel > -1 && currentAutoLevel !== loadingFragForLevel;
+    const levelChange = !!levelLoaded || fragBlockingSwitch;
     if (
-      !autoLevelEnabled ||
-      !media.playbackRate ||
-      (!levelLoaded && (media.paused || !media.readyState))
+      !levelChange &&
+      (media.paused || !media.playbackRate || !media.readyState)
     ) {
       return;
     }
 
     const bufferInfo = hls.mainForwardBufferInfo;
-    if (!levelLoaded && bufferInfo === null) {
+    if (!levelChange && bufferInfo === null) {
       return;
     }
 
@@ -290,7 +301,7 @@ class AbrController extends Logger implements AbrComponentAPI {
     const loadedFirstByte = stats.loaded && ttfb > -1;
     const bwEstimate: number = this.getBwEstimate();
     const levels = hls.levels;
-    const level = levels[frag.level];
+    const level = levels[loadingFragForLevel];
     const expectedLen = Math.max(
       stats.loaded,
       Math.round((duration * (frag.bitrate || level.averageBitrate)) / 8),
@@ -313,13 +324,14 @@ class AbrController extends Logger implements AbrComponentAPI {
     }
 
     const bwe = loadRate ? loadRate * 8 : bwEstimate;
-    const live = this.hls.latestLevelDetails?.live === true;
+    const live =
+      (levelLoaded?.details || this.hls.latestLevelDetails)?.live === true;
     const abrBandWidthUpFactor = this.hls.config.abrBandWidthUpFactor;
     let fragLevelNextLoadedDelay: number = Number.POSITIVE_INFINITY;
     let nextLoadLevel: number;
     // Iterate through lower level and try to find the largest one that avoids rebuffering
     for (
-      nextLoadLevel = frag.level - 1;
+      nextLoadLevel = loadingFragForLevel - 1;
       nextLoadLevel > minAutoLevel;
       nextLoadLevel--
     ) {
@@ -379,7 +391,7 @@ class AbrController extends Logger implements AbrComponentAPI {
 
     this.warn(`Fragment ${frag.sn}${
       part ? ' part ' + part.index : ''
-    } of level ${frag.level} is loading too slowly;
+    } of level ${loadingFragForLevel} is loading too slowly;
       Fragment duration: ${frag.duration.toFixed(3)}
       Time to underbuffer: ${bufferStarvationDelay.toFixed(3)} s
       Estimated load time for current fragment: ${fragLoadedDelay.toFixed(3)} s
@@ -396,7 +408,7 @@ class AbrController extends Logger implements AbrComponentAPI {
     hls.nextLoadLevel = hls.nextAutoLevel = nextLoadLevel;
 
     this.clearTimer();
-    this.timer = self.setInterval(() => {
+    const abortAndSwitch = () => {
       // Are nextLoadLevel details available or is stream-controller still in "WAITING_LEVEL" state?
       this.clearTimer();
       if (
@@ -428,7 +440,15 @@ class AbrController extends Logger implements AbrComponentAPI {
           this.resetEstimator(this.hls.levels[lowestSwitchLevel].bitrate);
         }
       }
-    }, fragLevelNextLoadedDelay * 1000);
+    };
+    if (fragBlockingSwitch || fragLoadedDelay > fragLevelNextLoadedDelay * 2) {
+      abortAndSwitch();
+    } else {
+      this.timer = self.setInterval(
+        abortAndSwitch,
+        fragLevelNextLoadedDelay * 1000,
+      );
+    }
 
     hls.trigger(Events.FRAG_LOAD_EMERGENCY_ABORTED, { frag, part, stats });
   };

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1335,7 +1335,7 @@ export default class BaseStreamController
               : liveSyncPosition) || frag.start
           : pos;
         this.log(
-          `Setting startPosition to ${startPosition} to match initial live edge. mainStart: ${mainStart} liveSyncPosition: ${liveSyncPosition} frag.start: ${frag?.start}`,
+          `Setting startPosition to ${startPosition} to match start frag at live edge. mainStart: ${mainStart} liveSyncPosition: ${liveSyncPosition} frag.start: ${frag?.start}`,
         );
         this.startPosition = this.nextLoadPosition = startPosition;
       }
@@ -1677,6 +1677,9 @@ export default class BaseStreamController
         // Leave this.startPosition at -1, so that we can use `getInitialLiveFragment` logic when startPosition has
         // not been specified via the config or an as an argument to startLoad (#3736).
         startPosition = this.hls.liveSyncPosition || sliding;
+        this.log(
+          `Setting startPosition to -1 to start at live edge ${startPosition}`,
+        );
         this.startPosition = -1;
       } else {
         this.log(`setting startPosition to 0 by default`);

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -503,7 +503,6 @@ export class FragmentTracker implements ComponentAPI {
 
   public removeFragment(fragment: Fragment) {
     const fragKey = getFragmentKey(fragment);
-    fragment.stats.loaded = 0;
     fragment.clearElementaryStreamInfo();
     const activeParts = this.activePartLists[fragment.type];
     if (activeParts) {

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1374,7 +1374,10 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
     if (
       !hls.loadingEnabled ||
       !hls.media ||
-      Math.abs(hls.media.currentTime - timelinePos) > 0.5
+      Math.abs(
+        (hls.mainForwardBufferInfo?.start || hls.media.currentTime) -
+          timelinePos,
+      ) > 0.5
     ) {
       hls.startLoad(timelinePos, skipSeekToStartPosition);
     } else if (!hls.bufferingEnabled) {
@@ -1784,21 +1787,21 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
       }
       const isInterstitial = this.isInterstitial(item);
       const bufferingPlayer = this.getBufferingPlayer();
-      const timeRemaining = bufferingPlayer
-        ? bufferingPlayer.remaining
-        : bufferingLast
-          ? bufferingLast.end - this.timelinePos
-          : 0;
-      this.log(
-        `buffered to boundary ${segmentToString(item)}` +
-          (bufferingLast ? ` (${timeRemaining.toFixed(2)} remaining)` : ''),
-      );
       this.bufferingItem = item;
       this.bufferedPos = Math.max(
         item.start,
         Math.min(item.end, this.timelinePos),
       );
       if (!this.playbackDisabled) {
+        const timeRemaining = bufferingPlayer
+          ? bufferingPlayer.remaining
+          : bufferingLast
+            ? bufferingLast.end - this.timelinePos
+            : 0;
+        this.log(
+          `buffered to boundary ${segmentToString(item)}` +
+            (bufferingLast ? ` (${timeRemaining.toFixed(2)} remaining)` : ''),
+        );
         if (isInterstitial) {
           // primary fragment loading will exit early in base-stream-controller while `bufferingItem` is set to an Interstitial block
           item.event.assetList.forEach((asset) => {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -733,11 +733,7 @@ export default class StreamController
       return;
     }
     const liveSyncPosition = this.hls.liveSyncPosition;
-    const mediaCurrentTime = media.currentTime;
-    const currentTime =
-      this.hasEnoughToStart || mediaCurrentTime > 0
-        ? mediaCurrentTime
-        : this.startPosition;
+    const currentTime = this.getLoadPosition();
     const start = levelDetails.fragmentStart;
     const end = levelDetails.edge;
     const withinSlidingWindow =


### PR DESCRIPTION
### This PR will...
When a live playlist update arrives before live start (before media is buffered and client can seek to buffered range), evaluate if the variant should be abandoned, and avoid seeking to catch up to live edge.

### Why is this Pull Request needed?
The live edge sync (catch up) check was running prior to live start. @grabofus pointed this out in #6998 and provided a fix in #7063. This change follows up by using the estimated playhead position and switching down on slow fragment load.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #6998

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
