### PR TITLE
Fix Interstitials playback with media source transfer

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -402,6 +402,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected doTick(): void;
     // (undocumented)
+    filterReplacedPrimary(frag: MediaFragment | null, details: LevelDetails | undefined): MediaFragment | null;
+    // (undocumented)
     protected flushBufferGap(frag: Fragment): void;
     // (undocumented)
     protected flushMainBuffer(startOffset: number, endOffset: number, type?: SourceBufferName | null): void;
@@ -468,7 +470,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected levels: Array<Level> | null;
     // (undocumented)
-    protected loadFragment(frag: Fragment, level: Level, targetBufferTime: number): void;
+    protected loadFragment(frag: MediaFragment, level: Level, targetBufferTime: number): void;
     // (undocumented)
     protected loadingParts: boolean;
     // (undocumented)

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1486,15 +1486,14 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     if (!media || !mediaSource) {
       return;
     }
+    // once received, don't listen anymore to sourceopen event
+    mediaSource.removeEventListener('sourceopen', this._onMediaSourceOpen);
     media.removeEventListener('emptied', this._onMediaEmptied);
     this.updateDuration();
     this.hls.trigger(Events.MEDIA_ATTACHED, {
       media,
       mediaSource: mediaSource as MediaSource,
     });
-
-    // once received, don't listen anymore to sourceopen event
-    mediaSource.removeEventListener('sourceopen', this._onMediaSourceOpen);
 
     if (this.mediaSource !== null) {
       this.checkPendingTracks();

--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -27,6 +27,7 @@ export class HlsAssetPlayer {
   public tracks: Partial<BufferCodecsData> | null = null;
   private hasDetails: boolean = false;
   private mediaAttached: HTMLMediaElement | null = null;
+  private _currentTime?: number;
 
   constructor(
     HlsPlayerClass: typeof Hls,
@@ -89,7 +90,7 @@ export class HlsAssetPlayer {
   get bufferedEnd(): number {
     const media = this.media || this.mediaAttached;
     if (!media) {
-      return 0;
+      return this.currentTime;
     }
     const bufferInfo = BufferHelper.bufferInfo(media, media.currentTime, 0.001);
     return this.getAssetTime(bufferInfo.end);
@@ -98,7 +99,7 @@ export class HlsAssetPlayer {
   get currentTime(): number {
     const media = this.media || this.mediaAttached;
     if (!media) {
-      return 0;
+      return this._currentTime || 0;
     }
     return this.getAssetTime(media.currentTime);
   }
@@ -151,6 +152,7 @@ export class HlsAssetPlayer {
   private removeMediaListeners() {
     const media = this.mediaAttached;
     if (media) {
+      this._currentTime = media.currentTime;
       media.removeEventListener('timeupdate', this.checkPlayout);
     }
   }
@@ -170,6 +172,7 @@ export class HlsAssetPlayer {
 
   detachMedia() {
     this.removeMediaListeners();
+    this.mediaAttached = null;
     this.hls.detachMedia();
   }
 
@@ -210,6 +213,6 @@ export class HlsAssetPlayer {
   }
 
   toString(): string {
-    return `HlsAssetPlayer: ${eventAssetToString(this.assetItem)} ${this.hls.sessionId} ${this.interstitial.appendInPlace ? 'append-in-place' : ''}`;
+    return `HlsAssetPlayer: ${eventAssetToString(this.assetItem)} ${this.hls?.sessionId} ${this.interstitial?.appendInPlace ? 'append-in-place' : ''}`;
   }
 }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -195,11 +195,11 @@ export default class InterstitialsController
   }
 
   resumeBuffering() {
-    this.playerQueue.forEach((player) => player.resumeBuffering());
+    this.getBufferingPlayer()?.resumeBuffering();
   }
 
   pauseBuffering() {
-    this.playerQueue.forEach((player) => player.pauseBuffering());
+    this.getBufferingPlayer()?.pauseBuffering();
   }
 
   destroy() {
@@ -760,6 +760,9 @@ export default class InterstitialsController
     player: Hls | HlsAssetPlayer,
     media: HTMLMediaElement,
   ) {
+    if (player.media === media) {
+      return;
+    }
     let attachMediaSourceData: MediaAttachingData | null = null;
     const primaryPlayer = this.hls;
     const isAssetPlayer = player !== primaryPlayer;
@@ -768,32 +771,44 @@ export default class InterstitialsController
     const detachedMediaSource = this.detachedData?.mediaSource;
 
     let logFromSource: string;
-    if (primaryPlayer.media && appendInPlace) {
-      attachMediaSourceData = primaryPlayer.transferMedia();
-      this.detachedData = attachMediaSourceData;
+    if (primaryPlayer.media) {
+      if (appendInPlace) {
+        attachMediaSourceData = primaryPlayer.transferMedia();
+        this.detachedData = attachMediaSourceData;
+      }
       logFromSource = `Primary`;
     } else if (detachedMediaSource) {
       const bufferingPlayer = this.getBufferingPlayer();
       if (bufferingPlayer) {
         attachMediaSourceData = bufferingPlayer.transferMedia();
+        logFromSource = `${bufferingPlayer}`;
+      } else {
+        logFromSource = `detached MediaSource`;
       }
-      logFromSource = `${bufferingPlayer}`;
     } else {
-      logFromSource = `<unknown>`;
+      logFromSource = `detached media`;
     }
-    this.log(
-      `transferring to ${isAssetPlayer ? player : 'Primary'}
-MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
-    );
-
     if (!attachMediaSourceData) {
       if (detachedMediaSource) {
         attachMediaSourceData = this.detachedData;
         this.log(
           `using detachedData: MediaSource ${stringify(attachMediaSourceData)}`,
         );
-      } else if (!this.detachedData || this.hls.media === media) {
-        // Media is attaching when `detachedData` and `hls.media` are populated. Detach to clear the MediaSource.
+      } else if (!this.detachedData || primaryPlayer.media === media) {
+        // Keep interstitial media transition consistent
+        const playerQueue = this.playerQueue;
+        if (playerQueue.length > 1) {
+          playerQueue.forEach((queuedPlayer) => {
+            if (
+              isAssetPlayer &&
+              queuedPlayer.interstitial.appendInPlace !== appendInPlace
+            ) {
+              const interstitial = queuedPlayer.interstitial;
+              this.clearInterstitial(queuedPlayer.interstitial, null);
+              interstitial.appendInPlace = false;
+            }
+          });
+        }
         this.hls.detachMedia();
         this.detachedData = { media };
       }
@@ -807,7 +822,7 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
     this.log(
       `${transferring ? 'transfering MediaSource' : 'attaching media'} to ${
         isAssetPlayer ? player : 'Primary'
-      }`,
+      } from ${logFromSource}`,
     );
     if (dataToAttach === attachMediaSourceData) {
       const isAssetAtEndOfSchedule =
@@ -1068,7 +1083,7 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
           player,
         });
         this.retreiveMediaSource(assetId, scheduledItem);
-        if (player.media && !this.detachedData) {
+        if (player.media && !this.detachedData?.mediaSource) {
           player.detachMedia();
         }
       }
@@ -1414,7 +1429,10 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
       main,
     };
     this.mediaSelection = currentSelection;
-    this.schedule.parseInterstitialDateRanges(currentSelection);
+    this.schedule.parseInterstitialDateRanges(
+      currentSelection,
+      this.hls.config.interstitialAppendInPlace,
+    );
 
     if (!this.effectivePlayingItem && this.schedule.items) {
       this.checkStart();
@@ -1554,9 +1572,6 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
       interstitialEvents.length || removedIds.length
     );
     if (interstitialsUpdated) {
-      if (this.hls.config.interstitialAppendInPlace === false) {
-        interstitialEvents.forEach((event) => (event.appendInPlace = false));
-      }
       this.log(
         `INTERSTITIALS_UPDATED (${
           interstitialEvents.length
@@ -1890,18 +1905,18 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     interstitial: InterstitialEvent,
     assetListIndex: number,
   ): HlsAssetPlayer | null {
+    const uri = interstitial.assetUrl;
     const assetListLength = interstitial.assetList.length;
     const neverLoaded = assetListLength === 0 && !interstitial.assetListLoader;
     const playOnce = interstitial.cue.once;
     if (neverLoaded) {
       this.log(
-        `Load interstitial asset ${assetListIndex + 1}/${assetListLength} ${interstitial}`,
+        `Load interstitial asset ${assetListIndex + 1}/${uri ? 1 : assetListLength} ${interstitial}`,
       );
       const timelineStart = interstitial.timelineStart;
       if (interstitial.appendInPlace) {
         this.flushFrontBuffer(timelineStart + 0.25);
       }
-      const uri = interstitial.assetUrl;
       if (uri) {
         return this.createAsset(
           interstitial,
@@ -2290,9 +2305,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     }
 
     // detach media and attach to interstitial player if it does not have another element attached
-    if (!player.media) {
-      this.bufferAssetPlayer(player, media);
-    }
+    this.bufferAssetPlayer(player, media);
   }
 
   private bufferAssetPlayer(player: HlsAssetPlayer, media: HTMLMediaElement) {
@@ -2308,11 +2321,19 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     if (bufferingPlayer === player) {
       return;
     }
+    const appendInPlaceNext = interstitial.appendInPlace;
+    if (
+      appendInPlaceNext &&
+      bufferingPlayer?.interstitial.appendInPlace === false
+    ) {
+      // Media is detached and not available to append in place
+      return;
+    }
     const activeTracks =
       bufferingPlayer?.tracks ||
       this.detachedData?.tracks ||
       this.requiredTracks;
-    if (interstitial.appendInPlace && assetItem !== this.playingAsset) {
+    if (appendInPlaceNext && assetItem !== this.playingAsset) {
       // Do not buffer another item if tracks are unknown or incompatible
       if (!player.tracks) {
         return;
@@ -2413,7 +2434,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
         } error: ${interstitial.error}`,
       );
       if (interstitial.appendInPlace) {
-        interstitial.appendInPlace = false;
         this.attachPrimary(flushStart, null);
         this.flushFrontBuffer(flushStart);
       }
@@ -2425,6 +2445,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
       if (!this.itemsMatch(playingItem, newPlayingItem)) {
         const scheduleIndex = this.schedule.findItemIndexAtTime(timelinePos);
         this.setSchedulePosition(scheduleIndex);
+      } else {
+        this.clearInterstitial(interstitial, null);
       }
     } else {
       this.checkStart();

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1532,6 +1532,8 @@ MediaSource ${stringify(attachMediaSourceData)} from ${logFromSource}`,
     if (!this.playingLastItem && playingItem) {
       const playingIndex = this.findItemIndex(playingItem);
       this.setSchedulePosition(playingIndex + 1);
+    } else {
+      this.shouldPlay = false;
     }
   }
 

--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -536,14 +536,11 @@ export function findPart(
 
 export function reassignFragmentLevelIndexes(levels: Level[]) {
   levels.forEach((level, index) => {
-    const fragments = level.details?.fragments;
-    if (fragments) {
-      fragments.forEach((fragment) => {
-        fragment.level = index;
-        if (fragment.initSegment) {
-          fragment.initSegment.level = index;
-        }
-      });
-    }
+    level.details?.fragments.forEach((fragment) => {
+      fragment.level = index;
+      if (fragment.initSegment) {
+        fragment.initSegment.level = index;
+      }
+    });
   });
 }


### PR DESCRIPTION
### This PR will...
Fixes handling of media element transfer between primary and asset HLS.js instances when abutting interstitials have different strategies for appending media (resetting the media source vs using the primary media source in place) and when the underlying primary content spans multiple discontinuities.

### Why is this Pull Request needed?

- Avoids loading and queueing primary init segments for discontinuities obscured by interstitials which could lead improper appends and handling of mixed codecs between primary and interstitial.
- Maintains asset player currentTime after media is detached
- Prevent playback from restarting on schedule change after primary media has ended

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
