### PR TITLE
Functional test runner setup changes for running in Safari locally

### DIFF
--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -13,9 +13,13 @@ const HlsjsLightBuild = !!process.env.HLSJS_LIGHT;
 const chai = require('chai');
 const expect = chai.expect;
 
+const UA = process.env.UA || 'chrome';
+const UA_VERSION = process.env.UA_VERSION || 'latest';
+const HLSJS_TEST_BASE = process.env.HLSJS_TEST_BASE;
+
 const browserConfig = {
-  version: 'latest',
-  name: 'chrome',
+  version: UA_VERSION,
+  name: UA,
 };
 
 /**
@@ -40,11 +44,6 @@ if (useSauce) {
     throw new Error('Missing sauce auth.');
   }
 
-  const UA_VERSION = process.env.UA_VERSION;
-  if (UA_VERSION) {
-    browserConfig.version = UA_VERSION;
-  }
-
   browserConfig.name = UA;
   browserConfig.platform = OS;
 }
@@ -60,11 +59,13 @@ if (browserConfig.platform) {
 }
 
 // Launch static server
-HttpServer.createServer({
-  showDir: false,
-  autoIndex: false,
-  root: './',
-}).listen(8000, useSauce ? '0.0.0.0' : '127.0.0.1');
+if (useSauce || !HLSJS_TEST_BASE) {
+  HttpServer.createServer({
+    showDir: false,
+    autoIndex: false,
+    root: './',
+  }).listen(8000, useSauce ? '0.0.0.0' : '127.0.0.1');
+}
 
 const wait = (ms) => new Promise((resolve) => global.setTimeout(resolve, ms));
 const stringifyResult = (result) =>
@@ -152,9 +153,7 @@ async function testSmoothSwitch(url, config) {
   const result = await browser.executeAsyncScript(
     function (url, config) {
       const callback = arguments[arguments.length - 1];
-      const startConfig = self.objectAssign(config, {
-        startLevel: 0,
-      });
+      const startConfig = self.objectAssign(config, { startLevel: 0 });
       self.startStream(url, startConfig, callback);
       self.hls.manualLevel = 0;
       const video = self.video;
@@ -163,11 +162,14 @@ async function testSmoothSwitch(url, config) {
           '[test] > ' + eventName + ' frag.level: ' + data.frag.level
         );
         const highestLevel = self.hls.levels.length - 1;
-        if (highestLevel === 0) {
+        const level = self.hls.levels[data.frag.level];
+        const fragmentCount = level.details.fragments.length;
+        if (highestLevel === 0 || fragmentCount === 1) {
           callback({
             highestLevel: highestLevel,
-            currentTimeDelta: 0,
-            message: 'No adaptive variants',
+            currentTimeDelta: 1, // pass the test by assigning currentTimeDelta > 0
+            message:
+              highestLevel === 0 ? 'No adaptive variants' : 'Only one segment',
             logs: self.logString,
           });
           return;
@@ -481,7 +483,18 @@ async function sauceDisconnect() {
   });
 }
 
+function getPageURLComponents() {
+  return {
+    base:
+      useSauce || !HLSJS_TEST_BASE ? 'http://localhost:8000' : HLSJS_TEST_BASE,
+    path: '/tests/functional/auto/',
+    file: `index${HlsjsLightBuild ? '-light' : ''}.html`,
+  };
+}
+
 describe(`testing hls.js playback in the browser on "${browserDescription}"`, function () {
+  const failedUrls = {};
+
   before(async function () {
     // high timeout because sometimes getSession() takes a while
     this.timeout(100000);
@@ -504,8 +517,27 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
       };
     }
 
-    browser = new webdriver.Builder();
-    if (useSauce) {
+    if (!useSauce) {
+      // Configure webdriver for local testing
+      if (browserConfig.name === 'safari') {
+        browser = new webdriver.Builder()
+          .forBrowser(webdriver.Browser.SAFARI)
+          .build();
+      } else if (browserConfig.name === 'chrome') {
+        browser = new webdriver.Builder()
+          .forBrowser(webdriver.Browser.CHROME)
+          .setChromeOptions()
+          .build();
+      } else if (browserConfig.name === 'firefox') {
+        browser = new webdriver.Builder()
+          .forBrowser(webdriver.Browser.FIREFOX)
+          .build();
+      } else {
+        browser = new webdriver.Builder()
+          .withCapabilities(capabilities)
+          .build();
+      }
+    } else {
       if (process.env.SAUCE_TUNNEL_ID) {
         capabilities['sauce:options'] = {
           build: 'HLSJS-' + process.env.SAUCE_TUNNEL_ID,
@@ -524,12 +556,13 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
       capabilities['sauce:options'].public = 'public restricted';
       capabilities['sauce:options'].avoidProxy = true;
       capabilities['sauce:options']['record-screenshots'] = false;
-      browser = browser.usingServer(
-        `https://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@ondemand.us-west-1.saucelabs.com:443/wd/hub`
-      );
+      browser = new webdriver.Builder()
+        .usingServer(
+          `https://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@ondemand.us-west-1.saucelabs.com:443/wd/hub`
+        )
+        .withCapabilities(capabilities)
+        .build();
     }
-
-    browser = browser.withCapabilities(capabilities).build();
 
     const start = Date.now();
 
@@ -556,13 +589,14 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
   beforeEach(async function () {
     try {
       await retry(async () => {
-        const testPageExt = HlsjsLightBuild ? '-light' : '';
-        const testPageUrl = `http://localhost:8000/tests/functional/auto/index${testPageExt}.html`;
+        const page = getPageURLComponents();
+        const testPageUrl = `${page.base}${page.path}${page.file}`;
         if (printDebugLogs) {
           console.log(`Loading test page: ${testPageUrl}`);
         }
         try {
           await browser.get(testPageUrl);
+          await browser.manage().window().setRect(0, 0, 1200, 850);
         } catch (e) {
           throw new Error('failed to open test page');
         }
@@ -592,10 +626,24 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
   afterEach(async function () {
     const failed = this.currentTest.isFailed();
     if (printDebugLogs || failed) {
-      const logString = await browser.executeScript(
-        'return window.logString || "";'
-      );
-      console.log(logString);
+      const json = await browser.executeScript(function () {
+        return JSON.stringify({
+          url: self.hls ? self.hls.url : 'undefined',
+          logs: self.logString || '',
+        });
+      });
+      const data = JSON.parse(json);
+      const url = data.url;
+
+      const page = getPageURLComponents();
+      console.log(`${page.base}/hls.js/demo/?src=${encodeURIComponent(url)}
+
+============================= LOGS =======================================
+${data.logs}
+==========================================================================
+`);
+      failedUrls[url] = url in failedUrls ? failedUrls[url] + 1 : 1;
+
       if (failed && useSauce) {
         browser.executeScript('sauce:job-result=failed');
       }
@@ -612,6 +660,9 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
     console.log('Quitting browser...');
     await browser.quit();
     console.log('Browser quit.');
+    if (Object.keys(failedUrls).length > 0) {
+      console.log(JSON.stringify(failedUrls, null, 2));
+    }
     if (useSauce) {
       await sauceDisconnect();
     }
@@ -619,23 +670,16 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
 
   const entries = Object.entries(streams);
   if (HlsjsLightBuild) {
-    entries.length = 13;
+    entries.length = 10;
   }
-
-  const isSafari = browserConfig.name === 'safari';
 
   entries
     // eslint-disable-next-line no-unused-vars
     .filter(([name, stream]) => !stream.skipFunctionalTests)
     // eslint-disable-next-line no-unused-vars
-    .forEach(([name, stream]) => {
+    .forEach(([name, stream], index) => {
       const url = stream.url;
       const config = stream.config || {};
-
-      // Segment media is shorted than playlist duration resulting in overlapping appends on switch
-      // This appears to prevent playback in Safari which causes smoothswitch and VOD ended event tests to fail
-      const isStreamsWithOverlappingAppends =
-        name === 'arte' || name === 'oceansAES';
 
       config.preferManagedMediaSource = false;
       if (
@@ -664,7 +708,7 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
         );
       }
 
-      if (stream.abr && (!isSafari || !isStreamsWithOverlappingAppends)) {
+      if (stream.abr) {
         it(
           `should "smooth switch" to highest level and still play after 2s for ${stream.description}`,
           testSmoothSwitch.bind(null, url, config)
@@ -685,12 +729,11 @@ describe(`testing hls.js playback in the browser on "${browserDescription}"`, fu
           `should play ${stream.description}`,
           testIsPlayingVOD.bind(null, url, config)
         );
-        if (!isSafari || !isStreamsWithOverlappingAppends) {
-          it(
-            `should seek 3s from end and receive video ended event for ${stream.description} with 2 or less buffered ranges`,
-            testSeekOnVOD.bind(null, url, config)
-          );
-        }
+
+        it(
+          `should seek 3s from end and receive video ended event for ${stream.description} with 2 or less buffered ranges`,
+          testSeekOnVOD.bind(null, url, config)
+        );
         // TODO: Seeking to or past VOD duration should result in the video ending
         // it(`should seek on end and receive video ended event for ${stream.description}`, testSeekEndVOD.bind(null, url));
       }


### PR DESCRIPTION
### This PR will...
Update functional test runner to run locally with Safari, Chrome, and Firefox.

Example:
`UA=safari npm run test:func`

Also adds a demo page debug url for each failed test:

```
    5) should seek 3s from end and receive video ended event for HLS fMP4...
http://localhost:8000/hls.js/demo/?src=https%3A%2F%...
```

and a summary of asset urls failures:

```
Quitting browser...
Browser quit.
{
  "http://example.com/test1.m3u8": 7,
  "http://example.com/test2.m3u8": 1
}


  121 passing (10m)
  8 failing
```

### Why is this Pull Request needed?
Legacy webdriver configuration is needed for saucelabs, but is unable to locate drivers locally on macos.


### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
