### PR TITLE
Fix QuotaExceededError regression caused by change in Chrome 138

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -810,7 +810,9 @@ class AudioStreamController
         if (data.parent !== 'audio') {
           return;
         }
-        this.resetLoadingState();
+        if (!this.reduceLengthAndFlushBuffer(data)) {
+          this.resetLoadingState();
+        }
         break;
       case ErrorDetails.BUFFER_FULL_ERROR:
         if (data.parent !== 'audio') {

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -785,7 +785,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     }
 
     // Block audio append until overlapping video append
-    const videoTrack = this.tracks.video;
+    const videoTrack = tracks.video;
     const videoSb = videoTrack?.buffer;
     if (videoSb && sn !== 'initSegment') {
       const partOrFrag = part || (frag as MediaFragment);
@@ -828,15 +828,12 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       execute: () => {
         chunkStats.executeStart = self.performance.now();
 
-        const track = this.tracks[type];
-        if (track) {
-          const sb = track.buffer;
-          if (sb) {
-            if (checkTimestampOffset) {
-              this.updateTimestampOffset(sb, fragStart, 0.1, type, sn, cc);
-            } else if (offset !== undefined && Number.isFinite(offset)) {
-              this.updateTimestampOffset(sb, offset, 0.000001, type, sn, cc);
-            }
+        const sb = this.tracks[type]?.buffer;
+        if (sb) {
+          if (checkTimestampOffset) {
+            this.updateTimestampOffset(sb, fragStart, 0.1, type, sn, cc);
+          } else if (offset !== undefined && Number.isFinite(offset)) {
+            this.updateTimestampOffset(sb, offset, 0.000001, type, sn, cc);
           }
         }
         this.appendExecutor(data, type);
@@ -892,7 +889,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
           fatal: false,
         };
         const mediaError = this.media?.error;
-        if ((error as DOMException).code === DOMException.QUOTA_EXCEEDED_ERR) {
+        if (
+          (error as DOMException).code === DOMException.QUOTA_EXCEEDED_ERR ||
+          error.name == 'QuotaExceededError'
+        ) {
           // QuotaExceededError: http://www.w3.org/TR/html5/infrastructure.html#quotaexceedederror
           // let's stop appending any segments, and report BUFFER_FULL_ERROR error
           event.details = ErrorDetails.BUFFER_FULL_ERROR;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -891,7 +891,8 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         const mediaError = this.media?.error;
         if (
           (error as DOMException).code === DOMException.QUOTA_EXCEEDED_ERR ||
-          error.name == 'QuotaExceededError'
+          error.name == 'QuotaExceededError' ||
+          `quota` in error
         ) {
           // QuotaExceededError: http://www.w3.org/TR/html5/infrastructure.html#quotaexceedederror
           // let's stop appending any segments, and report BUFFER_FULL_ERROR error

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -1,4 +1,5 @@
 import { ErrorActionFlags, NetworkErrorAction } from './error-controller';
+import { ErrorDetails } from '../errors';
 import { Events } from '../events';
 import { Level } from '../types/level';
 import {
@@ -216,7 +217,11 @@ export default class ContentSteeringController
         this.updatePathwayPriority(pathwayPriority);
         errorAction.resolved = this.pathwayId !== errorPathway;
       }
-      if (!errorAction.resolved) {
+      if (data.details === ErrorDetails.BUFFER_APPEND_ERROR && !data.fatal) {
+        // Error will become fatal in buffer-controller when reaching `appendErrorMaxRetry`
+        // Stream-controllers are expected to reduce buffer length even if this is not deemed a QuotaExceededError
+        errorAction.resolved = true;
+      } else if (!errorAction.resolved) {
         this.warn(
           `Could not resolve ${data.details} ("${
             data.error.message

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -218,7 +218,7 @@ export default class ErrorController
       case ErrorDetails.REMUX_ALLOC_ERROR:
       case ErrorDetails.BUFFER_APPEND_ERROR:
         // Buffer-controller can set errorAction when append errors can be ignored or resolved locally
-        if (!data.errorAction && hls.levels.length > 1) {
+        if (!data.errorAction) {
           data.errorAction = this.getLevelSwitchAction(
             data,
             data.level ?? hls.loadLevel,

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -218,7 +218,7 @@ export default class ErrorController
       case ErrorDetails.REMUX_ALLOC_ERROR:
       case ErrorDetails.BUFFER_APPEND_ERROR:
         // Buffer-controller can set errorAction when append errors can be ignored or resolved locally
-        if (!data.errorAction) {
+        if (!data.errorAction && hls.levels.length > 1) {
           data.errorAction = this.getLevelSwitchAction(
             data,
             data.level ?? hls.loadLevel,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1053,7 +1053,9 @@ export default class StreamController
         if (data.parent !== 'main') {
           return;
         }
-        this.resetLoadingState();
+        if (this.reduceLengthAndFlushBuffer(data)) {
+          this.resetLoadingState();
+        }
         break;
       case ErrorDetails.BUFFER_FULL_ERROR:
         if (data.parent !== 'main') {


### PR DESCRIPTION
### This PR will...
This change ensures that QuotaExceededError is handled properly even after changes proposed in https://github.com/whatwg/webidl/pull/1465 or any other change that would prevent identification of an append error as a "buffer full" (QuotaExceededError) error.

### Why is this Pull Request needed?
Handles error object with incorrect `code` (!= 22), and always reduces max buffer length on append error.

Prevents first append error that is not a buffer full from being escalated to fatal when there are no other levels (allowing for retries up to `appendErrorMaxRetry`).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7367

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
