### PR TITLE
Disable part loading for subtitle playlists

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -876,7 +876,7 @@ export default class BaseStreamController
     if (this.loadingParts && isMediaFragment(frag)) {
       const partList = details.partList;
       if (partList && progressCallback) {
-        if (targetBufferTime > frag.end && details.fragmentHint) {
+        if (targetBufferTime > details.fragmentEnd && details.fragmentHint) {
           frag = details.fragmentHint;
         }
         const partIndex = this.getNextPart(partList, frag, targetBufferTime);
@@ -1106,6 +1106,10 @@ export default class BaseStreamController
         // Buffer must be ahead of first part + duration of parts after last segment
         // and playback must be at or past segment adjacent to part list
         const firstPart = details.partList[0];
+        // Loading of VTT subtitle parts is not implemented in subtitle-stream-controller (#7460)
+        if (firstPart.fragment.type === PlaylistLevelType.SUBTITLE) {
+          return false;
+        }
         const safePartStart =
           firstPart.end + (details.fragmentHint?.duration || 0);
         if (bufferEnd >= safePartStart) {


### PR DESCRIPTION
### This PR will...
Disable part loading for subtitle playlists

### Why is this Pull Request needed?
Part loading has not been fully implemented in the subtitle-stream-controller, timeline-contoller, fragment-tracker, and other components that deal with tracking part loaded state needed for fragment selection and part loading progression.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
This is a stop gap measure for #7460. Rather than allow attempts at part loading which are not handled in sequence successfully (at best the first part is loaded and others skipped), the subtitle-stream-controller will only load complete segments,

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
