### PR TITLE
Warn on muxed mp4 with alt-audio

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1226,6 +1226,9 @@ export default class StreamController
 
     // Avoid buffering if backtracking this fragment
     if (video && details) {
+      if (!audio && video.type === 'audiovideo') {
+        this.logMuxedErr(frag);
+      }
       const prevFrag = details.fragments[frag.sn - 1 - details.startSN];
       const isFirstFragment = frag.sn === details.startSN;
       const isFirstInDiscontinuity = !prevFrag || frag.cc > prevFrag.cc;
@@ -1351,6 +1354,12 @@ export default class StreamController
     }
   }
 
+  private logMuxedErr(frag: Fragment) {
+    this.warn(
+      `${isMediaFragment(frag) ? 'Media' : 'Init'} segment with muxed audiovideo where only video expected: ${frag.url}`,
+    );
+  }
+
   private _bufferInitSegment(
     currentLevel: Level,
     tracks: TrackSet,
@@ -1366,6 +1375,9 @@ export default class StreamController
     // if audio track is expected to come from audio stream controller, discard any coming from main
     if (this.altAudio && !this.audioOnly) {
       delete tracks.audio;
+      if (tracks.audiovideo) {
+        this.logMuxedErr(frag);
+      }
     }
     // include levelCodec in audio and video tracks
     const { audio, video, audiovideo } = tracks;


### PR DESCRIPTION
### This PR will...
Warn when parsed init and media segments contain audio and video tracks but they are expected to only contain video.

### Why is this Pull Request needed?
HLS.js does not demux fragmented mp4.

### Are there any points in the code the reviewer needs to double check?
Replacing the parsed "audiovideo" result and stripping out audio codecs might get some media to play in Safari, but MSE video SourceBuffers should not be expected to drop audio samples in muxed appends.

### Resolves issues:
Related to #7142


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
