### PR TITLE
Use ResizeObserver to cap level to player size

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -942,7 +942,7 @@ class AbrController extends Logger implements AbrComponentAPI {
         ttfbEstimateSec,
         adjustedbw,
         bitrate * avgDuration,
-        levelDetails === undefined,
+        !levelDetails || levelDetails.live,
       );
 
       const canSwitchWithinTolerance =

--- a/tests/unit/controller/cap-level-controller.ts
+++ b/tests/unit/controller/cap-level-controller.ts
@@ -195,14 +195,15 @@ describe('CapLevelController', function () {
     });
 
     describe('start and stop', function () {
-      it('immediately caps and sets a timer for monitoring size size', function () {
+      it('immediately caps and begins monitoring size', function () {
         const detectPlayerSizeSpy = sinon.spy(
           capLevelController,
           'detectPlayerSize',
         );
         capLevelController.startCapping();
 
-        expect(capLevelController.timer).to.exist;
+        expect(capLevelController.timer || capLevelController.observer).to
+          .exist;
         expect(detectPlayerSizeSpy.callCount).to.equal(1);
       });
 
@@ -215,7 +216,6 @@ describe('CapLevelController', function () {
           Number.POSITIVE_INFINITY,
         );
         expect(capLevelController.restrictedLevels).to.be.empty;
-        expect(capLevelController.firstLevel).to.equal(-1);
         expect(capLevelController.timer).to.not.exist;
       });
     });
@@ -246,15 +246,11 @@ describe('CapLevelController', function () {
       expect(startCappingSpy.calledOnce).to.be.true;
     });
 
-    it('receives level information from the MANIFEST_PARSED event', function () {
+    it('resets restrictedLevels on MANIFEST_PARSED', function () {
       capLevelController.restrictedLevels = [1];
-      const data = {
+      capLevelController.onManifestParsed(Events.MANIFEST_PARSED, {
         levels: [{ foo: 'bar' }],
-        firstLevel: 0,
-      };
-
-      capLevelController.onManifestParsed(Events.MANIFEST_PARSED, data);
-      expect(capLevelController.firstLevel).to.equal(data.firstLevel);
+      });
       expect(capLevelController.restrictedLevels).to.be.empty;
     });
 


### PR DESCRIPTION
### This PR will...
Use ResizeObserver when available in cap-level-controller.

Improve buffer removal boundary used in fast switch-up to reduce stalling, for in live playback. 

### Why is this Pull Request needed?
Using `capLevelToPlayerSize` to detect the media element dimensions forces layout. The `ResizeObserver` avoids this speeding up player setup.

### Are there any points in the code the reviewer needs to double check?
Might want to debounce calling `this.detectPlayerSize` in the observer callback to avoid setting the level more than once when the media element size is animated by the browser during transitions like entering and exiting fullscreen.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
