### PR TITLE
Allow primary segment prefetching for interstitial resumption and exp…

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -402,7 +402,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected doTick(): void;
     // (undocumented)
-    filterReplacedPrimary(frag: MediaFragment | null, details: LevelDetails | undefined): MediaFragment | null;
+    protected filterReplacedPrimary(frag: MediaFragment | null, details: LevelDetails | undefined): MediaFragment | null;
     // (undocumented)
     protected flushBufferGap(frag: Fragment): void;
     // (undocumented)
@@ -509,6 +509,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     pauseBuffering(): void;
     // (undocumented)
     protected playlistType: PlaylistLevelType;
+    // (undocumented)
+    protected get primaryPrefetch(): boolean;
     // (undocumented)
     protected recoverWorkerError(data: ErrorData): void;
     // (undocumented)
@@ -2133,6 +2135,8 @@ export class HlsAssetPlayer {
     // (undocumented)
     get bufferedEnd(): number;
     // (undocumented)
+    bufferedInPlaceToEnd(media?: HTMLMediaElement | null): boolean;
+    // (undocumented)
     get currentTime(): number;
     // (undocumented)
     destroy(): void;
@@ -2689,6 +2693,8 @@ export class InterstitialEvent {
     // (undocumented)
     reset(): void;
     // (undocumented)
+    resetOnResume?: boolean;
+    // (undocumented)
     restrictions: PlaybackRestrictions;
     // (undocumented)
     resumeAnchor?: MediaFragmentRef;
@@ -2704,6 +2710,8 @@ export class InterstitialEvent {
     snapOptions: SnapOptions;
     // (undocumented)
     get startDate(): Date;
+    // (undocumented)
+    get startIsAligned(): boolean;
     // (undocumented)
     get startOffset(): number;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -209,7 +209,7 @@ export class AudioStreamController extends BaseStreamController implements Netwo
     // (undocumented)
     protected resetLoadingState(): void;
     // (undocumented)
-    startLoad(startPosition: number): void;
+    startLoad(startPosition: number, skipSeekToStartPosition?: boolean): void;
     // (undocumented)
     protected unregisterListeners(): void;
 }
@@ -558,6 +558,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     stopLoad(): void;
     // (undocumented)
     protected _streamEnded(bufferInfo: BufferInfo, levelDetails: LevelDetails): boolean;
+    // (undocumented)
+    protected get timelineOffset(): number;
     // (undocumented)
     protected transmuxer: TransmuxerInterface | null;
     // (undocumented)
@@ -4552,7 +4554,7 @@ export class SubtitleStreamController extends BaseStreamController implements Ne
     // (undocumented)
     protected registerListeners(): void;
     // (undocumented)
-    startLoad(startPosition: number): void;
+    startLoad(startPosition: number, skipSeekToStartPosition?: boolean): void;
     // (undocumented)
     protected unregisterListeners(): void;
 }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -189,7 +189,7 @@ class AudioStreamController
     );
   }
 
-  startLoad(startPosition: number) {
+  startLoad(startPosition: number, skipSeekToStartPosition?: boolean) {
     if (!this.levels) {
       this.startPosition = startPosition;
       this.state = State.STOPPED;
@@ -209,11 +209,9 @@ class AudioStreamController
     } else {
       this.state = State.WAITING_TRACK;
     }
-    this.nextLoadPosition =
-      this.startPosition =
-      this.lastCurrentTime =
-        startPosition;
-
+    this.nextLoadPosition = this.lastCurrentTime =
+      startPosition + this.timelineOffset;
+    this.startPosition = skipSeekToStartPosition ? -1 : startPosition;
     this.tick();
   }
 

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -325,7 +325,9 @@ class AudioStreamController
     // => if media not attached but start frag prefetch is enabled and start frag not requested yet, we will not exit loop
     if (
       !this.buffering ||
-      (!media && (this.startFragRequested || !config.startFragPrefetch)) ||
+      (!media &&
+        !this.primaryPrefetch &&
+        (this.startFragRequested || !config.startFragPrefetch)) ||
       !levels?.[trackId]
     ) {
       return;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -255,6 +255,17 @@ export default class BaseStreamController
     }
   }
 
+  protected get timelineOffset(): number {
+    const configuredTimelineOffset = this.config.timelineOffset;
+    if (configuredTimelineOffset) {
+      return (
+        this.getLevelDetails()?.appliedTimelineOffset ||
+        configuredTimelineOffset
+      );
+    }
+    return 0;
+  }
+
   protected onMediaAttached(
     event: Events.MEDIA_ATTACHED,
     data: MediaAttachedData,
@@ -1672,6 +1683,7 @@ export default class BaseStreamController
     if (startPosition < sliding) {
       startPosition = -1;
     }
+    const timelineOffset = this.timelineOffset;
     if (startPosition === -1) {
       // Use Playlist EXT-X-START:TIME-OFFSET when set
       // Prioritize Multivariant Playlist offset so that main, audio, and subtitle stream-controller start times match
@@ -1706,9 +1718,9 @@ export default class BaseStreamController
         this.log(`setting startPosition to 0 by default`);
         this.startPosition = startPosition = 0;
       }
-      this.lastCurrentTime = startPosition;
+      this.lastCurrentTime = startPosition + timelineOffset;
     }
-    this.nextLoadPosition = startPosition;
+    this.nextLoadPosition = startPosition + timelineOffset;
   }
 
   protected getLoadPosition(): number {

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -2078,7 +2078,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))}`,
     const selectedAudio = primary.audioTracks[primary.audioTrack];
     const selectedSubtitle = primary.subtitleTracks[primary.subtitleTrack];
     let startPosition = 0;
-    if (this.primaryLive) {
+    if (this.primaryLive || interstitial.appendInPlace) {
       const timePastStart = this.timelinePos - assetItem.timelineStart;
       if (timePastStart > 1) {
         const duration = assetItem.duration;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -176,7 +176,8 @@ export default class StreamController
         startPosition = lastCurrentTime;
       }
       this.state = State.IDLE;
-      this.nextLoadPosition = this.lastCurrentTime = startPosition;
+      this.nextLoadPosition = this.lastCurrentTime =
+        startPosition + this.timelineOffset;
       this.startPosition = skipSeekToStartPosition ? -1 : startPosition;
       this.tick();
     } else {
@@ -1105,13 +1106,11 @@ export default class StreamController
       }
 
       // Offset start position by timeline offset
-      const details = this.getLevelDetails();
-      const configuredTimelineOffset = this.config.timelineOffset;
-      if (configuredTimelineOffset && startPosition) {
-        startPosition +=
-          details?.appliedTimelineOffset || configuredTimelineOffset;
+      const timelineOffset = this.timelineOffset;
+      if (timelineOffset && startPosition) {
+        startPosition += timelineOffset;
       }
-
+      const details = this.getLevelDetails();
       const buffered = BufferHelper.getBuffered(media);
       const bufferStart = buffered.length ? buffered.start(0) : 0;
       const delta = bufferStart - startPosition;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -251,7 +251,9 @@ export default class StreamController
     // exit loop, as we either need more info (level not parsed) or we need media to be attached to load new fragment
     if (
       levelLastLoaded === null ||
-      (!media && (this.startFragRequested || !hls.config.startFragPrefetch))
+      (!media &&
+        !this.primaryPrefetch &&
+        (this.startFragRequested || !hls.config.startFragPrefetch))
     ) {
       return;
     }

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -94,16 +94,15 @@ export class SubtitleStreamController
     hls.off(Events.BUFFER_FLUSHING, this.onBufferFlushing, this);
   }
 
-  startLoad(startPosition: number) {
+  startLoad(startPosition: number, skipSeekToStartPosition?: boolean) {
     this.stopLoad();
     this.state = State.IDLE;
 
     this.setInterval(TICK_INTERVAL);
 
-    this.nextLoadPosition =
-      this.startPosition =
-      this.lastCurrentTime =
-        startPosition;
+    this.nextLoadPosition = this.lastCurrentTime =
+      startPosition + this.timelineOffset;
+    this.startPosition = skipSeekToStartPosition ? -1 : startPosition;
 
     this.tick();
   }

--- a/src/loader/interstitial-asset-list.ts
+++ b/src/loader/interstitial-asset-list.ts
@@ -31,7 +31,7 @@ export class AssetListLoader {
 
   loadAssetList(
     interstitial: InterstitialEventWithAssetList,
-    liveStartPosition: number,
+    hlsStartOffset: number | undefined,
   ): Loader<LoaderContext> | undefined {
     const assetListUrl = interstitial.assetListUrl;
     let url: URL;
@@ -51,18 +51,8 @@ export class AssetListLoader {
       this.hls.trigger(Events.ERROR, errorData);
       return;
     }
-    if (
-      liveStartPosition &&
-      !(interstitial.cue.pre || interstitial.cue.post) &&
-      url.protocol !== 'data:'
-    ) {
-      const startOffset = liveStartPosition - interstitial.startTime;
-      if (startOffset > 0) {
-        url.searchParams.set(
-          '_HLS_start_offset',
-          '' + Math.round(startOffset * 1000) / 1000,
-        );
-      }
+    if (hlsStartOffset && url.protocol !== 'data:') {
+      url.searchParams.set('_HLS_start_offset', '' + hlsStartOffset);
     }
     const config = this.hls.config;
     const Loader = config.loader;

--- a/tests/unit/utils/mock-media.ts
+++ b/tests/unit/utils/mock-media.ts
@@ -101,18 +101,31 @@ export class MockSourceBuffer extends EventTarget {
 }
 export class MockMediaElement extends EventTarget {
   private __src: string = '';
-  public currentTime: number = 0;
+  private __currentTime: number = 0;
   public duration: number = Infinity;
   public textTracks: any[] = [];
+
+  __timeUpdate(value: number) {
+    this.__currentTime = value;
+    this.dispatchEvent(new Event('timeupdate'));
+  }
+
+  get currentTime(): number {
+    return this.__currentTime;
+  }
+  set currentTime(value: number) {
+    this.__currentTime = value;
+    this.dispatchEvent(new Event('seeking'));
+  }
   get src(): string {
     return this.__src;
   }
   set src(value: string) {
     this.__src = value;
-    this.currentTime = 0;
+    this.__currentTime = 0;
   }
   load() {
-    this.currentTime = 0;
+    this.__currentTime = 0;
   }
   play() {
     return Promise.resolve();


### PR DESCRIPTION
### This PR will...
- Share MediaSource between primary and asset players when aligned at start (live w/ interstitials w/ video)
- Fix prefetching primary segments during detached playback of interstitials
- Fix prefetching asset segments at live start (first playlist segments were always prefetched)
- Handle shortened asset-list result

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #7117

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
