### PR TITLE
Ignore offsets related to default_display_window_flag in HEVC-TS demuxer

### DIFF
--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -516,10 +516,10 @@ class HevcVideoParser extends BaseVideoParser {
       eg.readBoolean(); // frame_field_info_present_flag
       default_display_window_flag = eg.readBoolean();
       if (default_display_window_flag) {
-        pic_left_offset += eg.readUEG();
-        pic_right_offset += eg.readUEG();
-        pic_top_offset += eg.readUEG();
-        pic_bottom_offset += eg.readUEG();
+        eg.skipUEG();
+        eg.skipUEG();
+        eg.skipUEG();
+        eg.skipUEG();
       }
       const vui_timing_info_present_flag = eg.readBoolean();
       if (vui_timing_info_present_flag) {
@@ -604,7 +604,7 @@ class HevcVideoParser extends BaseVideoParser {
 
     let width = pic_width_in_luma_samples,
       height = pic_height_in_luma_samples;
-    if (conformance_window_flag || default_display_window_flag) {
+    if (conformance_window_flag) {
       let chroma_scale_w = 1,
         chroma_scale_h = 1;
       if (chroma_format_idc === 1) {


### PR DESCRIPTION
### This PR will...
Fix video dimensions computed in HEVC-TS demuxer when SPS default_display_window_flag is present.

### Resolves issues:
#7392

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
