### PR TITLE
Add missing type exports for modules exported in hls.mjs

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -960,6 +960,11 @@ export type ContentSteeringOptions = {
     pathwayId: string;
 };
 
+// Warning: (ae-missing-release-tag) "Cues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const Cues: CuesInterface;
+
 // Warning: (ae-missing-release-tag) "CuesInterface" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1575,6 +1580,29 @@ export class EwmaBandWidthEstimator {
 export type ExtendedSourceBuffer = SourceBuffer & {
     onbufferedchange?: ((this: SourceBuffer, ev: Event) => any) | null;
 };
+
+// Warning: (ae-missing-release-tag) "FetchLoader" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class FetchLoader implements Loader<LoaderContext> {
+    constructor(config: HlsConfig);
+    // (undocumented)
+    abort(): void;
+    // (undocumented)
+    abortInternal(): void;
+    // (undocumented)
+    context: LoaderContext | null;
+    // (undocumented)
+    destroy(): void;
+    // (undocumented)
+    getCacheAge(): number | null;
+    // (undocumented)
+    getResponseHeader(name: string): string | null;
+    // (undocumented)
+    load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<LoaderContext>): void;
+    // (undocumented)
+    stats: LoaderStats;
+}
 
 // Warning: (ae-missing-release-tag) "FPSController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3700,6 +3728,38 @@ export class Logger implements ILogger {
     warn: ILogFunction;
 }
 
+// Warning: (ae-missing-release-tag) "M3U8Parser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class M3U8Parser {
+    // (undocumented)
+    static findGroup(groups: ({
+        id?: string;
+        audioCodec?: string;
+    } | {
+        id?: string;
+        textCodec?: string;
+    })[], mediaGroupId: string): {
+        id?: string;
+        audioCodec?: string;
+    } | {
+        id?: string;
+        textCodec?: string;
+    } | undefined;
+    // (undocumented)
+    static isMediaPlaylist(str: string): boolean;
+    // (undocumented)
+    static parseLevelPlaylist(string: string, baseurl: string, id: number, type: PlaylistLevelType, levelUrlId: number, multivariantVariableList: VariableMap | null): LevelDetails;
+    // (undocumented)
+    static parseMasterPlaylist(string: string, baseurl: string): ParsedMultivariantPlaylist;
+    // Warning: (ae-forgotten-export) The symbol "ParsedMultivariantMediaOptions" needs to be exported by the entry point hls.d.ts
+    //
+    // (undocumented)
+    static parseMasterPlaylistMedia(string: string, baseurl: string, parsed: ParsedMultivariantPlaylist): ParsedMultivariantMediaOptions;
+    // (undocumented)
+    static resolve(url: any, baseUrl: any): string;
+}
+
 // Warning: (ae-missing-release-tag) "MainPlaylistType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -4864,6 +4924,41 @@ export type VideoSelectionOption = {
     allowedVideoRanges?: Array<VideoRange>;
     videoCodec?: string;
 };
+
+// Warning: (ae-missing-release-tag) "XhrLoader" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class XhrLoader implements Loader<LoaderContext> {
+    constructor(config: HlsConfig);
+    // (undocumented)
+    abort(): void;
+    // (undocumented)
+    abortInternal(): void;
+    // (undocumented)
+    context: LoaderContext | null;
+    // (undocumented)
+    destroy(): void;
+    // (undocumented)
+    getCacheAge(): number | null;
+    // (undocumented)
+    getResponseHeader(name: string): string | null;
+    // (undocumented)
+    load(context: LoaderContext, config: LoaderConfiguration, callbacks: LoaderCallbacks<LoaderContext>): void;
+    // (undocumented)
+    loadInternal(): void;
+    // (undocumented)
+    loadprogress(event: ProgressEvent): void;
+    // (undocumented)
+    loadtimeout(): void;
+    // (undocumented)
+    openAndSendXhr(xhr: XMLHttpRequest, context: LoaderContext, config: LoaderConfiguration): void;
+    // (undocumented)
+    readystatechange(): void;
+    // (undocumented)
+    retry(retryConfig: RetryConfig): void;
+    // (undocumented)
+    stats: LoaderStats;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -44,6 +44,7 @@ import type TransmuxerInterface from './demux/transmuxer-interface';
 import type { HlsEventEmitter, HlsListeners } from './events';
 import type FragmentLoader from './loader/fragment-loader';
 import type { LevelDetails } from './loader/level-details';
+import type M3U8Parser from './loader/m3u8-parser';
 import type TaskLoop from './task-loop';
 import type { AttachMediaSourceData } from './types/buffer';
 import type {
@@ -59,8 +60,11 @@ import type {
   VideoSelectionOption,
 } from './types/media-playlist';
 import type { BufferInfo, BufferTimeRange } from './utils/buffer-helper';
+import type Cues from './utils/cues';
 import type EwmaBandWidthEstimator from './utils/ewma-bandwidth-estimator';
+import type FetchLoader from './utils/fetch-loader';
 import type { MediaDecodingInfo } from './utils/mediacapabilities-helper';
+import type XhrLoader from './utils/xhr-loader';
 
 /**
  * The `Hls` class is the core of the HLS.js library used to instantiate player instances.
@@ -1280,6 +1284,10 @@ export type {
   TransmuxerInterface,
   InFlightData,
   State,
+  XhrLoader,
+  FetchLoader,
+  Cues,
+  M3U8Parser,
 };
 export type {
   ABRControllerConfig,


### PR DESCRIPTION



### This PR will...
Add missing type exports (hls.d.mts) for modules exported in hls.mjs (src/exports-named.ts).

### Why is this Pull Request needed?
The module type exports (hls.d.mts) are simply copied from the default type exports. These only include types explicitly exported in src/hls.ts and not type definitions of the module exports defined in hls.mjs (src/exports-named.ts).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Related to #6707

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
