### PR TITLE
fix: clear to encrypted transition leading to PIPELINE_DECODE_ERROR

### DIFF
--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -126,7 +126,8 @@ export default class KeyLoader implements ComponentAPI {
               });
           }
         }
-      } else if (this.config.requireKeySystemAccessOnStart) {
+      }
+      if (this.config.requireKeySystemAccessOnStart) {
         const keySystemsInConfig = getKeySystemsForConfig(this.config);
         if (keySystemsInConfig.length) {
           return this.emeController.getKeySystemAccess(keySystemsInConfig);


### PR DESCRIPTION
### This PR will...

Fixes `PIPELINE_ERROR_DECODE` when transitioning from clear to encrypted content when the continuity preceeding the clear content either:
- is clear
- is encrypted but has no `EXT-X-KEY` (as it uses the key from the previous continuity)

### Why is this Pull Request needed?

This PR allows falling back to using the key system from the config when non of the encrypted fragments are deemed usable from the manifest.

### Are there any points in the code the reviewer needs to double check?

Is there a preference on 

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
