### PR TITLE
Prevent exception mapping date ranges when mapping PDT tags are dropped

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -770,6 +770,9 @@ export function mapDateRanges(
     const startDateTime = dateRange.startDate.getTime();
     dateRange.tagAnchor = lastProgramDateTime.ref;
     for (let j = programDateTimeCount; j--; ) {
+      if (programDateTimes[j]?.sn < details.startSN) {
+        break;
+      }
       const fragIndex = findFragmentWithStartDate(
         details,
         startDateTime,
@@ -802,6 +805,9 @@ function findFragmentWithStartDate(
       if (startDateTime <= pdtStart + durationBetweenPdt * 1000) {
         // map to fragment with date-time range
         const startIndex = programDateTimes[index].sn - details.startSN;
+        if (startIndex < 0) {
+          return -1;
+        }
         const fragments = details.fragments;
         if (fragments.length > programDateTimes.length) {
           const endSegment =


### PR DESCRIPTION
### This PR will...
Prevent exception mapping date ranges when mapping PDT tags are dropped

### Why is this Pull Request needed?

`mapDateRanges` > `findFragmentWithStartDate` may try to access out of range segments on live update when segments with program date time mapping to a date range are removed from the playlist.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7449

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
