### PR TITLE
Prevent same MediaKeys from being set on media element by eme-controller

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -31,7 +31,6 @@ import {
   getPartWith,
   updateFragPTSDTS,
 } from '../utils/level-helper';
-import { getKeySystemsForConfig } from '../utils/mediakeys-helper';
 import { appendUint8Array } from '../utils/mp4-tools';
 import TimeRanges from '../utils/time-ranges';
 import type { FragmentTracker } from './fragment-tracker';


### PR DESCRIPTION
### This PR will...
Ensure that setMediaKeys is only called once for the same MediaKeys.

### Why is this Pull Request needed?
In testing #7216 we found that setMediaKeys was set multiple times.

### Are there any points in the code the reviewer needs to double check?
Follow up to #7216

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
