### PR TITLE
Support interstitial schedule navigation on INTERSTITIAL_ASSET_ENDED

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1084,6 +1084,21 @@ export default class InterstitialsController
           scheduleIndex: index,
           player,
         });
+        if (currentItem !== this.playingItem) {
+          // Schedule change occured on INTERSTITIAL_ASSET_ENDED
+          if (
+            this.itemsMatch(currentItem, this.playingItem) &&
+            !this.playingAsset
+          ) {
+            this.advanceAfterAssetEnded(
+              interstitial,
+              this.findItemIndex(this.playingItem),
+              playingAssetListIndex,
+            );
+          }
+          // Navigation occured on INTERSTITIAL_ASSET_ENDED
+          return;
+        }
         this.retreiveMediaSource(assetId, scheduledItem);
         if (player.media && !this.detachedData?.mediaSource) {
           player.detachMedia();
@@ -1107,7 +1122,7 @@ export default class InterstitialsController
           this.updateSchedule();
           const items = this.schedule.items;
           if (scheduledItem && items) {
-            const updatedIndex = this.schedule.findItemIndex(scheduledItem);
+            const updatedIndex = this.findItemIndex(scheduledItem);
             this.advanceSchedule(
               updatedIndex,
               items,
@@ -2537,7 +2552,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     // If all assets in interstitial fail, mark the interstitial with an error
     if (!interstitial.assetList.some((asset) => !asset.error)) {
       interstitial.error = error;
-    } else if (interstitial.appendInPlace) {
+    } else {
       // Reset level details and reload/parse media playlists to align with updated schedule
       for (let i = assetListIndex; i < interstitial.assetList.length; i++) {
         this.resetAssetPlayer(interstitial.assetList[i].identifier);

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'eventemitter3';
 import Transmuxer, { isPromise } from '../demux/transmuxer';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
-import { enableLogs, type ILogFunction, type ILogger } from '../utils/logger';
+import { enableLogs, type ILogger } from '../utils/logger';
 import type { RemuxedTrack, RemuxerResult } from '../types/remuxer';
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 


### PR DESCRIPTION
### This PR will...
Support interstitial schedule navigation on INTERSTITIAL_ASSET_ENDED

### Why is this Pull Request needed?
Interstitial events are fired synchronously on schedule change. If an app navigates on one of these events, then the `setSchedulePosition` process that fired that event must be exited.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
