### PR TITLE
Support disabling alternate audio with config

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -259,7 +259,7 @@ export default class BufferController extends Logger implements ComponentAPI {
     // in case alt audio is not used, only one BUFFER_CODEC event will be fired from main stream controller
     // it will contain the expected nb of source buffers, no need to compute it
     let codecEvents: number = 2;
-    if ((data.audio && !data.video) || !data.altAudio || !__USE_ALT_AUDIO__) {
+    if ((data.audio && !data.video) || !data.altAudio) {
       codecEvents = 1;
     }
     this.bufferCodecEventsTotal = codecEvents;

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -390,6 +390,10 @@ export default class LevelController extends BasePlaylistController {
     // Audio is only alternate if manifest include a URI along with the audio group tag,
     // and this is not an audio-only stream where levels contain audio-only
     const audioOnly = audioCodecFound && !videoCodecFound;
+    const config = this.hls.config;
+    const altAudioEnabled = !!(
+      config.audioStreamController && config.audioTrackController
+    );
     const edata: ManifestParsedData = {
       levels,
       audioTracks,
@@ -400,7 +404,8 @@ export default class LevelController extends BasePlaylistController {
       stats: data.stats,
       audio: audioCodecFound,
       video: videoCodecFound,
-      altAudio: !audioOnly && audioTracks.some((t) => !!t.url),
+      altAudio:
+        altAudioEnabled && !audioOnly && audioTracks.some((t) => !!t.url),
     };
     this.hls.trigger(Events.MANIFEST_PARSED, edata);
   }


### PR DESCRIPTION
### This PR will...
Ignore alternate audio when audio controller class config options are null

### Why is this Pull Request needed?
This is already supported via build flags. When the same config changes are made without using build flags, the buffer controller logic should follow.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#7145

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
