### PR TITLE
feat: preserveManualLevelOnError option

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2238,6 +2238,7 @@ export type HlsConfig = {
     ignoreDevicePixelRatio: boolean;
     maxDevicePixelRatio: number;
     preferManagedMediaSource: boolean;
+    preserveManualLevelOnError: boolean;
     timelineOffset?: number;
     ignorePlaylistParsingErrors: boolean;
     loader: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -452,7 +452,6 @@ export const hlsDefaultConfig: HlsConfig = {
   interstitialLiveLookAhead: 10,
   useMediaCapabilities: __USE_MEDIA_CAPABILITIES__,
   preserveManualLevelOnError: false,
-  timelineOffset: undefined,
 
   certLoadPolicy: {
     default: defaultLoadPolicy,

--- a/src/config.ts
+++ b/src/config.ts
@@ -282,6 +282,7 @@ export type HlsConfig = {
   ignoreDevicePixelRatio: boolean;
   maxDevicePixelRatio: number;
   preferManagedMediaSource: boolean;
+  preserveManualLevelOnError: boolean;
   timelineOffset?: number;
   ignorePlaylistParsingErrors: boolean;
   loader: { new (confg: HlsConfig): Loader<LoaderContext> };
@@ -450,6 +451,8 @@ export const hlsDefaultConfig: HlsConfig = {
   interstitialAppendInPlace: true,
   interstitialLiveLookAhead: 10,
   useMediaCapabilities: __USE_MEDIA_CAPABILITIES__,
+  preserveManualLevelOnError: false,
+  timelineOffset: undefined,
 
   certLoadPolicy: {
     default: defaultLoadPolicy,

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -341,7 +341,7 @@ export default class ErrorController
       // Search for next level to retry
       let nextLevel = -1;
       const { levels, loadLevel, minAutoLevel, maxAutoLevel } = hls;
-      if (!hls.autoLevelEnabled) {
+      if (!hls.autoLevelEnabled && !hls.config.preserveManualLevelOnError) {
         hls.loadLevel = -1;
       }
       const fragErrorType = data.frag?.type;


### PR DESCRIPTION
### This PR will...

This PR introduces a new configuration option, `preserveManualLevelOnError`. When this option is set to `true`, hls.js will maintain the manually selected quality level even if network errors (such as `FRAG_LOAD_ERROR`, `FRAG_LOAD_TIMEOUT`, `KEY_LOAD_ERROR`, or `KEY_LOAD_TIMEOUT`) occur. If set to `false` (the default behavior), hls.js will switch back to auto level selection mode (`loadLevel = -1`) upon encountering such errors, attempting to find a rendition that can be loaded successfully.

### Why is this Pull Request needed?

[Currently](https://github.com/video-dev/hls.js/blob/master/src/controller/error-controller.ts#L345), when a user manually selects a specific quality level, hls.js defaults to switching back to automatic level selection if it encounters fragment loading or key loading errors. This behavior can be undesirable for users on unstable internet connections who prefer to remain on their chosen quality level, even if it means experiencing more retries or buffering, rather than having the player automatically switch to a different (often lower) quality. Furthermore, some users may wish to maintain their current quality setting even when facing playback errors, considering it the player developer's responsibility to resolve such issues rather than defaulting to a quality switch.

Services using hls.js may not always offer or want to provide automatic quality selection depending on the situation. Furthermore, they might prefer to implement different fallback mechanisms, making the current forced switch to auto quality in the player less ideal.

As discussed in issue [#7221](https://github.com/video-dev/hls.js/issues/7221), developers previously had to implement workarounds by manually resetting `autoLevelCapping` and `minAutoBitrate` on error events to achieve the desired behavior. This new `preserveManualLevelOnError` flag provides a simpler and more direct way to control this behavior.

### Are there any points in the code the reviewer needs to double check?

- The logic within the `getLevelSwitchAction` method in `src/controller/error-controller.ts` should be reviewed to ensure it correctly respects the `preserveManualLevelOnError` flag when `hls.autoLevelEnabled` is `false`.
- The default value for `preserveManualLevelOnError` in `src/config.ts` is set to `false` to maintain existing default behavior.
- Ensure the API documentation update in `api-extractor/report/hls.js.api.md` correctly reflects the new configuration option.

### Resolves issues:
- Fixes [#7221](https://github.com/video-dev/hls.js/issues/7221)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md

