### PR TITLE
Fix Widevine PSSH KEYID parsing

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3361,6 +3361,8 @@ export class LevelKey implements DecryptData {
     // (undocumented)
     keyId: Uint8Array<ArrayBuffer> | null;
     // (undocumented)
+    matches(key: LevelKey): boolean;
+    // (undocumented)
     readonly method: string;
     // (undocumented)
     pssh: Uint8Array<ArrayBuffer> | null;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -201,9 +201,7 @@ class AudioStreamController
     const syncFrag = findNearestWithCC(trackDetails, targetDiscontinuity, pos);
     // Only stop waiting for audioFrag.cc if an audio segment of the same discontinuity domain (cc) is found
     if (syncFrag) {
-      this.log(
-        `Waiting fragment cc (${waitingToAppend?.cc}) cancelled because video is at cc ${mainAnchor.cc}`,
-      );
+      this.log(`Syncing with main frag at ${syncFrag.start} cc ${syncFrag.cc}`);
       this.startFragRequested = false;
       this.nextLoadPosition = syncFrag.start;
       this.resetLoadingState();

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -52,6 +52,17 @@ export class LevelKey implements DecryptData {
       this.encrypted && !isFullSegmentEncryption(method);
   }
 
+  public matches(key: LevelKey): boolean {
+    return (
+      key.uri === this.uri &&
+      key.method === this.method &&
+      key.encrypted === this.encrypted &&
+      key.keyFormat === this.keyFormat &&
+      key.keyFormatVersions.join(',') === this.keyFormatVersions.join(',') &&
+      key.iv?.join(',') === this.iv?.join(',')
+    );
+  }
+
   public isSupported(): boolean {
     // If it's Segment encryption or No encryption, just select that key system
     if (this.method) {

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -572,10 +572,14 @@ export default class M3U8Parser {
               if (!levelkeys) {
                 levelkeys = {};
               }
-              if (levelkeys[levelKey.keyFormat]) {
-                levelkeys = Object.assign({}, levelkeys);
+              const currentKey = levelkeys[levelKey.keyFormat];
+              // Ignore duplicate playlist KEY tags
+              if (!currentKey?.matches(levelKey)) {
+                if (currentKey) {
+                  levelkeys = Object.assign({}, levelkeys);
+                }
+                levelkeys[levelKey.keyFormat] = levelKey;
               }
-              levelkeys[levelKey.keyFormat] = levelKey;
             } else {
               logger.warn(`[Keys] Ignoring invalid EXT-X-KEY tag: "${value1}"`);
             }

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -19,7 +19,7 @@ type EMEControllerTestable = Omit<
 > & {
   hls: HlsMock;
   keyIdToKeySessionPromise: {
-    [keyId: string]: Promise<MediaKeySessionContext>;
+    [keyUri: string]: Promise<MediaKeySessionContext>;
   };
   mediaKeySessions: MediaKeySessionContext[];
   onMediaAttached: (
@@ -314,7 +314,7 @@ describe('EMEController', function () {
       .then(() => {
         expect(emeController.keyIdToKeySessionPromise).to.deep.equal(
           {},
-          '`keyIdToKeySessionPromise` should be an empty dictionary when no key IDs are found',
+          '`keyIdToKeySessionPromise` should be an empty dictionary when no keys are found',
         );
       });
   });
@@ -411,26 +411,20 @@ describe('EMEController', function () {
       },
     } as any);
 
-    expect(
-      emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ],
-    ).to.be.a('Promise');
-    if (
-      !emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ]
-    ) {
+    expect(emeController.keyIdToKeySessionPromise['data://key-uri']).to.be.a(
+      'Promise',
+    );
+    if (!emeController.keyIdToKeySessionPromise['data://key-uri']) {
       return;
     }
-    return emeController.keyIdToKeySessionPromise[
-      '00000000000000000000000000000000'
-    ].finally(() => {
-      expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
-      expect(mediaKeysSetServerCertificateSpy).to.have.been.calledWith(
-        xhrInstance.response,
-      );
-    });
+    return emeController.keyIdToKeySessionPromise['data://key-uri'].finally(
+      () => {
+        expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
+        expect(mediaKeysSetServerCertificateSpy).to.have.been.calledWith(
+          xhrInstance.response,
+        );
+      },
+    );
   });
 
   it('should fetch the server certificate and trigger update failed error', function () {
@@ -494,21 +488,13 @@ describe('EMEController', function () {
       },
     } as any);
 
-    expect(
-      emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ],
-    ).to.be.a('Promise');
-    if (
-      !emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ]
-    ) {
+    expect(emeController.keyIdToKeySessionPromise['data://key-uri']).to.be.a(
+      'Promise',
+    );
+    if (!emeController.keyIdToKeySessionPromise['data://key-uri']) {
       return;
     }
-    return emeController.keyIdToKeySessionPromise[
-      '00000000000000000000000000000000'
-    ]
+    return emeController.keyIdToKeySessionPromise['data://key-uri']
       .catch(() => {})
       .finally(() => {
         expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
@@ -577,21 +563,13 @@ describe('EMEController', function () {
       },
     } as any);
 
-    expect(
-      emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ],
-    ).to.be.a('Promise');
-    if (
-      !emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ]
-    ) {
+    expect(emeController.keyIdToKeySessionPromise['data://key-uri']).to.be.a(
+      'Promise',
+    );
+    if (!emeController.keyIdToKeySessionPromise['data://key-uri']) {
       return;
     }
-    return emeController.keyIdToKeySessionPromise[
-      '00000000000000000000000000000000'
-    ]
+    return emeController.keyIdToKeySessionPromise['data://key-uri']
       .catch(() => {})
       .finally(() => {
         expect(emeController.hls.trigger).to.have.been.calledOnce;

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -15,10 +15,10 @@ const expect = chai.expect;
 
 type EMEControllerTestable = Omit<
   EMEController,
-  'hls' | 'keyIdToKeySessionPromise' | 'mediaKeySessions'
+  'hls' | 'keySessionPromises' | 'mediaKeySessions'
 > & {
   hls: HlsMock;
-  keyIdToKeySessionPromise: {
+  keySessionPromises: {
     [keyUri: string]: Promise<MediaKeySessionContext>;
   };
   mediaKeySessions: MediaKeySessionContext[];
@@ -312,9 +312,9 @@ describe('EMEController', function () {
         type: 'main',
       } as any)
       .then(() => {
-        expect(emeController.keyIdToKeySessionPromise).to.deep.equal(
+        expect(emeController.keySessionPromises).to.deep.equal(
           {},
-          '`keyIdToKeySessionPromise` should be an empty dictionary when no keys are found',
+          '`keySessionPromises` should be an empty dictionary when no keys are found',
         );
       });
   });
@@ -411,20 +411,18 @@ describe('EMEController', function () {
       },
     } as any);
 
-    expect(emeController.keyIdToKeySessionPromise['data://key-uri']).to.be.a(
+    expect(emeController.keySessionPromises['data://key-uri']).to.be.a(
       'Promise',
     );
-    if (!emeController.keyIdToKeySessionPromise['data://key-uri']) {
+    if (!emeController.keySessionPromises['data://key-uri']) {
       return;
     }
-    return emeController.keyIdToKeySessionPromise['data://key-uri'].finally(
-      () => {
-        expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
-        expect(mediaKeysSetServerCertificateSpy).to.have.been.calledWith(
-          xhrInstance.response,
-        );
-      },
-    );
+    return emeController.keySessionPromises['data://key-uri'].finally(() => {
+      expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
+      expect(mediaKeysSetServerCertificateSpy).to.have.been.calledWith(
+        xhrInstance.response,
+      );
+    });
   });
 
   it('should fetch the server certificate and trigger update failed error', function () {
@@ -488,13 +486,13 @@ describe('EMEController', function () {
       },
     } as any);
 
-    expect(emeController.keyIdToKeySessionPromise['data://key-uri']).to.be.a(
+    expect(emeController.keySessionPromises['data://key-uri']).to.be.a(
       'Promise',
     );
-    if (!emeController.keyIdToKeySessionPromise['data://key-uri']) {
+    if (!emeController.keySessionPromises['data://key-uri']) {
       return;
     }
-    return emeController.keyIdToKeySessionPromise['data://key-uri']
+    return emeController.keySessionPromises['data://key-uri']
       .catch(() => {})
       .finally(() => {
         expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
@@ -563,13 +561,13 @@ describe('EMEController', function () {
       },
     } as any);
 
-    expect(emeController.keyIdToKeySessionPromise['data://key-uri']).to.be.a(
+    expect(emeController.keySessionPromises['data://key-uri']).to.be.a(
       'Promise',
     );
-    if (!emeController.keyIdToKeySessionPromise['data://key-uri']) {
+    if (!emeController.keySessionPromises['data://key-uri']) {
       return;
     }
-    return emeController.keyIdToKeySessionPromise['data://key-uri']
+    return emeController.keySessionPromises['data://key-uri']
       .catch(() => {})
       .finally(() => {
         expect(emeController.hls.trigger).to.have.been.calledOnce;


### PR DESCRIPTION
### This PR will...
- Identify CDM key sessions by Key URI rather than parsed Key ID
- Deduplicate segment assigned EXT-X-KEY tag data (`levelKeys`/`decryptData`) with identical attributes in media playlists

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7369

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
