### PR TITLE
Add ESLint syntax rules to restrict async syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,12 @@
+const asyncKeywordConstraintMsg =
+  'The async keyword adds a `regenerator` dependency in the hls.js ES5 output not allowed in v1 due to bundle size constraints.';
+const selfVsWindowGlobalMsg =
+  'Use `self` instead of `window` to access the global context everywhere (including workers).';
+const arrayFindCompatibilityMsg =
+  'Usage of Array find methods is restricted for compatibility.';
+const arrayFindIndexCompatibilityMsg =
+  'Usage of Array findIndex methods is restricted for compatibility.';
+
 module.exports = {
   env: { browser: true, commonjs: true, es6: true },
   globals: {
@@ -27,18 +36,11 @@ module.exports = {
       2,
       {
         name: 'window',
-        message:
-          'Use `self` instead of `window` to access the global context everywhere (including workers).',
+        message: selfVsWindowGlobalMsg,
       },
       { name: 'SourceBuffer', message: 'Use `self.SourceBuffer`' },
       { name: 'setTimeout', message: 'Use `self.setTimeout`' },
       { name: 'setInterval', message: 'Use `self.setInterval`' },
-    ],
-
-    'no-restricted-properties': [
-      2,
-      { property: 'findIndex' }, // Intended to block usage of Array.prototype.findIndex
-      { property: 'find' }, // Intended to block usage of Array.prototype.find
     ],
 
     'import/first': 1,
@@ -67,6 +69,31 @@ module.exports = {
         'no-unused-vars': 0,
         'no-undef': 0,
         'no-use-before-define': 'off',
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'FunctionDeclaration[async=true]',
+            message: asyncKeywordConstraintMsg,
+          },
+          {
+            selector: 'ArrowFunctionExpression[async=true]',
+            message: asyncKeywordConstraintMsg,
+          },
+          {
+            selector: 'MethodDefinition[value.async=true]',
+            message: asyncKeywordConstraintMsg,
+          },
+          {
+            selector:
+              'MemberExpression[property.name="find"][object.type="Identifier"]',
+            message: arrayFindCompatibilityMsg,
+          },
+          {
+            selector:
+              'MemberExpression[property.name="findIndex"][object.type="Identifier"]',
+            message: arrayFindIndexCompatibilityMsg,
+          },
+        ],
         'import/order': [
           'warn',
           {
@@ -98,6 +125,8 @@ module.exports = {
         '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/no-import-type-side-effects': 'error',
         '@typescript-eslint/no-restricted-imports': 'error',
+        '@typescript-eslint/no-floating-promises': 'error',
+        '@typescript-eslint/no-misused-promises': 'error',
       },
     },
   ],

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -845,43 +845,49 @@ class AbrController extends Logger implements AbrComponentAPI {
             mediaCapabilities,
             this.supportedCache,
           );
-          levelInfo.supportedPromise.then((decodingInfo) => {
-            if (!this.hls) {
-              return;
-            }
-            levelInfo.supportedResult = decodingInfo;
-            const levels = this.hls.levels;
-            const index = levels.indexOf(levelInfo);
-            if (decodingInfo.error) {
-              this.warn(
-                `MediaCapabilities decodingInfo error: "${
-                  decodingInfo.error
-                }" for level ${index} ${stringify(decodingInfo)}`,
-              );
-            } else if (!decodingInfo.supported) {
-              this.warn(
-                `Unsupported MediaCapabilities decodingInfo result for level ${index} ${stringify(
-                  decodingInfo,
-                )}`,
-              );
-              if (index > -1 && levels.length > 1) {
-                this.log(`Removing unsupported level ${index}`);
-                this.hls.removeLevel(index);
-                if (this.hls.loadLevel === -1) {
-                  this.hls.nextLoadLevel = 0;
-                }
+          levelInfo.supportedPromise
+            .then((decodingInfo) => {
+              if (!this.hls) {
+                return;
               }
-            } else if (
-              decodingInfo.decodingInfoResults.some(
-                (info) =>
-                  info.smooth === false || info.powerEfficient === false,
-              )
-            ) {
-              this.log(
-                `MediaCapabilities decodingInfo for level ${index} not smooth or powerEfficient: ${stringify(decodingInfo)}`,
+              levelInfo.supportedResult = decodingInfo;
+              const levels = this.hls.levels;
+              const index = levels.indexOf(levelInfo);
+              if (decodingInfo.error) {
+                this.warn(
+                  `MediaCapabilities decodingInfo error: "${
+                    decodingInfo.error
+                  }" for level ${index} ${stringify(decodingInfo)}`,
+                );
+              } else if (!decodingInfo.supported) {
+                this.warn(
+                  `Unsupported MediaCapabilities decodingInfo result for level ${index} ${stringify(
+                    decodingInfo,
+                  )}`,
+                );
+                if (index > -1 && levels.length > 1) {
+                  this.log(`Removing unsupported level ${index}`);
+                  this.hls.removeLevel(index);
+                  if (this.hls.loadLevel === -1) {
+                    this.hls.nextLoadLevel = 0;
+                  }
+                }
+              } else if (
+                decodingInfo.decodingInfoResults.some(
+                  (info) =>
+                    info.smooth === false || info.powerEfficient === false,
+                )
+              ) {
+                this.log(
+                  `MediaCapabilities decodingInfo for level ${index} not smooth or powerEfficient: ${stringify(decodingInfo)}`,
+                );
+              }
+            })
+            .catch((error) => {
+              this.warn(
+                `Error handling MediaCapabilities decodingInfo: ${error}`,
               );
-            }
-          });
+            });
         } else {
           levelInfo.supportedResult = SUPPORTED_INFO_DEFAULT;
         }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -343,6 +343,7 @@ export default class BufferController extends Logger implements ComponentAPI {
       : null;
     const trackCount = trackNames ? trackNames.length : 0;
     const mediaSourceOpenCallback = () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       Promise.resolve().then(() => {
         if (this.media && this.mediaSourceOpenOrEnded) {
           this._onMediaSourceOpen();
@@ -417,6 +418,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
             >;
             this.sourceBuffers[sbIndex] = sbTuple as any;
             if (sb.updating && this.operationQueue) {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               this.operationQueue.prependBlocker(type);
             }
             this.trackSourceBuffer(type, track);

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -357,6 +357,7 @@ class EMEController extends Logger implements ComponentAPI {
     } else {
       this.warn(`Could not renew expired session. Missing pssh initData.`);
     }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.removeSession(mediaKeySessionContext);
   }
 
@@ -407,7 +408,7 @@ class EMEController extends Logger implements ComponentAPI {
     keySystemsToAttempt: KeySystems[],
   ): Promise<KeySystemFormats> {
     return new Promise((resolve, reject) => {
-      return this.getKeySystemSelectionPromise(keySystemsToAttempt)
+      this.getKeySystemSelectionPromise(keySystemsToAttempt)
         .then(({ keySystem }) => {
           const keySystemFormat = keySystemDomainToKeySystemFormat(keySystem);
           if (keySystemFormat) {
@@ -774,7 +775,9 @@ class EMEController extends Logger implements ComponentAPI {
         });
       } else if (messageType === 'license-release') {
         if (context.keySystem === KeySystems.FAIRPLAY) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.updateKeySession(context, strToUtf8array('acknowledged'));
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.removeSession(context);
         }
       } else {
@@ -864,6 +867,7 @@ class EMEController extends Logger implements ComponentAPI {
       .then(() => keyUsablePromise)
       .catch((error) => {
         licenseStatus.removeAllListeners();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.removeSession(context);
         throw error;
       })
@@ -1231,8 +1235,8 @@ class EMEController extends Logger implements ComponentAPI {
       }
       keySessionContext.licenseXhr = xhr;
 
-      this.setupLicenseXHR(xhr, url, keySessionContext, licenseChallenge).then(
-        ({ xhr, licenseChallenge }) => {
+      this.setupLicenseXHR(xhr, url, keySessionContext, licenseChallenge)
+        .then(({ xhr, licenseChallenge }) => {
           if (keySessionContext.keySystem == KeySystems.PLAYREADY) {
             licenseChallenge = this.unpackPlayReadyKeyMessage(
               xhr,
@@ -1240,8 +1244,8 @@ class EMEController extends Logger implements ComponentAPI {
             );
           }
           xhr.send(licenseChallenge);
-        },
-      );
+        })
+        .catch(reject);
     });
   }
 
@@ -1407,7 +1411,7 @@ class EMEController extends Logger implements ComponentAPI {
               () => reject(new Error(`MediaKeySession.remove() timeout`)),
               8000,
             );
-            mediaKeysSession.remove().then(resolve);
+            mediaKeysSession.remove().then(resolve).catch(reject);
           })
         : Promise.resolve();
       return removePromise

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -263,6 +263,7 @@ export default class LevelController extends BasePlaylistController {
 
     if (levels.length === 0) {
       // Dispatch error after MANIFEST_LOADED is done propagating
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       Promise.resolve().then(() => {
         if (this.hls) {
           let message = 'no level with compatible codecs found in manifest';

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1185,26 +1185,34 @@ export default class StreamController
 
   private _loadBitrateTestFrag(fragment: Fragment, level: Level) {
     fragment.bitrateTest = true;
-    this._doFragLoad(fragment, level).then((data) => {
-      const { hls } = this;
-      const frag = data?.frag;
-      if (!frag || this.fragContextChanged(frag)) {
-        return;
-      }
-      level.fragmentError = 0;
-      this.state = State.IDLE;
-      this.startFragRequested = false;
-      this.bitrateTest = false;
-      const stats = frag.stats;
-      // Bitrate tests fragments are neither parsed nor buffered
-      stats.parsing.start =
-        stats.parsing.end =
-        stats.buffering.start =
-        stats.buffering.end =
-          self.performance.now();
-      hls.trigger(Events.FRAG_LOADED, data as FragLoadedData);
-      frag.bitrateTest = false;
-    });
+    this._doFragLoad(fragment, level)
+      .then((data) => {
+        const { hls } = this;
+        const frag = data?.frag;
+        if (!frag || this.fragContextChanged(frag)) {
+          return;
+        }
+        level.fragmentError = 0;
+        this.state = State.IDLE;
+        this.startFragRequested = false;
+        this.bitrateTest = false;
+        const stats = frag.stats;
+        // Bitrate tests fragments are neither parsed nor buffered
+        stats.parsing.start =
+          stats.parsing.end =
+          stats.buffering.start =
+          stats.buffering.end =
+            self.performance.now();
+        hls.trigger(Events.FRAG_LOADED, data as FragLoadedData);
+        frag.bitrateTest = false;
+      })
+      .catch((reason) => {
+        if (this.state === State.STOPPED || this.state === State.ERROR) {
+          return;
+        }
+        this.warn(reason);
+        this.resetFragmentLoading(fragment);
+      });
   }
 
   private _handleTransmuxComplete(transmuxResult: TransmuxerResult) {

--- a/src/demux/sample-aes.ts
+++ b/src/demux/sample-aes.ts
@@ -56,14 +56,16 @@ class SampleAesDecrypter {
       encryptedData.byteOffset + encryptedData.length,
     );
 
-    this.decryptBuffer(encryptedBuffer).then((decryptedBuffer: ArrayBuffer) => {
-      const decryptedData = new Uint8Array(decryptedBuffer);
-      curUnit.set(decryptedData, 16);
+    this.decryptBuffer(encryptedBuffer)
+      .then((decryptedBuffer: ArrayBuffer) => {
+        const decryptedData = new Uint8Array(decryptedBuffer);
+        curUnit.set(decryptedData, 16);
 
-      if (!this.decrypter.isSync()) {
-        this.decryptAacSamples(samples, sampleIndex + 1, callback);
-      }
-    });
+        if (!this.decrypter.isSync()) {
+          this.decryptAacSamples(samples, sampleIndex + 1, callback);
+        }
+      })
+      .catch(callback);
   }
 
   decryptAacSamples(
@@ -136,13 +138,15 @@ class SampleAesDecrypter {
     const decodedData = discardEPB(curUnit.data);
     const encryptedData = this.getAvcEncryptedData(decodedData);
 
-    this.decryptBuffer(encryptedData.buffer).then((decryptedBuffer) => {
-      curUnit.data = this.getAvcDecryptedUnit(decodedData, decryptedBuffer);
+    this.decryptBuffer(encryptedData.buffer)
+      .then((decryptedBuffer) => {
+        curUnit.data = this.getAvcDecryptedUnit(decodedData, decryptedBuffer);
 
-      if (!this.decrypter.isSync()) {
-        this.decryptAvcSamples(samples, sampleIndex, unitIndex + 1, callback);
-      }
-    });
+        if (!this.decrypter.isSync()) {
+          this.decryptAvcSamples(samples, sampleIndex, unitIndex + 1, callback);
+        }
+      })
+      .catch(callback);
   }
 
   decryptAvcSamples(

--- a/src/utils/mediacapabilities-helper.ts
+++ b/src/utils/mediacapabilities-helper.ts
@@ -16,16 +16,26 @@ export type MediaDecodingInfo = {
   error?: Error;
 };
 
+// @ts-ignore
+const supportedResult: MediaCapabilitiesDecodingInfo = {
+  supported: true,
+  powerEfficient: true,
+  smooth: true,
+  // keySystemAccess: null,
+};
+
+// @ts-ignore
+const unsupportedResult: MediaCapabilitiesDecodingInfo = {
+  supported: false,
+  smooth: false,
+  powerEfficient: false,
+  // keySystemAccess: null,
+};
+
 export const SUPPORTED_INFO_DEFAULT: MediaDecodingInfo = {
   supported: true,
   configurations: [] as MediaDecodingConfiguration[],
-  decodingInfoResults: [
-    {
-      supported: true,
-      powerEfficient: true,
-      smooth: true,
-    },
-  ],
+  decodingInfoResults: [supportedResult],
 } as const;
 
 export function getUnsupportedResult(
@@ -35,13 +45,7 @@ export function getUnsupportedResult(
   return {
     supported: false,
     configurations,
-    decodingInfoResults: [
-      {
-        supported: false,
-        smooth: false,
-        powerEfficient: false,
-      },
-    ],
+    decodingInfoResults: [unsupportedResult],
     error,
   };
 }
@@ -113,7 +117,10 @@ export function getMediaDecodingInfoPromise(
   level: Level,
   audioTracksByGroup: AudioTracksByGroup,
   mediaCapabilities: MediaCapabilities | undefined,
-  cache: Record<string, Promise<MediaCapabilitiesDecodingInfo>> = {},
+  cache: Record<
+    string,
+    Promise<MediaCapabilitiesDecodingInfo> | undefined
+  > = {},
 ): Promise<MediaDecodingInfo> {
   const videoCodecs = level.videoCodec;
   if ((!videoCodecs && !level.audioCodec) || !mediaCapabilities) {

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -469,17 +469,21 @@ describe('EMEController', function () {
     emeController.onMediaAttached(Events.MEDIA_ATTACHED, {
       media: media as any as HTMLMediaElement,
     });
-    emeController.loadKey({
-      frag: {},
-      keyInfo: {
-        decryptdata: {
-          encrypted: true,
-          method: 'SAMPLE-AES',
-          uri: 'data://key-uri',
-          keyId: new Uint8Array(16),
+    emeController
+      .loadKey({
+        frag: {},
+        keyInfo: {
+          decryptdata: {
+            encrypted: true,
+            method: 'SAMPLE-AES',
+            uri: 'data://key-uri',
+            keyId: new Uint8Array(16),
+          },
         },
-      },
-    } as any);
+      } as any)
+      .catch((error) => {
+        // expected?
+      });
 
     expect(
       emeController.keyIdToKeySessionPromise[
@@ -545,17 +549,21 @@ describe('EMEController', function () {
     emeController.onMediaAttached(Events.MEDIA_ATTACHED, {
       media: media as any as HTMLMediaElement,
     });
-    emeController.loadKey({
-      frag: {},
-      keyInfo: {
-        decryptdata: {
-          encrypted: true,
-          method: 'SAMPLE-AES',
-          uri: 'data://key-uri',
-          keyId: new Uint8Array(16),
+    emeController
+      .loadKey({
+        frag: {},
+        keyInfo: {
+          decryptdata: {
+            encrypted: true,
+            method: 'SAMPLE-AES',
+            uri: 'data://key-uri',
+            keyId: new Uint8Array(16),
+          },
         },
-      },
-    } as any);
+      } as any)
+      .catch((error) => {
+        // expected?
+      });
 
     expect(
       emeController.keyIdToKeySessionPromise[

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -266,9 +266,10 @@ describe('ErrorController Integration Tests', function () {
       hls.loadSource('noSegmentsVod.m3u8');
       hls.stopLoad.should.have.been.calledOnce;
       return new Promise((resolve, reject) => {
-        hls.on(Events.ERROR, (event, data) =>
-          Promise.resolve().then(() => resolve(data)),
-        );
+        hls.on(Events.ERROR, (event, data) => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          Promise.resolve().then(() => resolve(data));
+        });
         hls.on(Events.LEVEL_LOADED, () =>
           reject(
             new Error(
@@ -713,6 +714,7 @@ segment.mp4
       hls.on(Events.FRAG_LOADING, loadingEventCallback(server, timers));
       hls.on(Events.ERROR, (event, data) => {
         errors.push(data);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => timers.tick(2000));
       });
       return new Promise((resolve, reject) => {
@@ -823,6 +825,7 @@ segment.mp4
       hls.on(Events.FRAG_LOADING, loadingEventCallback(server, timers));
       hls.on(Events.ERROR, (event, data) => {
         errors.push(data);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => timers.tick(2000));
       });
       return new Promise((resolve, reject) => {
@@ -968,6 +971,7 @@ function setupMockServerResponses(server: sinon.SinonFakeServer) {
 
 function loadingEventCallback(server, timers) {
   return (event, data) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     Promise.resolve().then(() => {
       server.respond();
     });


### PR DESCRIPTION
### This PR will...
Add ESLint syntax rules to restrict async syntax, no-floating-promises, and no-misused-promises

### Why is this Pull Request needed?

ESlint error messages explain reasoning:

- The async keyword adds a `regenerator` dependency in the hls.js ES5 output not allowed in v1 due to bundle size constraints.
- Use `self` instead of `window` to access the global context everywhere (including workers).
- Usage of Array find methods is restricted for compatibility.
- Usage of Array findIndex methods is restricted for compatibility.

Most of the line changes in files are WS.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
