### PR TITLE
Unblock audio appends when video source buffer is at EoS

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -790,7 +790,12 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     if (videoSb && sn !== 'initSegment') {
       const partOrFrag = part || (frag as MediaFragment);
       const blockedAudioAppend = this.blockedAudioAppend;
-      if (type === 'audio' && parent !== 'main' && !this.blockedAudioAppend) {
+      if (
+        type === 'audio' &&
+        parent !== 'main' &&
+        !this.blockedAudioAppend &&
+        !(videoTrack.ending || videoTrack.ended)
+      ) {
         const pStart = partOrFrag.start;
         const pTime = pStart + partOrFrag.duration * 0.05;
         const vbuffered = videoSb.buffered;
@@ -1077,6 +1082,9 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         this.tracksEnded();
         this.hls.trigger(Events.BUFFERED_TO_END, undefined);
       }
+    } else if (data.type === 'video') {
+      // Make sure pending audio appends are unblocked when video reaches end
+      this.unblockAudio();
     }
   }
 


### PR DESCRIPTION
### This PR will...
Unblock audio appends when video source buffer is at EoS.

### Why is this Pull Request needed?
If video reaches end-of-stream first, audio appends should not be blocked.
Blocked audio appends should be unblocked when video reaches end-of-stream.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
