### PR TITLE
Schedule level reload sooner if only 1 fragment in level

### DIFF
--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -518,6 +518,14 @@ export function computeReloadInterval(
         reloadInterval = lastSegmentDuration;
       }
     }
+
+    // If only 1 fragment, make sure to reload well before it ends to avoid race condition stall
+    if (fragments.length == 1) {
+      reloadInterval = (fragments[0].duration * 1000) / 2;
+      logger.log(
+        'computeReloadInterval found only 1 fragment, using duration / 2',
+      );
+    }
   } else {
     // estimate = 'miss half average';
     // follow HLS Spec, If the client reloads a Playlist file and finds that it has not


### PR DESCRIPTION
### This PR will...
Schedule a level reload sooner than fragment duration if there is only 1 fragment in the playlist

### Why is this Pull Request needed?
If the server is adding to a playlist, but there is only 1 fragment so far at the time of the playlist being loaded, the level will not be reloaded before playback reaches the end of the first fragment and a stall is encountered. This stall leads to a hiccup in audio/video as the player recovers by reloading the level and subsequent fragments.

### Are there any points in the code the reviewer needs to double check?
Is this the right place to put this logic?
