### PR TITLE
Fix loop loading on empty segment with worker disabled

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1971,27 +1971,29 @@ export default class BaseStreamController
       },
       false,
     );
-    if (!parsed && this.transmuxer?.error === null) {
-      const error = new Error(
-        `Found no media in fragment ${frag.sn} of ${this.playlistLabel()} ${frag.level} resetting transmuxer to fallback to playlist timing`,
-      );
+    if (!parsed) {
       if (level.fragmentError === 0) {
         // Mark and track the odd empty segment as a gap to avoid reloading
         this.treatAsGap(frag, level);
       }
-      this.warn(error.message);
-      this.hls.trigger(Events.ERROR, {
-        type: ErrorTypes.MEDIA_ERROR,
-        details: ErrorDetails.FRAG_PARSING_ERROR,
-        fatal: false,
-        error,
-        frag,
-        reason: `Found no media in msn ${frag.sn} of ${this.playlistLabel()} "${level.url}"`,
-      });
-      if (!this.hls) {
-        return;
+      if (this.transmuxer?.error === null) {
+        const error = new Error(
+          `Found no media in fragment ${frag.sn} of ${this.playlistLabel()} ${frag.level} resetting transmuxer to fallback to playlist timing`,
+        );
+        this.warn(error.message);
+        this.hls.trigger(Events.ERROR, {
+          type: ErrorTypes.MEDIA_ERROR,
+          details: ErrorDetails.FRAG_PARSING_ERROR,
+          fatal: false,
+          error,
+          frag,
+          reason: `Found no media in msn ${frag.sn} of ${this.playlistLabel()} "${level.url}"`,
+        });
+        if (!this.hls) {
+          return;
+        }
+        this.resetTransmuxer();
       }
-      this.resetTransmuxer();
       // For this error fallthrough. Marking parsed will allow advancing to next fragment.
     }
     this.state = State.PARSED;


### PR DESCRIPTION
### This PR will...
Treat empty segments as gaps even when error handling is signalled on the transmuxer.

### Why is this Pull Request needed?
This prevents loop loading by immediately marking the empty segment with a gap. Otherwise, the error handling flow must choose to penalize the variant even when there are no alternates to switch to. 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7075

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
