### PR TITLE
Support playback for elementary audio stream encrypted using Sample-AES

### DIFF
--- a/src/demux/audio/aacdemuxer.ts
+++ b/src/demux/audio/aacdemuxer.ts
@@ -5,14 +5,21 @@ import { getId3Data } from '@svta/common-media-library/id3/getId3Data';
 import * as ADTS from './adts';
 import BaseAudioDemuxer from './base-audio-demuxer';
 import * as MpegAudio from './mpegaudio';
+import SampleAesDecrypter from '../sample-aes';
 import type { HlsConfig } from '../../config';
 import type { HlsEventEmitter } from '../../events';
-import type { DemuxedAudioTrack } from '../../types/demuxer';
+import type {
+  AACAudioSample,
+  DemuxedAudioTrack,
+  DemuxerResult,
+  KeyData,
+} from '../../types/demuxer';
 import type { ILogger } from '../../utils/logger';
 
 class AACDemuxer extends BaseAudioDemuxer {
   private readonly observer: HlsEventEmitter;
   private readonly config: HlsConfig;
+  private sampleAes: SampleAesDecrypter | null = null;
 
   constructor(observer: HlsEventEmitter, config) {
     super();
@@ -90,6 +97,29 @@ class AACDemuxer extends BaseAudioDemuxer {
     if (frame && frame.missing === 0) {
       return frame;
     }
+  }
+
+  async demuxSampleAes(
+    data: Uint8Array,
+    keyData: KeyData,
+    timeOffset: number,
+  ): Promise<DemuxerResult> {
+    const demuxResult = this.demux(data, timeOffset);
+    const sampleAes = (this.sampleAes = new SampleAesDecrypter(
+      this.observer,
+      this.config,
+      keyData,
+    ));
+
+    return new Promise((resolve) => {
+      sampleAes.decryptAacSamples(
+        demuxResult.audioTrack.samples as AACAudioSample[],
+        0,
+        () => {
+          resolve(demuxResult);
+        },
+      );
+    });
   }
 }
 


### PR DESCRIPTION
### This PR will...

Allow `hls.js` to decrypt Elementary Audio Stream of Sample-AES.

### Why is this Pull Request needed?

Aside of traditional MPEG-TS based container, Sample-AES allows carry raw encrypted audio data.

Reference:
- https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/HLS_Sample_Encryption/Encryption/Encryption.html#//apple_ref/doc/uid/TP40012862-CH2-SW22
- https://github.com/iori-rs/iori/commit/dcc88475ab6b1042ddf9903c2400d78d461144ac

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
