### PR TITLE
Fix appending of Interstitials in place that exceed X-PLAYOUT-LIMIT

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2129,6 +2129,8 @@ export default Hls;
 export class HlsAssetPlayer {
     constructor(HlsPlayerClass: typeof Hls, userConfig: Partial<HlsConfig>, interstitial: InterstitialEvent, assetItem: InterstitialAssetItem);
     // (undocumented)
+    get appendInPlace(): boolean;
+    // (undocumented)
     get assetId(): InterstitialAssetId;
     // (undocumented)
     readonly assetItem: InterstitialAssetItem;


### PR DESCRIPTION
### This PR will...
Limit append-in-place buffering to playout-limit.

### Why is this Pull Request needed?
Buffering of interstitial assets was not stopped when the forward buffer past X-PLAYOUT-LIMIT. This is expected when each asset player resets the media source and X-PLAYOUT-LIMIT is enforced by monitoring currentTime.

When all assets are appended in place, sharing a single MediaSource, buffering must stop after reaching or exceeding the playout limit, so that the MediaSource can be transferred to the hls instance responsible for buffering the next scheduled segment.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7179

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
