### PR TITLE
Fix Widevine KEYID parsing

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3339,7 +3339,7 @@ export class LevelDetails {
 //
 // @public (undocumented)
 export class LevelKey implements DecryptData {
-    constructor(method: string, uri: string, format: string, formatversions?: number[], iv?: Uint8Array<ArrayBuffer> | null);
+    constructor(method: string, uri: string, format: string, formatversions?: number[], iv?: Uint8Array<ArrayBuffer> | null, keyId?: string);
     // (undocumented)
     static clearKeyUriToKeyIdMap(): void;
     // (undocumented)
@@ -3360,6 +3360,8 @@ export class LevelKey implements DecryptData {
     readonly keyFormatVersions: number[];
     // (undocumented)
     keyId: Uint8Array<ArrayBuffer> | null;
+    // (undocumented)
+    matches(key: LevelKey): boolean;
     // (undocumented)
     readonly method: string;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -201,9 +201,7 @@ class AudioStreamController
     const syncFrag = findNearestWithCC(trackDetails, targetDiscontinuity, pos);
     // Only stop waiting for audioFrag.cc if an audio segment of the same discontinuity domain (cc) is found
     if (syncFrag) {
-      this.log(
-        `Waiting fragment cc (${waitingToAppend?.cc}) cancelled because video is at cc ${mainAnchor.cc}`,
-      );
+      this.log(`Syncing with main frag at ${syncFrag.start} cc ${syncFrag.cc}`);
       this.startFragRequested = false;
       this.nextLoadPosition = syncFrag.start;
       this.resetLoadingState();

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -6,6 +6,7 @@ import {
   isSCTE35Attribute,
 } from '../loader/date-range';
 import { MetadataSchema } from '../types/demuxer';
+import { hexToArrayBuffer } from '../utils/hex';
 import { stringify } from '../utils/safe-json-stringify';
 import {
   clearCurrentCues,
@@ -73,15 +74,6 @@ const MAX_CUE_ENDTIME = (() => {
   return Number.POSITIVE_INFINITY;
 })();
 
-function hexToArrayBuffer(str): ArrayBuffer {
-  return Uint8Array.from(
-    str
-      .replace(/^0x/, '')
-      .replace(/([\da-fA-F]{2}) ?/g, '0x$1 ')
-      .replace(/ +$/, '')
-      .split(' '),
-  ).buffer;
-}
 class ID3TrackController implements ComponentAPI {
   private hls: Hls;
   private id3Track: TextTrack | null = null;

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -572,10 +572,14 @@ export default class M3U8Parser {
               if (!levelkeys) {
                 levelkeys = {};
               }
-              if (levelkeys[levelKey.keyFormat]) {
-                levelkeys = Object.assign({}, levelkeys);
+              const currentKey = levelkeys[levelKey.keyFormat];
+              // Ignore duplicate playlist KEY tags
+              if (!currentKey?.matches(levelKey)) {
+                if (currentKey) {
+                  levelkeys = Object.assign({}, levelkeys);
+                }
+                levelkeys[levelKey.keyFormat] = levelKey;
               }
-              levelkeys[levelKey.keyFormat] = levelKey;
             } else {
               logger.warn(`[Keys] Ignoring invalid EXT-X-KEY tag: "${value1}"`);
             }
@@ -856,6 +860,7 @@ function parseKey(
     decryptkeyformat,
     keyFormatVersions,
     decryptiv,
+    keyAttrs.KEYID,
   );
 }
 

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -3,7 +3,7 @@
  */
 
 const Hex = {
-  hexDump: function (array: Uint8Array) {
+  hexDump: function (array: Uint8Array<ArrayBuffer>) {
     let str = '';
     for (let i = 0; i < array.length; i++) {
       let h = array[i].toString(16);
@@ -16,5 +16,15 @@ const Hex = {
     return str;
   },
 };
+
+export function hexToArrayBuffer(str: string): ArrayBuffer {
+  return Uint8Array.from(
+    str
+      .replace(/^0x/, '')
+      .replace(/([\da-fA-F]{2}) ?/g, '0x$1 ')
+      .replace(/ +$/, '')
+      .split(' '),
+  ).buffer;
+}
 
 export default Hex;

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -177,7 +177,7 @@ export function isPersistentSessionType(
   );
 }
 
-export function parsePlayReadyWRM(keyBytes: Uint8Array) {
+export function parsePlayReadyWRM(keyBytes: Uint8Array<ArrayBuffer>) {
   const keyBytesUtf16 = new Uint16Array(
     keyBytes.buffer,
     keyBytes.byteOffset,

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -590,7 +590,7 @@ export function patchEncyptionData(
           const tenc = parseSinf(sinf);
           if (tenc) {
             // Look for default key id (keyID offset is always 8 within the tenc box):
-            const tencKeyId = tenc.subarray(8, 24);
+            const tencKeyId = tenc.subarray(8, 24) as Uint8Array<ArrayBuffer>;
             if (!tencKeyId.some((b) => b !== 0)) {
               logger.log(
                 `[eme] Patching keyId in 'enc${
@@ -1353,8 +1353,8 @@ export function mp4pssh(
 export type PsshData = {
   version: 0 | 1;
   systemId: KeySystemIds;
-  kids: null | Uint8Array[];
-  data: null | Uint8Array;
+  kids: null | Uint8Array<ArrayBuffer>[];
+  data: null | Uint8Array<ArrayBuffer>;
   offset: number;
   size: number;
 };
@@ -1382,7 +1382,7 @@ export function parseMultiPssh(
   return results;
 }
 
-function parsePssh(view: DataView): PsshData | PsshInvalidResult {
+function parsePssh(view: DataView<ArrayBuffer>): PsshData | PsshInvalidResult {
   const size = view.getUint32(0);
   const offset = view.byteOffset;
   const length = view.byteLength;
@@ -1405,8 +1405,8 @@ function parsePssh(view: DataView): PsshData | PsshInvalidResult {
     new Uint8Array(buffer, offset + 12, 16),
   ) as KeySystemIds;
 
-  let kids: null | Uint8Array[] = null;
-  let data: null | Uint8Array = null;
+  let kids: null | Uint8Array<ArrayBuffer>[] = null;
+  let data: null | Uint8Array<ArrayBuffer> = null;
   let dataSizeOffset = 0;
 
   if (version === 0) {


### PR DESCRIPTION
### This PR will...
Fix Widevine key management

- Use the Key ID in EXT-X-KEY KEYID when available for Widevine
- Deduplicate key data with the same attributes when parsing media playlists
- Ignore data in "encrypted" event (hls.js can't reliably parse the key id from PSSH without a Widevine protobuf parser)

### Why is this Pull Request needed?
The Widevine PSSH key id parsing in hls.js (read the 16 bytes 6 bytes back from the end) assumes no optional fields and can't always extract the key id that vendors are including in the playlist (the key id matching tenc box bytes and KEYID attribute value). Since it is difficult to match the "encrypted" event initdata to key tags in the playlist without being able to extract a matching key id, it is better to ignore the event and rely only on key data which is required to be included in HLS media playlists.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7369

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
