### PR TITLE
Interstitials improvements and fixes

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -631,7 +631,7 @@ export interface BufferAppendingData {
     // (undocumented)
     chunkMeta: ChunkMetadata;
     // (undocumented)
-    data: Uint8Array;
+    data: Uint8Array<ArrayBuffer>;
     // (undocumented)
     frag: Fragment;
     // (undocumented)
@@ -1807,7 +1807,7 @@ export class Fragment extends BaseSegment {
     level: number;
     // (undocumented)
     levelkeys?: {
-        [key: string]: LevelKey;
+        [key: string]: LevelKey | undefined;
     };
     // (undocumented)
     loader: Loader<FragmentLoaderContext> | null;
@@ -1925,7 +1925,7 @@ export class FragmentTracker implements ComponentAPI {
     detectPartialFragments(data: FragBufferedData): void;
     // (undocumented)
     fragBuffered(frag: MediaFragment, force?: true): void;
-    getAppendedFrag(position: number, levelType: PlaylistLevelType): Fragment | Part | null;
+    getAppendedFrag(position: number, levelType: PlaylistLevelType): MediaFragment | Part | null;
     getBufferedFrag(position: number, levelType: PlaylistLevelType): MediaFragment | null;
     // (undocumented)
     getFragAtPos(position: number, levelType: PlaylistLevelType, buffered?: boolean): MediaFragment | null;
@@ -2188,11 +2188,13 @@ export class HlsAssetPlayer {
     // (undocumented)
     get duration(): number;
     // (undocumented)
-    readonly hls: Hls;
+    hls: Hls | null;
     // (undocumented)
-    readonly interstitial: InterstitialEvent;
+    interstitial: InterstitialEvent;
     // (undocumented)
     get interstitialId(): InterstitialId;
+    // (undocumented)
+    loadSource(): void;
     // (undocumented)
     get media(): HTMLMediaElement | null;
     // (undocumented)
@@ -2799,6 +2801,8 @@ export type InterstitialId = string;
 export interface InterstitialPlayer {
     // (undocumented)
     assetPlayers: (HlsAssetPlayer | null)[];
+    // (undocumented)
+    bufferedEnd: number;
     // (undocumented)
     currentTime: number;
     // (undocumented)

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -87,8 +87,8 @@ export default class BasePlaylistController
       }
       if (foundIndex !== -1) {
         const attr = renditionReports[foundIndex];
-        const msn = parseInt(attr['LAST-MSN']) || previous?.lastPartSn;
-        let part = parseInt(attr['LAST-PART']) || previous?.lastPartIndex;
+        const msn = parseInt(attr['LAST-MSN']) || previous.lastPartSn;
+        let part = parseInt(attr['LAST-PART']) || previous.lastPartIndex;
         if (this.hls.config.lowLatencyMode) {
           const currentGoal = Math.min(
             previous.age - previous.partTarget,
@@ -164,7 +164,7 @@ export default class BasePlaylistController
       const offset = Math.max(timelineOffset || 0, 0);
       details.appliedTimelineOffset = offset;
       details.fragments.forEach((frag) => {
-        frag.start = frag.playlistOffset + offset;
+        frag.setStart(frag.playlistOffset + offset);
       });
     }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1912,7 +1912,7 @@ export default class BaseStreamController
         // this happens on IE/Edge, refer to https://github.com/video-dev/hls.js/pull/708
         // in that case flush the whole audio buffer to recover
         this.warn(
-          `Buffer full error while media.currentTime is not buffered, flush ${playlistType} buffer`,
+          `Buffer full error while media.currentTime (${this.getLoadPosition()}) is not buffered, flush ${playlistType} buffer`,
         );
       }
       if (frag) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1397,7 +1397,7 @@ export default class BaseStreamController
   }
 
   protected get primaryPrefetch(): boolean {
-    if (interstitialsEnabled(this.hls.config)) {
+    if (interstitialsEnabled(this.config)) {
       const playingInterstitial =
         this.hls.interstitialsManager?.playingItem?.event;
       if (playingInterstitial) {
@@ -1415,7 +1415,7 @@ export default class BaseStreamController
       return frag;
     }
     if (
-      interstitialsEnabled(this.hls.config) &&
+      interstitialsEnabled(this.config) &&
       frag.type !== PlaylistLevelType.SUBTITLE
     ) {
       // Do not load fragments outside the buffering schedule segment

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -278,9 +278,9 @@ export default class BufferController extends Logger implements ComponentAPI {
     data: MediaAttachingData,
   ) {
     const media = (this.media = data.media);
-    const MediaSource = getMediaSource(this.appendSource);
     this.transferData = this.overrides = undefined;
-    if (media && MediaSource) {
+    const MediaSource = getMediaSource(this.appendSource);
+    if (MediaSource) {
       const transferringMedia = !!data.mediaSource;
       if (transferringMedia || data.overrides) {
         this.transferData = data;
@@ -318,7 +318,7 @@ export default class BufferController extends Logger implements ComponentAPI {
 
   private assignMediaSource(ms: MediaSource) {
     this.log(
-      `${this.transferData?.mediaSource === ms ? 'transferred' : 'created'} media source: ${ms.constructor?.name}`,
+      `${this.transferData?.mediaSource === ms ? 'transferred' : 'created'} media source: ${(ms.constructor as any)?.name}`,
     );
     // MediaSource listeners are arrow functions with a lexical scope, and do not need to be bound
     ms.addEventListener('sourceopen', this._onMediaSourceOpen);
@@ -343,9 +343,11 @@ export default class BufferController extends Logger implements ComponentAPI {
       : null;
     const trackCount = trackNames ? trackNames.length : 0;
     const mediaSourceOpenCallback = () => {
-      if (this.media && this.mediaSourceOpenOrEnded) {
-        this._onMediaSourceOpen();
-      }
+      Promise.resolve().then(() => {
+        if (this.media && this.mediaSourceOpenOrEnded) {
+          this._onMediaSourceOpen();
+        }
+      });
     };
     if (transferredTracks && trackNames && trackCount) {
       if (!this.tracksReady) {
@@ -435,7 +437,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   }
 
   private _onEndStreaming = (event) => {
-    if (!this.hls) {
+    if (!this.hls as any) {
       return;
     }
     if (this.mediaSource?.readyState !== 'open') {
@@ -445,7 +447,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   };
 
   private _onStartStreaming = (event) => {
-    if (!this.hls) {
+    if (!this.hls as any) {
       return;
     }
     this.hls.resumeBuffering();
@@ -1025,10 +1027,15 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   public get bufferedToEnd(): boolean {
     return (
       this.sourceBufferCount > 0 &&
-      !this.sourceBuffers.some(
-        ([type]) =>
-          type && (!this.tracks[type]?.ended || this.tracks[type]?.ending),
-      )
+      !this.sourceBuffers.some(([type]) => {
+        if (type) {
+          const track = this.tracks[type];
+          if (track) {
+            return !track.ended || track.ending;
+          }
+        }
+        return false;
+      })
     );
   }
 
@@ -1162,13 +1169,14 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       );
     }
 
+    const frontBufferFlushThreshold = config.frontBufferFlushThreshold;
     if (
-      Number.isFinite(config.frontBufferFlushThreshold) &&
-      config.frontBufferFlushThreshold > 0
+      Number.isFinite(frontBufferFlushThreshold) &&
+      frontBufferFlushThreshold > 0
     ) {
       const frontBufferLength = Math.max(
         config.maxBufferLength,
-        config.frontBufferFlushThreshold,
+        frontBufferFlushThreshold,
       );
 
       const maxFrontBufferLength = Math.max(frontBufferLength, targetDuration);
@@ -1273,7 +1281,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const playlistEnd = details.edge;
     if (details.live && this.hls.config.liveDurationInfinity) {
       const len = details.fragments.length;
-      if (len && details.live && !!mediaSource.setLiveSeekableRange) {
+      if (len && !!(mediaSource as any).setLiveSeekableRange) {
         const start = Math.max(0, details.fragmentStart);
         const end = Math.max(start, playlistEnd);
 
@@ -1547,7 +1555,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   };
 
   private get mediaSrc(): string | undefined {
-    const media = this.media?.querySelector?.('source') || this.media;
+    const media = (this.media?.querySelector as any)?.('source') || this.media;
     return media?.src;
   }
 
@@ -1647,7 +1655,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   }
 
   // This method must result in an updateend event; if append is not called, onSBUpdateEnd must be called manually
-  private appendExecutor(data: Uint8Array, type: SourceBufferName) {
+  private appendExecutor(
+    data: Uint8Array<ArrayBuffer>,
+    type: SourceBufferName,
+  ) {
     const track = this.tracks[type];
     const sb = track?.buffer;
     if (!sb) {

--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -97,13 +97,14 @@ export class HlsAssetPlayer {
     if (this.hls?.bufferedToEnd) {
       return true;
     }
-    if (!media || !this._bufferedEosTime) {
+    if (!media) {
       return false;
     }
+    const duration = this._bufferedEosTime || this.duration;
     const start = this.timelineOffset;
     const bufferInfo = BufferHelper.bufferInfo(media, start, 0);
     const bufferedEnd = this.getAssetTime(bufferInfo.end);
-    return bufferedEnd >= this._bufferedEosTime - 0.02;
+    return bufferedEnd >= duration - 0.02;
   }
 
   private checkPlayout = () => {

--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -14,6 +14,7 @@ import type Hls from '../hls';
 import type { BufferCodecsData, MediaAttachingData } from '../types/events';
 
 export interface InterstitialPlayer {
+  bufferedEnd: number;
   currentTime: number;
   duration: number;
   assetPlayers: (HlsAssetPlayer | null)[];
@@ -25,8 +26,8 @@ export type HlsAssetPlayerConfig = Partial<HlsConfig> &
   Required<Pick<HlsConfig, 'assetPlayerId' | 'primarySessionId'>>;
 
 export class HlsAssetPlayer {
-  public readonly hls: Hls;
-  public readonly interstitial: InterstitialEvent;
+  public hls: Hls | null;
+  public interstitial: InterstitialEvent;
   public readonly assetItem: InterstitialAssetItem;
   public tracks: Partial<BufferCodecsData> | null = null;
   private hasDetails: boolean = false;
@@ -43,14 +44,6 @@ export class HlsAssetPlayer {
     const hls = (this.hls = new HlsPlayerClass(userConfig));
     this.interstitial = interstitial;
     this.assetItem = assetItem;
-    let uri: string = assetItem.uri;
-    try {
-      uri = getInterstitialUrl(uri, userConfig.primarySessionId).href;
-    } catch (error) {
-      // Ignore error parsing ASSET_URI or adding _HLS_primary_id to it. The
-      // issue should surface as an INTERSTITIAL_ASSET_ERROR loading the asset.
-    }
-    hls.loadSource(uri);
     const detailsLoaded = () => {
       this.hasDetails = true;
     };
@@ -77,7 +70,24 @@ export class HlsAssetPlayer {
   }
 
   get appendInPlace(): boolean {
-    return this.interstitial?.appendInPlace || false;
+    return this.interstitial.appendInPlace;
+  }
+
+  loadSource() {
+    const hls = this.hls;
+    if (!hls) {
+      return;
+    }
+    if (!hls.url) {
+      let uri: string = this.assetItem.uri;
+      try {
+        uri = getInterstitialUrl(uri, hls.config.primarySessionId || '').href;
+      } catch (error) {
+        // Ignore error parsing ASSET_URI or adding _HLS_primary_id to it. The
+        // issue should surface as an INTERSTITIAL_ASSET_ERROR loading the asset.
+      }
+      hls.loadSource(uri);
+    }
   }
 
   bufferedInPlaceToEnd(media?: HTMLMediaElement | null) {
@@ -97,7 +107,7 @@ export class HlsAssetPlayer {
   }
 
   private checkPlayout = () => {
-    if (this.reachedPlayout(this.currentTime)) {
+    if (this.reachedPlayout(this.currentTime) && this.hls) {
       this.hls.trigger(Events.PLAYOUT_LIMIT_REACHED, {});
     }
   };
@@ -172,7 +182,7 @@ export class HlsAssetPlayer {
     const timelineOffset = this.timelineOffset;
     if (value !== timelineOffset) {
       const diff = value - timelineOffset;
-      if (Math.abs(diff) > 1 / 90000) {
+      if (Math.abs(diff) > 1 / 90000 && this.hls) {
         if (this.hasDetails) {
           throw new Error(
             `Cannot set timelineOffset after playlists are loaded`,
@@ -208,39 +218,41 @@ export class HlsAssetPlayer {
 
   destroy() {
     this.removeMediaListeners();
-    this.hls.destroy();
-    // @ts-ignore
-    this.hls = this.interstitial = null;
+    if (this.hls) {
+      this.hls.destroy();
+    }
+    this.hls = null;
     // @ts-ignore
     this.tracks = this.mediaAttached = this.checkPlayout = null;
   }
 
   attachMedia(data: HTMLMediaElement | MediaAttachingData) {
-    this.hls.attachMedia(data);
+    this.loadSource();
+    this.hls?.attachMedia(data);
   }
 
   detachMedia() {
     this.removeMediaListeners();
     this.mediaAttached = null;
-    this.hls.detachMedia();
+    this.hls?.detachMedia();
   }
 
   resumeBuffering() {
-    this.hls.resumeBuffering();
+    this.hls?.resumeBuffering();
   }
 
   pauseBuffering() {
-    this.hls.pauseBuffering();
+    this.hls?.pauseBuffering();
   }
 
   transferMedia() {
     this.bufferSnapShot();
-    return this.hls.transferMedia();
+    return this.hls?.transferMedia() || null;
   }
 
   resetDetails() {
     const hls = this.hls;
-    if (this.hasDetails) {
+    if (hls && this.hasDetails) {
       hls.stopLoad();
       const deleteDetails = (obj) => delete obj.details;
       hls.levels.forEach(deleteDetails);
@@ -255,7 +267,7 @@ export class HlsAssetPlayer {
     listener: HlsListeners[E],
     context?: Context,
   ) {
-    this.hls.on(event, listener);
+    this.hls?.on(event, listener);
   }
 
   once<E extends keyof HlsListeners, Context = undefined>(
@@ -263,7 +275,7 @@ export class HlsAssetPlayer {
     listener: HlsListeners[E],
     context?: Context,
   ) {
-    this.hls.once(event, listener);
+    this.hls?.once(event, listener);
   }
 
   off<E extends keyof HlsListeners, Context = undefined>(
@@ -271,7 +283,7 @@ export class HlsAssetPlayer {
     listener: HlsListeners[E],
     context?: Context,
   ) {
-    this.hls.off(event, listener);
+    this.hls?.off(event, listener);
   }
 
   toString(): string {

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -143,7 +143,8 @@ export default class InterstitialsController
 
   private registerListeners() {
     const hls = this.hls;
-    if (hls as any) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (hls) {
       hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
       hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
       hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
@@ -166,7 +167,8 @@ export default class InterstitialsController
 
   private unregisterListeners() {
     const hls = this.hls;
-    if (hls as any) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (hls) {
       hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
       hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
       hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
@@ -209,7 +211,8 @@ export default class InterstitialsController
   destroy() {
     this.unregisterListeners();
     this.stopLoad();
-    if (this.assetListLoader as any) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (this.assetListLoader) {
       this.assetListLoader.destroy();
     }
     this.emptyPlayerQueue();
@@ -319,7 +322,8 @@ export default class InterstitialsController
   }
 
   public get interstitialsManager(): InterstitialsManager | null {
-    if (!this.hls as any) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!this.hls) {
       return null;
     }
     if (this.manager) {
@@ -936,7 +940,8 @@ export default class InterstitialsController
       // restart Interstitial at end
       if (this.playingLastItem && this.isInterstitial(playingItem)) {
         const restartAsset = playingItem.event.assetList[0];
-        if (restartAsset as any) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (restartAsset) {
           this.endedItem = this.playingItem;
           this.playingItem = null;
           this.setScheduleToAssetAtTime(currentTime, restartAsset);
@@ -1143,7 +1148,8 @@ export default class InterstitialsController
           // Schedule change occured on INTERSTITIAL_ASSET_ENDED
           if (
             this.itemsMatch(currentItem, this.playingItem) &&
-            (!this.playingAsset as any) // INTERSTITIAL_ASSET_ENDED side-effect
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            !this.playingAsset // INTERSTITIAL_ASSET_ENDED side-effect
           ) {
             this.advanceAfterAssetEnded(
               interstitial,
@@ -2132,7 +2138,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         }
       }
       const asset = interstitial.assetList[assetListIndex];
-      if (asset as any) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (asset) {
         const player = this.getAssetPlayer(asset.identifier);
         if (player) {
           player.loadSource();
@@ -2217,12 +2224,14 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     let videoPreference = userConfig.videoPreference;
     const currentLevel =
       primary.loadLevelObj || primary.levels[primary.currentLevel];
-    if (videoPreference || (currentLevel as any)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (videoPreference || currentLevel) {
       videoPreference = Object.assign({}, videoPreference);
       if (currentLevel.videoCodec) {
         videoPreference.videoCodec = currentLevel.videoCodec;
       }
-      if ((currentLevel as any).videoRange) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (currentLevel.videoRange) {
         videoPreference.allowedVideoRanges = [currentLevel.videoRange];
       }
     }
@@ -2796,7 +2805,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       this.setSchedulePosition(scheduleIndex);
     } else if (bufferingEvent?.identifier === interstitialId) {
       const assetItem = interstitial.assetList[0];
-      if (assetItem as any) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (assetItem) {
         const player = this.getAssetPlayer(assetItem.identifier);
         if (bufferingEvent.appendInPlace) {
           // If buffering (but not playback) has reached this item transfer media-source

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -2599,7 +2599,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     if (stallingAsset) {
       const player = this.getAssetPlayer(stallingAsset.identifier);
       if (player) {
-        const assetCurrentTime = player.currentTime;
+        const assetCurrentTime =
+          player.currentTime || currentTime - stallingAsset.timelineStart;
         const distanceFromEnd = player.duration - assetCurrentTime;
         this.warn(
           `Stalled at ${assetCurrentTime} of ${assetCurrentTime + distanceFromEnd} in ${player} ${interstitial} (media.currentTime: ${currentTime})`,
@@ -2619,9 +2620,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
             foundAssetIndex,
           );
         }
-      } else {
-        console.log(`UNHANDLED STALL @${currentTime}`);
-        // this.checkBuffer(true);
       }
     }
   }
@@ -2837,7 +2835,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           this.handleInPlaceStall(stallingItem.event);
           return;
         }
-
+        this.log(
+          `Primary player stall @${this.timelinePos} bufferedPos: ${this.bufferedPos}`,
+        );
         this.onTimeupdate();
         this.checkBuffer(true);
         break;

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -117,7 +117,7 @@ export default class InterstitialsController
   private timelinePos: number = -1;
 
   // Schedule
-  private schedule: InterstitialsSchedule;
+  private schedule: InterstitialsSchedule | null;
 
   // Schedule playback and buffering state
   private playingItem: InterstitialScheduleItem | null = null;
@@ -143,48 +143,49 @@ export default class InterstitialsController
 
   private registerListeners() {
     const hls = this.hls;
-    hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
-    hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
-    hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
-    hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
-    hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
-    hls.on(Events.AUDIO_TRACK_SWITCHING, this.onAudioTrackSwitching, this);
-    hls.on(Events.AUDIO_TRACK_UPDATED, this.onAudioTrackUpdated, this);
-    hls.on(Events.SUBTITLE_TRACK_SWITCH, this.onSubtitleTrackSwitch, this);
-    hls.on(Events.SUBTITLE_TRACK_UPDATED, this.onSubtitleTrackUpdated, this);
-    hls.on(Events.EVENT_CUE_ENTER, this.onInterstitialCueEnter, this);
-    hls.on(Events.ASSET_LIST_LOADED, this.onAssetListLoaded, this);
-    hls.on(Events.BUFFER_APPENDED, this.onBufferAppended, this);
-    hls.on(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
-    hls.on(Events.BUFFERED_TO_END, this.onBufferedToEnd, this);
-    hls.on(Events.MEDIA_ENDED, this.onMediaEnded, this);
-    hls.on(Events.ERROR, this.onError, this);
-    hls.on(Events.DESTROYING, this.onDestroying, this);
+    if (hls as any) {
+      hls.on(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
+      hls.on(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
+      hls.on(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+      hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
+      hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
+      hls.on(Events.AUDIO_TRACK_SWITCHING, this.onAudioTrackSwitching, this);
+      hls.on(Events.AUDIO_TRACK_UPDATED, this.onAudioTrackUpdated, this);
+      hls.on(Events.SUBTITLE_TRACK_SWITCH, this.onSubtitleTrackSwitch, this);
+      hls.on(Events.SUBTITLE_TRACK_UPDATED, this.onSubtitleTrackUpdated, this);
+      hls.on(Events.EVENT_CUE_ENTER, this.onInterstitialCueEnter, this);
+      hls.on(Events.ASSET_LIST_LOADED, this.onAssetListLoaded, this);
+      hls.on(Events.BUFFER_APPENDED, this.onBufferAppended, this);
+      hls.on(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
+      hls.on(Events.BUFFERED_TO_END, this.onBufferedToEnd, this);
+      hls.on(Events.MEDIA_ENDED, this.onMediaEnded, this);
+      hls.on(Events.ERROR, this.onError, this);
+      hls.on(Events.DESTROYING, this.onDestroying, this);
+    }
   }
 
   private unregisterListeners() {
     const hls = this.hls;
-    if (!hls) {
-      return;
+    if (hls as any) {
+      hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
+      hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
+      hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
+      hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
+      hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
+      hls.off(Events.AUDIO_TRACK_SWITCHING, this.onAudioTrackSwitching, this);
+      hls.off(Events.AUDIO_TRACK_UPDATED, this.onAudioTrackUpdated, this);
+      hls.off(Events.SUBTITLE_TRACK_SWITCH, this.onSubtitleTrackSwitch, this);
+      hls.off(Events.SUBTITLE_TRACK_UPDATED, this.onSubtitleTrackUpdated, this);
+      hls.off(Events.EVENT_CUE_ENTER, this.onInterstitialCueEnter, this);
+      hls.off(Events.ASSET_LIST_LOADED, this.onAssetListLoaded, this);
+      hls.off(Events.BUFFER_CODECS, this.onBufferCodecs, this);
+      hls.off(Events.BUFFER_APPENDED, this.onBufferAppended, this);
+      hls.off(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
+      hls.off(Events.BUFFERED_TO_END, this.onBufferedToEnd, this);
+      hls.off(Events.MEDIA_ENDED, this.onMediaEnded, this);
+      hls.off(Events.ERROR, this.onError, this);
+      hls.off(Events.DESTROYING, this.onDestroying, this);
     }
-    hls.off(Events.MEDIA_ATTACHING, this.onMediaAttaching, this);
-    hls.off(Events.MEDIA_ATTACHED, this.onMediaAttached, this);
-    hls.off(Events.MEDIA_DETACHING, this.onMediaDetaching, this);
-    hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
-    hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
-    hls.off(Events.AUDIO_TRACK_SWITCHING, this.onAudioTrackSwitching, this);
-    hls.off(Events.AUDIO_TRACK_UPDATED, this.onAudioTrackUpdated, this);
-    hls.off(Events.SUBTITLE_TRACK_SWITCH, this.onSubtitleTrackSwitch, this);
-    hls.off(Events.SUBTITLE_TRACK_UPDATED, this.onSubtitleTrackUpdated, this);
-    hls.off(Events.EVENT_CUE_ENTER, this.onInterstitialCueEnter, this);
-    hls.off(Events.ASSET_LIST_LOADED, this.onAssetListLoaded, this);
-    hls.off(Events.BUFFER_CODECS, this.onBufferCodecs, this);
-    hls.off(Events.BUFFER_APPENDED, this.onBufferAppended, this);
-    hls.off(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
-    hls.off(Events.BUFFERED_TO_END, this.onBufferedToEnd, this);
-    hls.off(Events.MEDIA_ENDED, this.onMediaEnded, this);
-    hls.off(Events.ERROR, this.onError, this);
-    hls.off(Events.DESTROYING, this.onDestroying, this);
   }
 
   startLoad() {
@@ -208,7 +209,7 @@ export default class InterstitialsController
   destroy() {
     this.unregisterListeners();
     this.stopLoad();
-    if (this.assetListLoader) {
+    if (this.assetListLoader as any) {
       this.assetListLoader.destroy();
     }
     this.emptyPlayerQueue();
@@ -221,10 +222,11 @@ export default class InterstitialsController
       this.mediaSelection =
       this.requiredTracks =
       this.altSelection =
+      this.schedule =
       this.manager =
         null;
     // @ts-ignore
-    this.hls = this.HlsPlayerClass = this.schedule = this.log = null;
+    this.hls = this.HlsPlayerClass = this.log = null;
     // @ts-ignore
     this.assetListLoader = null;
     // @ts-ignore
@@ -317,345 +319,365 @@ export default class InterstitialsController
   }
 
   public get interstitialsManager(): InterstitialsManager | null {
-    if (!this.manager) {
-      if (!this.hls) {
-        return null;
-      }
-      const c = this;
-      const effectiveBufferingItem = () => c.bufferingItem || c.waitingItem;
-      const getAssetPlayer = (asset: InterstitialAssetItem | null) =>
-        asset ? c.getAssetPlayer(asset.identifier) : asset;
-      const getMappedTime = (
-        item: InterstitialScheduleItem | null,
-        timelineType: TimelineType,
-        asset: InterstitialAssetItem | null,
-        controllerField: 'bufferedPos' | 'timelinePos',
-        assetPlayerField: 'bufferedEnd' | 'currentTime',
-      ) => {
-        if (item) {
-          let time = item[timelineType].start;
-          const interstitial = item.event;
-          if (interstitial) {
-            if (
-              timelineType === 'playout' ||
-              interstitial.timelineOccupancy !== TimelineOccupancy.Point
-            ) {
-              const assetPlayer = getAssetPlayer(asset);
-              if (assetPlayer?.interstitial === interstitial) {
-                time +=
-                  assetPlayer.assetItem.startOffset +
-                  assetPlayer[assetPlayerField];
-              }
+    if (!this.hls as any) {
+      return null;
+    }
+    if (this.manager) {
+      return this.manager;
+    }
+    const c = this;
+    const effectiveBufferingItem = () => c.bufferingItem || c.waitingItem;
+    const getAssetPlayer = (asset: InterstitialAssetItem | null) =>
+      asset ? c.getAssetPlayer(asset.identifier) : asset;
+    const getMappedTime = (
+      item: InterstitialScheduleItem | null,
+      timelineType: TimelineType,
+      asset: InterstitialAssetItem | null,
+      controllerField: 'bufferedPos' | 'timelinePos',
+      assetPlayerField: 'bufferedEnd' | 'currentTime',
+    ): number => {
+      if (item) {
+        let time = (
+          item[timelineType] as {
+            start: number;
+            end: number;
+          }
+        ).start;
+        const interstitial = item.event;
+        if (interstitial) {
+          if (
+            timelineType === 'playout' ||
+            interstitial.timelineOccupancy !== TimelineOccupancy.Point
+          ) {
+            const assetPlayer = getAssetPlayer(asset);
+            if (assetPlayer?.interstitial === interstitial) {
+              time +=
+                assetPlayer.assetItem.startOffset +
+                assetPlayer[assetPlayerField];
             }
-          } else {
-            const value =
-              controllerField === 'bufferedPos'
-                ? getBufferedEnd()
-                : c[controllerField];
-            time += value - item.start;
           }
-          return time;
+        } else {
+          const value =
+            controllerField === 'bufferedPos'
+              ? getBufferedEnd()
+              : c[controllerField];
+          time += value - item.start;
         }
-        return 0;
-      };
-      const findMappedTime = (
-        primaryTime: number,
-        timelineType: TimelineType,
-      ): number => {
-        if (
-          primaryTime !== 0 &&
-          timelineType !== 'primary' &&
-          c.schedule.length
-        ) {
-          const index = c.schedule.findItemIndexAtTime(primaryTime);
-          const item = c.schedule.items?.[index];
-          if (item) {
-            const diff = item[timelineType].start - item.start;
-            return primaryTime + diff;
-          }
+        return time;
+      }
+      return 0;
+    };
+    const findMappedTime = (
+      primaryTime: number,
+      timelineType: TimelineType,
+    ): number => {
+      if (
+        primaryTime !== 0 &&
+        timelineType !== 'primary' &&
+        c.schedule?.length
+      ) {
+        const index = c.schedule.findItemIndexAtTime(primaryTime);
+        const item = c.schedule.items?.[index];
+        if (item) {
+          const diff = item[timelineType].start - item.start;
+          return primaryTime + diff;
         }
-        return primaryTime;
-      };
-      const getBufferedEnd = (): number => {
-        const value = c.bufferedPos;
-        if (value === Number.MAX_VALUE) {
-          return getMappedDuration('primary');
-        }
-        return Math.max(value, 0);
-      };
-      const getMappedDuration = (timelineType: TimelineType): number => {
-        if (c.primaryDetails?.live) {
-          // return end of last event item or playlist
-          return c.primaryDetails.edge;
-        }
-        return c.schedule.durations[timelineType];
-      };
-      const seekTo = (time: number, timelineType: TimelineType) => {
-        const item = c.effectivePlayingItem;
-        if (item?.event?.restrictions.skip) {
-          return;
-        }
-        c.log(`seek to ${time} "${timelineType}"`);
-        const playingItem = c.effectivePlayingItem;
-        const targetIndex = c.schedule.findItemIndexAtTime(time, timelineType);
-        const targetItem = c.schedule.items?.[targetIndex];
-        const bufferingPlayer = c.getBufferingPlayer();
-        const bufferingInterstitial = bufferingPlayer?.interstitial;
-        const appendInPlace = bufferingInterstitial?.appendInPlace;
-        const seekInItem = playingItem && c.itemsMatch(playingItem, targetItem);
-        if (playingItem && (appendInPlace || seekInItem)) {
-          // seek in asset player or primary media (appendInPlace)
-          const assetPlayer = getAssetPlayer(c.playingAsset);
-          const media = assetPlayer?.media || c.primaryMedia;
-          if (media) {
-            const currentTime =
-              timelineType === 'primary'
-                ? media.currentTime
-                : getMappedTime(
-                    playingItem,
-                    timelineType,
-                    c.playingAsset,
-                    'timelinePos',
-                    'currentTime',
-                  );
+      }
+      return primaryTime;
+    };
+    const getBufferedEnd = (): number => {
+      const value = c.bufferedPos;
+      if (value === Number.MAX_VALUE) {
+        return getMappedDuration('primary');
+      }
+      return Math.max(value, 0);
+    };
+    const getMappedDuration = (timelineType: TimelineType): number => {
+      if (c.primaryDetails?.live) {
+        // return end of last event item or playlist
+        return c.primaryDetails.edge;
+      }
+      return c.schedule?.durations[timelineType] || 0;
+    };
+    const seekTo = (time: number, timelineType: TimelineType) => {
+      const item = c.effectivePlayingItem;
+      if (item?.event?.restrictions.skip || !c.schedule) {
+        return;
+      }
+      c.log(`seek to ${time} "${timelineType}"`);
+      const playingItem = c.effectivePlayingItem;
+      const targetIndex = c.schedule.findItemIndexAtTime(time, timelineType);
+      const targetItem = c.schedule.items?.[targetIndex];
+      const bufferingPlayer = c.getBufferingPlayer();
+      const bufferingInterstitial = bufferingPlayer?.interstitial;
+      const appendInPlace = bufferingInterstitial?.appendInPlace;
+      const seekInItem = playingItem && c.itemsMatch(playingItem, targetItem);
+      if (playingItem && (appendInPlace || seekInItem)) {
+        // seek in asset player or primary media (appendInPlace)
+        const assetPlayer = getAssetPlayer(c.playingAsset);
+        const media = assetPlayer?.media || c.primaryMedia;
+        if (media) {
+          const currentTime =
+            timelineType === 'primary'
+              ? media.currentTime
+              : getMappedTime(
+                  playingItem,
+                  timelineType,
+                  c.playingAsset,
+                  'timelinePos',
+                  'currentTime',
+                );
 
-            const diff = time - currentTime;
-            const seekToTime =
-              (appendInPlace ? currentTime : media.currentTime) + diff;
-            if (
-              seekToTime >= 0 &&
-              (!assetPlayer ||
-                appendInPlace ||
-                seekToTime <= assetPlayer.duration)
-            ) {
-              media.currentTime = seekToTime;
+          const diff = time - currentTime;
+          const seekToTime =
+            (appendInPlace ? currentTime : media.currentTime) + diff;
+          if (
+            seekToTime >= 0 &&
+            (!assetPlayer ||
+              appendInPlace ||
+              seekToTime <= assetPlayer.duration)
+          ) {
+            media.currentTime = seekToTime;
+            return;
+          }
+        }
+      }
+      // seek out of item or asset
+      if (targetItem) {
+        let seekToTime = time;
+        if (timelineType !== 'primary') {
+          const primarySegmentStart = targetItem[timelineType].start;
+          const diff = time - primarySegmentStart;
+          seekToTime = targetItem.start + diff;
+        }
+        const targetIsPrimary = !c.isInterstitial(targetItem);
+        if (
+          (!c.isInterstitial(playingItem) || playingItem.event.appendInPlace) &&
+          (targetIsPrimary || targetItem.event.appendInPlace)
+        ) {
+          const media =
+            c.media || (appendInPlace ? bufferingPlayer?.media : null);
+          if (media) {
+            media.currentTime = seekToTime;
+          }
+        } else if (playingItem) {
+          // check if an Interstitial between the current item and target item has an X-RESTRICT JUMP restriction
+          const playingIndex = c.findItemIndex(playingItem);
+          if (targetIndex > playingIndex) {
+            const jumpIndex = c.schedule.findJumpRestrictedIndex(
+              playingIndex + 1,
+              targetIndex,
+            );
+            if (jumpIndex > playingIndex) {
+              c.setSchedulePosition(jumpIndex);
               return;
             }
           }
-        }
-        // seek out of item or asset
-        if (targetItem) {
-          let seekToTime = time;
-          if (timelineType !== 'primary') {
-            const primarySegmentStart = targetItem[timelineType].start;
-            const diff = time - primarySegmentStart;
-            seekToTime = targetItem.start + diff;
-          }
-          const targetIsPrimary = !c.isInterstitial(targetItem);
-          if (
-            (!c.isInterstitial(playingItem) ||
-              playingItem.event.appendInPlace) &&
-            (targetIsPrimary || targetItem.event.appendInPlace)
-          ) {
-            const media =
-              c.media || (appendInPlace ? bufferingPlayer?.media : null);
-            if (media) {
-              media.currentTime = seekToTime;
-            }
-          } else if (playingItem) {
-            // check if an Interstitial between the current item and target item has an X-RESTRICT JUMP restriction
-            const playingIndex = c.findItemIndex(playingItem);
-            if (targetIndex > playingIndex) {
-              const jumpIndex = c.schedule.findJumpRestrictedIndex(
-                playingIndex + 1,
-                targetIndex,
-              );
-              if (jumpIndex > playingIndex) {
-                c.setSchedulePosition(jumpIndex);
-                return;
-              }
-            }
 
-            let assetIndex = 0;
-            if (targetIsPrimary) {
-              c.timelinePos = seekToTime;
-              c.checkBuffer();
-            } else {
-              const assetList = targetItem?.event?.assetList;
-              if (assetList) {
-                const eventTime =
-                  time - (targetItem[timelineType] || targetItem).start;
-                for (let i = assetList.length; i--; ) {
-                  const asset = assetList[i];
-                  if (
-                    asset.duration &&
-                    eventTime >= asset.startOffset &&
-                    eventTime < asset.startOffset + asset.duration
-                  ) {
-                    assetIndex = i;
-                    break;
-                  }
-                }
+          let assetIndex = 0;
+          if (targetIsPrimary) {
+            c.timelinePos = seekToTime;
+            c.checkBuffer();
+          } else {
+            const assetList = targetItem.event.assetList;
+            const eventTime =
+              time - (targetItem[timelineType] || targetItem).start;
+            for (let i = assetList.length; i--; ) {
+              const asset = assetList[i];
+              if (
+                asset.duration &&
+                eventTime >= asset.startOffset &&
+                eventTime < asset.startOffset + asset.duration
+              ) {
+                assetIndex = i;
+                break;
               }
             }
-            c.setSchedulePosition(targetIndex, assetIndex);
           }
+          c.setSchedulePosition(targetIndex, assetIndex);
         }
-      };
-      const getActiveInterstitial = () => {
-        const playingItem = c.effectivePlayingItem;
-        if (c.isInterstitial(playingItem)) {
-          return playingItem;
-        }
-        const bufferingItem = effectiveBufferingItem();
-        if (c.isInterstitial(bufferingItem)) {
-          return bufferingItem;
-        }
-        return null;
-      };
-      const interstitialPlayer: InterstitialPlayer = {
-        get currentTime() {
-          const interstitialItem = getActiveInterstitial();
-          const playingItem = c.effectivePlayingItem;
-          if (playingItem && playingItem === interstitialItem) {
-            return (
-              getMappedTime(
-                playingItem,
-                'playout',
-                c.effectivePlayingAsset,
-                'timelinePos',
-                'currentTime',
-              ) - playingItem.playout.start
-            );
-          }
-          return 0;
-        },
-        set currentTime(time: number) {
-          const interstitialItem = getActiveInterstitial();
-          const playingItem = c.effectivePlayingItem;
-          if (playingItem && playingItem === interstitialItem) {
-            seekTo(time + playingItem.playout.start, 'playout');
-          }
-        },
-        get duration() {
-          const interstitialItem = getActiveInterstitial();
-          if (interstitialItem) {
-            return (
-              interstitialItem.playout.end - interstitialItem.playout.start
-            );
-          }
-          return 0;
-        },
-        get assetPlayers() {
-          const assetList = getActiveInterstitial()?.event.assetList;
-          if (assetList) {
-            return assetList.map((asset) => c.getAssetPlayer(asset.identifier));
-          }
-          return [];
-        },
-        get playingIndex() {
-          const interstitial = getActiveInterstitial()?.event;
-          if (interstitial && c.effectivePlayingAsset) {
-            return interstitial.findAssetIndex(c.effectivePlayingAsset);
-          }
-          return -1;
-        },
-        get scheduleItem() {
-          return getActiveInterstitial();
-        },
-      };
-      this.manager = {
-        get events() {
-          return c.schedule?.events?.slice(0) || [];
-        },
-        get schedule() {
-          return c.schedule?.items?.slice(0) || [];
-        },
-        get interstitialPlayer() {
-          if (getActiveInterstitial()) {
-            return interstitialPlayer;
-          }
-          return null;
-        },
-        get playerQueue() {
-          return c.playerQueue.slice(0);
-        },
-        get bufferingAsset() {
-          return c.bufferingAsset;
-        },
-        get bufferingItem() {
-          return effectiveBufferingItem();
-        },
-        get bufferingIndex() {
-          const item = effectiveBufferingItem();
-          return c.findItemIndex(item);
-        },
-        get playingAsset() {
-          return c.effectivePlayingAsset;
-        },
-        get playingItem() {
-          return c.effectivePlayingItem;
-        },
-        get playingIndex() {
-          const item = c.effectivePlayingItem;
-          return c.findItemIndex(item);
-        },
-        primary: {
-          get bufferedEnd() {
-            return getBufferedEnd();
-          },
-          get currentTime() {
-            const timelinePos = c.timelinePos;
-            return timelinePos > 0 ? timelinePos : 0;
-          },
-          set currentTime(time: number) {
-            seekTo(time, 'primary');
-          },
-          get duration() {
-            return getMappedDuration('primary');
-          },
-          get seekableStart() {
-            return c.primaryDetails?.fragmentStart || 0;
-          },
-        },
-        integrated: {
-          get bufferedEnd() {
-            return getMappedTime(
-              effectiveBufferingItem(),
-              'integrated',
+      }
+    };
+    const getActiveInterstitial = () => {
+      const playingItem = c.effectivePlayingItem;
+      if (c.isInterstitial(playingItem)) {
+        return playingItem;
+      }
+      const bufferingItem = effectiveBufferingItem();
+      if (c.isInterstitial(bufferingItem)) {
+        return bufferingItem;
+      }
+      return null;
+    };
+    const interstitialPlayer: InterstitialPlayer = {
+      get bufferedEnd() {
+        const interstitialItem = effectiveBufferingItem();
+        const bufferingItem = c.bufferingItem;
+        if (bufferingItem && bufferingItem === interstitialItem) {
+          return (
+            getMappedTime(
+              bufferingItem,
+              'playout',
               c.bufferingAsset,
               'bufferedPos',
               'bufferedEnd',
-            );
-          },
-          get currentTime() {
-            return getMappedTime(
-              c.effectivePlayingItem,
-              'integrated',
+            ) - bufferingItem.playout.start ||
+            c.bufferingAsset?.startOffset ||
+            0
+          );
+        }
+        return 0;
+      },
+      get currentTime() {
+        const interstitialItem = getActiveInterstitial();
+        const playingItem = c.effectivePlayingItem;
+        if (playingItem && playingItem === interstitialItem) {
+          return (
+            getMappedTime(
+              playingItem,
+              'playout',
               c.effectivePlayingAsset,
               'timelinePos',
               'currentTime',
-            );
-          },
-          set currentTime(time: number) {
-            seekTo(time, 'integrated');
-          },
-          get duration() {
-            return getMappedDuration('integrated');
-          },
-          get seekableStart() {
-            return findMappedTime(
-              c.primaryDetails?.fragmentStart || 0,
-              'integrated',
-            );
-          },
+            ) - playingItem.playout.start
+          );
+        }
+        return 0;
+      },
+      set currentTime(time: number) {
+        const interstitialItem = getActiveInterstitial();
+        const playingItem = c.effectivePlayingItem;
+        if (playingItem && playingItem === interstitialItem) {
+          seekTo(time + playingItem.playout.start, 'playout');
+        }
+      },
+      get duration() {
+        const interstitialItem = getActiveInterstitial();
+        if (interstitialItem) {
+          return interstitialItem.playout.end - interstitialItem.playout.start;
+        }
+        return 0;
+      },
+      get assetPlayers() {
+        const assetList = getActiveInterstitial()?.event.assetList;
+        if (assetList) {
+          return assetList.map((asset) => c.getAssetPlayer(asset.identifier));
+        }
+        return [];
+      },
+      get playingIndex() {
+        const interstitial = getActiveInterstitial()?.event;
+        if (interstitial && c.effectivePlayingAsset) {
+          return interstitial.findAssetIndex(c.effectivePlayingAsset);
+        }
+        return -1;
+      },
+      get scheduleItem() {
+        return getActiveInterstitial();
+      },
+    };
+    return (this.manager = {
+      get events() {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        return c.schedule?.events?.slice(0) || [];
+      },
+      get schedule() {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        return c.schedule?.items?.slice(0) || [];
+      },
+      get interstitialPlayer() {
+        if (getActiveInterstitial()) {
+          return interstitialPlayer;
+        }
+        return null;
+      },
+      get playerQueue() {
+        return c.playerQueue.slice(0);
+      },
+      get bufferingAsset() {
+        return c.bufferingAsset;
+      },
+      get bufferingItem() {
+        return effectiveBufferingItem();
+      },
+      get bufferingIndex() {
+        const item = effectiveBufferingItem();
+        return c.findItemIndex(item);
+      },
+      get playingAsset() {
+        return c.effectivePlayingAsset;
+      },
+      get playingItem() {
+        return c.effectivePlayingItem;
+      },
+      get playingIndex() {
+        const item = c.effectivePlayingItem;
+        return c.findItemIndex(item);
+      },
+      primary: {
+        get bufferedEnd() {
+          return getBufferedEnd();
         },
-        skip: () => {
-          const item = c.effectivePlayingItem;
-          const event = item?.event;
-          if (event && !event.restrictions.skip) {
-            const index = c.findItemIndex(item);
-            if (event.appendInPlace) {
-              const time = item.playout.start + item.event.duration;
-              seekTo(time + 0.001, 'playout');
-            } else {
-              c.advanceAfterAssetEnded(event, index, Infinity);
-            }
+        get currentTime() {
+          const timelinePos = c.timelinePos;
+          return timelinePos > 0 ? timelinePos : 0;
+        },
+        set currentTime(time: number) {
+          seekTo(time, 'primary');
+        },
+        get duration() {
+          return getMappedDuration('primary');
+        },
+        get seekableStart() {
+          return c.primaryDetails?.fragmentStart || 0;
+        },
+      },
+      integrated: {
+        get bufferedEnd() {
+          return getMappedTime(
+            effectiveBufferingItem(),
+            'integrated',
+            c.bufferingAsset,
+            'bufferedPos',
+            'bufferedEnd',
+          );
+        },
+        get currentTime() {
+          return getMappedTime(
+            c.effectivePlayingItem,
+            'integrated',
+            c.effectivePlayingAsset,
+            'timelinePos',
+            'currentTime',
+          );
+        },
+        set currentTime(time: number) {
+          seekTo(time, 'integrated');
+        },
+        get duration() {
+          return getMappedDuration('integrated');
+        },
+        get seekableStart() {
+          return findMappedTime(
+            c.primaryDetails?.fragmentStart || 0,
+            'integrated',
+          );
+        },
+      },
+      skip: () => {
+        const item = c.effectivePlayingItem;
+        const event = item?.event;
+        if (event && !event.restrictions.skip) {
+          const index = c.findItemIndex(item);
+          if (event.appendInPlace) {
+            const time = item.playout.start + item.event.duration;
+            seekTo(time + 0.001, 'playout');
+          } else {
+            c.advanceAfterAssetEnded(event, index, Infinity);
           }
-        },
-      };
-    }
-    return this.manager;
+        }
+      },
+    });
   }
 
   // Schedule getters
@@ -805,8 +827,9 @@ export default class InterstitialsController
             ) {
               const interstitial = queuedPlayer.interstitial;
               this.clearInterstitial(queuedPlayer.interstitial, null);
-              interstitial.appendInPlace = false;
-              if (interstitial.appendInPlace) {
+              interstitial.appendInPlace = false; // setter may be a no-op;
+              // `appendInPlace` getter may still return `true` after insterstitial streaming has begun in that mode.
+              if (interstitial.appendInPlace as boolean) {
                 this.warn(
                   `Could not change append strategy for queued assets ${interstitial}`,
                 );
@@ -829,13 +852,14 @@ export default class InterstitialsController
         isAssetPlayer ? player : 'Primary'
       } from ${logFromSource}`,
     );
-    if (dataToAttach === attachMediaSourceData) {
+    const schedule = this.schedule;
+    if (dataToAttach === attachMediaSourceData && schedule) {
       const isAssetAtEndOfSchedule =
         isAssetPlayer &&
-        (player as HlsAssetPlayer).assetId === this.schedule.assetIdAtEnd;
+        (player as HlsAssetPlayer).assetId === schedule.assetIdAtEnd;
       // Prevent asset players from marking EoS on transferred MediaSource
       dataToAttach.overrides = {
-        duration: this.schedule.duration,
+        duration: schedule.duration,
         endOfStream: !isAssetPlayer || isAssetAtEndOfSchedule,
         cueRemoval: !isAssetPlayer,
       };
@@ -853,7 +877,7 @@ export default class InterstitialsController
 
   private onSeeking = () => {
     const currentTime = this.currentTime;
-    if (currentTime === undefined || this.playbackDisabled) {
+    if (currentTime === undefined || this.playbackDisabled || !this.schedule) {
       return;
     }
     const diff = currentTime - this.timelinePos;
@@ -912,7 +936,7 @@ export default class InterstitialsController
       // restart Interstitial at end
       if (this.playingLastItem && this.isInterstitial(playingItem)) {
         const restartAsset = playingItem.event.assetList[0];
-        if (restartAsset) {
+        if (restartAsset as any) {
           this.endedItem = this.playingItem;
           this.playingItem = null;
           this.setScheduleToAssetAtTime(currentTime, restartAsset);
@@ -975,7 +999,7 @@ export default class InterstitialsController
   // Scheduling methods
   private checkStart() {
     const schedule = this.schedule;
-    const interstitialEvents = schedule.events;
+    const interstitialEvents = schedule?.events;
     if (!interstitialEvents || this.playbackDisabled || !this.media) {
       return;
     }
@@ -1013,7 +1037,7 @@ export default class InterstitialsController
     if (!interstitial.isAssetPastPlayoutLimit(nextAssetIndex)) {
       // Advance to next asset list item
       this.setSchedulePosition(index, nextAssetIndex);
-    } else {
+    } else if (this.schedule) {
       // Advance to next schedule segment
       // check if we've reached the end of the program
       const scheduleItems = this.schedule.items;
@@ -1039,6 +1063,9 @@ export default class InterstitialsController
     playingAsset: InterstitialAssetItem,
   ) {
     const schedule = this.schedule;
+    if (!schedule) {
+      return;
+    }
     const parentIdentifier = playingAsset.parentIdentifier;
     const interstitial = schedule.getEvent(parentIdentifier);
     if (interstitial) {
@@ -1049,7 +1076,7 @@ export default class InterstitialsController
   }
 
   private setSchedulePosition(index: number, assetListIndex?: number) {
-    const scheduleItems = this.schedule.items;
+    const scheduleItems = this.schedule?.items;
     if (!scheduleItems || this.playbackDisabled) {
       return;
     }
@@ -1068,7 +1095,7 @@ export default class InterstitialsController
         assetId &&
         (!this.eventItemsMatch(currentItem, scheduledItem) ||
           (assetListIndex !== undefined &&
-            assetId !== interstitial.assetList?.[assetListIndex].identifier))
+            assetId !== interstitial.assetList[assetListIndex].identifier))
       ) {
         const playingAssetListIndex = interstitial.findAssetIndex(playingAsset);
         this.log(
@@ -1088,7 +1115,7 @@ export default class InterstitialsController
           // Schedule change occured on INTERSTITIAL_ASSET_ENDED
           if (
             this.itemsMatch(currentItem, this.playingItem) &&
-            !this.playingAsset
+            (!this.playingAsset as any) // INTERSTITIAL_ASSET_ENDED side-effect
           ) {
             this.advanceAfterAssetEnded(
               interstitial,
@@ -1120,12 +1147,12 @@ export default class InterstitialsController
         if (interstitial.cue.once) {
           // Remove interstitial with CUE attribute value of ONCE after it has played
           this.updateSchedule();
-          const items = this.schedule.items;
-          if (scheduledItem && items) {
+          const updatedScheduleItems = this.schedule?.items;
+          if (scheduledItem && updatedScheduleItems) {
             const updatedIndex = this.findItemIndex(scheduledItem);
             this.advanceSchedule(
               updatedIndex,
-              items,
+              updatedScheduleItems,
               assetListIndex,
               currentItem,
               playingLastItem,
@@ -1150,6 +1177,10 @@ export default class InterstitialsController
     currentItem: InterstitialScheduleItem | null,
     playedLastItem: boolean,
   ) {
+    const schedule = this.schedule;
+    if (!schedule) {
+      return;
+    }
     const scheduledItem = index >= 0 ? scheduleItems[index] : null;
     const media = this.primaryMedia;
     // Cleanup out of range Interstitials
@@ -1157,9 +1188,7 @@ export default class InterstitialsController
     if (playerQueue.length) {
       playerQueue.forEach((player) => {
         const interstitial = player.interstitial;
-        const queuedIndex = this.schedule.findEventIndex(
-          interstitial.identifier,
-        );
+        const queuedIndex = schedule.findEventIndex(interstitial.identifier);
         if (queuedIndex < index || queuedIndex > index + 1) {
           this.clearInterstitial(interstitial, scheduledItem);
         }
@@ -1175,7 +1204,7 @@ export default class InterstitialsController
       const interstitial = scheduledItem.event;
       // find asset index
       if (assetListIndex === undefined) {
-        assetListIndex = this.schedule.findAssetIndex(
+        assetListIndex = schedule.findAssetIndex(
           interstitial,
           this.timelinePos,
         );
@@ -1228,11 +1257,11 @@ export default class InterstitialsController
 
       // If asset-list is empty or missing asset index, advance to next item
       const assetItem = interstitial.assetList[assetListIndex];
-      if (!assetItem) {
+      if (!assetItem as any) {
         const nextItem = scheduleItems[index + 1];
         const media = this.media;
         if (
-          nextItem &&
+          (nextItem as any) &&
           media &&
           !this.isInterstitial(nextItem) &&
           media.currentTime < nextItem.start
@@ -1259,6 +1288,7 @@ export default class InterstitialsController
           assetItem,
           assetListIndex,
         );
+        player.loadSource();
       }
       if (!this.eventItemsMatch(scheduledItem, this.bufferingItem)) {
         if (interstitial.appendInPlace && this.isAssetBuffered(assetItem)) {
@@ -1287,7 +1317,7 @@ export default class InterstitialsController
       this.playingItem = currentItem;
       if (!currentItem.event.appendInPlace) {
         // Media must be re-attached to resume primary schedule if not sharing source
-        this.attachPrimary(this.schedule.durations.primary, null);
+        this.attachPrimary(schedule.durations.primary, null);
       }
     }
   }
@@ -1297,7 +1327,7 @@ export default class InterstitialsController
   }
 
   private get primaryDetails(): LevelDetails | undefined {
-    return this.mediaSelection?.main?.details;
+    return this.mediaSelection?.main.details;
   }
 
   private get primaryLive(): boolean {
@@ -1333,7 +1363,7 @@ export default class InterstitialsController
       return;
     }
 
-    const scheduleItems = this.schedule.items;
+    const scheduleItems = this.schedule?.items;
     if (!scheduleItems) {
       return;
     }
@@ -1431,7 +1461,7 @@ export default class InterstitialsController
   // HLS.js event callbacks
   private onManifestLoading() {
     this.stopLoad();
-    this.schedule.reset();
+    this.schedule?.reset();
     this.emptyPlayerQueue();
     this.clearScheduleState();
     this.shouldPlay = false;
@@ -1447,7 +1477,7 @@ export default class InterstitialsController
   }
 
   private onLevelUpdated(event: Events.LEVEL_UPDATED, data: LevelUpdatedData) {
-    if (data.level === -1) {
+    if (data.level === -1 || !this.schedule) {
       // level was removed
       return;
     }
@@ -1501,9 +1531,8 @@ export default class InterstitialsController
   ) {
     const audioOption = getBasicSelectionOption(data);
     this.playerQueue.forEach(
-      (player) =>
-        player.hls.setAudioOption(data) ||
-        player.hls.setAudioOption(audioOption),
+      ({ hls }) =>
+        hls && (hls.setAudioOption(data) || hls.setAudioOption(audioOption)),
     );
   }
 
@@ -1513,9 +1542,10 @@ export default class InterstitialsController
   ) {
     const subtitleOption = getBasicSelectionOption(data);
     this.playerQueue.forEach(
-      (player) =>
-        player.hls.setSubtitleOption(data) ||
-        (data.id !== -1 && player.hls.setSubtitleOption(subtitleOption)),
+      ({ hls }) =>
+        hls &&
+        (hls.setSubtitleOption(data) ||
+          (data.id !== -1 && hls.setSubtitleOption(subtitleOption))),
     );
   }
 
@@ -1550,6 +1580,9 @@ export default class InterstitialsController
   }
 
   private onBufferedToEnd(event: Events.BUFFERED_TO_END) {
+    if (!this.schedule) {
+      return;
+    }
     // Buffered to post-roll
     const interstitialEvents = this.schedule.events;
     if (this.bufferedPos < Number.MAX_VALUE && interstitialEvents) {
@@ -1589,6 +1622,9 @@ export default class InterstitialsController
     previousItems: InterstitialScheduleItem[] | null,
   ) => {
     const schedule = this.schedule;
+    if (!schedule) {
+      return;
+    }
     const playingItem = this.playingItem;
     const interstitialEvents = schedule.events || [];
     const scheduleItems = schedule.items || [];
@@ -1610,24 +1646,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     if (removedIds.length) {
       this.log(`Removed events ${removedIds}`);
     }
-
-    this.playerQueue.forEach((player) => {
-      if (player.interstitial.appendInPlace) {
-        const timelineStart = player.assetItem.timelineStart;
-        const diff = player.timelineOffset - timelineStart;
-        if (diff) {
-          try {
-            player.timelineOffset = timelineStart;
-          } catch (e) {
-            if (Math.abs(diff) > ALIGNED_END_THRESHOLD_SECONDS) {
-              this.warn(
-                `${e} ("${player.assetId}" ${player.timelineOffset}->${timelineStart})`,
-              );
-            }
-          }
-        }
-      }
-    });
 
     // Update schedule item references
     // Do not replace Interstitial playingItem without a match - used for INTERSTITIAL_ASSET_ENDED and INTERSTITIAL_ENDED
@@ -1669,6 +1687,24 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       });
     });
 
+    this.playerQueue.forEach((player) => {
+      if (player.interstitial.appendInPlace) {
+        const timelineStart = player.assetItem.timelineStart;
+        const diff = player.timelineOffset - timelineStart;
+        if (diff) {
+          try {
+            player.timelineOffset = timelineStart;
+          } catch (e) {
+            if (Math.abs(diff) > ALIGNED_END_THRESHOLD_SECONDS) {
+              this.warn(
+                `${e} ("${player.assetId}" ${player.timelineOffset}->${timelineStart})`,
+              );
+            }
+          }
+        }
+      }
+    });
+
     if (interstitialsUpdated || previousItems) {
       this.hls.trigger(Events.INTERSTITIALS_UPDATED, {
         events: interstitialEvents.slice(0),
@@ -1703,10 +1739,10 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     time?: number,
   ): T | null {
     // find item in this.schedule.items;
-    const items = this.schedule.items;
+    const items = this.schedule?.items;
     if (previousItem && items) {
       const index = this.findItemIndex(previousItem, time);
-      return (items[index] as T) || null;
+      return (items[index] as T | undefined) || null;
     }
     return null;
   }
@@ -1766,7 +1802,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     item: InterstitialScheduleItem | null,
     time?: number,
   ): number {
-    return item ? this.schedule.findItemIndex(item, time) : -1;
+    return item && this.schedule ? this.schedule.findItemIndex(item, time) : -1;
   }
 
   private updateSchedule() {
@@ -1774,12 +1810,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     if (!mediaSelection) {
       return;
     }
-    this.schedule.updateSchedule(mediaSelection, []);
+    this.schedule?.updateSchedule(mediaSelection, []);
   }
 
   // Schedule buffer control
   private checkBuffer(starved?: boolean) {
-    const items = this.schedule.items;
+    const items = this.schedule?.items;
     if (!items) {
       return;
     }
@@ -1803,7 +1839,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
   ) {
     const schedule = this.schedule;
     const bufferingItem = this.bufferingItem;
-    if (this.bufferedPos > bufferEnd) {
+    if (this.bufferedPos > bufferEnd || !schedule) {
       return;
     }
     if (items.length === 1 && this.itemsMatch(items[0], bufferingItem)) {
@@ -1884,7 +1920,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const bufferingLast = this.bufferingItem;
     const schedule = this.schedule;
 
-    if (!this.itemsMatch(item, bufferingLast)) {
+    if (!this.itemsMatch(item, bufferingLast) && schedule) {
       const { items, events } = schedule;
       if (!items || !events) {
         return bufferingLast;
@@ -1907,10 +1943,17 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       );
       if (!this.playbackDisabled) {
         if (isInterstitial) {
+          const bufferIndex = schedule.findAssetIndex(
+            item.event,
+            this.bufferedPos,
+          );
           // primary fragment loading will exit early in base-stream-controller while `bufferingItem` is set to an Interstitial block
-          item.event.assetList.forEach((asset) => {
+          item.event.assetList.forEach((asset, i) => {
             const player = this.getAssetPlayer(asset.identifier);
             if (player) {
+              if (i === bufferIndex) {
+                player.loadSource();
+              }
               player.resumeBuffering();
             }
           });
@@ -1978,10 +2021,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       // Buffered to Interstitial boundary
       const player = this.preloadAssets(interstitial, assetListIndex);
       if (player?.interstitial.appendInPlace) {
-        // If we have a player and asset list info, start buffering
-        const assetItem = interstitial.assetList[assetListIndex];
         const media = this.primaryMedia;
-        if (assetItem && media) {
+        if (media) {
           this.bufferAssetPlayer(player, media);
         }
       }
@@ -2060,9 +2101,14 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           this.createAssetPlayer(interstitial, asset, i);
         }
       }
-      return this.getAssetPlayer(
-        interstitial.assetList[assetListIndex].identifier,
-      );
+      const asset = interstitial.assetList[assetListIndex];
+      if (asset as any) {
+        const player = this.getAssetPlayer(asset.identifier);
+        if (player) {
+          player.loadSource();
+        }
+        return player;
+      }
     }
     return null;
   }
@@ -2141,12 +2187,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     let videoPreference = userConfig.videoPreference;
     const currentLevel =
       primary.loadLevelObj || primary.levels[primary.currentLevel];
-    if (videoPreference || currentLevel) {
+    if (videoPreference || (currentLevel as any)) {
       videoPreference = Object.assign({}, videoPreference);
       if (currentLevel.videoCodec) {
         videoPreference.videoCodec = currentLevel.videoCodec;
       }
-      if (currentLevel.videoRange) {
+      if ((currentLevel as any).videoRange) {
         videoPreference.allowedVideoRanges = [currentLevel.videoRange];
       }
     }
@@ -2175,8 +2221,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       liveDurationInfinity: false,
       testBandwidth: false,
       videoPreference,
-      audioPreference: selectedAudio || userConfig.audioPreference,
-      subtitlePreference: selectedSubtitle || userConfig.subtitlePreference,
+      audioPreference:
+        (selectedAudio as MediaPlaylist | undefined) ||
+        userConfig.audioPreference,
+      subtitlePreference:
+        (selectedSubtitle as MediaPlaylist | undefined) ||
+        userConfig.subtitlePreference,
     };
     if (interstitial.appendInPlace) {
       interstitial.appendInPlaceStarted = true;
@@ -2215,10 +2265,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           details: ErrorDetails.INTERSTITIAL_ASSET_ITEM_ERROR,
           error,
         };
+        const scheduleIndex =
+          this.schedule?.findEventIndex(interstitial.identifier) || -1;
         this.handleAssetItemError(
           errorData,
           interstitial,
-          this.schedule.findEventIndex(interstitial.identifier),
+          scheduleIndex,
           assetListIndex,
           error.message,
         );
@@ -2242,6 +2294,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     player.on(Events.LEVEL_PTS_UPDATED, (event, { details }) =>
       updateAssetPlayerDetails(details),
     );
+    player.on(Events.EVENT_CUE_ENTER, () => this.onInterstitialCueEnter());
     const onBufferCodecs = (
       event: Events.BUFFER_CODECS,
       data: BufferCodecsData,
@@ -2264,7 +2317,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const bufferedToEnd = () => {
       const inQueuPlayer = this.getAssetPlayer(assetId);
       this.log(`buffered to end of asset ${inQueuPlayer}`);
-      if (!inQueuPlayer) {
+      if (!inQueuPlayer || !this.schedule) {
         return;
       }
       // Preload at end of asset
@@ -2289,7 +2342,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const endedWithAssetIndex = (assetIndex) => {
       return () => {
         const inQueuPlayer = this.getAssetPlayer(assetId);
-        if (!inQueuPlayer) {
+        if (!inQueuPlayer || !this.schedule) {
           return;
         }
         this.shouldPlay = true;
@@ -2302,6 +2355,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     player.once(Events.MEDIA_ENDED, endedWithAssetIndex(assetListIndex));
     player.once(Events.PLAYOUT_LIMIT_REACHED, endedWithAssetIndex(Infinity));
     player.on(Events.ERROR, (event: Events.ERROR, data: ErrorData) => {
+      if (!this.schedule) {
+        return;
+      }
       const inQueuPlayer = this.getAssetPlayer(assetId);
       if (data.details === ErrorDetails.BUFFER_STALLED_ERROR) {
         if (inQueuPlayer?.media) {
@@ -2313,8 +2369,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
             distanceFromEnd / inQueuPlayer.media.playbackRate < 0.5
           ) {
             this.log(
-              `Advancing buffer past end of asset ${assetId} ${interstitial} at ${inQueuPlayer.media.currentTime}`,
+              `Advancing playhead ${distanceFromEnd}s to end of asset ${assetId} ${interstitial} at ${inQueuPlayer.media.currentTime}`,
             );
+            inQueuPlayer.media.currentTime += distanceFromEnd;
             bufferedToEnd();
           } else {
             this.warn(
@@ -2336,7 +2393,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     });
     player.on(Events.DESTROYING, () => {
       const inQueuPlayer = this.getAssetPlayer(assetId);
-      if (!inQueuPlayer) {
+      if (!inQueuPlayer || !this.schedule) {
         return;
       }
       const error = new Error(`Asset player destroyed unexpectedly ${assetId}`);
@@ -2452,12 +2509,16 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
   }
 
   private bufferAssetPlayer(player: HlsAssetPlayer, media: HTMLMediaElement) {
+    if (!this.schedule) {
+      return;
+    }
     const { interstitial, assetItem } = player;
     const scheduleIndex = this.schedule.findEventIndex(interstitial.identifier);
     const item = this.schedule.items?.[scheduleIndex];
     if (!item) {
       return;
     }
+    player.loadSource();
     this.setBufferingItem(item);
     this.bufferingAsset = assetItem;
     const bufferingPlayer = this.getBufferingPlayer();
@@ -2519,11 +2580,15 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     if (data.details === ErrorDetails.BUFFER_STALLED_ERROR) {
       return;
     }
-    const assetItem = interstitial.assetList[assetListIndex];
+    const assetItem = (interstitial.assetList[assetListIndex] ||
+      null) as InterstitialAssetItem | null;
     this.warn(
       `INTERSTITIAL_ASSET_ERROR ${assetItem ? eventAssetToString(assetItem) : assetItem} ${data.error}`,
     );
-    const assetId = assetItem?.identifier;
+    if (!this.schedule) {
+      return;
+    }
+    const assetId = assetItem?.identifier || '';
     const playerIndex = this.getAssetPlayerQueueIndex(assetId);
     const player = this.playerQueue[playerIndex] || null;
     const items = this.schedule.items;
@@ -2576,9 +2641,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       this.log(
         `Fallback to primary from event "${interstitial.identifier}" start: ${
           flushStart
-        } pos: ${this.timelinePos} playing: ${
-          playingItem ? segmentToString(playingItem) : '<none>'
-        } error: ${interstitial.error}`,
+        } pos: ${this.timelinePos} playing: ${segmentToString(
+          playingItem,
+        )} error: ${interstitial.error}`,
       );
       let timelinePos = this.timelinePos;
       if (timelinePos === -1) {
@@ -2591,6 +2656,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       if (interstitial.appendInPlace) {
         this.attachPrimary(flushStart, null);
         this.flushFrontBuffer(flushStart);
+      }
+      if (!this.schedule) {
+        return;
       }
       const scheduleIndex = this.schedule.findItemIndexAtTime(timelinePos);
       this.setSchedulePosition(scheduleIndex);
@@ -2607,7 +2675,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const interstitial = data.event;
     const interstitialId = interstitial.identifier;
     const assets = data.assetListResponse.ASSETS;
-    if (!this.schedule.hasEvent(interstitialId)) {
+    if (!this.schedule?.hasEvent(interstitialId)) {
       // Interstitial with id was removed
       return;
     }
@@ -2664,10 +2732,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     ) {
       // If buffering (but not playback) has reached this item transfer media-source
       const assetItem = interstitial.assetList[0];
-      const player = this.getAssetPlayer(assetItem.identifier);
-      const media = this.primaryMedia;
-      if (assetItem && player && media) {
-        this.bufferAssetPlayer(player, media);
+      if (assetItem as any) {
+        const player = this.getAssetPlayer(assetItem.identifier);
+        const media = this.primaryMedia;
+        if (player && media) {
+          this.bufferAssetPlayer(player, media);
+        }
       }
     }
   }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -2726,17 +2726,18 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         this.setBufferingItem(item);
       }
       this.setSchedulePosition(scheduleIndex);
-    } else if (
-      bufferingEvent?.identifier === interstitialId &&
-      bufferingEvent.appendInPlace
-    ) {
-      // If buffering (but not playback) has reached this item transfer media-source
+    } else if (bufferingEvent?.identifier === interstitialId) {
       const assetItem = interstitial.assetList[0];
       if (assetItem as any) {
         const player = this.getAssetPlayer(assetItem.identifier);
-        const media = this.primaryMedia;
-        if (player && media) {
-          this.bufferAssetPlayer(player, media);
+        if (bufferingEvent.appendInPlace) {
+          // If buffering (but not playback) has reached this item transfer media-source
+          const media = this.primaryMedia;
+          if (player && media) {
+            this.bufferAssetPlayer(player, media);
+          }
+        } else if (player) {
+          player.loadSource();
         }
       }
     }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -913,13 +913,19 @@ export default class InterstitialsController
       (backwardSeek && currentTime < playingItem.start) ||
       currentTime >= playingItem.end
     ) {
-      const scheduleIndex = this.schedule.findItemIndexAtTime(this.timelinePos);
+      const playingIndex = this.findItemIndex(playingItem);
+      let scheduleIndex = this.schedule.findItemIndexAtTime(currentTime);
+      if (scheduleIndex === -1) {
+        scheduleIndex = playingIndex + (backwardSeek ? -1 : 1);
+        this.log(
+          `seeked ${backwardSeek ? 'back ' : ''}to position not covered by schedule ${currentTime} (resolving from ${playingIndex} to ${scheduleIndex})`,
+        );
+      }
       if (!this.isInterstitial(playingItem) && this.media?.paused) {
         this.shouldPlay = false;
       }
       if (!backwardSeek) {
         // check if an Interstitial between the current item and target item has an X-RESTRICT JUMP restriction
-        const playingIndex = this.findItemIndex(playingItem);
         if (scheduleIndex > playingIndex) {
           const jumpIndex = this.schedule.findJumpRestrictedIndex(
             playingIndex + 1,

--- a/src/controller/interstitials-schedule.ts
+++ b/src/controller/interstitials-schedule.ts
@@ -217,7 +217,8 @@ export class InterstitialsSchedule extends Logger {
           if (
             timelinePos === timelineStart ||
             (timelinePos > timelineStart &&
-              timelinePos < timelineStart + (asset.duration || 0))
+              (timelinePos < timelineStart + (asset.duration || 0) ||
+                i === length - 1))
           ) {
             return i;
           }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1062,7 +1062,14 @@ export default class StreamController
           return;
         }
         if (this.reduceLengthAndFlushBuffer(data)) {
-          this.flushMainBuffer(0, Number.POSITIVE_INFINITY);
+          const isAssetPlayer =
+            !this.config.interstitialsController && this.config.assetPlayerId;
+          if (isAssetPlayer) {
+            // Use currentTime in buffer estimate to prevent loading more until playback advances
+            this._hasEnoughToStart = true;
+          } else {
+            this.flushMainBuffer(0, Number.POSITIVE_INFINITY);
+          }
         }
         break;
       case ErrorDetails.INTERNAL_EXCEPTION:

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -177,7 +177,7 @@ export class Fragment extends BaseSegment {
   // levelkeys are the EXT-X-KEY tags that apply to this segment for decryption
   // core difference from the private field _decryptdata is the lack of the initialized IV
   // _decryptdata will set the IV for this segment based on the segment number in the fragment
-  public levelkeys?: { [key: string]: LevelKey };
+  public levelkeys?: { [key: string]: LevelKey | undefined };
   // A string representing the fragment type
   public readonly type: PlaylistLevelType;
   // A reference to the loader. Set while the fragment is loading, and removed afterwards. Used to abort fragment loading
@@ -270,9 +270,11 @@ export class Fragment extends BaseSegment {
       } else {
         const keyFormats = Object.keys(this.levelkeys);
         if (keyFormats.length === 1) {
-          return (this._decryptdata = this.levelkeys[
-            keyFormats[0]
-          ].getDecryptData(this.sn));
+          const levelKey = (this._decryptdata =
+            this.levelkeys[keyFormats[0]] || null);
+          if (levelKey) {
+            return levelKey.getDecryptData(this.sn);
+          }
         } else {
           // Multiple keys. key-loader to call Fragment.setKeyFormat based on selected key-system.
         }
@@ -305,7 +307,7 @@ export class Fragment extends BaseSegment {
     } else if (this.levelkeys) {
       const keyFormats = Object.keys(this.levelkeys);
       const len = keyFormats.length;
-      if (len > 1 || (len === 1 && this.levelkeys[keyFormats[0]].encrypted)) {
+      if (len > 1 || (len === 1 && this.levelkeys[keyFormats[0]]?.encrypted)) {
         return true;
       }
     }

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -233,7 +233,7 @@ export class Fragment extends BaseSegment {
         return total;
       }
     }
-    if (this.byteRange) {
+    if (this.byteRange.length) {
       const start = this.byteRange[0];
       const end = this.byteRange[1];
       if (Number.isFinite(start) && Number.isFinite(end)) {

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -711,7 +711,7 @@ class PlaylistLoader implements NetworkComponentAPI {
     }
     const error = levelDetails.playlistParsingError;
     if (error) {
-      this.hls.logger.warn(error);
+      this.hls.logger.warn(`${error} ${levelDetails.url}`);
       if (!hls.config.ignorePlaylistParsingErrors) {
         hls.trigger(Events.ERROR, {
           type: ErrorTypes.NETWORK_ERROR,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -91,7 +91,7 @@ export interface BufferAppendingData {
   chunkMeta: ChunkMetadata;
   offset?: number | undefined;
   parent: PlaylistLevelType;
-  data: Uint8Array;
+  data: Uint8Array<ArrayBuffer>;
 }
 
 export interface BufferAppendedData {

--- a/src/utils/discontinuities.ts
+++ b/src/utils/discontinuities.ts
@@ -31,11 +31,10 @@ export function shouldAlignOnDiscontinuities(
 }
 
 function adjustFragmentStart(frag: Fragment, sliding: number) {
-  if (frag) {
-    const start = frag.start + sliding;
-    frag.start = frag.startPTS = start;
-    frag.endPTS = start + frag.duration;
-  }
+  const start = frag.start + sliding;
+  frag.startPTS = start;
+  frag.setStart(start);
+  frag.endPTS = start + frag.duration;
 }
 
 export function adjustSlidingStart(sliding: number, details: LevelDetails) {
@@ -68,13 +67,13 @@ export function alignStream(
     return;
   }
   alignDiscontinuities(details, switchDetails);
-  if (!details.alignedSliding && switchDetails) {
+  if (!details.alignedSliding) {
     // If the PTS wasn't figured out via discontinuity sequence that means there was no CC increase within the level.
     // Aligning via Program Date Time should therefore be reliable, since PDT should be the same within the same
     // discontinuity sequence.
     alignMediaPlaylistByPDT(details, switchDetails);
   }
-  if (!details.alignedSliding && switchDetails && !details.skippedSegments) {
+  if (!details.alignedSliding && !details.skippedSegments) {
     // Try to align on sn so that we pick a better start fragment.
     // Do not perform this on playlists with delta updates as this is only to align levels on switch
     // and adjustSliding only adjusts fragments after skippedSegments.

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -49,7 +49,10 @@ export function addCueToTrack(track: TextTrack, cue: VTTCue) {
   }
 }
 
-export function clearCurrentCues(track: TextTrack, enterHandler?: () => void) {
+export function clearCurrentCues(
+  track: TextTrack,
+  enterHandler?: (e?: Event) => void,
+) {
   // When track.mode is disabled, track.cues will be null.
   // To guarantee the removal of cues, we need to temporarily
   // change the mode to hidden

--- a/tests/unit/controller/audio-stream-controller.ts
+++ b/tests/unit/controller/audio-stream-controller.ts
@@ -7,12 +7,13 @@ import { State } from '../../../src/controller/base-stream-controller';
 import { FragmentTracker } from '../../../src/controller/fragment-tracker';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
+import { Fragment } from '../../../src/loader/fragment';
 import KeyLoader from '../../../src/loader/key-loader';
 import { LoadStats } from '../../../src/loader/load-stats';
 import { Level } from '../../../src/types/level';
+import { PlaylistLevelType } from '../../../src/types/loader';
 import { AttrList } from '../../../src/utils/attr-list';
 import { adjustSlidingStart } from '../../../src/utils/discontinuities';
-import type { Fragment } from '../../../src/loader/fragment';
 import type { LevelDetails } from '../../../src/loader/level-details';
 import type {
   AudioTrackLoadedData,
@@ -180,19 +181,19 @@ describe('AudioStreamController', function () {
     const getPlaylistData = function (
       startSN: number,
       endSN: number,
-      type: 'audio' | 'main',
+      type: PlaylistLevelType,
       live: boolean,
     ) {
       const targetduration = 10;
       const fragments: Fragment[] = Array.from(new Array(endSN - startSN)).map(
-        (u, i) =>
-          ({
-            sn: i + startSN,
-            cc: Math.floor((i + startSN) / 10),
-            start: i * targetduration,
-            duration: targetduration,
-            type,
-          }) as unknown as Fragment,
+        (u, i) => {
+          const frag = new Fragment(type, '');
+          frag.sn = i + startSN;
+          frag.cc = Math.floor((i + startSN) / 10);
+          frag.setStart(i * targetduration);
+          frag.duration = targetduration;
+          return frag;
+        },
       );
       return {
         details: {
@@ -221,7 +222,12 @@ describe('AudioStreamController', function () {
       endSN: number,
       live: boolean = false,
     ): LevelLoadedData {
-      const data = getPlaylistData(startSN, endSN, 'main', live);
+      const data = getPlaylistData(
+        startSN,
+        endSN,
+        PlaylistLevelType.MAIN,
+        live,
+      );
       const levelData: LevelLoadedData = {
         ...data,
         level: 0,
@@ -234,7 +240,12 @@ describe('AudioStreamController', function () {
       endSN: number,
       live: boolean = false,
     ): AudioTrackLoadedData {
-      const data = getPlaylistData(startSN, endSN, 'audio', live);
+      const data = getPlaylistData(
+        startSN,
+        endSN,
+        PlaylistLevelType.AUDIO,
+        live,
+      );
       const audioTrackData: AudioTrackLoadedData = {
         ...data,
         groupId: 'audio',

--- a/tests/unit/controller/base-stream-controller.ts
+++ b/tests/unit/controller/base-stream-controller.ts
@@ -68,7 +68,7 @@ describe('BaseStreamController', function () {
       const frag = new Fragment(PlaylistLevelType.MAIN, '') as MediaFragment;
       frag.duration = 5;
       frag.sn = i;
-      frag.start = i * 5;
+      frag.setStart(i * 5);
       details.fragments.push(frag);
     }
     details.live = live;

--- a/tests/unit/controller/buffer-controller.ts
+++ b/tests/unit/controller/buffer-controller.ts
@@ -137,7 +137,6 @@ describe('BufferController', function () {
         .stub(bufferController, 'createSourceBuffers')
         .callsFake(() => {
           Object.keys(bufferController.tracks).forEach((type) => {
-            bufferController.tracks ||= {};
             bufferController.tracks[type] = {
               appendBuffer: () => {},
               remove: () => {},

--- a/tests/unit/controller/cap-level-controller.ts
+++ b/tests/unit/controller/cap-level-controller.ts
@@ -1,30 +1,38 @@
+import chai from 'chai';
 import sinon from 'sinon';
-import Hls from '../../../src/hls';
+import sinonChai from 'sinon-chai';
 import CapLevelController from '../../../src/controller/cap-level-controller';
 import { Events } from '../../../src/events';
+import Hls from '../../../src/hls';
+import { Level } from '../../../src/types/level';
+import { parsedLevel } from '../utils/mock-level';
 
-const levels = [
-  {
+chai.use(sinonChai);
+const expect = chai.expect;
+
+const parsedLevels = [
+  parsedLevel({
     width: 360,
     height: 360,
-    bandwidth: 1000,
-  },
-  {
+    bitrate: 1000,
+  }),
+  parsedLevel({
     width: 540,
     height: 540,
-    bandwidth: 2000,
-  },
-  {
+    bitrate: 2000,
+  }),
+  parsedLevel({
     width: 540,
     height: 540,
-    bandwidth: 3000,
-  },
-  {
+    bitrate: 3000,
+  }),
+  parsedLevel({
     width: 720,
     height: 720,
-    bandwidth: 4000,
-  },
+    bitrate: 4000,
+  }),
 ];
+const levels = parsedLevels.map((parsedLevel) => new Level(parsedLevel));
 
 describe('CapLevelController', function () {
   describe('getMaxLevelByMediaSize', function () {
@@ -63,16 +71,6 @@ describe('CapLevelController', function () {
       const actual = CapLevelController.getMaxLevelByMediaSize([], 5000, 5000);
       expect(expected).to.equal(actual);
     });
-
-    it('Should return -1 if there levels is undefined', function () {
-      const expected = -1;
-      const actual = CapLevelController.getMaxLevelByMediaSize(
-        undefined,
-        5000,
-        5000,
-      );
-      expect(expected).to.equal(actual);
-    });
   });
 
   describe('getDimensions', function () {
@@ -100,7 +98,10 @@ describe('CapLevelController', function () {
       if (media.parentNode) {
         media.parentNode.removeChild(media);
       }
-      document.body.removeChild(document.querySelector('#test-fixture'));
+      const fixture = document.querySelector('#test-fixture');
+      if (fixture) {
+        document.body.removeChild(fixture);
+      }
       hls.destroy();
     });
 
@@ -126,7 +127,14 @@ describe('CapLevelController', function () {
     it('gets client bounds width and height when media element is in the DOM', function () {
       media.style.width = '1280px';
       media.style.height = '720px';
-      document.querySelector('#test-fixture').appendChild(media);
+
+      const fixture = document.querySelector('#test-fixture');
+      if (!fixture) {
+        expect(fixture).is.not.null;
+        return;
+      }
+      fixture.appendChild(media);
+
       const pixelRatio = capLevelController.contentScaleFactor;
       const bounds = capLevelController.getDimensions();
       expect(bounds.width).to.equal(1280);
@@ -150,11 +158,17 @@ describe('CapLevelController', function () {
 
       media.style.width = '1280px';
       media.style.height = '720px';
-      document.querySelector('#test-fixture').appendChild(media);
+
+      const fixture = document.querySelector('#test-fixture');
+      if (!fixture) {
+        expect(fixture).is.not.null;
+        return;
+      }
+      fixture.appendChild(media);
+
       capLevelController.onMediaAttaching(Events.MEDIA_ATTACHING, {
         media,
       });
-
       const pixelRatio = capLevelController.contentScaleFactor;
       bounds = capLevelController.getDimensions();
       expect(bounds.width).to.equal(1280);

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -158,9 +158,6 @@ describe('EMEController', function () {
     } as any);
 
     expect(emePromise).to.be.a('Promise');
-    if (!emePromise) {
-      return;
-    }
     return emePromise.finally(() => {
       expect(media.setMediaKeys).callCount(1);
       expect(reqMediaKsAccessSpy).callCount(1);
@@ -226,9 +223,6 @@ describe('EMEController', function () {
     } as any);
 
     expect(emePromise).to.be.a('Promise');
-    if (!emePromise) {
-      return;
-    }
     return emePromise.finally(() => {
       expect(reqMediaKsAccessSpy).callCount(1);
       const args = reqMediaKsAccessSpy.getCall(0)
@@ -416,13 +410,6 @@ describe('EMEController', function () {
         '00000000000000000000000000000000'
       ],
     ).to.be.a('Promise');
-    if (
-      !emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ]
-    ) {
-      return;
-    }
     return emeController.keyIdToKeySessionPromise[
       '00000000000000000000000000000000'
     ].finally(() => {
@@ -499,13 +486,6 @@ describe('EMEController', function () {
         '00000000000000000000000000000000'
       ],
     ).to.be.a('Promise');
-    if (
-      !emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ]
-    ) {
-      return;
-    }
     return emeController.keyIdToKeySessionPromise[
       '00000000000000000000000000000000'
     ]
@@ -582,13 +562,6 @@ describe('EMEController', function () {
         '00000000000000000000000000000000'
       ],
     ).to.be.a('Promise');
-    if (
-      !emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ]
-    ) {
-      return;
-    }
     return emeController.keyIdToKeySessionPromise[
       '00000000000000000000000000000000'
     ]

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -608,7 +608,7 @@ function createBufferAppendedData(
     frag: new Fragment(PlaylistLevelType.MAIN, ''),
     part: null,
     parent: PlaylistLevelType.MAIN,
-    type: audio && video ? 'audiovideo' : video ? 'video' : 'audio',
+    type: audio ? 'audiovideo' : 'video',
     timeRanges: {
       video: createMockBuffer(video),
       audio: createMockBuffer(audio || video),
@@ -655,7 +655,7 @@ function createMockFragment(
 ): Fragment {
   const frag = new Fragment(data.type, '');
   Object.assign(frag, data);
-  frag.start = data.startPTS;
+  frag.setStart(data.startPTS);
   frag.duration = data.endPTS - data.startPTS;
   types.forEach((t) => {
     frag.setElementaryStreamInfo(

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1469,10 +1469,10 @@ fileSequence6.mp4`;
       insterstitials.skip();
       const eventsAfterSkip = getTriggerCalls();
       const expectedSkipEvents = [
-        Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
         Events.INTERSTITIAL_ASSET_ENDED,
         Events.INTERSTITIAL_ENDED,
         Events.INTERSTITIALS_UPDATED, // removed Interstitial with CUE="ONCE"
+        Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
         Events.MEDIA_ATTACHING,
         Events.INTERSTITIALS_PRIMARY_RESUMED,
       ];
@@ -1568,17 +1568,13 @@ fileSequence6.mp4
             duration: 15,
           });
         } else if (bufferingIndex === 2) {
-          // buffered to primary (end of interstitial)
+          // buffered to primary (interstitial ended)
           expectIm(primary, e).to.include({ currentTime: 40, bufferedEnd: 40 });
           expectIm(integrated, e).to.include({
             currentTime: 45,
             bufferedEnd: 45,
           });
-          expectIm(interstitialPlayer, e).to.include({
-            playingIndex: 2,
-            currentTime: 15,
-            duration: 15,
-          });
+          expectIm(interstitialPlayer, e).to.be.null;
         }
       });
       hls.on(Events.INTERSTITIAL_STARTED, (t) => {
@@ -1914,9 +1910,9 @@ fileSequence6.mp4
       });
       const eventsAfterLastAsset = getTriggerCalls();
       const expectedEndLastAssetEvents = [
-        Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
         Events.INTERSTITIAL_ASSET_ENDED,
         Events.INTERSTITIAL_ENDED,
+        Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY,
         Events.MEDIA_ATTACHING,
         Events.INTERSTITIALS_PRIMARY_RESUMED,
       ];

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -36,10 +36,7 @@ class HLSTestPlayer extends Hls {
     hlsTestable.coreComponents.forEach((component) => component.destroy());
     hlsTestable.coreComponents.length = 0;
     hlsTestable.on(Events.MEDIA_ATTACHING, (t, data) => {
-      const media = data.media;
-      if (media) {
-        media.src = '';
-      }
+      data.media.src = '';
     });
     hlsTestable.on(Events.MEDIA_DETACHING, () => {
       const media = hlsTestable.media;
@@ -140,7 +137,7 @@ describe('InterstitialsController', function () {
       0,
       null,
     );
-    expect(details?.playlistParsingError).to.equal(null);
+    expect(details.playlistParsingError).to.equal(null);
     const attrs = new AttrList({});
     const level = new Level({
       name: '',
@@ -210,9 +207,6 @@ fileSequence4.ts
       expect(insterstitials.playingIndex).to.equal(0, 'playingIndex');
       expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
       expect(schedule).is.an('array').which.has.lengthOf(2);
-      if (!insterstitials.events || !schedule) {
-        return;
-      }
       const interstitialEvent = insterstitials.events[0];
       expect(interstitialEvent.identifier).to.equal('0');
       expect(interstitialEvent.restrictions.jump).to.equal(true);
@@ -296,11 +290,8 @@ fileSequence4.ts
         .is.an('array')
         .which.has.lengthOf(
           7,
-          `Schedule items: ${schedule?.map((item) => `${item.start}-${item.end}`).join(', ')}`,
+          `Schedule items: ${schedule.map((item) => `${item.start}-${item.end}`).join(', ')}`,
         );
-      if (!events || !schedule) {
-        return;
-      }
       const eventAssertions = [
         {
           startTime: 0,
@@ -478,13 +469,10 @@ fileSequence3.ts
       const events = insterstitials.events;
       const schedule = insterstitials.schedule;
       expect(events).is.an('array').which.has.lengthOf(5);
-      const scheduleDebugString = `Schedule items: ${schedule?.map((item) => `[${item.event ? 'I' : 'P'}:${item.start}-${item.end}]`).join(', ')}`;
+      const scheduleDebugString = `Schedule items: ${schedule.map((item) => `[${item.event ? 'I' : 'P'}:${item.start}-${item.end}]`).join(', ')}`;
       expect(schedule)
         .is.an('array')
         .which.has.lengthOf(9, scheduleDebugString);
-      if (!events || !schedule) {
-        return;
-      }
       [
         'primary',
         '1',
@@ -498,12 +486,12 @@ fileSequence3.ts
       ].forEach((typeOrIdentifier, i) => {
         if (typeOrIdentifier === 'primary') {
           expect(
-            schedule?.[i],
+            schedule[i],
             `Expected to find a primary segment at index ${i}: ${scheduleDebugString}`,
           ).to.have.property('nextEvent');
         } else {
           expect(
-            schedule?.[i],
+            schedule[i],
             `Expected to find an Interstitial at index ${i}: ${scheduleDebugString}`,
           )
             .to.have.property('event')
@@ -725,9 +713,6 @@ fileSequence3.mp4
       expect(insterstitials.playingIndex).to.equal(0, 'playingIndex');
       expect(insterstitials.events).is.an('array').which.has.lengthOf(2);
       expect(schedule).is.an('array').which.has.lengthOf(4);
-      if (!insterstitials.events || !schedule) {
-        return;
-      }
       expect(insterstitials.events[0].identifier).to.equal('ad1');
       expect(insterstitials.events[1].identifier).to.equal('ad2');
       expect(insterstitials.events[0]).to.equal(schedule[0].event);
@@ -827,9 +812,6 @@ fileSequence3.mp4
       const schedule = insterstitials.schedule;
       expect(insterstitials.events).is.an('array').which.has.lengthOf(2);
       expect(schedule).is.an('array').which.has.lengthOf(2);
-      if (!insterstitials.events || !schedule) {
-        return;
-      }
       expect(insterstitials.events[0].identifier).to.equal('ad1');
       expect(insterstitials.events[1].identifier).to.equal('ad2');
       expect(insterstitials.events[0]).to.equal(schedule[0].event);
@@ -891,9 +873,6 @@ fileSequence4.ts
         const events = insterstitials.events;
         expect(events).is.an('array').which.has.lengthOf(1);
         expect(schedule).is.an('array').which.has.lengthOf(2);
-        if (!events || !schedule) {
-          return;
-        }
         expect(events[0]).to.deep.include({
           identifier: '0',
           timelineOccupancy: TimelineOccupancy.Point,
@@ -986,9 +965,6 @@ fileSequence4.ts
         const events = insterstitials.events;
         expect(events).is.an('array').which.has.lengthOf(4);
         expect(schedule).is.an('array').which.has.lengthOf(5);
-        if (!events || !schedule) {
-          return;
-        }
         eventAssertions.forEach((assertions, i) => {
           expect(events[i].identifier).to.equal('' + i);
           expect(events[i], `Interstitial Event "${i}"`).to.deep.include(
@@ -1118,9 +1094,6 @@ fileSequence5.mp4`;
       }
       expect(insterstitials.events).is.an('array').which.has.lengthOf(2);
       expect(insterstitials.schedule).is.an('array').which.has.lengthOf(4);
-      if (!insterstitials.events || !insterstitials.schedule) {
-        return;
-      }
       const callsWithPrerollBeforeAttach = getTriggerCalls();
       expect(callsWithPrerollBeforeAttach).to.deep.equal(
         [Events.LEVEL_UPDATED, Events.INTERSTITIALS_UPDATED],
@@ -1185,9 +1158,6 @@ fileSequence3.mp4
       }
       expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
       expect(insterstitials.schedule).is.an('array').which.has.lengthOf(2);
-      if (!insterstitials.events || !insterstitials.schedule) {
-        return;
-      }
       const callsBeforeAttach = getTriggerCalls();
       expect(callsBeforeAttach).to.deep.equal(
         [
@@ -1255,9 +1225,6 @@ fileSequence3.mp4
       }
       expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
       expect(insterstitials.schedule).is.an('array').which.has.lengthOf(2);
-      if (!insterstitials.events || !insterstitials.schedule) {
-        return;
-      }
       const callsBeforeAttach = getTriggerCalls();
       expect(callsBeforeAttach).to.deep.equal(
         [
@@ -1333,9 +1300,6 @@ fileSequence6.mp4`;
       }
       expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
       expect(insterstitials.schedule).is.an('array').which.has.lengthOf(3);
-      if (!insterstitials.events || !insterstitials.schedule) {
-        return;
-      }
       const eventsBeforeAttach = getTriggerCalls();
       expect(eventsBeforeAttach).to.deep.equal(
         [Events.LEVEL_UPDATED, Events.INTERSTITIALS_UPDATED],
@@ -1463,9 +1427,6 @@ fileSequence6.mp4`;
       }
       expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
       expect(insterstitials.schedule).is.an('array').which.has.lengthOf(3);
-      if (!insterstitials.events || !insterstitials.schedule) {
-        return;
-      }
       const eventsAfterPlaylist = getTriggerCalls();
       expect(eventsAfterPlaylist).to.deep.equal(
         [
@@ -1799,9 +1760,6 @@ fileSequence6.mp4
 
       expect(im.events).is.an('array').which.has.lengthOf(1);
       expect(im.schedule).is.an('array').which.has.lengthOf(3);
-      if (!im.events || !im.schedule) {
-        return;
-      }
       const eventsBeforeAttach = getTriggerCalls();
       expect(eventsBeforeAttach).to.deep.equal(
         [Events.LEVEL_UPDATED, Events.INTERSTITIALS_UPDATED],
@@ -2008,9 +1966,6 @@ fileSequence6.mp4`;
       }
       expect(insterstitials.events).is.an('array').which.has.lengthOf(1);
       expect(insterstitials.schedule).is.an('array').which.has.lengthOf(3);
-      if (!insterstitials.events || !insterstitials.schedule) {
-        return;
-      }
 
       // Capture asset-list request
       const loadSpy = sandbox.spy(hls.config.loader.prototype, 'load');

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -10,6 +10,7 @@ import { PlaylistLevelType } from '../../../src/types/loader';
 import { AttrList } from '../../../src/utils/attr-list';
 import { getMediaSource } from '../../../src/utils/mediasource-helper';
 import HlsMock from '../../mocks/hls.mock';
+import { parsedLevel } from '../utils/mock-level';
 import type { Fragment } from '../../../src/loader/fragment';
 import type { LevelDetails } from '../../../src/loader/level-details';
 import type { ParsedMultivariantPlaylist } from '../../../src/loader/m3u8-parser';
@@ -17,7 +18,6 @@ import type {
   ManifestLoadedData,
   ManifestParsedData,
 } from '../../../src/types/events';
-import type { LevelParsed } from '../../../src/types/level';
 import type { PlaylistLoaderContext } from '../../../src/types/loader';
 import type {
   MediaAttributes,
@@ -48,18 +48,6 @@ type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
   ) => void;
   redundantFailover: (levelIndex: number) => void;
 };
-
-function parsedLevel(
-  options: Partial<LevelParsed> & { bitrate: number },
-): LevelParsed {
-  const level: LevelParsed = {
-    attrs: new AttrList({ BANDWIDTH: options.bitrate }),
-    bitrate: options.bitrate,
-    name: '',
-    url: `${options.bitrate}.m3u8`,
-  };
-  return Object.assign(level, options);
-}
 
 function mediaPlaylist(options: Partial<MediaPlaylist>): MediaPlaylist {
   const track: MediaPlaylist = {

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -48,7 +48,7 @@ const generatePlaylist = (sequenceNumbers, offset = 0, duration = 5) => {
   playlist.fragments = sequenceNumbers.map((n, i) => {
     const frag = new Fragment(PlaylistLevelType.MAIN, '');
     frag.sn = n;
-    frag.start = i * 5 + offset;
+    frag.setStart(i * 5 + offset);
     frag.duration = duration;
     return frag;
   });
@@ -67,7 +67,9 @@ const getIteratedSequence = (oldPlaylist, newPlaylist) => {
 };
 
 const getFragmentSequenceNumbers = (details: LevelDetails) =>
-  details.fragments.map((f) => `${f?.sn}-${f?.cc}`).join(',');
+  details.fragments
+    .map((f: MediaFragment | null) => `${f?.sn}-${f?.cc}`)
+    .join(',');
 
 describe('LevelHelper Tests', function () {
   let sandbox;
@@ -204,7 +206,7 @@ describe('LevelHelper Tests', function () {
     it('matches start when the new playlist starts before the old', function () {
       const oldPlaylist = generatePlaylist([3, 4, 5]);
       oldPlaylist.fragments.forEach((f) => {
-        f.start += 10;
+        f.addStart(10);
       });
       const newPlaylist = generatePlaylist([1, 2, 3]);
       mergeDetails(oldPlaylist, newPlaylist);
@@ -374,12 +376,12 @@ fileSequence11.ts
         .which.equals(details.fragments[2].ref)
         .which.has.property('sn')
         .which.equals(5);
-      expect(details.dateRanges.one.startTime).to.equal(4);
-      expect(details.dateRanges.two.startTime).to.equal(10);
-      expect(details.dateRanges.three.startTime).to.equal(16);
-      expect(details.dateRanges.one.tagOrder, 'one.tagOrder').to.equal(0);
-      expect(details.dateRanges.two.tagOrder, 'two.tagOrder').to.equal(1);
-      expect(details.dateRanges.three.tagOrder, 'three.tagOrder').to.equal(2);
+      expect(details.dateRanges.one!.startTime).to.equal(4);
+      expect(details.dateRanges.two!.startTime).to.equal(10);
+      expect(details.dateRanges.three!.startTime).to.equal(16);
+      expect(details.dateRanges.one!.tagOrder, 'one.tagOrder').to.equal(0);
+      expect(details.dateRanges.two!.tagOrder, 'two.tagOrder').to.equal(1);
+      expect(details.dateRanges.three!.tagOrder, 'three.tagOrder').to.equal(2);
       expect(
         detailsUpdated.hasProgramDateTime,
         'detailsUpdated.hasProgramDateTime',
@@ -407,25 +409,26 @@ fileSequence11.ts
         .which.has.property('tagAnchor')
         .which.has.property('sn')
         .which.equals(5);
-      expect(detailsUpdated.dateRanges.one.startTime).to.equal(4);
-      expect(detailsUpdated.dateRanges.two.startTime).to.equal(10);
-      expect(detailsUpdated.dateRanges.three.startTime).to.equal(16);
-      expect(detailsUpdated.dateRanges.four.startTime).to.equal(76);
+      expect(detailsUpdated.dateRanges.one!.startTime).to.equal(4);
+      expect(detailsUpdated.dateRanges.two!.startTime).to.equal(10);
+      expect(detailsUpdated.dateRanges.three!.startTime).to.equal(16);
+      expect(detailsUpdated.dateRanges.four!.startTime).to.equal(76);
       expect(
-        detailsUpdated.dateRanges.one.tagOrder,
+        detailsUpdated.dateRanges.one!.tagOrder,
         'one.tagOrder updated',
       ).to.equal(0);
       expect(
-        detailsUpdated.dateRanges.two.tagOrder,
+        detailsUpdated.dateRanges.two!.tagOrder,
         'two.tagOrder updated',
       ).to.equal(1);
       expect(
-        detailsUpdated.dateRanges.three.tagOrder,
+        detailsUpdated.dateRanges.three!.tagOrder,
         'three.tagOrder updated',
       ).to.equal(2);
-      expect(detailsUpdated.dateRanges.four.tagOrder, 'four.tagOrder').to.equal(
-        3,
-      );
+      expect(
+        detailsUpdated.dateRanges.four!.tagOrder,
+        'four.tagOrder',
+      ).to.equal(3);
       expect(detailsUpdated.playlistParsingError).to.be.null;
     });
 
@@ -1096,8 +1099,8 @@ fileSequence18.ts`;
         Object.keys(details.dateRanges),
         'first playlist daterange ids',
       ).to.have.deep.equal(['d0', 'd1', 'd2', 'd3', 'd4']);
-      expect(details.dateRanges.d2.startTime).to.equal(2.94);
-      expect(details.dateRanges.d3.startTime).to.equal(3.94);
+      expect(details.dateRanges.d2!.startTime).to.equal(2.94);
+      expect(details.dateRanges.d3!.startTime).to.equal(3.94);
       expect(
         detailsUpdated.hasProgramDateTime,
         'detailsUpdated.hasProgramDateTime',
@@ -1116,8 +1119,8 @@ fileSequence18.ts`;
         .which.equals(detailsUpdated.fragments[0].ref)
         .which.has.property('sn')
         .which.equals(3);
-      expect(detailsUpdated.dateRanges.d2.startTime).to.equal(2.94);
-      expect(detailsUpdated.dateRanges.d3.startTime).to.equal(3.94);
+      expect(detailsUpdated.dateRanges.d2!.startTime).to.equal(2.94);
+      expect(detailsUpdated.dateRanges.d3!.startTime).to.equal(3.94);
       // Multiple #EXT-X-SKIP tags are not allowed
       expect(detailsUpdated.playlistParsingError).to.include({
         message: `#EXT-X-SKIP must not appear more than once (#EXT-X-SKIP:SKIPPED-SEGMENTS=2,RECENTLY-REMOVED-DATERANGES="d0")`,

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -210,7 +210,7 @@ describe('StreamController', function () {
     fragPrevious.programDateTime = 1505502671523;
     fragPrevious.duration = 5.0;
     fragPrevious.level = 1;
-    fragPrevious.start = 10.0;
+    fragPrevious.setStart(10.0);
     fragPrevious.sn = 2; // Fragment with PDT 1505502671523 in level 1 does not have the same sn as in level 2 where cc is 1
     fragPrevious.cc = 0;
 
@@ -274,7 +274,7 @@ describe('StreamController', function () {
         fragPrevious.programDateTime = 1505502681523;
         fragPrevious.duration = 5.0;
         fragPrevious.level = 1;
-        fragPrevious.start = 15.0;
+        fragPrevious.setStart(15.0);
         fragPrevious.sn = 3;
         streamController['fragPrevious'] = fragPrevious;
 
@@ -475,7 +475,7 @@ describe('StreamController', function () {
       ) as MediaFragment;
       firstFrag.duration = 5.0;
       firstFrag.level = 1;
-      firstFrag.start = 0;
+      firstFrag.setStart(0);
       firstFrag.sn = 1;
       firstFrag.cc = 0;
       firstFrag.elementaryStreams.video = {

--- a/tests/unit/hls.ts
+++ b/tests/unit/hls.ts
@@ -57,7 +57,7 @@ describe('Hls', function () {
       const hls = new Hls({ capLevelOnFPSDrop: true });
       expect(hls.media).to.equal(null);
       const media = document.createElement('video');
-      expect(media || null).to.not.equal(null);
+      expect(media).to.be.an('HTMLVideoElement');
       hls.attachMedia(media);
       expect(hls.media).to.equal(media);
       detachTest(hls, media, 6);
@@ -72,7 +72,7 @@ describe('Hls', function () {
       });
       expect(hls.media).to.equal(null);
       const media = document.createElement('video');
-      expect(media || null).to.not.equal(null);
+      expect(media).to.be.an('HTMLVideoElement');
       hls.attachMedia(media);
       expect(hls.media).to.equal(media);
       hls.trigger(Events.MEDIA_ATTACHED, { media });

--- a/tests/unit/loader/m3u8-parser.ts
+++ b/tests/unit/loader/m3u8-parser.ts
@@ -1996,10 +1996,10 @@ segment.m4s
       );
       expect(details.playlistParsingError).to.be.null;
       expect(details.dateRangeTagCount).to.equal(4);
-      expect(details.dateRanges.pre.isInterstitial).to.be.true;
-      expect(details.dateRanges.mid1.isInterstitial).to.be.true;
-      expect(details.dateRanges.mid2.isInterstitial).to.be.true;
-      expect(details.dateRanges.post.isInterstitial).to.be.true;
+      expect(details.dateRanges.pre!.isInterstitial).to.be.true;
+      expect(details.dateRanges.mid1!.isInterstitial).to.be.true;
+      expect(details.dateRanges.mid2!.isInterstitial).to.be.true;
+      expect(details.dateRanges.post!.isInterstitial).to.be.true;
       expect(details.dateRanges).to.have.property('pre').which.deep.includes({
         tagOrder: 0,
       });
@@ -2012,15 +2012,15 @@ segment.m4s
       expect(details.dateRanges).to.have.property('post').which.deep.includes({
         tagOrder: 3,
       });
-      expect(details.dateRanges.pre.cue.pre).to.be.true;
-      expect(details.dateRanges.mid1.cue.once).to.be.true;
-      expect(details.dateRanges.post.cue.post).to.be.true;
-      expect(details.dateRanges.post.cue.once).to.be.true;
+      expect(details.dateRanges.pre!.cue.pre).to.be.true;
+      expect(details.dateRanges.mid1!.cue.once).to.be.true;
+      expect(details.dateRanges.post!.cue.post).to.be.true;
+      expect(details.dateRanges.post!.cue.once).to.be.true;
       // DateRange start times are mapped to the primary timeline and not changed by CUE Interstitial DURATION
-      expect(details.dateRanges.pre.startTime).to.equal(-7200);
-      expect(details.dateRanges.mid1.startTime).to.equal(10);
-      expect(details.dateRanges.mid2.startTime).to.equal(25);
-      expect(details.dateRanges.post.startTime).to.equal(0);
+      expect(details.dateRanges.pre!.startTime).to.equal(-7200);
+      expect(details.dateRanges.mid1!.startTime).to.equal(10);
+      expect(details.dateRanges.mid2!.startTime).to.equal(25);
+      expect(details.dateRanges.post!.startTime).to.equal(0);
     });
 
     it('ensures DateRanges are mapped to a segment whose TimeRange covers the start date of the DATERANGE tag', function () {
@@ -2047,14 +2047,14 @@ segment.m4s
         null,
       );
       expect(details.playlistParsingError).to.be.null;
-      expect(details.dateRanges.sooner.isValid).to.equal(
+      expect(details.dateRanges.sooner!.isValid).to.equal(
         true,
         'is valid DateRange',
       );
-      expect(details.dateRanges.sooner.tagAnchor)
+      expect(details.dateRanges.sooner!.tagAnchor)
         .to.have.property('sn')
         .which.equals(2);
-      expect(details.dateRanges.sooner.startTime).to.equal(10);
+      expect(details.dateRanges.sooner!.startTime).to.equal(10);
     });
 
     it('ensures DateRanges that start before the program are mapped to the first PDT tag', function () {
@@ -2081,14 +2081,14 @@ segment.m4s
         null,
       );
       expect(details.playlistParsingError).to.be.null;
-      expect(details.dateRanges.earlier.isValid).to.equal(
+      expect(details.dateRanges.earlier!.isValid).to.equal(
         true,
         'is valid DateRange',
       );
-      expect(details.dateRanges.earlier.tagAnchor)
+      expect(details.dateRanges.earlier!.tagAnchor)
         .to.have.property('sn')
         .which.equals(1);
-      expect(details.dateRanges.earlier.startTime).to.equal(-10);
+      expect(details.dateRanges.earlier!.startTime).to.equal(-10);
     });
 
     it('adds PROGRAM-DATE-TIME and DATERANGE tag text to fragment[].tagList for backwards compatibility', function () {
@@ -2758,10 +2758,6 @@ a{$mvpVariable}.mp4
         TYPE: 'PART',
         URI: 'part-5.1.mp4',
       });
-      if (details.partList === null) {
-        expect(details.partList, 'partList').to.not.equal(null);
-        return;
-      }
       if (!details.renditionReports) {
         expect(details.renditionReports, 'renditionReports').to.not.be
           .undefined;
@@ -2913,7 +2909,7 @@ a{$bar}.mp4
         details,
         'Missing preceding EXT-X-DEFINE tag for Variable Reference: "bar"',
       );
-      expect(details.fragments?.[0].relurl).to.equal('a{$bar}.mp4');
+      expect(details.fragments[0].relurl).to.equal('a{$bar}.mp4');
     });
 
     it('fails to parse Media Playlist when variable reference precedes definition', function () {

--- a/tests/unit/utils/mediacapabilities-helper.ts
+++ b/tests/unit/utils/mediacapabilities-helper.ts
@@ -7,6 +7,11 @@ import type {
   MediaPlaylist,
 } from '../../../src/types/media-playlist';
 
+declare const navigator: {
+  prototype: Navigator;
+  mediaCapabilities?: MediaCapabilities;
+};
+
 describe('getMediaDecodingInfoPromise', function () {
   it('adds queries to cache', function () {
     if (!navigator.mediaCapabilities) {

--- a/tests/unit/utils/mock-level.ts
+++ b/tests/unit/utils/mock-level.ts
@@ -1,0 +1,15 @@
+import { AttrList } from '../../../src/utils/attr-list';
+import type { LevelParsed } from '../../../src/types/level';
+
+export function parsedLevel(
+  options: Partial<LevelParsed> & { bitrate: number },
+): LevelParsed {
+  const { bitrate, height } = options;
+  const level: LevelParsed = {
+    attrs: new AttrList({ BANDWIDTH: bitrate }),
+    bitrate,
+    name: `${height}-${bitrate}`,
+    url: `${bitrate}.m3u8`,
+  };
+  return Object.assign(level, options);
+}


### PR DESCRIPTION
### This PR will...
- Fix DateRange start sliding in Live  (use `frag.setStart` over `frag.start =` to update `DateRange.tagAnchor` ref)
- Skip gaps between interstitial assets
- Make MEDIA_ATTACHED async on transferMedia (`this.media` undefined in id3-track-controller `onMediaAttached` otherwise)
- Add metadata cue timing to assets for better asset event timing
- Removed unnecessary conditionals in changed files (added looser typing in cases where object[index] result may be undefined)
- Defer asset playlist loading until buffered to asset (assets are loaded in order to allow for shifts in playlist duration)
- Consider event asset-list loading when advancing the schedule buffering item
- Handle append-in-line interstitials with shorter that playout-limit fill
- Advance asset player buffering on asset error prior to starting interstitial b1f996b
- Handle seeking into unplayable ranges caused by truncated interstitials

### Why is this Pull Request needed?
Fixes Interstitial timing issues in Live. Improves handling of HLS Interstitials with asset lists with inaccurate durations.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7426

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
