### PR TITLE
Use SourceBuffer `timestampOffset`

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -4344,9 +4344,9 @@ export interface RemuxedMetadata {
 // @public (undocumented)
 export interface RemuxedTrack {
     // (undocumented)
-    data1: Uint8Array;
+    data1: Uint8Array<ArrayBuffer>;
     // (undocumented)
-    data2?: Uint8Array;
+    data2?: Uint8Array<ArrayBuffer>;
     // (undocumented)
     dropped?: number;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -635,6 +635,8 @@ export interface BufferAppendingData {
     // (undocumented)
     frag: Fragment;
     // (undocumented)
+    offset?: number | undefined;
+    // (undocumented)
     parent: PlaylistLevelType;
     // (undocumented)
     part: Part | null;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1132,12 +1132,16 @@ export default class BaseStreamController
     if (!buffer?.length) {
       return;
     }
-
+    const offsetTimestamp = this.initPTS[frag.cc];
+    const offset = offsetTimestamp
+      ? -offsetTimestamp.baseTime / offsetTimestamp.timescale
+      : undefined;
     const segment: BufferAppendingData = {
       type: data.type,
       frag,
       part,
       chunkMeta,
+      offset,
       parent: frag.type,
       data: buffer,
     };

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -757,7 +757,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const { tracks } = this;
     const { data, type, parent, frag, part, chunkMeta, offset } = eventData;
     const chunkStats = chunkMeta.buffering[type];
-    const sn = frag.sn;
+    const { sn, cc } = frag;
     const bufferAppendingStart = self.performance.now();
     chunkStats.start = bufferAppendingStart;
     const fragBuffering = frag.stats.buffering;
@@ -833,9 +833,9 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
           const sb = track.buffer;
           if (sb) {
             if (checkTimestampOffset) {
-              this.updateTimestampOffset(sb, fragStart, 0.1, type, sn);
+              this.updateTimestampOffset(sb, fragStart, 0.1, type, sn, cc);
             } else if (offset !== undefined && Number.isFinite(offset)) {
-              this.updateTimestampOffset(sb, offset, 0.000001, type, sn);
+              this.updateTimestampOffset(sb, offset, 0.000001, type, sn, cc);
             }
           }
         }
@@ -1596,11 +1596,12 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     tolerance: number,
     type: SourceBufferName,
     sn: number | 'initSegment',
+    cc: number,
   ) {
     const delta = timestampOffset - sb.timestampOffset;
     if (Math.abs(delta) >= tolerance) {
       this.log(
-        `Updating ${type} SourceBuffer timestampOffset to ${timestampOffset} (delta: ${delta}) sn: ${sn})`,
+        `Updating ${type} SourceBuffer timestampOffset to ${timestampOffset} (sn: ${sn} cc: ${cc})`,
       );
       sb.timestampOffset = timestampOffset;
     }

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -583,7 +583,11 @@ export default class GapController extends TaskLoop {
               let moreToLoad = false;
               let pos = startProvisioned.end;
               while (pos < startTime) {
-                const provisioned = fragmentTracker.getPartialFragment(pos);
+                const provisioned =
+                  fragmentTracker.getAppendedFrag(
+                    pos,
+                    PlaylistLevelType.MAIN,
+                  ) || fragmentTracker.getPartialFragment(pos);
                 if (provisioned) {
                   pos += provisioned.duration;
                 } else {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1247,11 +1247,22 @@ export default class StreamController
       }
 
       // This would be nice if Number.isFinite acted as a typeguard, but it doesn't. See: https://github.com/Microsoft/TypeScript/issues/10038
-      const initPTS = initSegment.initPTS as number;
+      const baseTime = initSegment.initPTS as number;
       const timescale = initSegment.timescale as number;
-      if (Number.isFinite(initPTS)) {
-        this.initPTS[frag.cc] = { baseTime: initPTS, timescale };
-        hls.trigger(Events.INIT_PTS_FOUND, { frag, id, initPTS, timescale });
+      const initPTS = this.initPTS[frag.cc];
+      if (
+        Number.isFinite(baseTime) &&
+        (!initPTS ||
+          initPTS.baseTime !== baseTime ||
+          initPTS.timescale !== timescale)
+      ) {
+        this.initPTS[frag.cc] = { baseTime, timescale };
+        hls.trigger(Events.INIT_PTS_FOUND, {
+          frag,
+          id,
+          initPTS: baseTime,
+          timescale,
+        });
       }
     }
 

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -196,7 +196,8 @@ function forwardMessage(event, data, instanceNo) {
 
 function forwardWorkerLogs(logger: ILogger, instanceNo: number) {
   for (const logFn in logger) {
-    const func: ILogFunction = (message?) => {
+    logger[logFn] = function () {
+      const message = Array.prototype.join.call(arguments, ' ');
       forwardMessage(
         'workerLog',
         {
@@ -206,7 +207,6 @@ function forwardWorkerLogs(logger: ILogger, instanceNo: number) {
         instanceNo,
       );
     };
-    logger[logFn] = func;
   }
 }
 

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -1003,8 +1003,7 @@ function parsePES(stream: ElementaryStreamData, logger: ILogger): PES | null {
         (frag[10] & 0xff) * 4194304 + // 1 << 22
         (frag[11] & 0xfe) * 16384 + // 1 << 14
         (frag[12] & 0xff) * 128 + // 1 << 7
-        (frag[13] & 0xfe) / 2 +
-        900000; // padding for silent audio insertion
+        (frag[13] & 0xfe) / 2;
 
       if (pesFlags & 0x40) {
         pesDts =
@@ -1012,8 +1011,7 @@ function parsePES(stream: ElementaryStreamData, logger: ILogger): PES | null {
           (frag[15] & 0xff) * 4194304 + // 1 << 22
           (frag[16] & 0xfe) * 16384 + // 1 << 14
           (frag[17] & 0xff) * 128 + // 1 << 7
-          (frag[18] & 0xfe) / 2 +
-          900000; // padding for silent audio insertion
+          (frag[18] & 0xfe) / 2;
 
         if (pesPts - pesDts > 60 * 90000) {
           logger.warn(

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -1003,7 +1003,8 @@ function parsePES(stream: ElementaryStreamData, logger: ILogger): PES | null {
         (frag[10] & 0xff) * 4194304 + // 1 << 22
         (frag[11] & 0xfe) * 16384 + // 1 << 14
         (frag[12] & 0xff) * 128 + // 1 << 7
-        (frag[13] & 0xfe) / 2;
+        (frag[13] & 0xfe) / 2 +
+        900000; // padding for silent audio insertion
 
       if (pesFlags & 0x40) {
         pesDts =
@@ -1011,7 +1012,8 @@ function parsePES(stream: ElementaryStreamData, logger: ILogger): PES | null {
           (frag[15] & 0xff) * 4194304 + // 1 << 22
           (frag[16] & 0xfe) * 16384 + // 1 << 14
           (frag[17] & 0xff) * 128 + // 1 << 7
-          (frag[18] & 0xfe) / 2;
+          (frag[18] & 0xfe) / 2 +
+          900000; // padding for silent audio insertion
 
         if (pesPts - pesDts > 60 * 90000) {
           logger.warn(

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -934,7 +934,7 @@ export default class MP4Remuxer extends Logger implements Remuxer {
             this.warn(
               `Audio frame @ ${(pts / inputTimeScale).toFixed(
                 3,
-              )}s overlaps nextAudioPts by ${Math.round(
+              )}s overlaps marker by ${Math.round(
                 (1000 * delta) / inputTimeScale,
               )} ms.`,
             );
@@ -957,7 +957,7 @@ export default class MP4Remuxer extends Logger implements Remuxer {
           // Adjust nextPts so that silent samples are aligned with media pts. This will prevent media samples from
           // later being shifted if nextPts is based on timeOffset and delta is not a multiple of inputSampleDuration.
           nextPts = pts - missing * inputSampleDuration;
-          if (nextPts - initTime < 0) {
+          while (nextPts < 0 && missing && inputSampleDuration) {
             missing--;
             nextPts += inputSampleDuration;
           }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -898,11 +898,10 @@ export default class MP4Remuxer implements Remuxer {
         return;
       }
 
-      // if (videoTimeOffset === 0) {
-      //   // Set the start to 0 to match video so that start gaps larger than inputSampleDuration are filled with silence
-      //   nextAudioPts = 0;
-      // } else
-      if (accurateTimeOffset && !alignedWithVideo) {
+      if (videoTimeOffset === 0) {
+        // Set the start to match video so that start gaps larger than inputSampleDuration are filled with silence
+        nextAudioPts = initTime;
+      } else if (accurateTimeOffset && !alignedWithVideo) {
         // When not seeking, not live, and LevelDetails.PTSKnown, use fragment start as predicted next audio PTS
         nextAudioPts = Math.max(0, timeOffsetMpegTS);
       } else {

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -5,11 +5,7 @@ import {
 import { ElementaryStreamTypes } from '../loader/fragment';
 import { getCodecCompatibleName } from '../utils/codecs';
 import { patchEncyptionData } from '../utils/mp4-tools';
-import {
-  getSampleData,
-  offsetStartDTS,
-  parseInitSegment,
-} from '../utils/mp4-tools';
+import { getSampleData, parseInitSegment } from '../utils/mp4-tools';
 import type { HlsConfig } from '../config';
 import type { HlsEventEmitter } from '../events';
 import type { DecryptData } from '../loader/level-key';
@@ -250,8 +246,8 @@ class PassThroughRemuxer implements Remuxer {
     const startTime = audioTrack
       ? decodeTime - initPTS.baseTime / initPTS.timescale
       : (lastEndTime as number);
-    offsetStartDTS(initData, data, initPTS.baseTime / initPTS.timescale);
     const endTime = startTime + duration;
+
     if (duration > 0) {
       this.lastEndTime = endTime;
     } else {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -89,6 +89,7 @@ export interface BufferAppendingData {
   frag: Fragment;
   part: Part | null;
   chunkMeta: ChunkMetadata;
+  offset?: number | undefined;
   parent: PlaylistLevelType;
   data: Uint8Array;
 }

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -36,8 +36,8 @@ export interface Remuxer {
 }
 
 export interface RemuxedTrack {
-  data1: Uint8Array;
-  data2?: Uint8Array;
+  data1: Uint8Array<ArrayBuffer>;
+  data2?: Uint8Array<ArrayBuffer>;
   startPTS: number;
   endPTS: number;
   startDTS: number;

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -159,17 +159,21 @@ module.exports = {
     description: 'Duplicate sequential PDT values',
     abr: false,
   },
-  pdtLargeGap: {
-    url: 'https://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8',
-    description: 'PDTs with large gaps following discontinuities',
-    abr: false,
-    // gaps are introduced by missing audio samples in the TS segments
-    // silent audio insertion can only prepend missing back to the last appended time provided there is room
-    // The discontinuities and starting offset of the timestamps do not allow prepending earlier than the start of the disco
-    allowedBufferedRangesInSeekTest: 7,
-    // Ignore "should buffer up to maxBufferLength" result
-    avBufferOffset: 39,
-  },
+  pdtLargeGap: createTestStreamWithConfig(
+    {
+      url: 'https://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8',
+      description: 'PDTs with large gaps following discontinuities',
+      abr: false,
+    },
+    {
+      // gaps are introduced by missing audio samples in the TS segments
+      // silent audio insertion can only prepend missing back to the last appended time provided there is room
+      // The discontinuities and starting offset of the timestamps do not allow prepending earlier than the start of the disco
+      allowedBufferedRangesInSeekTest: 7,
+      // Ignore "should buffer up to maxBufferLength" result
+      avBufferOffset: 39,
+    },
+  ),
   pdtBadValues: {
     url: 'https://playertest.longtailvideo.com/adaptive/progdatime/playlist2.m3u8',
     description: 'PDTs with bad values',

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -167,6 +167,8 @@ module.exports = {
     // silent audio insertion can only prepend missing back to the last appended time provided there is room
     // The discontinuities and starting offset of the timestamps do not allow prepending earlier than the start of the disco
     allowedBufferedRangesInSeekTest: 7,
+    // Ignore "should buffer up to maxBufferLength" result
+    avBufferOffset: 39,
   },
   pdtBadValues: {
     url: 'https://playertest.longtailvideo.com/adaptive/progdatime/playlist2.m3u8',

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -163,6 +163,10 @@ module.exports = {
     url: 'https://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8',
     description: 'PDTs with large gaps following discontinuities',
     abr: false,
+    // gaps are introduced by missing audio samples in the TS segments
+    // silent audio insertion can only prepend missing back to the last appended time provided there is room
+    // The discontinuities and starting offset of the timestamps do not allow prepending earlier than the start of the disco
+    allowedBufferedRangesInSeekTest: 7,
   },
   pdtBadValues: {
     url: 'https://playertest.longtailvideo.com/adaptive/progdatime/playlist2.m3u8',


### PR DESCRIPTION
### This PR will...

Use SourceBuffer `timestampOffset` rather than modify mp4 decode timestamps.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

This is a work-in-progress. Known issues include improper offset of discontinuities with MPEG-TS or muxed content. Additional testing and review is needed to find and fix the application of `initPTS` offsets on append.

### Resolves issues:

- #5715
- #7310 (this is an issue with audio samples starting before video and the base media decode timestamp of audio of the first append being moved forward to 0 to avoid using a signed value for what is expected to be unsigned)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
