### PR TITLE
Allow removing TextTracks created by hls.js

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3918,7 +3918,6 @@ export interface MediaKeySessionContext {
 export type MediaOverrides = {
     duration?: number;
     endOfStream?: boolean;
-    cueRemoval?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "MediaPlaylist" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3959,6 +3958,8 @@ export interface MediaPlaylist {
     name: string;
     // (undocumented)
     textCodec?: string;
+    // (undocumented)
+    trackNode?: HTMLTrackElement;
     // (undocumented)
     type: MediaPlaylistType | 'main';
     // (undocumented)
@@ -4583,9 +4584,9 @@ export class SubtitleTrackController extends BasePlaylistController {
     // (undocumented)
     protected onManifestParsed(event: Events.MANIFEST_PARSED, data: ManifestParsedData): void;
     // (undocumented)
-    protected onMediaAttached(event: Events.MEDIA_ATTACHED, data: MediaAttachedData): void;
+    protected onMediaAttaching(event: Events.MEDIA_ATTACHING, data: MediaAttachedData): void;
     // (undocumented)
-    protected onMediaDetaching(event: Events.MEDIA_DETACHING, data: MediaDetachingData): void;
+    protected onMediaDetached(event: Events.MEDIA_DETACHED, data: MediaDetachingData): void;
     // (undocumented)
     protected onSubtitleTrackLoaded(event: Events.SUBTITLE_TRACK_LOADED, data: TrackLoadedData): void;
     // (undocumented)

--- a/demo/main.js
+++ b/demo/main.js
@@ -43,7 +43,7 @@ let stopOnStall = getDemoConfigPropOrDefault('stopOnStall', false);
 let bufferingIdx = -1;
 let selectedTestStream = null;
 
-let video = document.querySelector('#video');
+const video = document.querySelector('#video');
 const startTime = Date.now();
 
 let lastSeekingIdx;
@@ -222,6 +222,7 @@ $(document).ready(function () {
   $('#metricsButtonWindow').toggle(self.windowSliding);
   $('#metricsButtonFixed').toggle(!self.windowSliding);
 
+  addVideoEventListeners(video);
   loadSelectedStream();
 
   let tabIndexesCSV = localStorage.getItem(STORAGE_KEYS.demo_tabs);
@@ -353,32 +354,7 @@ function loadSelectedStream() {
 
   logStatus('Loading manifest and attaching video element...');
 
-  const expiredTracks = [].filter.call(
-    video.textTracks,
-    (track) => track.kind !== 'metadata'
-  );
-  if (expiredTracks.length) {
-    const kinds = expiredTracks
-      .map((track) => track.kind)
-      .filter((kind, index, self) => self.indexOf(kind) === index);
-    logStatus(
-      `Replacing video element to remove ${kinds.join(' and ')} text tracks`
-    );
-    const videoWithExpiredTextTracks = video;
-    video = videoWithExpiredTextTracks.cloneNode(false);
-    video.removeAttribute('src');
-    video.volume = videoWithExpiredTextTracks.volume;
-    video.muted = videoWithExpiredTextTracks.muted;
-    videoWithExpiredTextTracks.parentNode.insertBefore(
-      video,
-      videoWithExpiredTextTracks
-    );
-    videoWithExpiredTextTracks.parentNode.removeChild(
-      videoWithExpiredTextTracks
-    );
-  }
   addChartEventListeners(hls);
-  addVideoEventListeners(video);
 
   hls.loadSource(url);
   hls.autoLevelCapping = levelCapping;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -540,8 +540,6 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       }
       this.media = null;
     }
-
-    this.hls.trigger(Events.MEDIA_DETACHED, data);
   }
 
   private onBufferReset() {

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -834,7 +834,6 @@ export default class InterstitialsController
       dataToAttach.overrides = {
         duration: this.schedule.duration,
         endOfStream: !isAssetPlayer || isAssetAtEndOfSchedule,
-        cueRemoval: !isAssetPlayer,
       };
     }
     player.attachMedia(dataToAttach);

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -2,18 +2,13 @@ import { Events } from '../events';
 import { PlaylistLevelType } from '../types/loader';
 import Cea608Parser from '../utils/cea-608-parser';
 import { IMSC1_CODEC, parseIMSC1 } from '../utils/imsc1-ttml-parser';
-import {
-  subtitleOptionsIdentical,
-  subtitleTrackMatchesTextTrack,
-} from '../utils/media-option-attributes';
+import { subtitleOptionsIdentical } from '../utils/media-option-attributes';
 import { appendUint8Array } from '../utils/mp4-tools';
 import OutputFilter from '../utils/output-filter';
 import {
   addCueToTrack,
-  clearCurrentCues,
-  filterSubtitleTracks,
+  createTrackNode,
   removeCuesInRange,
-  sendAddTrackEvent,
 } from '../utils/texttrack-utils';
 import { parseWebVTT } from '../utils/webvtt-parser';
 import type { HlsConfig } from '../config';
@@ -59,11 +54,10 @@ export class TimelineController implements ComponentAPI {
   private config: HlsConfig;
   private enabled: boolean = true;
   private Cues: CuesInterface;
-  private textTracks: Array<TextTrack> = [];
   private tracks: Array<MediaPlaylist> = [];
   private initPTS: RationalTimestamp[] = [];
   private unparsedVttFrags: Array<FragLoadedData | FragDecryptedData> = [];
-  private captionsTracks: Record<string, TextTrack> = {};
+  private captionsTracks: Record<string, HTMLTrackElement> = {};
   private nonNativeCaptionsTracks: Record<string, NonNativeCaptionsTrack> = {};
   private cea608Parser1?: Cea608Parser;
   private cea608Parser2?: Cea608Parser;
@@ -103,7 +97,7 @@ export class TimelineController implements ComponentAPI {
       },
     };
 
-    hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
+    hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.MANIFEST_LOADED, this.onManifestLoaded, this);
@@ -119,7 +113,7 @@ export class TimelineController implements ComponentAPI {
 
   public destroy(): void {
     const { hls } = this;
-    hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
+    hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
     hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.MANIFEST_LOADED, this.onManifestLoaded, this);
@@ -176,7 +170,7 @@ export class TimelineController implements ComponentAPI {
     }
 
     if (this.config.renderTextTracksNatively) {
-      const track = this.captionsTracks[trackName];
+      const track = this.captionsTracks[trackName].track;
       this.Cues.newCue(track, startTime, endTime, screen);
     } else {
       const cues = this.Cues.newCue(null, startTime, endTime, screen);
@@ -208,27 +202,6 @@ export class TimelineController implements ComponentAPI {
     }
   }
 
-  private getExistingTrack(label: string, language: string): TextTrack | null {
-    const { media } = this;
-    if (media) {
-      for (let i = 0; i < media.textTracks.length; i++) {
-        const textTrack = media.textTracks[i];
-        if (
-          canReuseVttTextTrack(textTrack, {
-            name: label,
-            lang: language,
-            characteristics:
-              'transcribes-spoken-dialog,describes-music-and-sound',
-            attrs: {} as any,
-          })
-        ) {
-          return textTrack;
-        }
-      }
-    }
-    return null;
-  }
-
   public createCaptionsTrack(trackName: string) {
     if (this.config.renderTextTracksNatively) {
       this.createNativeTrack(trackName);
@@ -241,21 +214,17 @@ export class TimelineController implements ComponentAPI {
     if (this.captionsTracks[trackName]) {
       return;
     }
-    const { captionsProperties, captionsTracks, media } = this;
+    const { captionsProperties, captionsTracks } = this;
     const { label, languageCode } = captionsProperties[trackName];
-    // Enable reuse of existing text track.
-    const existingTrack = this.getExistingTrack(label, languageCode);
-    if (!existingTrack) {
-      const textTrack = this.createTextTrack('captions', label, languageCode);
-      if (textTrack) {
-        // Set a special property on the track so we know it's managed by Hls.js
-        textTrack[trackName] = true;
-        captionsTracks[trackName] = textTrack;
-      }
-    } else {
-      captionsTracks[trackName] = existingTrack;
-      clearCurrentCues(captionsTracks[trackName]);
-      sendAddTrackEvent(captionsTracks[trackName], media as HTMLMediaElement);
+    const media = this.media;
+    if (media) {
+      captionsTracks[trackName] = createTrackNode(
+        media,
+        'captions',
+        label,
+        languageCode,
+        true,
+      );
     }
   }
 
@@ -280,43 +249,43 @@ export class TimelineController implements ComponentAPI {
     this.hls.trigger(Events.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [track] });
   }
 
-  private createTextTrack(
-    kind: TextTrackKind,
-    label: string,
-    lang?: string,
-  ): TextTrack | undefined {
-    const media = this.media;
-    if (!media) {
-      return;
-    }
-    return media.addTextTrack(kind, label, lang);
-  }
-
-  private onMediaAttaching(
-    event: Events.MEDIA_ATTACHING,
+  // should be called after SubtitleTrackController.onMediaAttaching
+  private onMediaAttached(
+    event: Events.MEDIA_ATTACHED,
     data: MediaAttachingData,
   ) {
-    this.media = data.media;
-    if (!data.mediaSource) {
-      this._cleanTracks();
+    const media = data.media;
+    this.media = media;
+    if (this.config.renderTextTracksNatively) {
+      for (const track of this.tracks) {
+        media.appendChild(track.trackNode!);
+      }
     }
   }
 
+  // should be called before SubtitleTrackController.onMediaDetached
   private onMediaDetaching(
     event: Events.MEDIA_DETACHING,
     data: MediaDetachingData,
   ) {
     const transferringMedia = !!data.transferMedia;
+    const media = this.media;
     this.media = null;
     if (transferringMedia) {
       return;
     }
 
-    const { captionsTracks } = this;
-    Object.keys(captionsTracks).forEach((trackName) => {
-      clearCurrentCues(captionsTracks[trackName]);
-      delete captionsTracks[trackName];
-    });
+    if (media && this.config.renderTextTracksNatively) {
+      for (const track of this.tracks) {
+        media.removeChild(track.trackNode!);
+      }
+      const { captionsTracks } = this;
+      for (const trackName in captionsTracks) {
+        const trackNode = captionsTracks[trackName];
+        media.removeChild(trackNode);
+      }
+    }
+    this.captionsTracks = {};
     this.nonNativeCaptionsTracks = {};
   }
 
@@ -328,31 +297,14 @@ export class TimelineController implements ComponentAPI {
     // Detect discontinuity in subtitle manifests
     this.prevCC = -1;
     this.vttCCs = newVTTCCs();
-    // Reset tracks
-    this._cleanTracks();
     this.tracks = [];
     this.captionsTracks = {};
     this.nonNativeCaptionsTracks = {};
-    this.textTracks = [];
     this.unparsedVttFrags = [];
     this.initPTS = [];
     if (this.cea608Parser1 && this.cea608Parser2) {
       this.cea608Parser1.reset();
       this.cea608Parser2.reset();
-    }
-  }
-
-  private _cleanTracks() {
-    // clear outdated subtitles
-    const { media } = this;
-    if (!media) {
-      return;
-    }
-    const textTracks = media.textTracks;
-    if (textTracks) {
-      for (let i = 0; i < textTracks.length; i++) {
-        clearCurrentCues(textTracks[i]);
-      }
     }
   }
 
@@ -368,67 +320,24 @@ export class TimelineController implements ComponentAPI {
         this.tracks = tracks;
         return;
       }
-      this.textTracks = [];
-      this.tracks = tracks;
 
       if (this.config.renderTextTracksNatively) {
         const media = this.media;
-        const inUseTracks: (TextTrack | null)[] | null = media
-          ? filterSubtitleTracks(media.textTracks)
-          : null;
-
-        this.tracks.forEach((track, index) => {
-          // Reuse tracks with the same label and lang, but do not reuse 608/708 tracks
-          let textTrack: TextTrack | undefined;
-          if (inUseTracks) {
-            let inUseTrack: TextTrack | null = null;
-            for (let i = 0; i < inUseTracks.length; i++) {
-              if (
-                inUseTracks[i] &&
-                canReuseVttTextTrack(inUseTracks[i], track)
-              ) {
-                inUseTrack = inUseTracks[i];
-                inUseTracks[i] = null;
-                break;
-              }
-            }
-            if (inUseTrack) {
-              textTrack = inUseTrack;
+        if (media) {
+          for (const track of this.tracks) {
+            if (!tracks.includes(track)) {
+              media.removeChild(track.trackNode!);
             }
           }
-          if (textTrack) {
-            clearCurrentCues(textTrack);
-          } else {
-            const textTrackKind = captionsOrSubtitlesFromCharacteristics(track);
-            textTrack = this.createTextTrack(
-              textTrackKind,
-              track.name,
-              track.lang,
-            );
-            if (textTrack) {
-              textTrack.mode = 'disabled';
+          for (const track of tracks) {
+            if (track.trackNode!.parentNode !== media) {
+              media.appendChild(track.trackNode!);
             }
-          }
-          if (textTrack) {
-            this.textTracks.push(textTrack);
-          }
-        });
-        // Warn when video element has captions or subtitle TextTracks carried over from another source
-        if (inUseTracks?.length) {
-          const unusedTextTracks = inUseTracks
-            .filter((t) => t !== null)
-            .map((t) => (t as TextTrack).label);
-          if (unusedTextTracks.length) {
-            this.hls.logger.warn(
-              `Media element contains unused subtitle tracks: ${unusedTextTracks.join(
-                ', ',
-              )}. Replace media element for each source to clear TextTracks and captions menu.`,
-            );
           }
         }
-      } else if (this.tracks.length) {
+      } else if (tracks.length) {
         // Create a list of tracks for the provider to consume
-        const tracksList = this.tracks.map((track) => {
+        const tracksList = tracks.map((track) => {
           return {
             label: track.name,
             kind: track.type.toLowerCase(),
@@ -440,6 +349,7 @@ export class TimelineController implements ComponentAPI {
           tracks: tracksList,
         });
       }
+      this.tracks = tracks;
     }
   }
 
@@ -635,7 +545,7 @@ export class TimelineController implements ComponentAPI {
   private _appendCues(cues: VTTCue[], fragLevel: number) {
     const hls = this.hls;
     if (this.config.renderTextTracksNatively) {
-      const textTrack = this.textTracks[fragLevel];
+      const textTrack = this.tracks[fragLevel].trackNode?.track;
       // WebVTTParser.parse is an async method and if the currently selected text track mode is set to "disabled"
       // before parsing is done then don't try to access currentTrack.cues.getCueById as cues will be null
       // and trying to access getCueById method of cues will throw an exception
@@ -711,20 +621,22 @@ export class TimelineController implements ComponentAPI {
     if (!type || type === 'video') {
       const { captionsTracks } = this;
       Object.keys(captionsTracks).forEach((trackName) =>
-        removeCuesInRange(captionsTracks[trackName], startOffset, endOffset),
+        removeCuesInRange(
+          captionsTracks[trackName].track,
+          startOffset,
+          endOffset,
+        ),
       );
     }
     if (this.config.renderTextTracksNatively) {
       // Clear VTT/IMSC1 subtitle cues from the subtitle TextTracks when the back buffer is flushed
       if (startOffset === 0 && endOffsetSubtitles !== undefined) {
-        const { textTracks } = this;
-        Object.keys(textTracks).forEach((trackName) =>
-          removeCuesInRange(
-            textTracks[trackName],
-            startOffset,
-            endOffsetSubtitles,
-          ),
-        );
+        for (const track of this.tracks) {
+          const textTrack = track.trackNode?.track;
+          if (textTrack) {
+            removeCuesInRange(textTrack, startOffset, endOffsetSubtitles);
+          }
+        }
       }
     }
   }
@@ -756,35 +668,6 @@ export class TimelineController implements ComponentAPI {
     }
     return actualCCBytes;
   }
-}
-
-function captionsOrSubtitlesFromCharacteristics(
-  track: Pick<MediaPlaylist, 'name' | 'lang' | 'attrs' | 'characteristics'>,
-): TextTrackKind {
-  if (track.characteristics) {
-    if (
-      /transcribes-spoken-dialog/gi.test(track.characteristics) &&
-      /describes-music-and-sound/gi.test(track.characteristics)
-    ) {
-      return 'captions';
-    }
-  }
-
-  return 'subtitles';
-}
-
-function canReuseVttTextTrack(
-  inUseTrack: TextTrack | null,
-  manifestTrack: Pick<
-    MediaPlaylist,
-    'name' | 'lang' | 'attrs' | 'characteristics'
-  >,
-): boolean {
-  return (
-    !!inUseTrack &&
-    inUseTrack.kind === captionsOrSubtitlesFromCharacteristics(manifestTrack) &&
-    subtitleTrackMatchesTextTrack(manifestTrack, inUseTrack)
-  );
 }
 
 function intersection(x1: number, x2: number, y1: number, y2: number): number {

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -476,8 +476,10 @@ export default class Hls implements HlsEventEmitter {
    */
   detachMedia() {
     this.logger.log('detachMedia');
-    this.trigger(Events.MEDIA_DETACHING, {});
+    const data = {};
+    this.trigger(Events.MEDIA_DETACHING, data);
     this._media = null;
+    this.trigger(Events.MEDIA_DETACHED, data);
   }
 
   /**
@@ -486,7 +488,9 @@ export default class Hls implements HlsEventEmitter {
   transferMedia(): AttachMediaSourceData | null {
     this._media = null;
     const transferMedia = this.bufferController.transferMedia();
-    this.trigger(Events.MEDIA_DETACHING, { transferMedia });
+    const data = { transferMedia };
+    this.trigger(Events.MEDIA_DETACHING, data);
+    this.trigger(Events.MEDIA_DETACHED, data);
     return transferMedia;
   }
 

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -73,7 +73,6 @@ export type SourceBuffersTuple = [
 export type MediaOverrides = {
   duration?: number;
   endOfStream?: boolean;
-  cueRemoval?: boolean;
 };
 
 export interface BufferOperationQueues {

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -70,6 +70,8 @@ export interface MediaPlaylist {
   url: string;
   videoCodec?: string;
   width?: number;
+  // keep a reference to the track node that is associated with this MediaPlaylist
+  trackNode?: HTMLTrackElement;
 }
 
 export interface MediaAttributes extends AttrList {

--- a/src/utils/media-option-attributes.ts
+++ b/src/utils/media-option-attributes.ts
@@ -47,15 +47,3 @@ export function mediaAttributesIdentical(
       attrs1[subtitleAttribute] !== attrs2[subtitleAttribute],
   );
 }
-
-export function subtitleTrackMatchesTextTrack(
-  subtitleTrack: Pick<MediaPlaylist, 'name' | 'lang' | 'attrs'>,
-  textTrack: TextTrack,
-) {
-  return (
-    textTrack.label.toLowerCase() === subtitleTrack.name.toLowerCase() &&
-    (!textTrack.language ||
-      textTrack.language.toLowerCase() ===
-        (subtitleTrack.lang || '').toLowerCase())
-  );
-}

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -1,16 +1,45 @@
 import { logger } from './logger';
 
-export function sendAddTrackEvent(track: TextTrack, videoEl: HTMLMediaElement) {
-  let event: Event;
-  try {
-    event = new Event('addtrack');
-  } catch (err) {
-    // for IE11
-    event = document.createEvent('Event');
-    event.initEvent('addtrack', false, false);
+// This is a replacement of the native addTextTrack method.
+// TextTracks created by the native method are unremovable since their livecycles
+// are neither related to the current media nor managed by user code.
+export function createTrackNode(
+  videoEl: HTMLMediaElement,
+  kind: TextTrackKind,
+  label: string,
+  lang?: string,
+  append: boolean = false,
+): HTMLTrackElement {
+  const el = videoEl.ownerDocument.createElement('track');
+  el.kind = kind;
+  el.label = label;
+  if (lang) {
+    el.srclang = lang;
   }
-  (event as any).track = track;
-  videoEl.dispatchEvent(event);
+  // To avoid an issue of the built-in captions menu in Chrome
+  if (navigator.userAgent.includes('Chrome/')) {
+    el.src = 'data:,WEBVTT';
+  }
+  el.track.mode = 'disabled';
+  if (append) {
+    videoEl.appendChild(el);
+  }
+  return el;
+}
+
+export function captionsOrSubtitlesFromCharacteristics(
+  characteristics?: string,
+): TextTrackKind {
+  if (characteristics) {
+    if (
+      /transcribes-spoken-dialog/gi.test(characteristics) &&
+      /describes-music-and-sound/gi.test(characteristics)
+    ) {
+      return 'captions';
+    }
+  }
+
+  return 'subtitles';
 }
 
 export function addCueToTrack(track: TextTrack, cue: VTTCue) {
@@ -42,27 +71,6 @@ export function addCueToTrack(track: TextTrack, cue: VTTCue) {
           `[texttrack-utils]: Legacy TextTrackCue fallback failed: ${err2}`,
         );
       }
-    }
-  }
-  if (mode === 'disabled') {
-    track.mode = mode;
-  }
-}
-
-export function clearCurrentCues(track: TextTrack, enterHandler?: () => void) {
-  // When track.mode is disabled, track.cues will be null.
-  // To guarantee the removal of cues, we need to temporarily
-  // change the mode to hidden
-  const mode = track.mode;
-  if (mode === 'disabled') {
-    track.mode = 'hidden';
-  }
-  if (track.cues) {
-    for (let i = track.cues.length; i--; ) {
-      if (enterHandler) {
-        track.cues[i].removeEventListener('enter', enterHandler);
-      }
-      track.removeCue(track.cues[i]);
     }
   }
   if (mode === 'disabled') {
@@ -150,21 +158,4 @@ export function getCuesInRange(
     }
   }
   return cuesFound;
-}
-
-export function filterSubtitleTracks(
-  textTrackList: TextTrackList,
-): TextTrack[] {
-  const tracks: TextTrack[] = [];
-  for (let i = 0; i < textTrackList.length; i++) {
-    const track = textTrackList[i];
-    // Edge adds a track without a label; we don't want to use it
-    if (
-      (track.kind === 'subtitles' || track.kind === 'captions') &&
-      track.label
-    ) {
-      tracks.push(textTrackList[i]);
-    }
-  }
-  return tracks;
 }

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1139,6 +1139,7 @@ fileSequence5.mp4`;
         Events.INTERSTITIAL_STARTED,
         Events.INTERSTITIAL_ASSET_STARTED,
         Events.MEDIA_DETACHING,
+        Events.MEDIA_DETACHED,
       ];
       expect(callsWithPrerollAfterAttach).to.deep.equal(
         expectedEvents,
@@ -1382,6 +1383,7 @@ fileSequence6.mp4`;
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );
@@ -1499,6 +1501,7 @@ fileSequence6.mp4`;
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );
@@ -1885,6 +1888,7 @@ fileSequence6.mp4
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );
@@ -2060,6 +2064,7 @@ fileSequence6.mp4`;
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );

--- a/tests/unit/controller/timeline-controller.js
+++ b/tests/unit/controller/timeline-controller.js
@@ -1,181 +1,57 @@
 import { TimelineController } from '../../../src/controller/timeline-controller';
 import Hls from '../../../src/hls';
 import { Events } from '../../../src/events';
+import { createTrackNode } from '../../../src/utils/texttrack-utils';
 
 describe('TimelineController', function () {
   let timelineController;
   let hls;
+  let videoElement;
 
   beforeEach(function () {
+    videoElement = document.createElement('video');
     hls = new Hls();
     hls.config.enableWebVTT = true;
-    hls.config.renderNatively = true;
+    hls.config.renderTextTracksNatively = true;
     timelineController = new TimelineController(hls);
-    timelineController.media = document.createElement('video');
+    timelineController.media = videoElement;
   });
 
-  describe('reuse text track', function () {
-    it('should reuse text track when track order is same between manifests', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(
-        Events.SUBTITLE_TRACKS_UPDATED,
-        {
-          subtitleTracks: [
-            { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
-            { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
-          ],
-        },
-      );
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].label).to.equal('en');
-      expect(timelineController.textTracks[1].label).to.equal('ru');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-
-      timelineController.onSubtitleTracksUpdated(
-        Events.SUBTITLE_TRACKS_UPDATED,
-        {
-          subtitleTracks: [
-            { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
-            { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
-          ],
-        },
-      );
-
-      // text tracks model contain only newly added manifest tracks, in same order
-      expect(timelineController.textTracks[0].label).to.equal('en');
-      expect(timelineController.textTracks[1].label).to.equal('ru');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the previously added text tracks, in same order as the manifest order
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-    });
-
-    it('should reuse text track when track order is not same between manifests', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
+  describe('removable TextTracks', function () {
+    it('should remove TextTracks in onMediaDetaching and add them again in onMediaAttached', function () {
+      const eventData = {
         subtitleTracks: [
           {
             id: 0,
             name: 'en',
-            lang: 'en',
             attrs: { LANGUAGE: 'en', NAME: 'en' },
           },
           {
             id: 1,
             name: 'ru',
-            lang: 'ru',
             attrs: { LANGUAGE: 'ru', NAME: 'ru' },
           },
         ],
+      };
+      // We have to use Object.defineProperty to set the trackNode property here
+      Object.defineProperty(eventData.subtitleTracks[0], 'trackNode', {
+        value: createTrackNode(videoElement, 'subtitles', 'en', 'en'),
       });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].label).to.equal('en');
-      expect(timelineController.textTracks[1].label).to.equal('ru');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'ru',
-            lang: 'ru',
-            attrs: { LANGUAGE: 'ru', NAME: 'ru' },
-          },
-          {
-            id: 1,
-            name: 'en',
-            lang: 'en',
-            attrs: { LANGUAGE: 'en', NAME: 'en' },
-          },
-        ],
+      Object.defineProperty(eventData.subtitleTracks[1], 'trackNode', {
+        value: createTrackNode(videoElement, 'subtitles', 'ru', 'ru'),
       });
+      timelineController.onSubtitleTracksUpdated(
+        Events.SUBTITLE_TRACKS_UPDATED,
+        eventData,
+      );
 
-      // text tracks model contain only newly added manifest tracks, in same order
-      expect(timelineController.textTracks[0].label).to.equal('ru');
-      expect(timelineController.textTracks[1].label).to.equal('en');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the previously added text tracks).to.equal(in opposite order to the manifest order
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-    });
-  });
-
-  describe('text track kind', function () {
-    it('should be kind captions when there is both transcribes-spoken-dialog and describes-music-and-sound', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-      const characteristics =
-        'public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound';
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            characteristics,
-            attrs: {
-              CHARACTERISTICS: characteristics,
-            },
-          },
-        ],
+      expect(videoElement.textTracks.length).to.equal(2);
+      timelineController.onMediaDetaching(Events.MEDIA_DETACHING, {});
+      expect(videoElement.textTracks.length).to.equal(0);
+      timelineController.onMediaAttached(Events.MEDIA_ATTACHED, {
+        media: videoElement,
       });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].kind).to.equal('captions');
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].kind).to.equal('captions');
-    });
-
-    it('should be kind subtitles when there is no describes-music-and-sound', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            attrs: {
-              CHARACTERISTICS: 'public.accessibility.transcribes-spoken-dialog',
-            },
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].kind).to.equal('subtitles');
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].kind).to.equal('subtitles');
-    });
-
-    it('should be kind subtitles when there is no CHARACTERISTICS', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            attrs: {},
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].kind).to.equal('subtitles');
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].kind).to.equal('subtitles');
+      expect(videoElement.textTracks.length).to.equal(2);
     });
   });
 });

--- a/tests/unit/utils/texttrack-utils.js
+++ b/tests/unit/utils/texttrack-utils.js
@@ -1,8 +1,4 @@
-import {
-  sendAddTrackEvent,
-  clearCurrentCues,
-} from '../../../src/utils/texttrack-utils';
-import sinon from 'sinon';
+import { removeCuesInRange } from '../../../src/utils/texttrack-utils';
 
 describe('text track utils', function () {
   const cues = [
@@ -29,42 +25,14 @@ describe('text track utils', function () {
     });
   });
 
-  describe('synthetic addtrack event', function () {
-    it('should have the provided track as data', function (done) {
-      const dispatchSpy = sinon.spy(video, 'dispatchEvent');
-      video.addEventListener('addtrack', function (e) {
-        expect(e.track).to.equal(track);
-        done();
-      });
-
-      sendAddTrackEvent(track, video);
-      expect(dispatchSpy.calledOnce).to.be.true;
-    });
-
-    it('should fallback to document.createEvent if window.Event constructor throws', function (done) {
-      const stub = sinon.stub(self, 'Event');
-      stub.throws();
-
-      const spy = sinon.spy(document, 'createEvent');
-
-      video.addEventListener('addtrack', function (e) {
-        expect(e.track).to.equal(track);
-        done();
-      });
-
-      sendAddTrackEvent(track, video);
-      expect(spy.calledOnce).to.be.true;
-    });
-  });
-
   describe('clear current cues', function () {
     it('should not fail with empty cue list', function () {
       const emptyTrack = video.addTextTrack('subtitles', 'empty');
-      expect(clearCurrentCues(emptyTrack)).to.not.throw;
+      expect(removeCuesInRange(emptyTrack, 0, 10)).to.not.throw;
     });
 
     it('should clear the cues from track', function () {
-      clearCurrentCues(track);
+      removeCuesInRange(track, 0, 10);
       expect(track.cues.length).to.equal(0);
     });
   });


### PR DESCRIPTION
Allow removing TextTracks created by hls.js
### This PR will...

- use `appendChild` instead of `addTextTrack` to allow reverse operation
- replace track flush and reuse workflow with simple removal
- add `trackNode` field in `MediaPlaylist` to indicate associated `TextTrack`
- fix `MEDIA_DETACHED` event in wrong order and sometimes not triggering

### Why is this Pull Request needed?

This PR allows video elements to have the same lifecycle as hls.js instances. After detaching, you may attach them to new hls.js instances with nothing to worry about. It also fixed a bug caused by track reuse, where content overlapping occurs if a video contains multiple captions sharing the same language and label. eg: https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8

### Are there any points in the code the reviewer needs to double check?

Yes. Since the changes involve more than one place, extensive testing from multiple aspects may be necessary to ensure no issues are left behind. Especially I'm not sure whether it works well with `transferMedia()`

### Resolves issues:
https://github.com/video-dev/hls.js/issues/2198

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md