### PR TITLE
Minor improvements to docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -756,10 +756,10 @@ Decreasing this value will mean that each stall will have less affect on `hls.ta
 
 (default: `Infinity`)
 
-maximum delay allowed from edge of live, expressed in multiple of `EXT-X-TARGETDURATION`.
-if set to 10, the player will seek back to `liveSyncDurationCount` whenever the next fragment to be loaded is older than N-10, N being the last fragment of the live playlist.
-If set, this value must be strictly superior to `liveSyncDurationCount`
-a value too close from `liveSyncDurationCount` is likely to cause playback stalls.
+Maximum delay allowed from edge of live, expressed in multiple of `EXT-X-TARGETDURATION`.
+If set to 10, the player will seek back to `liveSyncDurationCount` whenever the next fragment to be loaded is older than N-10, N being the last fragment of the live playlist.
+If set, this value must be strictly superior to `liveSyncDurationCount`.
+A value too close from `liveSyncDurationCount` is likely to cause playback stalls.
 
 ### `liveSyncDuration`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -758,7 +758,7 @@ Decreasing this value will mean that each stall will have less affect on `hls.ta
 
 maximum delay allowed from edge of live, expressed in multiple of `EXT-X-TARGETDURATION`.
 if set to 10, the player will seek back to `liveSyncDurationCount` whenever the next fragment to be loaded is older than N-10, N being the last fragment of the live playlist.
-If set, this value must be stricly superior to `liveSyncDurationCount`
+If set, this value must be strictly superior to `liveSyncDurationCount`
 a value too close from `liveSyncDurationCount` is likely to cause playback stalls.
 
 ### `liveSyncDuration`
@@ -776,7 +776,7 @@ A value too low (inferior to ~3 segment durations) is likely to cause playback s
 
 Alternative parameter to `liveMaxLatencyDurationCount`, expressed in seconds vs number of segments.
 If defined in the configuration object, `liveMaxLatencyDuration` will take precedence over the default `liveMaxLatencyDurationCount`.
-If set, this value must be stricly superior to `liveSyncDuration` which must be defined as well.
+If set, this value must be strictly superior to `liveSyncDuration` which must be defined as well.
 You can't define this parameter and either `liveSyncDurationCount` or `liveMaxLatencyDurationCount` in your configuration object at the same time.
 A value too close from `liveSyncDuration` is likely to cause playback stalls.
 


### PR DESCRIPTION
Some minor spello/typo punctuation that triggered me while reading up on config for live streams. Excellent use of the word superior.

Great project, thanks.
