### PR TITLE
Add an `hlsjsConfig` query param to populate the demo editor

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -19,11 +19,14 @@ const testStreams = require('../tests/test-streams');
 const defaultTestStreamUrl = testStreams[Object.keys(testStreams)[0]].url;
 const sourceURL = decodeURIComponent(getURLParam('src', defaultTestStreamUrl));
 
-let demoConfig = getURLParam('demoConfig', null);
-if (demoConfig) {
-  demoConfig = JSON.parse(atob(demoConfig));
-} else {
-  demoConfig = {};
+let demoConfig = {};
+const demoConfigParam = getURLParam('demoConfig', null);
+if (demoConfigParam) {
+  try {
+    demoConfig = JSON.parse(atob(demoConfigParam));
+  } catch (error) {
+    console.warn('Failed to parse demoConfig:', error);
+  }
 }
 
 const hlsjsDefaults = {
@@ -32,6 +35,16 @@ const hlsjsDefaults = {
   lowLatencyMode: true,
   backBufferLength: 60 * 1.5,
 };
+
+const hlsjsConfigParam = getURLParam('hlsjsConfig', null);
+let hlsjsConfig = hlsjsDefaults;
+if (hlsjsConfigParam) {
+  try {
+    hlsjsConfig = JSON.parse(atob(hlsjsConfigParam));
+  } catch (error) {
+    console.warn('Failed to parse hlsjsConfig:', error);
+  }
+}
 
 let enableStreaming = getDemoConfigPropOrDefault('enableStreaming', true);
 let autoRecoverError = getDemoConfigPropOrDefault('autoRecoverError', true);
@@ -1497,12 +1510,17 @@ function onDemoConfigChanged(firstLoad) {
     persistEditorValue();
   }
 
+  updatePermalink(firstLoad);
+}
+
+function updatePermalink(firstLoad) {
   const serializedDemoConfig = btoa(JSON.stringify(demoConfig));
+  const serializedHlsjsConfig = btoa(JSON.stringify(hlsjsConfig));
   const baseURL = document.URL.split('?')[0];
   const streamURL = $('#streamURL').val();
   const permalinkURL = `${baseURL}?src=${encodeURIComponent(
     streamURL
-  )}&demoConfig=${serializedDemoConfig}`;
+  )}&demoConfig=${serializedDemoConfig}&hlsjsConfig=${serializedHlsjsConfig}`;
 
   $('#StreamPermalink').html(`<a href="${permalinkURL}">${permalinkURL}</a>`);
   if (!firstLoad && self.location.href !== permalinkURL) {
@@ -1565,7 +1583,7 @@ function setupConfigEditor() {
   configEditor.setTheme('ace/theme/github');
   configEditor.session.setMode('ace/mode/json');
 
-  const contents = hlsjsDefaults;
+  const contents = hlsjsConfig;
   const shouldRestorePersisted =
     JSON.parse(localStorage.getItem(STORAGE_KEYS.Editor_Persistence)) === true;
 
@@ -1737,6 +1755,8 @@ function updateConfigEditorValue(obj) {
 
 function applyConfigEditorValue() {
   onDemoConfigChanged();
+  hlsjsConfig = getEditorValue({ parse: true });
+  updatePermalink(false);
   loadSelectedStream();
 }
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -38,9 +38,11 @@ const hlsjsDefaults = {
 
 const hlsjsConfigParam = getURLParam('hlsjsConfig', null);
 let hlsjsConfig = hlsjsDefaults;
+let hlsjsConfigLoadedFromUrl = false;
 if (hlsjsConfigParam) {
   try {
     hlsjsConfig = JSON.parse(atob(hlsjsConfigParam));
+    hlsjsConfigLoadedFromUrl = true;
   } catch (error) {
     console.warn('Failed to parse hlsjsConfig:', error);
   }
@@ -1585,6 +1587,7 @@ function setupConfigEditor() {
 
   const contents = hlsjsConfig;
   const shouldRestorePersisted =
+    !hlsjsConfigLoadedFromUrl &&
     JSON.parse(localStorage.getItem(STORAGE_KEYS.Editor_Persistence)) === true;
 
   if (shouldRestorePersisted) {


### PR DESCRIPTION
### This PR will...

Add a new the `hlsjsConfig` query param to populate the editor on load. It is added automatically to the permalink whenever a change to the editor is applied.

### Why is this Pull Request needed?
It makes it easier to share the demo page with the right config (and playback URL).

### Are there any points in the code the reviewer needs to double check?
I have done some QA (e.g. with/without `hlsjsConfig`, with/without peristance), but I don't know if I have covered all the edge cases.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
