### PR TITLE
Prevent overlapping track appends in muxed fmp4 on discontinuity

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2578,6 +2578,8 @@ export interface InitSegmentData {
     // (undocumented)
     timescale: number | undefined;
     // (undocumented)
+    trackId: number | undefined;
+    // (undocumented)
     tracks?: TrackSet;
 }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -217,6 +217,19 @@ export default class BaseStreamController
       return false;
     }
     // Stream is not "ended" when there is a second buffered range starting before the end of the playlist
+    const bufferedRanges = bufferInfo.buffered;
+    if (
+      this.config.maxBufferHole &&
+      bufferedRanges &&
+      bufferedRanges.length > 1
+    ) {
+      // make sure bufferInfo accounts for any gaps
+      bufferInfo = BufferHelper.bufferedInfo(
+        bufferedRanges,
+        bufferInfo.start,
+        0,
+      );
+    }
     const nextStart = bufferInfo.nextStart;
     const hasSecondBufferedRange =
       nextStart && nextStart > timelineStart && nextStart < levelDetails.edge;

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -354,6 +354,7 @@ export default class MP4Remuxer implements Remuxer {
     let initPTS: number | undefined;
     let initDTS: number | undefined;
     let timescale: number | undefined;
+    let trackId: number | undefined;
 
     if (computePTSDTS) {
       initPTS = initDTS = Infinity;
@@ -394,6 +395,7 @@ export default class MP4Remuxer implements Remuxer {
         },
       };
       if (computePTSDTS) {
+        trackId = audioTrack.id;
         timescale = audioTrack.inputTimeScale;
         if (!_initPTS || timescale !== _initPTS.timescale) {
           // remember first PTS of this demuxing context. for audio, PTS = DTS
@@ -420,6 +422,7 @@ export default class MP4Remuxer implements Remuxer {
         },
       };
       if (computePTSDTS) {
+        trackId = videoTrack.id;
         timescale = videoTrack.inputTimeScale;
         if (!_initPTS || timescale !== _initPTS.timescale) {
           const startPTS = this.getVideoStartPts(videoSamples);
@@ -459,6 +462,7 @@ export default class MP4Remuxer implements Remuxer {
         tracks,
         initPTS,
         timescale,
+        trackId,
       };
     }
   }

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -99,4 +99,5 @@ export interface InitSegmentData {
   tracks?: TrackSet;
   initPTS: number | undefined;
   timescale: number | undefined;
+  trackId: number | undefined;
 }

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -5,6 +5,7 @@ import { logger } from '../utils/logger';
 import type { KeySystemIds } from './mediakeys-helper';
 import type { DecryptData } from '../loader/level-key';
 import type { PassthroughTrack, UserdataSample } from '../types/demuxer';
+import type { ILogger } from '../utils/logger';
 
 const UINT32_MAX = Math.pow(2, 32) - 1;
 const push = [].push;
@@ -121,7 +122,7 @@ type SidxInfo = {
   references: any[];
 };
 
-export function parseSegmentIndex(sidx: Uint8Array): SidxInfo | null {
+function parseSegmentIndex(sidx: Uint8Array): SidxInfo | null {
   const references: any[] = [];
 
   const version = sidx[0];
@@ -620,80 +621,6 @@ export function parseSinf(sinf: Uint8Array): Uint8Array | null {
   return null;
 }
 
-/**
- * Determine the base media decode start time, in seconds, for an MP4
- * fragment. If multiple fragments are specified, the earliest time is
- * returned.
- *
- * The base media decode time can be parsed from track fragment
- * metadata:
- * ```
- * moof > traf > tfdt.baseMediaDecodeTime
- * ```
- * It requires the timescale value from the mdhd to interpret.
- *
- * @param initData - a hash of track type to timescale values
- * @param fmp4 - the bytes of the mp4 fragment
- * @returns the earliest base media decode start time for the
- * fragment, in seconds
- */
-export function getStartDTS(
-  initData: InitData,
-  fmp4: Uint8Array,
-): number | null {
-  // we need info from two children of each track fragment box
-  return findBox(fmp4, ['moof', 'traf']).reduce(
-    (result: number | null, traf) => {
-      const tfdt = findBox(traf, ['tfdt'])[0];
-      const version = tfdt[0];
-      const start = findBox(traf, ['tfhd']).reduce(
-        (result: number | null, tfhd) => {
-          // get the track id from the tfhd
-          const id = readUint32(tfhd, 4);
-          const track = initData[id];
-          if (track) {
-            let baseTime = readUint32(tfdt, 4);
-            if (version === 1) {
-              // If value is too large, assume signed 64-bit. Negative track fragment decode times are invalid, but they exist in the wild.
-              // This prevents large values from being used for initPTS, which can cause playlist sync issues.
-              // https://github.com/video-dev/hls.js/issues/5303
-              if (baseTime === UINT32_MAX) {
-                logger.warn(
-                  `[mp4-demuxer]: Ignoring assumed invalid signed 64-bit track fragment decode time`,
-                );
-                return result;
-              }
-              baseTime *= UINT32_MAX + 1;
-              baseTime += readUint32(tfdt, 8);
-            }
-            // assume a 90kHz clock if no timescale was specified
-            const scale = track.timescale || 90e3;
-            // convert base time to seconds
-            const startTime = baseTime / scale;
-            if (
-              Number.isFinite(startTime) &&
-              (result === null || startTime < result)
-            ) {
-              return startTime;
-            }
-          }
-          return result;
-        },
-        null,
-      );
-      if (
-        start !== null &&
-        Number.isFinite(start) &&
-        (result === null || start < result)
-      ) {
-        return start;
-      }
-      return result;
-    },
-    null,
-  );
-}
-
 /*
   For Reference:
   aligned(8) class TrackFragmentHeaderBox
@@ -707,10 +634,22 @@ export function getStartDTS(
      unsigned int(32)  default_sample_flags
   }
  */
-export function getDuration(data: Uint8Array, initData: InitData) {
-  let rawDuration = 0;
-  let videoDuration = 0;
-  let audioDuration = 0;
+export type TrackTimes = {
+  duration: number;
+  keyFrameIndex?: number;
+  keyFrameStart?: number;
+  start: number;
+  sampleCount: number;
+  timescale: number;
+  type: HdlrType;
+};
+
+export function getSampleData(
+  data: Uint8Array,
+  initData: InitData,
+  logger: ILogger,
+): Record<number, TrackTimes> {
+  const tracks: Record<number, TrackTimes> = {};
   const trafs = findBox(data, ['moof', 'traf']);
   for (let i = 0; i < trafs.length; i++) {
     const traf = trafs[i];
@@ -725,41 +664,140 @@ export function getDuration(data: Uint8Array, initData: InitData) {
     if (!track) {
       continue;
     }
+    let sampleCount: number | undefined;
+    let firstKeyFrame: number | undefined;
+    const trackTimes: TrackTimes =
+      tracks[id] ||
+      (tracks[id] = {
+        start: NaN,
+        duration: 0,
+        sampleCount: 0,
+        timescale: track.timescale,
+        type: track.type,
+      });
+    // get start DTS
+    const tfdt = findBox(traf, ['tfdt'])[0];
+
+    if (tfdt) {
+      const version = tfdt[0];
+      let baseTime = readUint32(tfdt, 4);
+      if (version === 1) {
+        // If value is too large, assume signed 64-bit. Negative track fragment decode times are invalid, but they exist in the wild.
+        // This prevents large values from being used for initPTS, which can cause playlist sync issues.
+        // https://github.com/video-dev/hls.js/issues/5303
+        if (baseTime === UINT32_MAX) {
+          logger.warn(
+            `[mp4-demuxer]: Ignoring assumed invalid signed 64-bit track fragment decode time`,
+          );
+        } else {
+          baseTime *= UINT32_MAX + 1;
+          baseTime += readUint32(tfdt, 8);
+        }
+      }
+      if (
+        Number.isFinite(baseTime) &&
+        (!Number.isFinite(trackTimes.start) || baseTime < trackTimes.start)
+      ) {
+        trackTimes.start = baseTime;
+      }
+    }
+
     const trackDefault = track.default;
     const tfhdFlags = readUint32(tfhd, 0) | trackDefault?.flags!;
-    let sampleDuration: number | undefined = trackDefault?.duration;
+    let defaultSampleDuration: number = trackDefault?.duration || 0;
     if (tfhdFlags & 0x000008) {
       // 0x000008 indicates the presence of the default_sample_duration field
       if (tfhdFlags & 0x000002) {
         // 0x000002 indicates the presence of the sample_description_index field, which precedes default_sample_duration
         // If present, the default_sample_duration exists at byte offset 12
-        sampleDuration = readUint32(tfhd, 12);
+        defaultSampleDuration = readUint32(tfhd, 12);
       } else {
         // Otherwise, the duration is at byte offset 8
-        sampleDuration = readUint32(tfhd, 8);
+        defaultSampleDuration = readUint32(tfhd, 8);
       }
     }
-    // assume a 90kHz clock if no timescale was specified
-    const timescale = track.timescale || 90e3;
     const truns = findBox(traf, ['trun']);
+    let sampleDTS = trackTimes.start || 0;
+    let rawDuration = 0;
+    let sampleDuration = defaultSampleDuration;
     for (let j = 0; j < truns.length; j++) {
-      rawDuration = computeRawDurationFromSamples(truns[j]);
-      if (!rawDuration && sampleDuration) {
-        const sampleCount = readUint32(truns[j], 4);
-        rawDuration = sampleDuration * sampleCount;
-      }
+      const trun = truns[j];
+      sampleCount = readUint32(trun, 4);
+      trackTimes.sampleCount += sampleCount;
       if (track.type === ElementaryStreamTypes.VIDEO) {
-        videoDuration += rawDuration / timescale;
-      } else if (track.type === ElementaryStreamTypes.AUDIO) {
-        audioDuration += rawDuration / timescale;
+        if (firstKeyFrame === undefined) {
+          firstKeyFrame = -1;
+        }
+        const dataOffsetPresent = trun[3] & 0x01;
+        const firstSampleFlagsPresent = trun[3] & 0x04;
+        const sampleDurationPresent = trun[2] & 0x01;
+        const sampleSizePresent = trun[2] & 0x02;
+        const sampleFlagsPresent = trun[2] & 0x04;
+        const sampleCompositionTimeOffsetPresent = trun[2] & 0x08;
+        let offset = 8;
+        let remaining = sampleCount;
+        if (dataOffsetPresent) {
+          offset += 4;
+        }
+        if (firstSampleFlagsPresent && sampleCount) {
+          const isNonSyncSample = trun[offset + 1] & 0x01;
+          if (!isNonSyncSample) {
+            firstKeyFrame = 0;
+          }
+          offset += 4;
+          if (sampleDurationPresent) {
+            sampleDuration = readUint32(trun, offset);
+            offset += 4;
+          } else {
+            sampleDuration = defaultSampleDuration;
+          }
+          if (sampleSizePresent) {
+            offset += 4;
+          }
+          if (sampleCompositionTimeOffsetPresent) {
+            offset += 4;
+          }
+          sampleDTS += sampleDuration;
+          rawDuration += sampleDuration;
+          remaining--;
+        }
+        while (remaining--) {
+          if (sampleDurationPresent) {
+            sampleDuration = readUint32(trun, offset);
+            offset += 4;
+          } else {
+            sampleDuration = defaultSampleDuration;
+          }
+          if (sampleSizePresent) {
+            offset += 4;
+          }
+          if (sampleFlagsPresent) {
+            const isNonSyncSample = trun[offset + 1] & 0x01;
+            if (!isNonSyncSample) {
+              if (firstKeyFrame === -1) {
+                firstKeyFrame = sampleCount - (remaining + 1);
+                trackTimes.keyFrameStart = sampleDTS;
+              }
+            }
+            offset += 4;
+          }
+          if (sampleCompositionTimeOffsetPresent) {
+            offset += 4;
+          }
+          sampleDTS += sampleDuration;
+          rawDuration += sampleDuration;
+        }
+        trackTimes.keyFrameIndex = firstKeyFrame;
+      } else {
+        rawDuration += defaultSampleDuration * sampleCount;
       }
     }
+    trackTimes.duration += rawDuration;
   }
-  if (videoDuration === 0 && audioDuration === 0) {
+  if (!Object.keys(tracks).some((trackId) => tracks[trackId].duration)) {
     // If duration samples are not available in the traf use sidx subsegment_duration
     let sidxMinStart = Infinity;
     let sidxMaxEnd = 0;
-    let sidxDuration = 0;
     const sidxs = findBox(data, ['sidx']);
     for (let i = 0; i < sidxs.length; i++) {
       const sidx = parseSegmentIndex(sidxs[i]);
@@ -776,76 +814,18 @@ export function getDuration(data: Uint8Array, initData: InitData) {
           sidxMaxEnd,
           subSegmentDuration + sidx.earliestPresentationTime / sidx.timescale,
         );
-        sidxDuration = sidxMaxEnd - sidxMinStart;
       }
     }
-    if (sidxDuration && Number.isFinite(sidxDuration)) {
-      return sidxDuration;
+    if (sidxMaxEnd && Number.isFinite(sidxMaxEnd)) {
+      Object.keys(tracks).forEach((trackId) => {
+        if (!tracks[trackId].duration) {
+          tracks[trackId].duration =
+            sidxMaxEnd * tracks[trackId].timescale - tracks[trackId].start;
+        }
+      });
     }
   }
-  if (videoDuration) {
-    return videoDuration;
-  }
-  return audioDuration;
-}
-
-/*
-  For Reference:
-  aligned(8) class TrackRunBox
-           extends FullBox(‘trun’, version, tr_flags) {
-     unsigned int(32)  sample_count;
-     // the following are optional fields
-     signed int(32) data_offset;
-     unsigned int(32)  first_sample_flags;
-     // all fields in the following array are optional
-     {
-        unsigned int(32)  sample_duration;
-        unsigned int(32)  sample_size;
-        unsigned int(32)  sample_flags
-        if (version == 0)
-           { unsigned int(32)
-        else
-           { signed int(32)
-     }[ sample_count ]
-  }
- */
-export function computeRawDurationFromSamples(trun): number {
-  const flags = readUint32(trun, 0);
-  // Flags are at offset 0, non-optional sample_count is at offset 4. Therefore we start 8 bytes in.
-  // Each field is an int32, which is 4 bytes
-  let offset = 8;
-  // data-offset-present flag
-  if (flags & 0x000001) {
-    offset += 4;
-  }
-  // first-sample-flags-present flag
-  if (flags & 0x000004) {
-    offset += 4;
-  }
-
-  let duration = 0;
-  const sampleCount = readUint32(trun, 4);
-  for (let i = 0; i < sampleCount; i++) {
-    // sample-duration-present flag
-    if (flags & 0x000100) {
-      const sampleDuration = readUint32(trun, offset);
-      duration += sampleDuration;
-      offset += 4;
-    }
-    // sample-size-present flag
-    if (flags & 0x000200) {
-      offset += 4;
-    }
-    // sample-flags-present flag
-    if (flags & 0x000400) {
-      offset += 4;
-    }
-    // sample-composition-time-offsets-present flag
-    if (flags & 0x000800) {
-      offset += 4;
-    }
-  }
-  return duration;
+  return tracks;
 }
 
 // TODO: Remove `offsetStartDTS` in favor of using `timestampOffset` (issue #5715)


### PR DESCRIPTION
### This PR will...
- Parse fmp4 truns to find audio and video base time and sample durations in one place
- Detect missing sync sample at start of fmp4 and error for switch or backtracking
- Use the same track for timestamp offsets with muxed mp4 (base initPTS on audio or video, whichever has the earliest sample times)
- Jump gaps in muxed audio video buffer on stall as long as the gap does not traverse more than one segment boundary
- Ensure that EoS is signaled only once the playhead is in the last buffered range

### Why is this Pull Request needed?
Prevents decode errors cause by overlapping appends

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#7114 (where pipeline error is a result of overlapping appends, not where platform decode error is unavoidable)
- #7114

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
