### PR TITLE
Skip Interstitial assets that error rather than falling back to primary for entire break

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2197,6 +2197,8 @@ export class HlsAssetPlayer {
     // (undocumented)
     get remaining(): number;
     // (undocumented)
+    resetDetails(): void;
+    // (undocumented)
     resumeBuffering(): void;
     // (undocumented)
     get startOffset(): number;

--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -238,6 +238,18 @@ export class HlsAssetPlayer {
     return this.hls.transferMedia();
   }
 
+  resetDetails() {
+    const hls = this.hls;
+    if (this.hasDetails) {
+      hls.stopLoad();
+      const deleteDetails = (obj) => delete obj.details;
+      hls.levels.forEach(deleteDetails);
+      hls.allAudioTracks.forEach(deleteDetails);
+      hls.allSubtitleTracks.forEach(deleteDetails);
+      this.hasDetails = false;
+    }
+  }
+
   on<E extends keyof HlsListeners, Context = undefined>(
     event: E,
     listener: HlsListeners[E],

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -2525,7 +2525,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       const playerIndex = this.getAssetPlayerQueueIndex(assetItem.identifier);
       player = this.playerQueue[playerIndex] || null;
     }
-    const playerAttached = player?.media === this.primaryMedia;
     const items = this.schedule.items;
     const interstitialAssetError = Object.assign({}, data, {
       fatal: false,
@@ -2546,9 +2545,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const playingAsset = this.playingAsset;
     const error = new Error(errorMessage);
     if (assetItem) {
-      if (playingAsset !== assetItem) {
-        this.clearAssetPlayer(assetItem.identifier, null);
-      }
+      this.clearAssetPlayer(assetItem.identifier, null);
       assetItem.error = error;
     }
 
@@ -2563,9 +2560,10 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       }
       this.updateSchedule();
     }
-
-    if (playerAttached || playingAsset || interstitial.error) {
+    if (interstitial.error) {
       this.primaryFallback(interstitial);
+    } else if (playingAsset) {
+      this.advanceAfterAssetEnded(interstitial, scheduleIndex, assetListIndex);
     }
   }
 
@@ -2591,12 +2589,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       if (this.itemsMatch(playingItem, newPlayingItem)) {
         this.clearInterstitial(interstitial, null);
       }
-      const scheduleIndex = this.schedule.findItemIndexAtTime(timelinePos);
-      this.setSchedulePosition(scheduleIndex);
       if (interstitial.appendInPlace) {
         this.attachPrimary(flushStart, null);
         this.flushFrontBuffer(flushStart);
       }
+      const scheduleIndex = this.schedule.findItemIndexAtTime(timelinePos);
+      this.setSchedulePosition(scheduleIndex);
     } else {
       this.checkStart();
     }

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -313,6 +313,22 @@ export function getInterstitialUrl(
   return url;
 }
 
+export function getNextAssetIndex(
+  interstitial: InterstitialEvent,
+  assetListIndex: number,
+  inBounds?: boolean,
+): number {
+  while (interstitial.assetList[++assetListIndex]?.error) {
+    /* no-op */
+  }
+  if (inBounds && assetListIndex) {
+    if (assetListIndex >= interstitial.assetList.length) {
+      return -1;
+    }
+  }
+  return assetListIndex;
+}
+
 function eventToString(interstitial: InterstitialEvent): string {
   return `["${interstitial.identifier}" ${interstitial.cue.pre ? '<pre>' : interstitial.cue.post ? '<post>' : ''}${interstitial.timelineStart.toFixed(2)}-${interstitial.resumeTime.toFixed(2)}]`;
 }

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -118,14 +118,17 @@ export class InterstitialEvent {
   }
 
   public isAssetPastPlayoutLimit(assetIndex: number): boolean {
-    if (assetIndex >= this.assetList.length) {
+    if (assetIndex > 0 && assetIndex >= this.assetList.length) {
       return true;
     }
     const playoutLimit = this.playoutLimit;
     if (assetIndex <= 0 || isNaN(playoutLimit)) {
       return false;
     }
-    const assetOffset = this.assetList[assetIndex].startOffset;
+    if (playoutLimit === 0) {
+      return true;
+    }
+    const assetOffset = this.assetList[assetIndex]?.startOffset || 0;
     return assetOffset > playoutLimit;
   }
 
@@ -316,15 +319,9 @@ export function getInterstitialUrl(
 export function getNextAssetIndex(
   interstitial: InterstitialEvent,
   assetListIndex: number,
-  inBounds?: boolean,
 ): number {
   while (interstitial.assetList[++assetListIndex]?.error) {
     /* no-op */
-  }
-  if (inBounds && assetListIndex) {
-    if (assetListIndex >= interstitial.assetList.length) {
-      return -1;
-    }
   }
   return assetListIndex;
 }


### PR DESCRIPTION
### This PR will...
1. Skip asset indexes whose assets have errors when advancing through interstitials in the schedule
2. Reset asset player timeline offset when an earlier asset has errors (delete loaded media playlists with applied offsets)

### Why is this Pull Request needed?
1. Fixes MediaSource reset playback with asset errors
2. Fixes append-in-place playback with asset errors

### Are there any points in the code the reviewer needs to double check?
I could have simply destroyed asset players whose timelines would be impacted by an error and schedule change, but that would result in the HLS multivariant playlist getting reloaded. Since the `LevelDetails` are delete instead, media playlist will need to be reloaded to generate new offsets. This may no longer be required after timestamp offsets are support #5715, but for now it is a hard requirement.

### Resolves issues:
Fixes #7180

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
