### PR TITLE
Fix syntax in `recoverMediaError` example in API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -362,7 +362,7 @@ It should not be used in response to non-fatal hls.js error events.
 ```js
 let attemptedErrorRecovery = null;
 
-video.addEventListener('error', (event) {
+video.addEventListener('error', (event) => {
   const mediaError = event.currentTarget.error;
   if (mediaError.code === mediaError.MEDIA_ERR_DECODE) {
     const now = Date.now();
@@ -380,11 +380,19 @@ hls.on(Hls.Events.ERROR, function (name, data) {
       case Hls.ErrorTypes.MEDIA_ERROR: {
         const now = Date.now();
         if (!attemptedErrorRecovery || now - attemptedErrorRecovery > 5000) {
-          console.log('Fatal media error encountered (' + video.error + + '), attempting to recover');
+          console.log(
+            'Fatal media error encountered (' +
+              video.error +
+              +'), attempting to recover',
+          );
           attemptedErrorRecovery = now;
           hls.recoverMediaError();
         } else {
-          console.log('Skipping media error recovery (only ' + (now - attemptedErrorRecovery) + 'ms since last error)');
+          console.log(
+            'Skipping media error recovery (only ' +
+              (now - attemptedErrorRecovery) +
+              'ms since last error)',
+          );
         }
         break;
       }


### PR DESCRIPTION
### This PR will...

Fix a syntax error in the `recoverMediaError` example code in API.md

### Why is this Pull Request needed?

The `=>` is necessary when defining the event handler function.

### Are there any points in the code the reviewer needs to double check?

No

### Resolves issues:

Addresses a syntax problem introduced in:
84e4fbdc3f755b2fc279741d13cdddde1de2f58b #7447

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
