### PR TITLE
Fix unnecessary setting of MediaSource duration with stale value

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1102,11 +1102,13 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   }
 
   private updateDuration() {
-    const durationAndRange = this.getDurationAndRange();
-    if (!durationAndRange) {
-      return;
-    }
-    this.blockUntilOpen(() => this.updateMediaSource(durationAndRange));
+    this.blockUntilOpen(() => {
+      const durationAndRange = this.getDurationAndRange();
+      if (!durationAndRange) {
+        return;
+      }
+      this.updateMediaSource(durationAndRange);
+    });
   }
 
   private onError(event: Events.ERROR, data: ErrorData) {


### PR DESCRIPTION
### This PR will...
Wait to check if duration and seekable range should be set until any blocking operation is complete.
 
### Why is this Pull Request needed?
Ensures that MediaSource duration is not set to a value less than its current value. Doing so invokes buffer ejection and can result in the next append failing because it puts the source in an updating state.

### Are there any points in the code the reviewer needs to double check?

Branched from #7311, these changes should be rebased once that PR is merged.

### Resolves issues:
Fixes #7321

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
