### PR TITLE
Initialize key-system access on first segment request with encrypted segments

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2995,7 +2995,7 @@ export class KeyLoader implements ComponentAPI {
     // (undocumented)
     load(frag: Fragment): Promise<KeyLoadedData>;
     // (undocumented)
-    loadClear(loadingFrag: Fragment, encryptedFragments: Fragment[]): null | Promise<void>;
+    loadClear(loadingFrag: Fragment, encryptedFragments: Fragment[], startFragRequested: boolean): null | Promise<void>;
     // (undocumented)
     loadInternal(frag: Fragment, keySystemFormat?: KeySystemFormats): Promise<KeyLoadedData>;
     // (undocumented)

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -817,6 +817,7 @@ export default class BaseStreamController
       keyLoadingPromise = this.keyLoader.loadClear(
         frag,
         details.encryptedFragments,
+        this.startFragRequested,
       );
       if (keyLoadingPromise) {
         this.log(`[eme] blocking frag load until media-keys acquired`);


### PR DESCRIPTION
### This PR will...

Initialize key-system access on first segment request with encrypted segments, without requiring `config.requireKeySystemAccessOnStart: true`.

### Why is this Pull Request needed?
Fixes clear to encrypted transitions with CDMs that error when media keys are not set prior to setting up a decoder for initial clear content.

### Are there any points in the code the reviewer needs to double check?

- Follow up to issue #7383

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
