### PR TITLE
Improve HEVC codec parsing

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -410,7 +410,8 @@ function parseStsd(stsd: Uint8Array): StsdData {
         const levelIDC = hvcCBox[12];
         const constraintIndicator = hvcCBox.subarray(6, 12);
         codec += '.' + profileSpace + generalProfileIdc;
-        codec += '.' + profileCompat.toString(16).toUpperCase();
+        codec +=
+          '.' + reverse32BitInt(profileCompat).toString(16).toUpperCase();
         codec += '.' + tierFlag + levelIDC;
         let constraintString = '';
         for (let i = constraintIndicator.length; i--; ) {
@@ -535,6 +536,14 @@ function parseSupplementalDoViCodec(
       addLeadingZero(doViLevel)
     );
   }
+}
+
+function reverse32BitInt(val: number) {
+  let result = 0;
+  for (let i = 0; i < 32; i++) {
+    result |= ((val >> i) & 1) << (32 - 1 - i);
+  }
+  return result >>> 0;
 }
 
 function skipBERInteger(bytes: Uint8Array, i: number): number {


### PR DESCRIPTION
### This PR will...
Improve HEVC codec parsing by writing profile compatibility flag in reverse bit order. 

### Why is this Pull Request needed?
The codec string parsed from hvcC boxes in mp4 init segments contained extra zeros (noticed in #7114). This change fixes the issue:

before `"hvc1.1.60000000.L150"` and after `"hvc1.1.6.L150"`

### Are there any points in the code the reviewer needs to double check?
This does not appear to have impacted support checks or SourceBuffer creation on most platforms. Of the issues where these media parsed codecs were noted, none of the failures were a result of the codec string parsing as far as I know.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
