### PR TITLE
fix: align AUDIO_TRACK_LOAD_TIMEOUT with timeoutRetry policy

### DIFF
--- a/src/utils/error-helper.ts
+++ b/src/utils/error-helper.ts
@@ -9,6 +9,9 @@ export function isTimeoutError(error: ErrorData): boolean {
     case ErrorDetails.KEY_LOAD_TIMEOUT:
     case ErrorDetails.LEVEL_LOAD_TIMEOUT:
     case ErrorDetails.MANIFEST_LOAD_TIMEOUT:
+    case ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
+    case ErrorDetails.SUBTITLE_TRACK_LOAD_TIMEOUT:
+    case ErrorDetails.ASSET_LIST_LOAD_TIMEOUT:
       return true;
   }
   return false;


### PR DESCRIPTION
…adPolicy issue-7420

### This PR will...
This PR fixes an inconsistency in the retry policy for timeouts
```
export function isTimeoutError(error: ErrorData): boolean {
  switch (error.details) {
    case ErrorDetails.FRAG_LOAD_TIMEOUT:
    case ErrorDetails.KEY_LOAD_TIMEOUT:
    case ErrorDetails.LEVEL_LOAD_TIMEOUT:
    case ErrorDetails.MANIFEST_LOAD_TIMEOUT:
    case ErrorDetails.AUDIO_TRACK_LOAD_TIMEOUT:
    case ErrorDetails.SUBTITLE_TRACK_LOAD_TIMEOUT:
    case ErrorDetails.ASSET_LIST_LOAD_TIMEOUT:
      return true;
  }
  return false;
}
```
### Why is this Pull Request needed?
Timeout events "AUDIO_TRACK_LOAD_TIMEOUT, SUBTITLE_TRACK_LOAD_TIMEOUT, ASSET_LIST_LOAD_TIMEOUT" should consistently follow `timeoutRetry`, not `errorRetry`