### PR TITLE
Fix live "discontinuity sequence mismatch" regression

### DIFF
--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -168,13 +168,15 @@ export function mergeDetails(
     oldDetails,
     newDetails,
     (oldFrag, newFrag, newFragIndex, newFragments) => {
-      if (newDetails.skippedSegments) {
-        if (newFrag.cc !== oldFrag.cc) {
-          const ccOffset = oldFrag.cc - newFrag.cc;
-          for (let i = newFragIndex; i < newFragments.length; i++) {
-            newFragments[i].cc += ccOffset;
-          }
+      if (!newDetails.startCC && newFrag.cc !== oldFrag.cc) {
+        const ccOffset = oldFrag.cc - newFrag.cc;
+        for (let i = newFragIndex; i < newFragments.length; i++) {
+          newFragments[i].cc += ccOffset;
         }
+        newDetails.startCC =
+          getFragmentWithSN(oldDetails, newDetails.startSN - 1)?.cc ??
+          newFragments[0].cc;
+        newDetails.endCC = newFragments[newFragments.length - 1].cc;
       }
       if (
         Number.isFinite(oldFrag.startPTS) &&
@@ -523,7 +525,7 @@ export function computeReloadInterval(
 export function getFragmentWithSN(
   details: LevelDetails | undefined,
   sn: number,
-  fragCurrent: Fragment | null,
+  fragCurrent?: Fragment | null,
 ): MediaFragment | null {
   if (!details) {
     return null;


### PR DESCRIPTION
### This PR will...
Fix regression in live playlist updates containing discontinuities but missing DISCONTINUITY-SEQUENCE

### Why is this Pull Request needed?
Validation of discontinuity sequence mismatch produced parsing errors where previously there were none. While discontinuity sequences (Fragment `cc` indexes) were not being properly updated, this did not immediately error previously. 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7163

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
