### PR TITLE
#7109: Use segment or audio samples duration in case of single sample video chunk

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -860,11 +860,13 @@ export class CaptionScreen {
 //
 // @public (undocumented)
 export class ChunkMetadata {
-    constructor(level: number, sn: number, id: number, size?: number, part?: number, partial?: boolean);
+    constructor(level: number, sn: number, id: number, size?: number, part?: number, partial?: boolean, duration?: number | null);
     // (undocumented)
     readonly buffering: {
         [key in SourceBufferName]: HlsChunkPerformanceTiming;
     };
+    // (undocumented)
+    readonly duration: number | null;
     // (undocumented)
     readonly id: number;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -660,6 +660,7 @@ class AudioStreamController
         payload.byteLength,
         partIndex,
         partial,
+        !partial ? frag.duration : null,
       );
       transmuxer.push(
         payload,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -741,6 +741,7 @@ export default class BaseStreamController
       0,
       part ? part.index : -1,
       !complete,
+      complete ? fragLoadedEndData.frag.duration : null,
     );
     transmuxer.flush(chunkMeta);
   }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -821,6 +821,7 @@ export default class StreamController
       payload.byteLength,
       partIndex,
       partial,
+      !partial ? frag.duration : null,
     );
     const initPTS = this.initPTS[frag.cc];
 

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -303,6 +303,7 @@ export default class Transmuxer {
       accurateTimeOffset,
       true,
       this.id,
+      chunkMeta.duration,
     );
     transmuxResults.push({
       remuxResult,
@@ -411,6 +412,7 @@ export default class Transmuxer {
       accurateTimeOffset,
       false,
       this.id,
+      chunkMeta.duration,
     );
     return {
       remuxResult,
@@ -437,6 +439,7 @@ export default class Transmuxer {
           accurateTimeOffset,
           false,
           this.id,
+          chunkMeta.duration,
         );
         return {
           remuxResult,

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -23,6 +23,7 @@ export interface Remuxer {
     accurateTimeOffset: boolean,
     flush: boolean,
     playlistType: PlaylistLevelType,
+    fragmentDuration: number | null,
   ): RemuxerResult;
   resetInitSegment(
     initSegment: Uint8Array | undefined,

--- a/src/types/transmuxer.ts
+++ b/src/types/transmuxer.ts
@@ -14,6 +14,7 @@ export class ChunkMetadata {
   public readonly id: number;
   public readonly size: number;
   public readonly partial: boolean;
+  public readonly duration: number | null;
   public readonly transmuxing: HlsChunkPerformanceTiming =
     getNewPerformanceTiming();
   public readonly buffering: {
@@ -31,6 +32,7 @@ export class ChunkMetadata {
     size = 0,
     part = -1,
     partial = false,
+    duration: number | null = null,
   ) {
     this.level = level;
     this.sn = sn;
@@ -38,6 +40,7 @@ export class ChunkMetadata {
     this.size = size;
     this.part = part;
     this.partial = partial;
+    this.duration = duration;
   }
 }
 

--- a/tests/unit/demuxer/transmuxer.ts
+++ b/tests/unit/demuxer/transmuxer.ts
@@ -130,7 +130,12 @@ describe('TransmuxerInterface tests', function () {
     const videoCodec = '';
     const duration = 0;
     const accurateTimeOffset = true;
-    let chunkMeta = new ChunkMetadata(currentFrag.level, currentFrag.sn + 1, 0);
+    let chunkMeta = new ChunkMetadata(
+      currentFrag.level,
+      currentFrag.sn + 1,
+      0,
+      currentFrag.duration,
+    );
     let state = new TransmuxState(false, true, true, false, 0, false);
     transmuxerInterface.push(
       data,
@@ -224,7 +229,12 @@ describe('TransmuxerInterface tests', function () {
     const videoCodec = '';
     const duration = 0;
     const accurateTimeOffset = true;
-    const chunkMeta = new ChunkMetadata(newFrag.level, newFrag.sn, 0);
+    const chunkMeta = new ChunkMetadata(
+      newFrag.level,
+      newFrag.sn,
+      0,
+      newFrag.duration,
+    );
 
     const configureStub = sinon.stub(
       transmuxerInterfacePrivates.transmuxer,


### PR DESCRIPTION
### This PR will...
Change the computation of duration of MP4 video sample when transmuxed from MPEG-TS fragment with single video sample. The duration of segment reported via `#EXTINF` tag will be used as duration of single video sample or if this duration now available - the length of audio samples will be used.

### Why is this Pull Request needed?
Currently playback of HLS streams with TS fragments stuck in case of fragment has single video sample. 

### Are there any points in the code the reviewer needs to double check?
The issue has been encountered before and reported as https://github.com/video-dev/hls.js/issues/4783 and supposedly fixed by https://github.com/video-dev/hls.js/pull/4794.
It also seems like this is kind of corner case for TS -> MP4 transmuxing which also encountered in [Shaka Player](https://github.com/shaka-project/shaka-player/pull/5686). 

### Resolves issues:
#7109

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md


PS: This is probably just one approach to resolve problem and it might be not fully correct. The feedback from maintainers much appreciated.