### PR TITLE
Detect unhandled encryption and fallback or error

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -563,6 +563,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected transmuxer: TransmuxerInterface | null;
     // (undocumented)
+    protected unhandledEncryptionError(initSegment: InitSegmentData, frag: Fragment): boolean;
+    // (undocumented)
     protected unregisterListeners(): void;
     // (undocumented)
     protected waitForCdnTuneIn(details: LevelDetails): boolean | 0;
@@ -578,6 +580,8 @@ export interface BaseTrack {
     codec?: string;
     // (undocumented)
     container: string;
+    // (undocumented)
+    encrypted?: boolean;
     // (undocumented)
     id: 'audio' | 'main';
     // (undocumented)
@@ -4357,6 +4361,8 @@ export interface RemuxedTrack {
     data2?: Uint8Array<ArrayBuffer>;
     // (undocumented)
     dropped?: number;
+    // (undocumented)
+    encrypted?: boolean;
     // (undocumented)
     endDTS: number;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -884,6 +884,9 @@ class AudioStreamController
 
     if (initSegment?.tracks) {
       const mapFragment = frag.initSegment || frag;
+      if (this.unhandledEncryptionError(initSegment, frag)) {
+        return;
+      }
       this._bufferInitSegment(
         level,
         initSegment.tracks,

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -577,80 +577,82 @@ class EMEController extends Logger implements ComponentAPI {
       this.keyFormatPromise = this.getKeyFormatPromise(keyFormats);
     }
 
-    this.keyFormatPromise.then((keySystemFormat) => {
-      const keySystem = keySystemFormatToKeySystemDomain(keySystemFormat);
-      if (initDataType !== 'sinf' || keySystem !== KeySystems.FAIRPLAY) {
-        this.log(
-          `Ignoring "${event.type}" event with init data type: "${initDataType}" for selected key-system ${keySystem}`,
-        );
-        return;
-      }
-
-      // Match sinf keyId to playlist skd://keyId=
-      let keyId: Uint8Array<ArrayBuffer> | undefined;
-      try {
-        const json = bin2str(new Uint8Array(initData));
-        const sinf = base64Decode(JSON.parse(json).sinf);
-        const tenc = parseSinf(sinf);
-        if (!tenc) {
-          throw new Error(
-            `'schm' box missing or not cbcs/cenc with schi > tenc`,
+    this.keyFormatPromise
+      .then((keySystemFormat) => {
+        const keySystem = keySystemFormatToKeySystemDomain(keySystemFormat);
+        if (initDataType !== 'sinf' || keySystem !== KeySystems.FAIRPLAY) {
+          this.log(
+            `Ignoring "${event.type}" event with init data type: "${initDataType}" for selected key-system ${keySystem}`,
           );
+          return;
         }
-        keyId = new Uint8Array(tenc.subarray(8, 24));
-      } catch (error) {
-        this.warn(`${logMessage} Failed to parse sinf: ${error}`);
-        return;
-      }
 
-      const keyIdHex = Hex.hexDump(keyId);
-      const { keyIdToKeySessionPromise, mediaKeySessions } = this;
-      let keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex];
-
-      for (let i = 0; i < mediaKeySessions.length; i++) {
-        // Match playlist key
-        const keyContext = mediaKeySessions[i];
-        const decryptdata = keyContext.decryptdata;
-        if (!decryptdata.keyId) {
-          continue;
+        // Match sinf keyId to playlist skd://keyId=
+        let keyId: Uint8Array<ArrayBuffer> | undefined;
+        try {
+          const json = bin2str(new Uint8Array(initData));
+          const sinf = base64Decode(JSON.parse(json).sinf);
+          const tenc = parseSinf(sinf);
+          if (!tenc) {
+            throw new Error(
+              `'schm' box missing or not cbcs/cenc with schi > tenc`,
+            );
+          }
+          keyId = new Uint8Array(tenc.subarray(8, 24));
+        } catch (error) {
+          this.warn(`${logMessage} Failed to parse sinf: ${error}`);
+          return;
         }
-        const oldKeyIdHex = Hex.hexDump(decryptdata.keyId);
-        if (
-          keyIdHex === oldKeyIdHex ||
-          decryptdata.uri.replace(/-/g, '').indexOf(keyIdHex) !== -1
-        ) {
-          keySessionContextPromise = keyIdToKeySessionPromise[oldKeyIdHex];
-          if (!keySessionContextPromise) {
+
+        const keyIdHex = Hex.hexDump(keyId);
+        const { keyIdToKeySessionPromise, mediaKeySessions } = this;
+        let keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex];
+
+        for (let i = 0; i < mediaKeySessions.length; i++) {
+          // Match playlist key
+          const keyContext = mediaKeySessions[i];
+          const decryptdata = keyContext.decryptdata;
+          if (!decryptdata.keyId) {
             continue;
           }
-          if (decryptdata.pssh) {
+          const oldKeyIdHex = Hex.hexDump(decryptdata.keyId);
+          if (
+            keyIdHex === oldKeyIdHex ||
+            decryptdata.uri.replace(/-/g, '').indexOf(keyIdHex) !== -1
+          ) {
+            keySessionContextPromise = keyIdToKeySessionPromise[oldKeyIdHex];
+            if (!keySessionContextPromise) {
+              continue;
+            }
+            if (decryptdata.pssh) {
+              break;
+            }
+            delete keyIdToKeySessionPromise[oldKeyIdHex];
+            decryptdata.pssh = new Uint8Array(initData);
+            decryptdata.keyId = keyId;
+            keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
+              keySessionContextPromise.then(() => {
+                return this.generateRequestWithPreferredKeySession(
+                  keyContext,
+                  initDataType,
+                  initData,
+                  'encrypted-event-key-match',
+                );
+              });
+            keySessionContextPromise.catch((error) => this.handleError(error));
             break;
           }
-          delete keyIdToKeySessionPromise[oldKeyIdHex];
-          decryptdata.pssh = new Uint8Array(initData);
-          decryptdata.keyId = keyId;
-          keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
-            keySessionContextPromise.then(() => {
-              return this.generateRequestWithPreferredKeySession(
-                keyContext,
-                initDataType,
-                initData,
-                'encrypted-event-key-match',
-              );
-            });
-          keySessionContextPromise.catch((error) => this.handleError(error));
-          break;
         }
-      }
 
-      if (!keySessionContextPromise) {
-        this.handleError(
-          new Error(
-            `Key ID ${keyIdHex} not encountered in playlist. Key-system sessions ${mediaKeySessions.length}.`,
-          ),
-        );
-      }
-    });
+        if (!keySessionContextPromise) {
+          this.handleError(
+            new Error(
+              `Key ID ${keyIdHex} not encountered in playlist. Key-system sessions ${mediaKeySessions.length}.`,
+            ),
+          );
+        }
+      })
+      .catch((error) => this.handleError(error));
   };
 
   private onWaitingForKey = (event: Event) => {

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -413,10 +413,10 @@ export default class ErrorController
               )) ||
             (findAudioCodecAlternate &&
               level.audioCodec === levelCandidate.audioCodec) ||
-            (!findAudioCodecAlternate &&
-              level.audioCodec !== levelCandidate.audioCodec) ||
             (findVideoCodecAlternate &&
-              level.codecSet === levelCandidate.codecSet)
+              level.codecSet === levelCandidate.codecSet) ||
+            (!findAudioCodecAlternate &&
+              level.codecSet !== levelCandidate.codecSet)
           ) {
             // For video/audio/subs frag errors find another group ID or fallthrough to redundant fail-over
             continue;

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -21,6 +21,7 @@ export interface BaseTrack {
   container: string;
   codec?: string;
   supplemental?: string;
+  encrypted?: boolean;
   levelCodec?: string;
   pendingCodec?: string;
   metadata?: {

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -52,6 +52,7 @@ export interface RemuxedTrack {
   transferredData1?: ArrayBuffer;
   transferredData2?: ArrayBuffer;
   dropped?: number;
+  encrypted?: boolean;
 }
 
 export interface RemuxedMetadata {


### PR DESCRIPTION
### This PR will...

Detect unhandled encryption (cbcs) in mp4 init segments and fallback or error when hls.js is not configured to use EME.

No error or fallback is performed if media is detached or media.mediaKeys is set. This is to allow for custom EME integrations.

When hls.js is setup with `emeEnabled: true` this check is skipped because the "encrypted" event handler will error if there is no configured key-system and associated license information. 


### Why is this Pull Request needed?
This handles improperly packaged HLS carrying encrypted segments without any KEY tags to signal the encryption.

This does not apply to full segment encryption.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
