### PR TITLE
Fix MediaKeys cleanup on player destroy and reuse (setMediaKeys(null)…

### DIFF
--- a/src/utils/event-listener-helper.ts
+++ b/src/utils/event-listener-helper.ts
@@ -1,5 +1,5 @@
 export function addEventListener(
-  el: HTMLElement,
+  el: EventTarget,
   type: string,
   listener: EventListenerOrEventListenerObject,
 ) {
@@ -8,7 +8,7 @@ export function addEventListener(
 }
 
 export function removeEventListener(
-  el: HTMLElement,
+  el: EventTarget,
   type: string,
   listener: EventListenerOrEventListenerObject,
 ) {

--- a/src/utils/utf8-utils.ts
+++ b/src/utils/utf8-utils.ts
@@ -11,7 +11,7 @@ export type Frame = DecodedFrame<ArrayBuffer | string>;
  * This library is free.  You can redistribute it and/or modify it.
  */
 
-export function strToUtf8array(str: string): Uint8Array {
+export function strToUtf8array(str: string) {
   return Uint8Array.from(unescape(encodeURIComponent(str)), (c) =>
     c.charCodeAt(0),
   );


### PR DESCRIPTION
### This PR will...
- Fix MediaKeys cleanup on player destroy and reuse
- Address Uint8Array type parameter issues

### Why is this Pull Request needed?
Ensures that `setMediaKeys(null)` is called on destroy before detaching.

### Are there any points in the code the reviewer needs to double check?
Skipping `setMediaKeys(null)` may have regressed with #6966
cc @JackPu

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
