### PR TITLE
Timestamp offset stability fix for muxed audiovideo mp4

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -197,7 +197,7 @@ export class AudioStreamController extends BaseStreamController implements Netwo
     // (undocumented)
     protected onHandlerDestroying(): void;
     // (undocumented)
-    onInitPtsFound(event: Events.INIT_PTS_FOUND, { frag, id, initPTS, timescale }: InitPTSFoundData): void;
+    onInitPtsFound(event: Events.INIT_PTS_FOUND, { frag, id, initPTS, timescale, trackId }: InitPTSFoundData): void;
     // (undocumented)
     protected onManifestLoading(): void;
     // (undocumented)
@@ -458,7 +458,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     get inFlightFrag(): InFlightData;
     // (undocumented)
-    protected initPTS: RationalTimestamp[];
+    protected initPTS: TimestampOffset[];
     // (undocumented)
     protected isLoopLoading(frag: Fragment, targetBufferTime: number): boolean;
     // (undocumented)
@@ -2584,6 +2584,8 @@ export interface InitPTSFoundData {
     initPTS: number;
     // (undocumented)
     timescale: number;
+    // (undocumented)
+    trackId: number;
 }
 
 // Warning: (ae-missing-release-tag) "InitSegmentData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4796,6 +4798,13 @@ export enum TimelineOccupancy {
     Range = 1
 }
 
+// Warning: (ae-missing-release-tag) "TimestampOffset" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TimestampOffset = RationalTimestamp & {
+    trackId: number;
+};
+
 // Warning: (ae-missing-release-tag) "Track" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -4866,7 +4875,7 @@ export class TransmuxerInterface {
     // (undocumented)
     flush(chunkMeta: ChunkMetadata): void;
     // (undocumented)
-    push(data: ArrayBuffer, initSegmentData: Uint8Array | undefined, audioCodec: string | undefined, videoCodec: string | undefined, frag: MediaFragment, part: Part | null, duration: number, accurateTimeOffset: boolean, chunkMeta: ChunkMetadata, defaultInitPTS?: RationalTimestamp): void;
+    push(data: ArrayBuffer, initSegmentData: Uint8Array | undefined, audioCodec: string | undefined, videoCodec: string | undefined, frag: MediaFragment, part: Part | null, duration: number, accurateTimeOffset: boolean, chunkMeta: ChunkMetadata, defaultInitPTS?: TimestampOffset): void;
     // (undocumented)
     reset(): void;
 }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -142,16 +142,16 @@ class AudioStreamController
   // INIT_PTS_FOUND is triggered when the video track parsed in the stream-controller has a new PTS value
   onInitPtsFound(
     event: Events.INIT_PTS_FOUND,
-    { frag, id, initPTS, timescale }: InitPTSFoundData,
+    { frag, id, initPTS, timescale, trackId }: InitPTSFoundData,
   ) {
     // Always update the new INIT PTS
     // Can change due level switch
     if (id === PlaylistLevelType.MAIN) {
       const cc = frag.cc;
       const inFlightFrag = this.fragCurrent;
-      this.initPTS[cc] = { baseTime: initPTS, timescale };
+      this.initPTS[cc] = { baseTime: initPTS, timescale, trackId };
       this.log(
-        `InitPTS for cc: ${cc} found from main: ${initPTS}/${timescale}`,
+        `InitPTS for cc: ${cc} found from main: ${initPTS / timescale} (${initPTS}/${timescale}) trackId: ${trackId}`,
       );
       this.mainAnchor = frag;
       // If we are waiting, tick immediately to unblock audio fragment transmuxing

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -912,7 +912,7 @@ export default class BaseStreamController
       this.log(
         `LL-Part loading OFF after next part miss @${targetBufferTime.toFixed(
           2,
-        )}`,
+        )} Check buffer at sn: ${frag.sn} loaded parts: ${details.partList?.filter((p) => p.loaded).map((p) => `[${p.start}-${p.end}]`)}`,
       );
       this.loadingParts = false;
     } else if (!frag.url) {
@@ -1496,9 +1496,14 @@ export default class BaseStreamController
       if (loaded) {
         nextPart = -1;
       } else if (
-        (contiguous || part.independent || independentAttrOmitted) &&
-        part.fragment === frag
+        contiguous ||
+        ((part.independent || independentAttrOmitted) && part.fragment === frag)
       ) {
+        if (part.fragment !== frag) {
+          this.warn(
+            `Need buffer at ${targetBufferTime} but next part to buffer starts at ${part.start}`,
+          );
+        }
         nextPart = i;
       }
       contiguous = loaded;
@@ -1510,8 +1515,17 @@ export default class BaseStreamController
     partList: Part[],
     targetBufferTime: number,
   ): boolean {
-    const lastPart = partList[partList.length - 1];
-    return lastPart && targetBufferTime > lastPart.start && lastPart.loaded;
+    let part: Part;
+    for (let i = partList.length; i--; ) {
+      part = partList[i];
+      if (!part.loaded) {
+        return false;
+      }
+      if (targetBufferTime > part.start) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /*

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -59,7 +59,7 @@ import type {
 import type { Level } from '../types/level';
 import type { RemuxedTrack } from '../types/remuxer';
 import type { Bufferable, BufferInfo } from '../utils/buffer-helper';
-import type { RationalTimestamp } from '../utils/timescale-conversion';
+import type { TimestampOffset } from '../utils/timescale-conversion';
 
 type ResolveFragLoaded = (FragLoadedEndData) => void;
 type RejectFragLoaded = (LoadError) => void;
@@ -111,7 +111,7 @@ export default class BaseStreamController
   protected levelLastLoaded: Level | null = null;
   protected startFragRequested: boolean = false;
   protected decrypter: Decrypter;
-  protected initPTS: RationalTimestamp[] = [];
+  protected initPTS: TimestampOffset[] = [];
   protected buffering: boolean = true;
   protected loadingParts: boolean = false;
   private loopSn?: string | number;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1501,7 +1501,7 @@ export default class BaseStreamController
       ) {
         if (part.fragment !== frag) {
           this.warn(
-            `Need buffer at ${targetBufferTime} but next part to buffer starts at ${part.start}`,
+            `Need buffer at ${targetBufferTime} but next unloaded part starts at ${part.start}`,
           );
         }
         nextPart = i;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1248,7 +1248,6 @@ export default class StreamController
         });
       }
 
-      // This would be nice if Number.isFinite acted as a typeguard, but it doesn't. See: https://github.com/Microsoft/TypeScript/issues/10038
       const baseTime = initSegment.initPTS as number;
       const timescale = initSegment.timescale as number;
       const initPTS = this.initPTS[frag.cc];
@@ -1258,12 +1257,18 @@ export default class StreamController
           initPTS.baseTime !== baseTime ||
           initPTS.timescale !== timescale)
       ) {
-        this.initPTS[frag.cc] = { baseTime, timescale };
+        const trackId = initSegment.trackId as number;
+        this.initPTS[frag.cc] = {
+          baseTime,
+          timescale,
+          trackId,
+        };
         hls.trigger(Events.INIT_PTS_FOUND, {
           frag,
           id,
           initPTS: baseTime,
           timescale,
+          trackId,
         });
       }
     }

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -36,7 +36,7 @@ import type { MediaPlaylist } from '../types/media-playlist';
 import type { VTTCCs } from '../types/vtt';
 import type { CaptionScreen } from '../utils/cea-608-parser';
 import type { CuesInterface } from '../utils/cues';
-import type { RationalTimestamp } from '../utils/timescale-conversion';
+import type { TimestampOffset } from '../utils/timescale-conversion';
 
 type TrackProperties = {
   label: string;
@@ -61,7 +61,7 @@ export class TimelineController implements ComponentAPI {
   private Cues: CuesInterface;
   private textTracks: Array<TextTrack> = [];
   private tracks: Array<MediaPlaylist> = [];
-  private initPTS: RationalTimestamp[] = [];
+  private initPTS: TimestampOffset[] = [];
   private unparsedVttFrags: Array<FragLoadedData | FragDecryptedData> = [];
   private captionsTracks: Record<string, TextTrack> = {};
   private nonNativeCaptionsTracks: Record<string, NonNativeCaptionsTrack> = {};
@@ -191,11 +191,11 @@ export class TimelineController implements ComponentAPI {
   // Triggered when an initial PTS is found; used for synchronisation of WebVTT.
   private onInitPtsFound(
     event: Events.INIT_PTS_FOUND,
-    { frag, id, initPTS, timescale }: InitPTSFoundData,
+    { frag, id, initPTS, timescale, trackId }: InitPTSFoundData,
   ) {
     const { unparsedVttFrags } = this;
     if (id === PlaylistLevelType.MAIN) {
-      this.initPTS[frag.cc] = { baseTime: initPTS, timescale };
+      this.initPTS[frag.cc] = { baseTime: initPTS, timescale, trackId };
     }
 
     // Due to asynchronous processing, initial PTS may arrive later than the first VTT fragments are loaded.

--- a/src/demux/audio/base-audio-demuxer.ts
+++ b/src/demux/audio/base-audio-demuxer.ts
@@ -14,7 +14,10 @@ import {
 } from '../../types/demuxer';
 import { appendUint8Array } from '../../utils/mp4-tools';
 import { dummyTrack } from '../dummy-demuxed-track';
-import type { RationalTimestamp } from '../../utils/timescale-conversion';
+import type {
+  RationalTimestamp,
+  TimestampOffset,
+} from '../../utils/timescale-conversion';
 
 class BaseAudioDemuxer implements Demuxer {
   protected _audioTrack?: DemuxedAudioTrack;
@@ -22,7 +25,7 @@ class BaseAudioDemuxer implements Demuxer {
   protected frameIndex: number = 0;
   protected cachedData: Uint8Array | null = null;
   protected basePTS: number | null = null;
-  protected initPTS: RationalTimestamp | null = null;
+  protected initPTS: TimestampOffset | null = null;
   protected lastPTS: number | null = null;
 
   resetInitSegment(
@@ -42,7 +45,7 @@ class BaseAudioDemuxer implements Demuxer {
     };
   }
 
-  resetTimeStamp(deaultTimestamp: RationalTimestamp | null) {
+  resetTimeStamp(deaultTimestamp: TimestampOffset | null) {
     this.initPTS = deaultTimestamp;
     this.resetContiguity();
   }

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -21,7 +21,7 @@ import type Hls from '../hls';
 import type { MediaFragment, Part } from '../loader/fragment';
 import type { ErrorData, FragDecryptedData } from '../types/events';
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
-import type { RationalTimestamp } from '../utils/timescale-conversion';
+import type { TimestampOffset } from '../utils/timescale-conversion';
 
 let transmuxerInstanceCount: number = 0;
 
@@ -193,7 +193,7 @@ export default class TransmuxerInterface {
     duration: number,
     accurateTimeOffset: boolean,
     chunkMeta: ChunkMetadata,
-    defaultInitPTS?: RationalTimestamp,
+    defaultInitPTS?: TimestampOffset,
   ) {
     chunkMeta.transmuxing.start = self.performance.now();
     const { instanceNo, transmuxer } = this;

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -21,7 +21,7 @@ import type { Remuxer } from '../types/remuxer';
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
 import type { TypeSupported } from '../utils/codecs';
 import type { ILogger } from '../utils/logger';
-import type { RationalTimestamp } from '../utils/timescale-conversion';
+import type { TimestampOffset } from '../utils/timescale-conversion';
 
 let now: () => number;
 // performance.now() not available on WebWorker, at least on Safari Desktop
@@ -312,7 +312,7 @@ export default class Transmuxer {
     chunkMeta.transmuxing.executeEnd = now();
   }
 
-  resetInitialTimestamp(defaultInitPts: RationalTimestamp | null) {
+  resetInitialTimestamp(defaultInitPts: TimestampOffset | null) {
     const { demuxer, remuxer } = this;
     if (!demuxer || !remuxer) {
       return;
@@ -517,14 +517,14 @@ export class TransmuxConfig {
   public videoCodec?: string;
   public initSegmentData?: Uint8Array;
   public duration: number;
-  public defaultInitPts: RationalTimestamp | null;
+  public defaultInitPts: TimestampOffset | null;
 
   constructor(
     audioCodec: string | undefined,
     videoCodec: string | undefined,
     initSegmentData: Uint8Array | undefined,
     duration: number,
-    defaultInitPts?: RationalTimestamp,
+    defaultInitPts?: TimestampOffset,
   ) {
     this.audioCodec = audioCodec;
     this.videoCodec = videoCodec;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1533,4 +1533,7 @@ export type {
   KeySystems,
   KeySystemFormats,
 } from './utils/mediakeys-helper';
-export type { RationalTimestamp } from './utils/timescale-conversion';
+export type {
+  RationalTimestamp,
+  TimestampOffset,
+} from './utils/timescale-conversion';

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -25,14 +25,14 @@ import type {
 import type { TrackSet } from '../types/track';
 import type { TypeSupported } from '../utils/codecs';
 import type { InitData, InitDataTrack, TrackTimes } from '../utils/mp4-tools';
-import type { RationalTimestamp } from '../utils/timescale-conversion';
+import type { TimestampOffset } from '../utils/timescale-conversion';
 
 class PassThroughRemuxer extends Logger implements Remuxer {
   private emitInitSegment: boolean = false;
   private audioCodec?: string;
   private videoCodec?: string;
   private initData?: InitData;
-  private initPTS: (RationalTimestamp & { trackId?: number }) | null = null;
+  private initPTS: TimestampOffset | null = null;
   private initTracks?: TrackSet;
   private lastEndTime: number | null = null;
   private isVideoContiguous: boolean = false;
@@ -48,7 +48,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
 
   public destroy() {}
 
-  public resetTimeStamp(defaultInitPTS: RationalTimestamp | null) {
+  public resetTimeStamp(defaultInitPTS: TimestampOffset | null) {
     this.lastEndTime = null;
     const initPTS = this.initPTS;
     if (initPTS && defaultInitPTS) {
@@ -182,7 +182,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       return result;
     }
     if (this.emitInitSegment) {
-      initSegment.tracks = this.initTracks as TrackSet;
+      initSegment.tracks = this.initTracks;
       this.emitInitSegment = false;
     }
 
@@ -199,54 +199,71 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     const videoEndTime = toStartEndOrDefault(videoSampleTimestamps, 0, true);
     const audioEndTime = toStartEndOrDefault(audioSampleTimestamps, 0, true);
 
-    let baseOffsetSamples: TrackTimes | undefined;
     let decodeTime = timeOffset;
-    let duration: number = 0;
-    if (
+    let duration = 0;
+
+    const syncOnAudio =
       audioSampleTimestamps &&
       (!videoSampleTimestamps ||
         (!initPTS && audioStartTime < videoStartTime) ||
-        (initPTS && initPTS.trackId === initData.audio!.id))
-    ) {
-      initSegment.trackId = initData.audio!.id;
-      baseOffsetSamples = audioSampleTimestamps;
-      duration = audioEndTime - audioStartTime;
-    } else if (videoSampleTimestamps) {
-      initSegment.trackId = initData.video!.id;
-      baseOffsetSamples = videoSampleTimestamps;
-      duration = videoEndTime - videoStartTime;
-    }
+        (initPTS && initPTS.trackId === initData.audio!.id));
+    const baseOffsetSamples = syncOnAudio
+      ? audioSampleTimestamps
+      : videoSampleTimestamps;
+
     if (baseOffsetSamples) {
       const timescale = baseOffsetSamples.timescale;
-      decodeTime = baseOffsetSamples.start / timescale;
-      initSegment.initPTS = baseOffsetSamples.start - timeOffset * timescale;
-      initSegment.timescale = timescale;
-      if (!initPTS) {
-        this.initPTS = initPTS = {
-          baseTime: initSegment.initPTS,
-          timescale,
-          trackId: initSegment.trackId,
-        };
-      }
-    }
+      const baseTime = baseOffsetSamples.start - timeOffset * timescale;
+      const trackId = syncOnAudio ? initData.audio!.id : initData.video!.id;
 
-    if (
-      (accurateTimeOffset || !initPTS) &&
-      (isInvalidInitPts(initPTS, decodeTime, timeOffset, duration) ||
-        initSegment.timescale !== initPTS.timescale)
-    ) {
-      initSegment.initPTS = decodeTime - timeOffset;
-      initSegment.timescale = 1;
-      if (initPTS && initPTS.timescale === 1) {
-        this.warn(
-          `Adjusting initPTS @${timeOffset} from ${initPTS.baseTime / initPTS.timescale} to ${initSegment.initPTS}`,
+      decodeTime = baseOffsetSamples.start / timescale;
+      duration = syncOnAudio
+        ? audioEndTime - audioStartTime
+        : videoEndTime - videoStartTime;
+
+      if (
+        (accurateTimeOffset || !initPTS) &&
+        (isInvalidInitPts(initPTS, decodeTime, timeOffset, duration) ||
+          timescale !== initPTS.timescale)
+      ) {
+        if (initPTS) {
+          this.warn(
+            `Timestamps at playlist time: ${accurateTimeOffset ? '' : '~'}${timeOffset} ${baseTime / timescale} != initPTS: ${initPTS.baseTime / initPTS.timescale} (${initPTS.baseTime}/${initPTS.timescale}) trackId: ${initPTS.trackId}`,
+          );
+        }
+        this.log(
+          `Found initPTS at playlist time: ${timeOffset} offset: ${decodeTime - timeOffset} (${baseTime}/${timescale}) trackId: ${trackId}`,
         );
+        initPTS = null;
+        initSegment.initPTS = baseTime;
+        initSegment.timescale = timescale;
+        initSegment.trackId = trackId;
+      }
+    } else {
+      this.warn(
+        `No audio or video samples found for initPTS at playlist time: ${timeOffset}`,
+      );
+    }
+    if (!initPTS) {
+      if (
+        !initSegment.timescale ||
+        initSegment.trackId === undefined ||
+        initSegment.initPTS === undefined
+      ) {
+        this.warn('Could not set initPTS');
+        initSegment.initPTS = decodeTime;
+        initSegment.timescale = 1;
+        initSegment.trackId = -1;
       }
       this.initPTS = initPTS = {
         baseTime: initSegment.initPTS,
-        timescale: 1,
+        timescale: initSegment.timescale,
+        trackId: initSegment.trackId,
       };
     }
+    initSegment.initPTS = initPTS.baseTime;
+    initSegment.timescale = initPTS.timescale;
+    initSegment.trackId = initPTS.trackId;
 
     const startTime = audioTrack
       ? decodeTime - initPTS.baseTime / initPTS.timescale
@@ -348,7 +365,7 @@ function toStartEndOrDefault(
 }
 
 function isInvalidInitPts(
-  initPTS: RationalTimestamp | null,
+  initPTS: TimestampOffset | null,
   startDTS: number,
   timeOffset: number,
   duration: number,

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -260,10 +260,11 @@ class PassThroughRemuxer extends Logger implements Remuxer {
         timescale: initSegment.timescale,
         trackId: initSegment.trackId,
       };
+    } else {
+      initSegment.initPTS = initPTS.baseTime;
+      initSegment.timescale = initPTS.timescale;
+      initSegment.trackId = initPTS.trackId;
     }
-    initSegment.initPTS = initPTS.baseTime;
-    initSegment.timescale = initPTS.timescale;
-    initSegment.trackId = initPTS.trackId;
 
     const startTime = audioTrack
       ? decodeTime - initPTS.baseTime / initPTS.timescale

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -374,6 +374,7 @@ export interface InitPTSFoundData {
   frag: MediaFragment;
   initPTS: number;
   timescale: number;
+  trackId: number;
 }
 
 export interface FragLoadingData {

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -11,7 +11,7 @@ import type {
 import type { PlaylistLevelType } from './loader';
 import type { TrackSet } from './track';
 import type { DecryptData } from '../loader/level-key';
-import type { RationalTimestamp } from '../utils/timescale-conversion';
+import type { TimestampOffset } from '../utils/timescale-conversion';
 
 export interface Remuxer {
   remux(
@@ -30,7 +30,7 @@ export interface Remuxer {
     videoCodec: string | undefined,
     decryptdata: DecryptData | null,
   ): void;
-  resetTimeStamp(defaultInitPTS: RationalTimestamp | null): void;
+  resetTimeStamp(defaultInitPTS: TimestampOffset | null): void;
   resetNextTimestamp(): void;
   destroy(): void;
 }

--- a/src/utils/imsc1-ttml-parser.ts
+++ b/src/utils/imsc1-ttml-parser.ts
@@ -4,7 +4,7 @@ import { toTimescaleFromScale } from './timescale-conversion';
 import VTTCue from './vttcue';
 import { parseTimeStamp } from './vttparser';
 import { generateCueId } from './webvtt-parser';
-import type { RationalTimestamp } from './timescale-conversion';
+import type { TimestampOffset } from './timescale-conversion';
 
 export const IMSC1_CODEC = 'stpp.ttml.im1t';
 
@@ -24,7 +24,7 @@ const textAlignToLineAlign: Partial<Record<string, LineAlignSetting>> = {
 
 export function parseIMSC1(
   payload: ArrayBuffer,
-  initPTS: RationalTimestamp,
+  initPTS: TimestampOffset,
   callBack: (cues: Array<VTTCue>) => any,
   errorCallBack: (error: Error) => any,
 ) {

--- a/src/utils/timescale-conversion.ts
+++ b/src/utils/timescale-conversion.ts
@@ -5,6 +5,8 @@ export type RationalTimestamp = {
   timescale: number; // ticks per second
 };
 
+export type TimestampOffset = RationalTimestamp & { trackId: number };
+
 export function toTimescaleFromBase(
   baseTime: number,
   destScale: number,

--- a/src/utils/webvtt-parser.ts
+++ b/src/utils/webvtt-parser.ts
@@ -3,7 +3,7 @@ import { hash } from './hash';
 import { toMpegTsClockFromTimescale } from './timescale-conversion';
 import { VTTParser } from './vttparser';
 import { normalizePts } from '../remux/mp4-remuxer';
-import type { RationalTimestamp } from './timescale-conversion';
+import type { TimestampOffset } from './timescale-conversion';
 import type { VTTCCs } from '../types/vtt';
 
 const LINEBREAKS = /\r\n|\n\r|\n|\r/g;
@@ -80,7 +80,7 @@ const calculateOffset = function (vttCCs: VTTCCs, cc, presentationTime) {
 
 export function parseWebVTT(
   vttByteArray: ArrayBuffer,
-  initPTS: RationalTimestamp | undefined,
+  initPTS: TimestampOffset | undefined,
   vttCCs: VTTCCs,
   cc: number,
   timeOffset: number,


### PR DESCRIPTION
### This PR will...
Fix resetting of initPTS when muxed audiovideo sample start times are inconsistent

### Why is this Pull Request needed?
When the audio sample start time offsets from playlist times differ between segments or parts, this can cause small changes in initPTS. These changes may cause issues with appending and fragment/part finding.

1. `trackId` is set in stream-controller `this.initPTS[frag.cc]` so that the trackId is maintained between variant switches. This prevents initPTS track and timescale from changing on switch, especially if audio doesn't always start before video in segments or parts.
2. pasthrough-remuxer `initSegment` result remains consistent with initPTS unless `isInvalidInitPts` returns true. This prevents the stream-controller from resetting initPTS when `initSegment.initPTS` changes slightly.
3. initPTS with a timescale of 1 is no longer created when `baseOffsetSamples` are used to gather `initPTS` and `timescale`.


### Are there any points in the code the reviewer needs to double check?

 
Verify past fixes are still valid:

- [x] #7310
- [x] #7114
- [x] #5452
- [x] #5195

### Resolves issues:
Fixes #7431

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
