### PR TITLE
Defer segment requests when network connection is lost

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -392,6 +392,8 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected checkLiveUpdate(details: LevelDetails): void;
     // (undocumented)
+    protected checkRetryDate(): void;
+    // (undocumented)
     protected clearTrackerIfNeeded(frag: Fragment): void;
     // (undocumented)
     protected config: HlsConfig;
@@ -527,8 +529,6 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     protected resetFragmentLoading(frag: Fragment): void;
     // (undocumented)
     protected resetLoadingState(): void;
-    // (undocumented)
-    protected resetStartWhenNotLoaded(level: Level | null): void;
     // (undocumented)
     protected resetTransmuxer(): void;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -255,15 +255,7 @@ class AudioStreamController
         break;
       }
       case State.FRAG_LOADING_WAITING_RETRY: {
-        const now = performance.now();
-        const retryDate = this.retryDate;
-        // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-        if (!retryDate || now >= retryDate) {
-          const { levels, trackId } = this;
-          this.log('RetryDate reached, switch back to IDLE state');
-          this.resetStartWhenNotLoaded(levels?.[trackId] || null);
-          this.state = State.IDLE;
-        }
+        this.checkRetryDate();
         break;
       }
       case State.WAITING_INIT_PTS: {

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -258,11 +258,7 @@ class AudioStreamController
         const now = performance.now();
         const retryDate = this.retryDate;
         // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-        if (
-          !retryDate ||
-          now >= retryDate ||
-          (this.media?.seeking && retryDate !== Infinity)
-        ) {
+        if (!retryDate || now >= retryDate) {
           const { levels, trackId } = this;
           this.log('RetryDate reached, switch back to IDLE state');
           this.resetStartWhenNotLoaded(levels?.[trackId] || null);

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -258,7 +258,11 @@ class AudioStreamController
         const now = performance.now();
         const retryDate = this.retryDate;
         // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-        if (!retryDate || now >= retryDate || this.media?.seeking) {
+        if (
+          !retryDate ||
+          now >= retryDate ||
+          (this.media?.seeking && retryDate !== Infinity)
+        ) {
           const { levels, trackId } = this;
           this.log('RetryDate reached, switch back to IDLE state');
           this.resetStartWhenNotLoaded(levels?.[trackId] || null);

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -453,7 +453,7 @@ export default class BaseStreamController
     }
     super.onHandlerDestroying();
     // @ts-ignore
-    this.hls = this.onMediaSeeking = this.onMediaEnded = this.onOnline = null;
+    this.hls = this.onMediaSeeking = this.onMediaEnded = null;
   }
 
   protected onHandlerDestroyed() {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1907,11 +1907,11 @@ export default class BaseStreamController
       errorAction.resolved = true;
     } else if ((retry || noAlternate) && retryCount < retryConfig.maxNumRetry) {
       const offlineStatus = offlineHttpStatus(data.response?.code);
-      this.resetStartWhenNotLoaded();
       const delay = getRetryDelay(retryConfig, retryCount);
-      errorAction.resolved = true;
+      this.resetStartWhenNotLoaded();
       this.retryDate = self.performance.now() + delay;
       this.state = State.FRAG_LOADING_WAITING_RETRY;
+      errorAction.resolved = true;
       if (offlineStatus) {
         this.log(`Waiting for connection (offline)`);
         this.retryDate = Infinity;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -219,11 +219,7 @@ export default class StreamController
           const now = self.performance.now();
           const retryDate = this.retryDate;
           // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-          if (
-            !retryDate ||
-            now >= retryDate ||
-            (this.media?.seeking && retryDate !== Infinity)
-          ) {
+          if (!retryDate || now >= retryDate) {
             const { levels, level } = this;
             const currentLevel = levels?.[level];
             this.resetStartWhenNotLoaded(currentLevel || null);

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -215,17 +215,7 @@ export default class StreamController
         break;
       }
       case State.FRAG_LOADING_WAITING_RETRY:
-        {
-          const now = self.performance.now();
-          const retryDate = this.retryDate;
-          // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-          if (!retryDate || now >= retryDate) {
-            const { levels, level } = this;
-            const currentLevel = levels?.[level];
-            this.resetStartWhenNotLoaded(currentLevel || null);
-            this.state = State.IDLE;
-          }
-        }
+        this.checkRetryDate();
         break;
       default:
         break;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -219,7 +219,11 @@ export default class StreamController
           const now = self.performance.now();
           const retryDate = this.retryDate;
           // if current time is gt than retryDate, or if media seeking let's switch to IDLE state to retry loading
-          if (!retryDate || now >= retryDate || this.media?.seeking) {
+          if (
+            !retryDate ||
+            now >= retryDate ||
+            (this.media?.seeking && retryDate !== Infinity)
+          ) {
             const { levels, level } = this;
             const currentLevel = levels?.[level];
             this.resetStartWhenNotLoaded(currentLevel || null);

--- a/src/utils/error-helper.ts
+++ b/src/utils/error-helper.ts
@@ -71,10 +71,14 @@ export function shouldRetry(
     : retry;
 }
 
-export function retryForHttpStatus(httpStatus: number | undefined) {
+export function retryForHttpStatus(httpStatus: number | undefined): boolean {
   // Do not retry on status 4xx, status 0 (CORS error), or undefined (decrypt/gap/parse error)
   return (
-    (httpStatus === 0 && navigator.onLine === false) ||
+    offlineHttpStatus(httpStatus) ||
     (!!httpStatus && (httpStatus < 400 || httpStatus > 499))
   );
+}
+
+export function offlineHttpStatus(httpStatus: number | undefined): boolean {
+  return httpStatus === 0 && navigator.onLine === false;
 }


### PR DESCRIPTION
### This PR will...
- Wait to retry fragment request when `navigator.onLine` is false
- Only treat no-alternate segment request failures as gaps in live playlists. Follow up to:
  - #7464
  - #7410
- Only schedule immediate tick on seeking when buffer is empty and state is idle (add some throttling based on feedback in #7472)

### Why is this Pull Request needed?
Avoid fatal error and unnecessary retries when offline (temporarily).
Allow skipping of blocked segments in live, but not in VOD where all content should be expected to load eventually.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7471

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
