### PR TITLE
docs: add note regarding ESM use with old browsers

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,7 +4,10 @@ The 1.4 version of hls.js now ships with an ESM version of the library (`dist/hl
 
 If you are using the UMD version (`dist/hls.js`), no changes are required.
 
-**Important Note:** If you are using a bundler, such as webpack, the ESM version of the package will likely be used by default. If this is the case, make sure to add the `workerPath` config option after upgrading to hls.js 1.4 or above.
+**Important Notes:**
+
+- If you are using a bundler, such as webpack, the ESM version of the package will likely be used by default. If this is the case, make sure to add the `workerPath` config option after upgrading to hls.js 1.4 or above.
+- Older web engines may experience severe performance degradation when using the ESM version of this package. If targeting older web engines, consider bundling your client application in `loose` mode to avoid additional function overhead. Alternatively, use the UMD/ES5 version of the package.
 
 # Migrating from hls.js 0.x to 1.x
 


### PR DESCRIPTION
### This PR will...
Adds a note to the MIGRATING document regarding performance issues on older web engines (for example, Chrome v56/63 on Samsung TV's).

### Why is this Pull Request needed?
Performance issues discovered when using the ESM (default) version of this library when compiling client applications in `strict` mode. Communicates recommendations to avoid this.

### Are there any points in the code the reviewer needs to double check?
n/a

### Addresses issues:
#7106 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
