### PR TITLE
Fix interstitial "_HLS_primary_id" value in asset requests

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2155,7 +2155,7 @@ export default Hls;
 //
 // @public (undocumented)
 export class HlsAssetPlayer {
-    constructor(HlsPlayerClass: typeof Hls, userConfig: Partial<HlsConfig>, interstitial: InterstitialEvent, assetItem: InterstitialAssetItem);
+    constructor(HlsPlayerClass: typeof Hls, userConfig: HlsAssetPlayerConfig, interstitial: InterstitialEvent, assetItem: InterstitialAssetItem);
     // (undocumented)
     get appendInPlace(): boolean;
     // (undocumented)
@@ -2210,6 +2210,11 @@ export class HlsAssetPlayer {
     // (undocumented)
     transferMedia(): AttachMediaSourceData | null;
 }
+
+// Warning: (ae-missing-release-tag) "HlsAssetPlayerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HlsAssetPlayerConfig = Partial<HlsConfig> & Required<Pick<HlsConfig, 'assetPlayerId' | 'primarySessionId'>>;
 
 // Warning: (ae-missing-release-tag) "HlsChunkPerformanceTiming" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -20,6 +20,10 @@ export interface InterstitialPlayer {
   playingIndex: number;
   scheduleItem: InterstitialScheduleEventItem | null;
 }
+
+export type HlsAssetPlayerConfig = Partial<HlsConfig> &
+  Required<Pick<HlsConfig, 'assetPlayerId' | 'primarySessionId'>>;
+
 export class HlsAssetPlayer {
   public readonly hls: Hls;
   public readonly interstitial: InterstitialEvent;
@@ -32,7 +36,7 @@ export class HlsAssetPlayer {
 
   constructor(
     HlsPlayerClass: typeof Hls,
-    userConfig: Partial<HlsConfig>,
+    userConfig: HlsAssetPlayerConfig,
     interstitial: InterstitialEvent,
     assetItem: InterstitialAssetItem,
   ) {
@@ -41,7 +45,7 @@ export class HlsAssetPlayer {
     this.assetItem = assetItem;
     let uri: string = assetItem.uri;
     try {
-      uri = getInterstitialUrl(uri, hls.sessionId).href;
+      uri = getInterstitialUrl(uri, userConfig.primarySessionId).href;
     } catch (error) {
       // Ignore error parsing ASSET_URI or adding _HLS_primary_id to it. The
       // issue should surface as an INTERSTITIAL_ASSET_ERROR loading the asset.

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -31,8 +31,10 @@ import { Logger } from '../utils/logger';
 import { isCompatibleTrackChange } from '../utils/mediasource-helper';
 import { getBasicSelectionOption } from '../utils/rendition-helper';
 import { stringify } from '../utils/safe-json-stringify';
-import type { InterstitialPlayer } from './interstitial-player';
-import type { HlsConfig } from '../config';
+import type {
+  HlsAssetPlayerConfig,
+  InterstitialPlayer,
+} from './interstitial-player';
 import type Hls from '../hls';
 import type { LevelDetails } from '../loader/level-details';
 import type { SourceBufferName } from '../types/buffer';
@@ -2140,7 +2142,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       }
     }
     const assetId = assetItem.identifier;
-    const playerConfig: Partial<HlsConfig> = {
+    const playerConfig: HlsAssetPlayerConfig = {
       ...userConfig,
       autoStartLoad: true,
       startFragPrefetch: true,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1334,6 +1334,7 @@ export type {
 } from './controller/error-controller';
 export type {
   HlsAssetPlayer,
+  HlsAssetPlayerConfig,
   InterstitialPlayer,
 } from './controller/interstitial-player';
 export type { PlayheadTimes } from './controller/interstitials-controller';

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -2014,6 +2014,7 @@ fileSequence6.mp4`;
 
       // Capture asset-list request
       const loadSpy = sandbox.spy(hls.config.loader.prototype, 'load');
+      const primaryId = hls.sessionId;
 
       // Attach media
       hls.trigger.resetHistory();
@@ -2032,7 +2033,7 @@ fileSequence6.mp4`;
         assetListUrl,
         '_HLS_primary_id and _HLS_start_offset match',
       ).to.equal(
-        `https://example.com/mid.json?_HLS_primary_id=${hls.sessionId}&_HLS_start_offset=10`,
+        `https://example.com/mid.json?_HLS_primary_id=${primaryId}&_HLS_start_offset=10`,
       );
       expect(eventsAfterAttach).to.deep.equal(
         expectedEvents,
@@ -2046,7 +2047,7 @@ fileSequence6.mp4`;
       hls.trigger.resetHistory();
       const interstitial = insterstitials.events[0];
       interstitial.assetListResponse = {
-        ASSETS: [{ URI: '', DURATION: '30' }],
+        ASSETS: [{ URI: 'https://example.com/midroll.m3u8', DURATION: '30' }],
       };
       hls.trigger(Events.ASSET_LIST_LOADED, {
         event: interstitial,
@@ -2078,6 +2079,16 @@ fileSequence6.mp4`;
         insterstitials.interstitialPlayer?.scheduleItem?.event,
         `interstitialPlayer.scheduleItem`,
       ).to.include({ identifier: 'mid-live' });
+      expect(
+        insterstitials.interstitialPlayer?.assetPlayers,
+        `interstitialPlayer.assetPlayers[]`,
+      ).to.have.lengthOf(1);
+      expect(
+        insterstitials.interstitialPlayer?.assetPlayers[0]?.hls?.url,
+        `interstitialPlayer.assetPlayers[0].hls.url`,
+      ).to.equal(
+        `https://example.com/midroll.m3u8?_HLS_primary_id=${primaryId}`,
+      );
     });
   });
 });


### PR DESCRIPTION
### This PR will...
Fix incorrect "_HLS_primary_id" value for interstitial asset requests

### Why is this Pull Request needed?
The asset player session ID was being sent instead of the primary player session ID.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
