### PR TITLE
Handle EME key status errors such as "internal-error" and "output-restricted" before appending media

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3004,7 +3004,7 @@ export class KeyLoader implements ComponentAPI {
     emeController: EMEController | null;
     // (undocumented)
     keyUriToKeyInfo: {
-        [keyuri: string]: KeyLoaderInfo;
+        [keyuri: string]: KeyLoaderInfo | undefined;
     };
     // (undocumented)
     load(frag: Fragment): Promise<KeyLoadedData>;

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2985,8 +2985,8 @@ export interface KeyLoadedData {
 // Warning: (ae-missing-release-tag) "KeyLoader" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export class KeyLoader implements ComponentAPI {
-    constructor(config: HlsConfig);
+export class KeyLoader extends Logger implements ComponentAPI {
+    constructor(config: HlsConfig, logger: ILogger);
     // (undocumented)
     abort(type?: PlaylistLevelType): void;
     // (undocumented)
@@ -3002,10 +3002,6 @@ export class KeyLoader implements ComponentAPI {
     detach(): void;
     // (undocumented)
     emeController: EMEController | null;
-    // (undocumented)
-    keyUriToKeyInfo: {
-        [keyuri: string]: KeyLoaderInfo | undefined;
-    };
     // (undocumented)
     load(frag: Fragment): Promise<KeyLoadedData>;
     // (undocumented)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1189,8 +1189,8 @@ export type EMEControllerConfig = {
     licenseResponseCallback?: (this: Hls, xhr: XMLHttpRequest, url: string, keyContext: MediaKeySessionContext) => ArrayBuffer;
     emeEnabled: boolean;
     widevineLicenseUrl?: string;
-    drmSystems: DRMSystemsConfiguration;
-    drmSystemOptions: DRMSystemOptions;
+    drmSystems: DRMSystemsConfiguration | undefined;
+    drmSystemOptions: DRMSystemOptions | undefined;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
     requireKeySystemAccessOnStart: boolean;
 };
@@ -1204,9 +1204,11 @@ export const enum ErrorActionFlags {
     // (undocumented)
     MoveAllAlternatesMatchingHost = 1,
     // (undocumented)
+    MoveAllAlternatesMatchingKey = 4,
+    // (undocumented)
     None = 0,
     // (undocumented)
-    SwitchToSDR = 4
+    SwitchToSDR = 8
 }
 
 // Warning: (ae-missing-release-tag) "ErrorController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1238,6 +1240,8 @@ export interface ErrorData {
     chunkMeta?: ChunkMetadata;
     // (undocumented)
     context?: PlaylistLoaderContext;
+    // (undocumented)
+    decryptdata?: LevelKey;
     // (undocumented)
     details: ErrorDetails;
     // @deprecated (undocumented)
@@ -3277,6 +3281,8 @@ export class LevelDetails {
     fragments: MediaFragment[];
     // (undocumented)
     get fragmentStart(): number;
+    // (undocumented)
+    hasKey(levelKey: LevelKey): boolean;
     // (undocumented)
     get hasProgramDateTime(): boolean;
     // (undocumented)

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,8 +119,8 @@ export type EMEControllerConfig = {
   ) => ArrayBuffer;
   emeEnabled: boolean;
   widevineLicenseUrl?: string;
-  drmSystems: DRMSystemsConfiguration;
-  drmSystemOptions: DRMSystemOptions;
+  drmSystems: DRMSystemsConfiguration | undefined;
+  drmSystemOptions: DRMSystemOptions | undefined;
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
   requireKeySystemAccessOnStart: boolean;
 };

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -841,10 +841,9 @@ export default class BaseStreamController
         }
       });
       this.hls.trigger(Events.KEY_LOADING, { frag });
-      if (this.fragCurrent === null) {
-        keyLoadingPromise = Promise.reject(
-          new Error(`frag load aborted, context changed in KEY_LOADING`),
-        );
+      if ((this.fragCurrent as Fragment | null) === null) {
+        this.log(`context changed in KEY_LOADING`);
+        return Promise.resolve(null);
       }
     } else if (!frag.encrypted) {
       keyLoadingPromise = this.keyLoader.loadClear(

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2038,8 +2038,8 @@ export default class BaseStreamController
   }
 
   protected resetWhenMissingContext(chunkMeta: ChunkMetadata | Fragment) {
-    this.warn(
-      `The loading context changed while buffering fragment ${chunkMeta.sn} of ${this.playlistLabel()} ${chunkMeta.level}. This chunk will not be buffered.`,
+    this.log(
+      `Loading context changed while buffering sn ${chunkMeta.sn} of ${this.playlistLabel()} ${chunkMeta.level === -1 ? '<removed>' : chunkMeta.level}. This chunk will not be buffered.`,
     );
     this.removeUnbufferedFrags();
     this.resetStartWhenNotLoaded(this.levelLastLoaded);

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -526,6 +526,7 @@ export default class ErrorController
           // Penalize all levels with key
           const levels = this.hls.levels;
           let levelIndex = hls.loadLevel;
+          const removeLevels: number[] = [];
           for (let i = levels.length; i--; ) {
             if (this.variantHasKey(levels[i], levelKey)) {
               this.log(
@@ -534,10 +535,17 @@ export default class ErrorController
               levels[i].fragmentError++;
               levels[i].loadError++;
               levelIndex = i;
+              removeLevels.unshift(i);
             }
           }
           const switchAction = this.getLevelSwitchAction(data, levelIndex);
           nextAutoLevel = switchAction.nextAutoLevel;
+          for (let i = removeLevels.length; i--; ) {
+            if (nextAutoLevel !== i) {
+              this.log(`Removing level ${i} with key error (${data.error})`);
+              this.hls.removeLevel(i);
+            }
+          }
         }
         break;
       }
@@ -564,6 +572,9 @@ export default class ErrorController
         const levels = this.hls.levels;
         for (let i = levels.length; i--; ) {
           if (levels[i][`${data.sourceBufferName}Codec`] === codec) {
+            this.log(
+              `Removing level ${i} for ${data.details} ("${codec}" not supported)`,
+            );
             this.hls.removeLevel(i);
           }
         }

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -9,6 +9,7 @@ import {
   isTimeoutError,
   shouldRetry,
 } from '../utils/error-helper';
+import { arrayToHex } from '../utils/hex';
 import { Logger } from '../utils/logger';
 import type { RetryConfig } from '../config';
 import type { LevelKey } from '../hls';
@@ -530,7 +531,7 @@ export default class ErrorController
           for (let i = levels.length; i--; ) {
             if (this.variantHasKey(levels[i], levelKey)) {
               this.log(
-                `Banned key found in level ${i} or a track in audio group "${levels[i].audioGroups?.join(',')}"`,
+                `Banned key found in level ${i} or audio group "${levels[i].audioGroups?.join(',')}" (${data.frag?.type} fragment) ${arrayToHex(levelKey.keyId || [])}`,
               );
               levels[i].fragmentError++;
               levels[i].loadError++;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -233,7 +233,7 @@ export default class Hls implements HlsEventEmitter {
     ));
 
     const id3TrackController = new ID3TrackController(this);
-    const keyLoader = new KeyLoader(this.config);
+    const keyLoader = new KeyLoader(this.config, this.logger);
     const streamController = (this.streamController = new StreamController(
       this,
       fragmentTracker,

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -30,7 +30,7 @@ export interface KeyLoaderInfo {
 }
 export default class KeyLoader implements ComponentAPI {
   private readonly config: HlsConfig;
-  public keyUriToKeyInfo: { [keyuri: string]: KeyLoaderInfo } = {};
+  public keyUriToKeyInfo: { [keyuri: string]: KeyLoaderInfo | undefined } = {};
   public emeController: EMEController | null = null;
 
   constructor(config: HlsConfig) {
@@ -39,7 +39,7 @@ export default class KeyLoader implements ComponentAPI {
 
   abort(type?: PlaylistLevelType) {
     for (const uri in this.keyUriToKeyInfo) {
-      const loader = this.keyUriToKeyInfo[uri].loader;
+      const loader = this.keyUriToKeyInfo[uri]!.loader;
       if (loader) {
         if (type && type !== loader.context?.frag.type) {
           return;
@@ -51,7 +51,7 @@ export default class KeyLoader implements ComponentAPI {
 
   detach() {
     for (const uri in this.keyUriToKeyInfo) {
-      const keyInfo = this.keyUriToKeyInfo[uri];
+      const keyInfo = this.keyUriToKeyInfo[uri]!;
       // Remove cached EME keys on detach
       if (
         keyInfo.mediaKeySessionContext ||
@@ -65,7 +65,7 @@ export default class KeyLoader implements ComponentAPI {
   destroy() {
     this.detach();
     for (const uri in this.keyUriToKeyInfo) {
-      const loader = this.keyUriToKeyInfo[uri].loader;
+      const loader = this.keyUriToKeyInfo[uri]!.loader;
       if (loader) {
         loader.destroy();
       }
@@ -200,7 +200,8 @@ export default class KeyLoader implements ComponentAPI {
         case 'usable-in-future':
           return keyInfo.keyLoadPromise.then((keyLoadedData) => {
             // Return the correct fragment with updated decryptdata key and loaded keyInfo
-            decryptdata.key = keyLoadedData.keyInfo.decryptdata.key;
+            const { keyInfo } = keyLoadedData;
+            decryptdata.key = keyInfo.decryptdata.key;
             return { frag, keyInfo };
           });
       }

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -206,10 +206,6 @@ export default class KeyLoader extends Logger implements ComponentAPI {
             // Return the correct fragment with updated decryptdata key and loaded keyInfo
             const { keyInfo } = keyLoadedData;
             decryptdata.key = keyInfo.decryptdata.key;
-            // log key-status unblocking change for debugging only
-            // this.log(
-            //   `${frag.type} ${frag.level} key ${arrayToHex(decryptdata.keyId || [])} "${keyStatus}" session key ${keyInfo.decryptdata.keyId ? arrayToHex(keyInfo.decryptdata.keyId) : null}`,
-            // );
             return { frag, keyInfo };
           });
       }

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -248,18 +248,19 @@ export default class KeyLoader implements ComponentAPI {
     if (this.emeController && this.config.emeEnabled) {
       const keySessionContextPromise =
         this.emeController.loadKey(keyLoadedData);
-      if (keySessionContextPromise) {
-        return (keyInfo.keyLoadPromise = keySessionContextPromise.then(
-          (keySessionContext) => {
-            keyInfo.mediaKeySessionContext = keySessionContext;
-            return keyLoadedData;
-          },
-        )).catch((error) => {
-          // Remove promise for license renewal or retry
-          keyInfo.keyLoadPromise = null;
-          throw error;
-        });
-      }
+      return (keyInfo.keyLoadPromise = keySessionContextPromise.then(
+        (keySessionContext) => {
+          keyInfo.mediaKeySessionContext = keySessionContext;
+          return keyLoadedData;
+        },
+      )).catch((error) => {
+        // Remove promise for license renewal or retry
+        keyInfo.keyLoadPromise = null;
+        if (error.data) {
+          error.data.frag = frag;
+        }
+        throw error;
+      });
     }
     return Promise.resolve(keyLoadedData);
   }

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -97,7 +97,7 @@ export class LevelDetails {
         frag.setKeyFormat(levelKey.keyFormat as KeySystemFormats);
         decryptdata = frag.decryptdata;
       }
-      return decryptdata && levelKey.matches(decryptdata);
+      return !!decryptdata && levelKey.matches(decryptdata);
     });
   }
 

--- a/src/loader/level-details.ts
+++ b/src/loader/level-details.ts
@@ -1,7 +1,9 @@
 import type { DateRange } from './date-range';
 import type { Fragment, MediaFragment, Part } from './fragment';
+import type { LevelKey } from './level-key';
 import type { VariableMap } from '../types/level';
 import type { AttrList } from '../utils/attr-list';
+import type { KeySystemFormats } from '../utils/mediakeys-helper';
 
 const DEFAULT_TARGET_DURATION = 10;
 
@@ -86,6 +88,17 @@ export class LevelDetails {
     } else {
       this.misses = previous.misses + 1;
     }
+  }
+
+  hasKey(levelKey: LevelKey): boolean {
+    return this.encryptedFragments.some((frag) => {
+      let decryptdata = frag.decryptdata;
+      if (!decryptdata) {
+        frag.setKeyFormat(levelKey.keyFormat as KeySystemFormats);
+        decryptdata = frag.decryptdata;
+      }
+      return decryptdata && levelKey.matches(decryptdata);
+    });
   }
 
   get hasProgramDateTime(): boolean {

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -1,3 +1,4 @@
+import { arrayValuesMatch, optionalArrayValuesMatch } from '../utils/arrays';
 import { isFullSegmentEncryption } from '../utils/encryption-methods-util';
 import { hexToArrayBuffer } from '../utils/hex';
 import { convertDataUriToArrayBytes } from '../utils/keysystem-util';
@@ -63,9 +64,9 @@ export class LevelKey implements DecryptData {
       key.method === this.method &&
       key.encrypted === this.encrypted &&
       key.keyFormat === this.keyFormat &&
-      key.keyFormatVersions.join(',') === this.keyFormatVersions.join(',') &&
-      key.iv?.join(',') === this.iv?.join(',') &&
-      key.keyId?.join(',') === this.keyId?.join(',')
+      arrayValuesMatch(key.keyFormatVersions, this.keyFormatVersions) &&
+      optionalArrayValuesMatch(key.iv, this.iv) &&
+      optionalArrayValuesMatch(key.keyId, this.keyId)
     );
   }
 

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -64,7 +64,8 @@ export class LevelKey implements DecryptData {
       key.encrypted === this.encrypted &&
       key.keyFormat === this.keyFormat &&
       key.keyFormatVersions.join(',') === this.keyFormatVersions.join(',') &&
-      key.iv?.join(',') === this.iv?.join(',')
+      key.iv?.join(',') === this.iv?.join(',') &&
+      key.keyId?.join(',') === this.keyId?.join(',')
     );
   }
 
@@ -84,12 +85,9 @@ export class LevelKey implements DecryptData {
           case KeySystemFormats.PLAYREADY:
           case KeySystemFormats.CLEARKEY:
             return (
-              [
-                'ISO-23001-7',
-                'SAMPLE-AES',
-                'SAMPLE-AES-CENC',
-                'SAMPLE-AES-CTR',
-              ].indexOf(this.method) !== -1
+              ['SAMPLE-AES', 'SAMPLE-AES-CENC', 'SAMPLE-AES-CTR'].indexOf(
+                this.method,
+              ) !== -1
             );
         }
       }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -319,6 +319,7 @@ export interface ErrorData {
   bytes?: number;
   chunkMeta?: ChunkMetadata;
   context?: PlaylistLoaderContext;
+  decryptdata?: LevelKey;
   event?: keyof HlsListeners | 'demuxerWorker';
   frag?: Fragment;
   part?: Part | null;

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,0 +1,22 @@
+export function arrayValuesMatch(
+  a: (string | number)[] | Uint8Array,
+  b: (string | number)[] | Uint8Array,
+): boolean {
+  if (a.length === b.length) {
+    return !a.some((value: string | number, i: number) => value !== b[i]);
+  }
+  return false;
+}
+
+export function optionalArrayValuesMatch(
+  a: (string | number)[] | Uint8Array | null | undefined,
+  b: (string | number)[] | Uint8Array | null | undefined,
+): boolean {
+  if (!a && !b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return arrayValuesMatch(a, b);
+}

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -2,20 +2,18 @@
  *  hex dump helper class
  */
 
-const Hex = {
-  hexDump: function (array: Uint8Array<ArrayBuffer>) {
-    let str = '';
-    for (let i = 0; i < array.length; i++) {
-      let h = array[i].toString(16);
-      if (h.length < 2) {
-        h = '0' + h;
-      }
-
-      str += h;
+export function arrayToHex(array: Uint8Array<ArrayBuffer> | number[]) {
+  let str = '';
+  for (let i = 0; i < array.length; i++) {
+    let h = array[i].toString(16);
+    if (h.length < 2) {
+      h = '0' + h;
     }
-    return str;
-  },
-};
+
+    str += h;
+  }
+  return str;
+}
 
 export function hexToArrayBuffer(str: string): ArrayBuffer {
   return Uint8Array.from(
@@ -26,5 +24,9 @@ export function hexToArrayBuffer(str: string): ArrayBuffer {
       .split(' '),
   ).buffer;
 }
+
+const Hex = {
+  hexDump: arrayToHex,
+};
 
 export default Hex;

--- a/src/utils/mediakeys-helper.ts
+++ b/src/utils/mediakeys-helper.ts
@@ -167,13 +167,14 @@ function createMediaKeySystemConfigurations(
 }
 
 export function isPersistentSessionType(
-  drmSystemOptions: DRMSystemOptions,
+  drmSystemOptions: DRMSystemOptions | undefined,
 ): boolean {
   return (
-    drmSystemOptions.sessionType === 'persistent-license' ||
-    !!drmSystemOptions.sessionTypes?.some(
-      (type) => type === 'persistent-license',
-    )
+    !!drmSystemOptions &&
+    (drmSystemOptions.sessionType === 'persistent-license' ||
+      !!drmSystemOptions.sessionTypes?.some(
+        (type) => type === 'persistent-license',
+      ))
   );
 }
 

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -1,5 +1,5 @@
 import { utf8ArrayToStr } from '@svta/common-media-library/utils/utf8ArrayToStr';
-import Hex from './hex';
+import { arrayToHex } from './hex';
 import { ElementaryStreamTypes } from '../loader/fragment';
 import { logger } from '../utils/logger';
 import type { KeySystemIds } from './mediakeys-helper';
@@ -596,7 +596,7 @@ export function patchEncyptionData(
               logger.log(
                 `[eme] Patching keyId in 'enc${
                   isAudio ? 'a' : 'v'
-                }>sinf>>tenc' box: ${Hex.hexDump(tencKeyId)} -> ${Hex.hexDump(
+                }>sinf>>tenc' box: ${arrayToHex(tencKeyId)} -> ${arrayToHex(
                   keyId,
                 )}`,
               );
@@ -1401,7 +1401,7 @@ function parsePssh(view: DataView<ArrayBuffer>): PsshData | PsshInvalidResult {
     return { offset, size };
   }
   const buffer = view.buffer;
-  const systemId = Hex.hexDump(
+  const systemId = arrayToHex(
     new Uint8Array(buffer, offset + 12, 16),
   ) as KeySystemIds;
 

--- a/tests/unit/controller/audio-stream-controller.ts
+++ b/tests/unit/controller/audio-stream-controller.ts
@@ -139,7 +139,7 @@ describe('AudioStreamController', function () {
     sandbox = sinon.createSandbox();
     hls = new Hls();
     fragmentTracker = new FragmentTracker(hls);
-    keyLoader = new KeyLoader(hlsDefaultConfig);
+    keyLoader = new KeyLoader(hlsDefaultConfig, hls.logger);
     audioStreamController = new AudioStreamController(
       hls,
       fragmentTracker,

--- a/tests/unit/controller/base-stream-controller.ts
+++ b/tests/unit/controller/base-stream-controller.ts
@@ -42,7 +42,7 @@ describe('BaseStreamController', function () {
     baseStreamController = new BaseStreamController(
       hls,
       fragmentTracker,
-      new KeyLoader(hlsDefaultConfig),
+      new KeyLoader(hlsDefaultConfig, hls.logger),
     ) as unknown as BaseStreamControllerTestable;
     bufferInfo = {
       len: 1,

--- a/tests/unit/controller/subtitle-stream-controller.ts
+++ b/tests/unit/controller/subtitle-stream-controller.ts
@@ -42,7 +42,7 @@ describe('SubtitleStreamController', function () {
     hls = new Hls({});
     mediaMock.currentTime = 0;
     fragmentTracker = new FragmentTracker(hls);
-    keyLoader = new KeyLoader(hls.config);
+    keyLoader = new KeyLoader(hls.config, hls.logger);
 
     subtitleStreamController = new SubtitleStreamController(
       hls,


### PR DESCRIPTION
### This PR will...
- Handle EME key status errors such as "internal-error" before appending media
- Ban keys with status "internal-error" so that additional license requests are not made for them when found in other playlists
- Fallback to variants and renditions that have not been loaded or do not contain the key
- Multiple key status changes in a single session are handled based on the session playlist key ID
- Sessions where the playlist key ID changes to status "internal-error" are closed
- Remove levels with unresolved key status errors ("internal-error" or "output-restricted" w/o defined HDCP-LEVEL attributes)

### Why is this Pull Request needed?
@yajin2021 reported that other variants should be selected when a key error occurs:
- #7401
- #7413

Preventing appends of media with bad keys prevents the CDM from locking up playback. I was not able to append the media optimistically, and then remove it from the buffer on key error before a switch. Either hls.js queued too much media (appending more after the first key error) or any appends that cannot be decrypted interfere with playback.

### Are there any points in the code the reviewer needs to double check?

Created #7474 for https://github.com/video-dev/hls.js/pull/7414#issuecomment-3211437085 to be addressed in a future release.
- #7474

### Resolves issues:
- #7413
- #7469

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
