### PR TITLE
Fix errors in SourceBuffer creation when media parsed codec is unsupported

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1424,11 +1424,9 @@ export default class StreamController
     // include levelCodec in audio and video tracks
     const { audio, video, audiovideo } = tracks;
     if (audio) {
-      let audioCodec = pickMostCompleteCodecName(
-        audio.codec,
-        currentLevel.audioCodec,
-      );
-      // Add level and profile to make up for passthrough-remuxer not being able to parse full codec
+      const levelCodec = currentLevel.audioCodec;
+      let audioCodec = pickMostCompleteCodecName(audio.codec, levelCodec);
+      // Add level and profile to make up for remuxer not being able to parse full codec
       // (logger warning "Unhandled audio codec...")
       if (audioCodec === 'mp4a') {
         audioCodec = 'mp4a.40.5';
@@ -1467,9 +1465,9 @@ export default class StreamController
         audioCodec = 'mp4a.40.2';
         this.log(`Android: force audio codec to ${audioCodec}`);
       }
-      if (currentLevel.audioCodec && currentLevel.audioCodec !== audioCodec) {
+      if (levelCodec && levelCodec !== audioCodec) {
         this.log(
-          `Swapping manifest audio codec "${currentLevel.audioCodec}" for "${audioCodec}"`,
+          `Swapping manifest audio codec "${levelCodec}" for "${audioCodec}"`,
         );
       }
       audio.levelCodec = audioCodec;
@@ -1478,7 +1476,7 @@ export default class StreamController
         `Init audio buffer, container:${
           audio.container
         }, codecs[selected/level/parsed]=[${audioCodec || ''}/${
-          currentLevel.audioCodec || ''
+          levelCodec || ''
         }/${audio.codec}]`,
       );
       delete tracks.audiovideo;

--- a/src/utils/codecs.ts
+++ b/src/utils/codecs.ts
@@ -232,7 +232,12 @@ export function pickMostCompleteCodecName(
     (parsedCodec.length > 4 ||
       ['ac-3', 'ec-3', 'alac', 'fLaC', 'Opus'].indexOf(parsedCodec) !== -1)
   ) {
-    return parsedCodec;
+    if (
+      isCodecSupportedAsType(parsedCodec, 'audio') ||
+      isCodecSupportedAsType(parsedCodec, 'video')
+    ) {
+      return parsedCodec;
+    }
   }
   if (levelCodec) {
     const levelCodecs = levelCodec.split(',');
@@ -248,6 +253,10 @@ export function pickMostCompleteCodecName(
     }
   }
   return levelCodec || parsedCodec;
+}
+
+function isCodecSupportedAsType(codec: string, type: CodecType): boolean {
+  return isCodecType(codec, type) && isCodecMediaSourceSupported(codec, type);
 }
 
 export function convertAVC1ToAVCOTI(videoCodecs: string): string {


### PR DESCRIPTION
### This PR will...
Fix errors in SourceBuffer creation when media parsed codec is unsupported

### Why is this Pull Request needed?
#7302 shares an asset that somehow worked in v1.5, presumably because of a workaround for bad mp4a parsed codec strings that may have been removed in v1.6.

This change ensures that supported CODECS codec values will be used instead of the mp4 stsd parsed value when the latter fails an isTypeSupported check.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #7302 and #7355

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
