### PR TITLE
Fix exception when seeking to program end

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1235,7 +1235,7 @@ export default class InterstitialsController
     if (!schedule) {
       return;
     }
-    const scheduledItem = index >= 0 ? scheduleItems[index] : null;
+    const scheduledItem = scheduleItems[index] || null;
     const media = this.primaryMedia;
     // Cleanup out of range Interstitials
     const playerQueue = this.playerQueue;
@@ -1354,7 +1354,7 @@ export default class InterstitialsController
       if (this.shouldPlay) {
         playWithCatch(player.media);
       }
-    } else if (scheduledItem !== null) {
+    } else if (scheduledItem) {
       this.resumePrimary(scheduledItem, index, currentItem);
       if (this.shouldPlay) {
         playWithCatch(this.hls.media);


### PR DESCRIPTION
### This PR will...
Fix exception when seeking to program end

### Why is this Pull Request needed?
Upon seeking to the end `setSchedulePosition` is called with an index of 1. If there are no interstitials and the schedule contains only one item, this is out of bounds. That is OK. The issue is that `scheduledItem` is undefined rather than null. resulting in `resumePrimary` getting called with an undefined `scheduledItem`. TypeScript always infers that `scheduleItems[index]` will return a result.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
