### PR TITLE
Fix handling of variants with mixed video codecs starting with "avc1"

### DIFF
--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -127,7 +127,7 @@ export default class LevelController extends BasePlaylistController {
           undefined;
       }
 
-      if (videoCodec?.indexOf('avc1') === 0) {
+      if (videoCodec) {
         videoCodec = levelParsed.videoCodec = convertAVC1ToAVCOTI(videoCodec);
       }
 

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -256,13 +256,11 @@ export function convertAVC1ToAVCOTI(videoCodecs: string): string {
   const codecs = videoCodecs.split(',');
   for (let i = 0; i < codecs.length; i++) {
     const avcdata = codecs[i].split('.');
-    if (avcdata.length > 2) {
-      let result = avcdata.shift() + '.';
-      result += parseInt(avcdata.shift() as string).toString(16);
-      result += (
-        '000' + parseInt(avcdata.shift() as string).toString(16)
-      ).slice(-4);
-      codecs[i] = result;
+    // only convert codec strings starting with avc1 (Examples: avc1.64001f,dvh1.05.07)
+    if (avcdata.length > 2 && avcdata[0] === 'avc1') {
+      codecs[i] = `avc1.${parseInt(avcdata[1]).toString(16)}${(
+        '000' + parseInt(avcdata[2]).toString(16)
+      ).slice(-4)}`;
     }
   }
   return codecs.join(',');

--- a/tests/unit/utils/codecs.ts
+++ b/tests/unit/utils/codecs.ts
@@ -25,6 +25,15 @@ describe('codecs', function () {
         'avc1.64001E,avc1.64001f',
       );
     });
+
+    it('only converts avc1 codec strings in mixed video codecs', function () {
+      expect(convertAVC1ToAVCOTI('avc1.66.30,dvh1.05.07')).to.equal(
+        'avc1.42001e,dvh1.05.07',
+      );
+      expect(convertAVC1ToAVCOTI('dvh1.05.07,avc1.77.30')).to.equal(
+        'dvh1.05.07,avc1.4d001e',
+      );
+    });
   });
 
   describe('fillInMissingAV01Params', function () {


### PR DESCRIPTION
### This PR will...
Fix modification of codec strings that do not start with "avc1" in `convertAVC1ToAVCOTI`

### Why is this Pull Request needed?
When a variant has mixed video codecs (Ex: "avc1.64001f,dvh1.05.07"), the non-avc1 codec is modified by `convertAVC1ToAVCOTI`, changing it into something potentially invalid and not supported by the browser.

This change makes sure that the correct codec strings are checked for compatibility in this case, preventing these levels from being removed and manifest incompatible codecs error from firing when all variants contain a similar mix. 

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
