### PR TITLE
Fix interstitial asset events not firing when attaching primary early for playout-limit change

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -561,7 +561,9 @@ This configuration will be applied by default to all instances.
 
 (default: `false`)
 
-Setting `config.debug = true;` will turn on debug logs on JS console.
+Setting `config.debug = true` enables JavaScript debug console logs. Debug mode also disables catching exceptions in even handler callbacks.
+In debug mode, when an event listener throws, the exception is not caught. This allows uncaught exeptions to trigger the JavaScript debugger.
+In production mode (`config.debug = false`), exceptions that are caught in event handlers are redispatched as errors with `type: OTHER_ERROR, details: INTERNAL_EXCEPTION, error: <caught exception>`.
 
 A logger object could also be provided for custom logging: `config.debug = customLogger;`.
 

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -86,6 +86,10 @@ function playWithCatch(media: HTMLMediaElement | null) {
   });
 }
 
+function timelineMessage(label: string, time: number) {
+  return `[${label}] Advancing timeline position to ${time}`;
+}
+
 export default class InterstitialsController
   extends Logger
   implements NetworkComponentAPI
@@ -1029,7 +1033,7 @@ export default class InterstitialsController
     const effectivePlayingItem = this.effectivePlayingItem;
     if (timelinePos === -1) {
       const startPosition = this.hls.startPosition;
-      this.log(`[checkStart] Advancing timeline position to ${startPosition}`);
+      this.log(timelineMessage('checkStart', startPosition));
       this.timelinePos = startPosition;
       if (interstitialEvents.length && interstitialEvents[0].cue.pre) {
         const index = schedule.findEventIndex(interstitialEvents[0].identifier);
@@ -1093,9 +1097,7 @@ export default class InterstitialsController
         }
         const resumptionTime = interstitial.resumeTime;
         if (this.timelinePos < resumptionTime) {
-          this.log(
-            `[advanceAfterAssetEnded] Advancing timeline position to ${resumptionTime}`,
-          );
+          this.log(timelineMessage('advanceAfterAssetEnded', resumptionTime));
           this.timelinePos = resumptionTime;
           if (interstitial.appendInPlace) {
             this.advanceInPlace(resumptionTime);
@@ -1401,9 +1403,7 @@ export default class InterstitialsController
         timelinePos >= scheduledItem.end
       ) {
         timelinePos = this.getPrimaryResumption(scheduledItem, index);
-        this.log(
-          `[resumePrimary] Advancing timeline position to ${timelinePos}`,
-        );
+        this.log(timelineMessage('resumePrimary', timelinePos));
         this.timelinePos = timelinePos;
       }
       this.attachPrimary(timelinePos, scheduledItem);
@@ -1484,7 +1484,7 @@ export default class InterstitialsController
     }
     if (!skipSeekToStartPosition) {
       // Set primary position to resume time
-      this.log(`[attachPrimary] Advancing timeline position to ${timelinePos}`);
+      this.log(timelineMessage('attachPrimary', timelinePos));
       this.timelinePos = timelinePos;
       this.startLoadingPrimaryAt(timelinePos, skipSeekToStartPosition);
     }


### PR DESCRIPTION
### This PR will...
- Fix interstitial asset events not firing when attaching primary early for playout-limit change
- Add interstitials-controller logging for timeline position changes, trimming buffered interstitials on schedule updates (with interstitial time range changes), and clearing of schedule state
- Update `config.debug` docs (unrelated)

### Why is this Pull Request needed?
When a PLAYOUT-LIMIT is added to an interstitial, shortening it's playout duration, if media has been buffered past the playout limit in append-in-place mode, the interstitial controller will re-attach primary to remove the content buffered past the limit and resume primary buffering. A side-effect of this was that the interstitial schedule `timelinePos` state was advanced from the currentTime (mid-interstitial-asset-playback) to the primary start. This prevents the interstitial controller from detecting asset playback progression in append-in-place mode, which depends on observing currentTime advance past timelinePos.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
