### PR TITLE
Fix subtitle segment loading at live start

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -202,8 +202,18 @@ export class TimelineController implements ComponentAPI {
     // Parse any unparsed fragments upon receiving the initial PTS.
     if (unparsedVttFrags.length) {
       this.unparsedVttFrags = [];
-      unparsedVttFrags.forEach((frag) => {
-        this.onFragLoaded(Events.FRAG_LOADED, frag as FragLoadedData);
+      unparsedVttFrags.forEach((data) => {
+        if (this.initPTS[data.frag.cc]) {
+          this.onFragLoaded(Events.FRAG_LOADED, data as FragLoadedData);
+        } else {
+          this.hls.trigger(Events.SUBTITLE_FRAG_PROCESSED, {
+            success: false,
+            frag: data.frag,
+            error: new Error(
+              'Subtitle discontinuity domain does not match main',
+            ),
+          });
+        }
       });
     }
   }

--- a/tests/unit/controller/subtitle-stream-controller.ts
+++ b/tests/unit/controller/subtitle-stream-controller.ts
@@ -1,14 +1,18 @@
+import chai from 'chai';
 import sinon from 'sinon';
-
-import Hls from '../../../src/hls';
-import { Events } from '../../../src/events';
+import sinonChai from 'sinon-chai';
+import { State } from '../../../src/controller/base-stream-controller';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
+import { SubtitleStreamController } from '../../../src/controller/subtitle-stream-controller';
+import { Events } from '../../../src/events';
+import Hls from '../../../src/hls';
 import { Fragment } from '../../../src/loader/fragment';
+import KeyLoader from '../../../src/loader/key-loader';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import { AttrList } from '../../../src/utils/attr-list';
-import KeyLoader from '../../../src/loader/key-loader';
-import { State } from '../../../src/controller/base-stream-controller';
-import { SubtitleStreamController } from '../../../src/controller/subtitle-stream-controller';
+
+chai.use(sinonChai);
+const expect = chai.expect;
 
 const mediaMock = {
   currentTime: 0,
@@ -20,11 +24,11 @@ const tracksMock = [
   {
     id: 0,
     details: { url: '', fragments: [] },
-    attrs: new AttrList(),
+    attrs: new AttrList({}),
   },
   {
     id: 1,
-    attrs: new AttrList(),
+    attrs: new AttrList({}),
   },
 ];
 
@@ -38,7 +42,7 @@ describe('SubtitleStreamController', function () {
     hls = new Hls({});
     mediaMock.currentTime = 0;
     fragmentTracker = new FragmentTracker(hls);
-    keyLoader = new KeyLoader({});
+    keyLoader = new KeyLoader(hls.config);
 
     subtitleStreamController = new SubtitleStreamController(
       hls,

--- a/tests/unit/controller/timeline-controller.ts
+++ b/tests/unit/controller/timeline-controller.ts
@@ -1,6 +1,11 @@
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
 import { TimelineController } from '../../../src/controller/timeline-controller';
-import Hls from '../../../src/hls';
 import { Events } from '../../../src/events';
+import Hls from '../../../src/hls';
+
+chai.use(sinonChai);
+const expect = chai.expect;
 
 describe('TimelineController', function () {
   let timelineController;


### PR DESCRIPTION
### This PR will...
Fix subtitle segment loading hanging on live start with mismatched discontinuity

### Why is this Pull Request needed?
The subtitle-stream-controller must determine where to begin loading segments in the same way that the audio-stream-controller does, in sync with the live start determined by the main stream-controller.

### Are there any points in the code the reviewer needs to double check?
If subtitle segments are loaded in another discontinuity domain for which the init PTS is not resolved, the segment data should be dropped, and subtitle segment loading resumed.

### Resolves issues:
Fixes #7347

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
