### PR TITLE
fix: xboxone keyStatuses.forEach callback not work well

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -921,6 +921,13 @@ class EMEController extends Logger implements ComponentAPI {
   private onKeyStatusChange(mediaKeySessionContext: MediaKeySessionContext) {
     mediaKeySessionContext.mediaKeysSession.keyStatuses.forEach(
       (status: MediaKeyStatus, keyId: BufferSource) => {
+        // keyStatuses.forEach is not standard API so the callback value looks weird on xboxone
+        // xboxone callback(keyId, status) so we need to exchange them
+        if (typeof keyId === 'string' && typeof status === 'object') {
+          const temp = keyId;
+          keyId = status;
+          status = temp;
+        }
         this.log(
           `key status change "${status}" for keyStatuses keyId: ${Hex.hexDump(
             'buffer' in keyId


### PR DESCRIPTION
### This PR will...

We are going to fix a compatibility issue of `mediaKeysSession.keyStatuses.forEach` on Xbox One devices.

![WX20250401-115900@2x](https://github.com/user-attachments/assets/8fd5f609-319a-43c5-87f0-f21643663d47)
When we debug Xbox One devices, we found an error thrown in the line https://github.com/video-dev/hls.js/blob/master/src/controller/eme-controller.ts#L926

In fact, we noticed the callback arguments are a little different from Chrome. The first argument is the `keyed` object, and the second one is the `status` string. So, I add some special code to switch them. 



### Why is this Pull Request needed?

it will make Xbox One device work as our epxcted.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
