### PR TITLE
Add `requireKeySystemAccessOnStart` (fixes Chrome PIPELINE_DECODE_ERROR on clear to encrypted transition)

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1137,6 +1137,8 @@ export class EMEController extends Logger implements ComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
+    getKeySystemAccess(keySystemsToAttempt: KeySystems[]): Promise<void>;
+    // (undocumented)
     getSelectedKeySystemFormats(): KeySystemFormats[];
     // (undocumented)
     loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext>;

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1155,7 +1155,7 @@ export type EMEControllerConfig = {
     drmSystems: DRMSystemsConfiguration;
     drmSystemOptions: DRMSystemOptions;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
-    experimentalKeySystemAccessForClearContent?: boolean;
+    requireKeySystemAccessOnStart?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1137,6 +1137,8 @@ export class EMEController extends Logger implements ComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
+    getSelectedKeySystemFormats(): KeySystemFormats[];
+    // (undocumented)
     loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext>;
     // (undocumented)
     selectKeySystem(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
@@ -2920,7 +2922,7 @@ export class KeyLoader implements ComponentAPI {
     // (undocumented)
     load(frag: Fragment): Promise<KeyLoadedData>;
     // (undocumented)
-    loadClear(loadingFrag: Fragment, encryptedFragments: Fragment[]): void | Promise<void>;
+    loadClear(loadingFrag: Fragment, encryptedFragments: Fragment[]): null | Promise<void>;
     // (undocumented)
     loadInternal(frag: Fragment, keySystemFormat?: KeySystemFormats): Promise<KeyLoadedData>;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1155,7 +1155,7 @@ export type EMEControllerConfig = {
     drmSystems: DRMSystemsConfiguration;
     drmSystemOptions: DRMSystemOptions;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
-    requireKeySystemAccessOnStart?: boolean;
+    requireKeySystemAccessOnStart: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1139,9 +1139,9 @@ export class EMEController extends Logger implements ComponentAPI {
     // (undocumented)
     loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext>;
     // (undocumented)
-    selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats>;
+    selectKeySystem(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
     // (undocumented)
-    test_selectKeySystemFromConfig(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
+    selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats>;
 }
 
 // Warning: (ae-missing-release-tag) "EMEControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1155,6 +1155,7 @@ export type EMEControllerConfig = {
     drmSystems: DRMSystemsConfiguration;
     drmSystemOptions: DRMSystemOptions;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
+    experimentalKeySystemAccessForClearContent?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1140,6 +1140,8 @@ export class EMEController extends Logger implements ComponentAPI {
     loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext>;
     // (undocumented)
     selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats>;
+    // (undocumented)
+    test_selectKeySystemFromConfig(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
 }
 
 // Warning: (ae-missing-release-tag) "EMEControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,7 @@ export type EMEControllerConfig = {
   drmSystems: DRMSystemsConfiguration;
   drmSystemOptions: DRMSystemOptions;
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
+  experimentalKeySystemAccessForClearContent?: boolean;
 };
 
 export interface FragmentLoaderConstructor {

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,7 +122,7 @@ export type EMEControllerConfig = {
   drmSystems: DRMSystemsConfiguration;
   drmSystemOptions: DRMSystemOptions;
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
-  experimentalKeySystemAccessForClearContent?: boolean;
+  requireKeySystemAccessOnStart: boolean;
 };
 
 export interface FragmentLoaderConstructor {
@@ -433,6 +433,7 @@ export const hlsDefaultConfig: HlsConfig = {
   requestMediaKeySystemAccessFunc: __USE_EME_DRM__
     ? requestMediaKeySystemAccess
     : null, // used by eme-controller
+  requireKeySystemAccessOnStart: false, // used by eme-controller
   testBandwidth: true,
   progressive: false,
   lowLatencyMode: true,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -839,28 +839,12 @@ export default class BaseStreamController
         );
       }
     } else if (!frag.encrypted) {
-      this.log(
-        `Loading clear ${frag.sn} of [${details.startSN}-${details.endSN}] ${details.encryptedFragments.length ? 'with' : 'without'} encrypted segments in the manifest`,
-      );
-      const keyLoadPromise = this.keyLoader.loadClear(
+      keyLoadingPromise = this.keyLoader.loadClear(
         frag,
         details.encryptedFragments,
       );
-      if (keyLoadPromise) {
-        this.state = State.KEY_LOADING;
-        this.fragCurrent = frag;
-        // Note: Omitted KEY_LOADING event here as we didn't have that for loadClear
-        keyLoadingPromise = keyLoadPromise.then(() => {
-          // TODO: Not sure about this. Do we need to check if the current fragment changed?
-          // For clear segments even if we get the first encrypted fragment back, that won't
-          // match the current fragment of the stream controller.
-          if (!this.fragContextChanged(frag)) {
-            // Note: Omitted KEY_LOADED event here as we didn't have that for loadClear
-            if (this.state === State.KEY_LOADING) {
-              this.state = State.IDLE;
-            }
-          }
-        });
+      if (keyLoadingPromise) {
+        this.log(`[eme] blocking frag load until media-keys acquired`);
       }
     }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -867,11 +867,10 @@ export default class BaseStreamController
           );
         }
       } else if (details.encryptedFragments.length) {
+        // TODO: this should also move the state to KEY_LOADING, as we can't buffer unencrypted segments before media keys are set
         this.keyLoader.loadClear(frag, details.encryptedFragments);
       }
     }
-    // else if (!frag.encrypted && details.encryptedFragments.length) {
-    // }
 
     const fragPrevious = this.fragPrevious;
     if (

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -825,9 +825,6 @@ export default class BaseStreamController
       this.fragCurrent = frag;
       keyLoadingPromise = this.keyLoader.load(frag).then((keyLoadedData) => {
         if (!this.fragContextChanged(keyLoadedData.frag)) {
-          this.log(
-            'Emitting KEY_LOADED event without key info - blame this if something goes wrong',
-          );
           this.hls.trigger(Events.KEY_LOADED, keyLoadedData);
           if (this.state === State.KEY_LOADING) {
             this.state = State.IDLE;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -844,8 +844,6 @@ export default class BaseStreamController
         details.encryptedFragments,
       );
       if (keyLoadingPromise) {
-        // TODO: This gets logged on every clear segment load regardless of having key system initialized.
-        // keyLoader.loadClear should be optimized to not return a promise if we don't need to wait for key system access.
         this.log(`[eme] blocking frag load until media-keys acquired`);
       }
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -844,6 +844,8 @@ export default class BaseStreamController
         details.encryptedFragments,
       );
       if (keyLoadingPromise) {
+        // TODO: This gets logged on every clear segment load regardless of having key system initialized.
+        // keyLoader.loadClear should be optimized to not return a promise if we don't need to wait for key system access.
         this.log(`[eme] blocking frag load until media-keys acquired`);
       }
     }

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -396,6 +396,25 @@ class EMEController extends Logger implements ComponentAPI {
     return this.keyFormatPromise;
   }
 
+  public test_selectKeySystemFromConfig(
+    keySystemsToAttempt: KeySystems[],
+  ): Promise<KeySystemFormats> {
+    return new Promise((resolve, reject) => {
+      return this.getKeySystemSelectionPromise(keySystemsToAttempt)
+        .then(({ keySystem }) => {
+          const keySystemFormat = keySystemToKeySystemFormat(keySystem);
+          if (keySystemFormat) {
+            resolve(keySystemFormat);
+          } else {
+            reject(
+              new Error(`Unable to find format for key-system "${keySystem}"`),
+            );
+          }
+        })
+        .catch(reject);
+    });
+  }
+
   private getKeyFormatPromise(
     keyFormats: KeySystemFormats[],
   ): Promise<KeySystemFormats> {

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -294,6 +294,7 @@ class EMEController extends Logger implements ComponentAPI {
                   certificate,
                 );
               }
+              this.attemptSetMediaKeys(keySystem, mediaKeys);
               return mediaKeys;
             });
           });

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -294,7 +294,6 @@ class EMEController extends Logger implements ComponentAPI {
                   certificate,
                 );
               }
-              this.attemptSetMediaKeys(keySystem, mediaKeys);
               return mediaKeys;
             });
           });
@@ -395,6 +394,14 @@ class EMEController extends Logger implements ComponentAPI {
       .filter(({ hasMediaKeys }) => !!hasMediaKeys)
       .map(({ keySystem }) => keySystemToKeySystemFormat(keySystem))
       .filter((keySystem): keySystem is KeySystemFormats => !!keySystem);
+  }
+
+  public getKeySystemAccess(keySystemsToAttempt: KeySystems[]): Promise<void> {
+    return this.getKeySystemSelectionPromise(keySystemsToAttempt).then(
+      ({ keySystem, mediaKeys }) => {
+        return this.attemptSetMediaKeys(keySystem, mediaKeys);
+      },
+    );
   }
 
   public selectKeySystem(

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -16,7 +16,7 @@ import type {
   LoaderStats,
   PlaylistLevelType,
 } from '../types/loader';
-import type { KeySystemFormats } from '../utils/mediakeys-helper';
+import type { KeySystemFormats, KeySystems } from '../utils/mediakeys-helper';
 
 export interface KeyLoaderInfo {
   decryptdata: LevelKey;
@@ -127,6 +127,18 @@ export default class KeyLoader implements ComponentAPI {
     }
 
     return this.loadInternal(frag);
+  }
+
+  test_loadKeysBeforeFragLoad(
+    frag: Fragment,
+    keySystems: KeySystems[],
+  ): Promise<KeyLoadedData> {
+    if (this.emeController) {
+      return this.emeController
+        ?.test_selectKeySystemFromConfig(keySystems)
+        .then(() => ({ frag, keyInfo: null as any }));
+    }
+    return Promise.resolve({ frag, keyInfo: null as any });
   }
 
   loadInternal(

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -91,7 +91,7 @@ export default class KeyLoader implements ComponentAPI {
   loadClear(
     loadingFrag: Fragment,
     encryptedFragments: Fragment[],
-  ): void | Promise<void> {
+  ): null | Promise<void> {
     if (this.emeController && this.config.emeEnabled) {
       // access key-system with nearest key on start (loading frag is unencrypted)
       if (encryptedFragments.length) {
@@ -109,7 +109,7 @@ export default class KeyLoader implements ComponentAPI {
               });
           }
         }
-      } else if (this.config.experimentalKeySystemAccessForClearContent) {
+      } else if (this.config.requireKeySystemAccessOnStart) {
         const keySystemsInConfig = getKeySystemsForConfig(this.config);
         if (keySystemsInConfig.length) {
           return this.emeController
@@ -120,6 +120,7 @@ export default class KeyLoader implements ComponentAPI {
         }
       }
     }
+    return null;
   }
 
   load(frag: Fragment): Promise<KeyLoadedData> {

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -109,7 +109,10 @@ export default class KeyLoader implements ComponentAPI {
               });
           }
         }
-      } else if (this.config.requireKeySystemAccessOnStart) {
+      } else if (
+        this.config.requireKeySystemAccessOnStart &&
+        !this.emeController.getSelectedKeySystemFormats().length
+      ) {
         const keySystemsInConfig = getKeySystemsForConfig(this.config);
         if (keySystemsInConfig.length) {
           return this.emeController


### PR DESCRIPTION
### This PR will...

Request key system access based on the eme configuration (with `config.requireKeySystemAccessOnStart`  enabled) and block loading clear content until the media keys are set.

This resolves an issue on Chrome where if clear content is encrypted into the SourceBuffer followed by setting media keys then transitioning to encrypted content, Chrome will die with `PIPELINE_DECODE_ERROR`:
![image](https://github.com/user-attachments/assets/fb9c354a-4f44-4fa0-bc4e-49873f2bec7e)

### Why is this Pull Request needed?

- If the HLS stream starts with clear content only in the manifest, and later transitions to encrypted content
- If the HLS stream starts with mixed content in the manifest, but the first buffered segment is unencrypted. This creates a race-condition today, where the first clear segment might load before the media keys could be set. This has been noticed on MediaTailor live stream with prerolls, where the prerolls were loaded from disk cache, loading faster than it took the media keys to be set.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/4230
https://github.com/video-dev/hls.js/issues/5753

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
