### PR TITLE
Schedule renovate to run on the 28th day of the month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:recommended"],
   "labels": ["dependencies", "skip-change-log"],
+  "schedule": ["* 0 28 * *"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "prCreation": "immediate",


### PR DESCRIPTION
Reduce the frequency of PR creation by renovate by scheduling it to run once a month.

Maintainers can create PRs for updated dependencies under "Pending Status Checks" in the renovate dashboard:
https://developer.mend.io/github/video-dev/hls.js