### PR TITLE
Force schedule update on asset or interstitial error 

### DIFF
--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -87,6 +87,8 @@ export class HlsAssetPlayer {
         // issue should surface as an INTERSTITIAL_ASSET_ERROR loading the asset.
       }
       hls.loadSource(uri);
+    } else if (hls.levels.length && !(hls as any).started) {
+      hls.startLoad(-1, true);
     }
   }
 
@@ -100,7 +102,7 @@ export class HlsAssetPlayer {
     if (!media) {
       return false;
     }
-    const duration = this._bufferedEosTime || this.duration;
+    const duration = Math.min(this._bufferedEosTime || Infinity, this.duration);
     const start = this.timelineOffset;
     const bufferInfo = BufferHelper.bufferInfo(media, start, 0);
     const bufferedEnd = this.getAssetTime(bufferInfo.end);
@@ -159,6 +161,13 @@ export class HlsAssetPlayer {
     const duration = this.assetItem.duration;
     if (!duration) {
       return 0;
+    }
+    const playoutLimit = this.interstitial.playoutLimit;
+    if (playoutLimit) {
+      const assetPlayout = playoutLimit - this.startOffset;
+      if (assetPlayout > 0 && assetPlayout < duration) {
+        return assetPlayout;
+      }
     }
     return duration;
   }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -961,6 +961,10 @@ export default class InterstitialsController
       (backwardSeek && currentTime < start) ||
       currentTime >= start + duration
     ) {
+      if (playingItem.event?.appendInPlace) {
+        this.clearInterstitial(playingItem.event, playingItem);
+        this.flushFrontBuffer(currentTime);
+      }
       this.setScheduleToAssetAtTime(currentTime, playingAsset);
     }
   };

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -905,7 +905,7 @@ export default class InterstitialsController
         currentTime - diff,
       );
       if (resetCount) {
-        this.updateSchedule();
+        this.updateSchedule(true);
       }
     }
     this.checkBuffer();
@@ -1119,8 +1119,10 @@ export default class InterstitialsController
     if (!scheduleItems || this.playbackDisabled) {
       return;
     }
-    this.log(`setSchedulePosition ${index}, ${assetListIndex}`);
     const scheduledItem = index >= 0 ? scheduleItems[index] : null;
+    this.log(
+      `setSchedulePosition ${index}, ${assetListIndex} (${scheduledItem ? segmentToString(scheduledItem) : scheduledItem})`,
+    );
     // Cleanup current item / asset
     const currentItem = this.waitingItem || this.playingItem;
     const playingLastItem = this.playingLastItem;
@@ -1837,12 +1839,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     return item && this.schedule ? this.schedule.findItemIndex(item, time) : -1;
   }
 
-  private updateSchedule() {
+  private updateSchedule(forceUpdate: boolean = false) {
     const mediaSelection = this.mediaSelection;
     if (!mediaSelection) {
       return;
     }
-    this.schedule?.updateSchedule(mediaSelection, []);
+    this.schedule?.updateSchedule(mediaSelection, [], forceUpdate);
   }
 
   // Schedule buffer control
@@ -2699,8 +2701,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       for (let i = assetListIndex; i < interstitial.assetList.length; i++) {
         this.resetAssetPlayer(interstitial.assetList[i].identifier);
       }
-      this.updateSchedule();
     }
+    this.updateSchedule(true);
     if (interstitial.error) {
       this.primaryFallback(interstitial);
     } else if (playingAsset && playingAsset.identifier === assetId) {
@@ -2719,7 +2721,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const flushStart = interstitial.timelineStart;
     const playingItem = this.effectivePlayingItem;
     // Update schedule now that interstitial/assets are flagged with `error` for fallback
-    this.updateSchedule();
     if (playingItem) {
       this.log(
         `Fallback to primary from event "${interstitial.identifier}" start: ${
@@ -2802,6 +2803,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
             interstitial.error = new Error(
               `Interstitial no longer within playback range ${this.timelinePos} ${interstitial}`,
             );
+            this.updateSchedule(true);
             this.primaryFallback(interstitial);
             return;
           }
@@ -2837,6 +2839,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       case ErrorDetails.ASSET_LIST_LOAD_TIMEOUT: {
         const interstitial = data.interstitial;
         if (interstitial) {
+          this.updateSchedule(true);
           this.primaryFallback(interstitial);
         }
         break;

--- a/src/controller/interstitials-schedule.ts
+++ b/src/controller/interstitials-schedule.ts
@@ -303,12 +303,14 @@ export class InterstitialsSchedule extends Logger {
   public updateSchedule(
     mediaSelection: MediaSelection,
     removedInterstitials: InterstitialEvent[] = [],
+    forceUpdate: boolean = false,
   ) {
     const events = this.events || [];
     if (events.length || removedInterstitials.length || this.length < 2) {
       const currentItems = this.items;
       const updatedItems = this.parseSchedule(events, mediaSelection);
       const updated =
+        forceUpdate ||
         removedInterstitials.length ||
         currentItems?.length !== updatedItems.length ||
         updatedItems.some((item, i) => {


### PR DESCRIPTION
### This PR will...
- Force schedule update on asset or interstitial error 
- Flush and clear assets when seeking back to earlier asset in interstitial

### Why is this Pull Request needed?
Forcing an update handles cases where playout duration is not changed by error but schedule update is needed.
Flushing and clearing asset players when seeking back to an earlier asset handles shifts in the timeline cause by faulty assets earlier in the event.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
