### PR TITLE
Do not skip loading of parts that were previously buffered

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -247,7 +247,8 @@ export class FragmentTracker implements ComponentAPI {
     if (!activeParts) {
       return;
     }
-    this.activePartLists[levelType] = activeParts.filter(
+    this.activePartLists[levelType] = filterParts(
+      activeParts,
       (part) => part.fragment.sn >= snToKeep,
     );
   }
@@ -507,7 +508,8 @@ export class FragmentTracker implements ComponentAPI {
     const activeParts = this.activePartLists[fragment.type];
     if (activeParts) {
       const snToRemove = fragment.sn;
-      this.activePartLists[fragment.type] = activeParts.filter(
+      this.activePartLists[fragment.type] = filterParts(
+        activeParts,
         (part) => part.fragment.sn !== snToRemove,
       );
     }
@@ -541,4 +543,14 @@ function isPartial(fragmentEntity: FragmentEntity): boolean {
 
 function getFragmentKey(fragment: Fragment): string {
   return `${fragment.type}_${fragment.level}_${fragment.sn}`;
+}
+
+function filterParts(partList: Part[], predicate: (part: Part) => boolean) {
+  return partList.filter((part) => {
+    const keep = predicate(part);
+    if (!keep) {
+      part.clearElementaryStreamInfo();
+    }
+    return keep;
+  });
 }


### PR DESCRIPTION
### This PR will...
Fix clearing of part loaded status.

### Why is this Pull Request needed?
Parts that were previously buffered return true when querying `part.loaded` because `elementaryStream` data was not removed. This prevented the reloading of parts that was previously appended and removed from the buffer.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #7165

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
