### PR TITLE
Export `M3U8Parser` for external use

### DIFF
--- a/src/exports-named.ts
+++ b/src/exports-named.ts
@@ -12,6 +12,7 @@ import ErrorController from './controller/error-controller';
 import FPSController from './controller/fps-controller';
 import SubtitleTrackController from './controller/subtitle-track-controller';
 import Hls from './hls';
+import M3U8Parser from './loader/m3u8-parser';
 import Cues from './utils/cues';
 import FetchLoader from './utils/fetch-loader';
 import XhrLoader from './utils/xhr-loader';
@@ -36,6 +37,7 @@ export {
   XhrLoader,
   FetchLoader,
   Cues,
+  M3U8Parser,
 };
 
 export { Events } from './events';


### PR DESCRIPTION
This PR exports `M3U8Parser` and makes it available for use outside of this libraries without relying on external packages for parsing playlists. The motivation for this is detailed in https://github.com/video-dev/hls.js/issues/2183. The change follows @robwalch's recommendation from https://github.com/video-dev/hls.js/issues/2183#issuecomment-1836864069.

### Are there any points in the code the reviewer needs to double check?

Is there a need to update any documentation?

### Resolves issues:

Closes https://github.com/video-dev/hls.js/issues/2183.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
