### PR TITLE
Parse keyid from multi-key widevine PSSH

### DIFF
--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -3,7 +3,7 @@ import { hexToArrayBuffer } from '../utils/hex';
 import { convertDataUriToArrayBytes } from '../utils/keysystem-util';
 import { logger } from '../utils/logger';
 import { KeySystemFormats, parsePlayReadyWRM } from '../utils/mediakeys-helper';
-import { mp4pssh } from '../utils/mp4-tools';
+import { mp4pssh, parseMultiPssh } from '../utils/mp4-tools';
 
 let keyUriToKeyIdMap: { [uri: string]: Uint8Array<ArrayBuffer> } = {};
 
@@ -142,9 +142,14 @@ export class LevelKey implements DecryptData {
           // the playlist-key before the "encrypted" event. (Comment out to only use "encrypted" path.)
           this.pssh = keyBytes;
           // In case of Widevine, if KEYID is not in the playlist, assume only two fields in the pssh KEY tag URI.
-          if (!this.keyId && keyBytes.length >= 22) {
-            const offset = keyBytes.length - 22;
-            this.keyId = keyBytes.subarray(offset, offset + 16);
+          if (!this.keyId && keyBytes) {
+            const results = parseMultiPssh(keyBytes.buffer);
+            if (results[0] && 'version' in results[0]) {
+              const psshData = results[0];
+              if (psshData?.kids?.[0]) {
+                this.keyId = psshData.kids[0];
+              }
+            }
           }
           break;
         case KeySystemFormats.PLAYREADY: {

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -142,14 +142,16 @@ export class LevelKey implements DecryptData {
           // the playlist-key before the "encrypted" event. (Comment out to only use "encrypted" path.)
           this.pssh = keyBytes;
           // In case of Widevine, if KEYID is not in the playlist, assume only two fields in the pssh KEY tag URI.
-          if (!this.keyId && keyBytes) {
-            const results = parseMultiPssh(keyBytes.buffer);
-            if (results[0] && 'version' in results[0]) {
-              const psshData = results[0];
-              if (psshData?.kids?.[0]) {
-                this.keyId = psshData.kids[0];
-              }
-            }
+          if (!this.keyId) {
+            const [psshData] = parseMultiPssh(keyBytes.buffer);
+            this.keyId =
+              psshData && 'kids' in psshData && psshData.kids?.[0]
+                ? psshData.kids[0]
+                : null;
+          }
+          if (!this.keyId) {
+            const offset = keyBytes.length - 22;
+            this.keyId = keyBytes.subarray(offset, offset + 16);
           }
           break;
         case KeySystemFormats.PLAYREADY: {


### PR DESCRIPTION
### This PR will...

Parse keyId for widevine. PSSH box defines as follows:

```
aligned(8) class ProtectionSystemSpecificHeaderBox extends FullBox('pssh', version, flags=0)
{
    unsigned int(8)[16]                SystemID;
    if (version > 0)
    {
         unsigned int(32)              KID_count;
         {
             unsigned int(8)[16]       KID;
         } [KID_count];
    }
    unsigned int(32)                   DataSize;
    unsigned int(8)[DataSize]          Data;
}
```

The length of the DataSize and Data fields is not always 6. For widevine, it is defined in [WidevineCencHeader.proto](https://github.com/alfg/widevine/blob/master/proto/WidevineCencHeader.proto )

### Why is this Pull Request needed?
Parse KeyId for widevine correctly

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
