### PR TITLE
Allow removing TextTracks created by hls.js

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -4015,7 +4015,6 @@ export interface MediaKeySessionContext {
 export type MediaOverrides = {
     duration?: number;
     endOfStream?: boolean;
-    cueRemoval?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "MediaPlaylist" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4056,6 +4055,8 @@ export interface MediaPlaylist {
     name: string;
     // (undocumented)
     textCodec?: string;
+    // (undocumented)
+    trackNode?: HTMLTrackElement;
     // (undocumented)
     type: MediaPlaylistType | 'main';
     // (undocumented)

--- a/demo/main.js
+++ b/demo/main.js
@@ -43,7 +43,7 @@ let stopOnStall = getDemoConfigPropOrDefault('stopOnStall', false);
 let bufferingIdx = -1;
 let selectedTestStream = null;
 
-let video = document.querySelector('#video');
+const video = document.querySelector('#video');
 const startTime = Date.now();
 
 let lastSeekingIdx;
@@ -222,6 +222,7 @@ $(document).ready(function () {
   $('#metricsButtonWindow').toggle(self.windowSliding);
   $('#metricsButtonFixed').toggle(!self.windowSliding);
 
+  addVideoEventListeners(video);
   loadSelectedStream();
 
   let tabIndexesCSV = localStorage.getItem(STORAGE_KEYS.demo_tabs);
@@ -353,32 +354,7 @@ function loadSelectedStream() {
 
   logStatus('Loading manifest and attaching video element...');
 
-  const expiredTracks = [].filter.call(
-    video.textTracks,
-    (track) => track.kind !== 'metadata'
-  );
-  if (expiredTracks.length) {
-    const kinds = expiredTracks
-      .map((track) => track.kind)
-      .filter((kind, index, self) => self.indexOf(kind) === index);
-    logStatus(
-      `Replacing video element to remove ${kinds.join(' and ')} text tracks`
-    );
-    const videoWithExpiredTextTracks = video;
-    video = videoWithExpiredTextTracks.cloneNode(false);
-    video.removeAttribute('src');
-    video.volume = videoWithExpiredTextTracks.volume;
-    video.muted = videoWithExpiredTextTracks.muted;
-    videoWithExpiredTextTracks.parentNode.insertBefore(
-      video,
-      videoWithExpiredTextTracks
-    );
-    videoWithExpiredTextTracks.parentNode.removeChild(
-      videoWithExpiredTextTracks
-    );
-  }
   addChartEventListeners(hls);
-  addVideoEventListeners(video);
 
   hls.loadSource(url);
   hls.autoLevelCapping = levelCapping;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -544,8 +544,6 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       }
       this.media = null;
     }
-
-    this.hls.trigger(Events.MEDIA_DETACHED, data);
   }
 
   private onBufferReset() {

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -871,7 +871,6 @@ export default class InterstitialsController
       dataToAttach.overrides = {
         duration: schedule.duration,
         endOfStream: !isAssetPlayer || isAssetAtEndOfSchedule,
-        cueRemoval: !isAssetPlayer,
       };
     }
     player.attachMedia(dataToAttach);

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -480,8 +480,10 @@ export default class Hls implements HlsEventEmitter {
    */
   detachMedia() {
     this.logger.log('detachMedia');
-    this.trigger(Events.MEDIA_DETACHING, {});
+    const data = {};
+    this.trigger(Events.MEDIA_DETACHING, data);
     this._media = null;
+    this.trigger(Events.MEDIA_DETACHED, data);
   }
 
   /**
@@ -490,7 +492,9 @@ export default class Hls implements HlsEventEmitter {
   transferMedia(): AttachMediaSourceData | null {
     this._media = null;
     const transferMedia = this.bufferController.transferMedia();
-    this.trigger(Events.MEDIA_DETACHING, { transferMedia });
+    const data = { transferMedia };
+    this.trigger(Events.MEDIA_DETACHING, data);
+    this.trigger(Events.MEDIA_DETACHED, data);
     return transferMedia;
   }
 

--- a/src/types/buffer.ts
+++ b/src/types/buffer.ts
@@ -74,7 +74,6 @@ export type SourceBuffersTuple = [
 export type MediaOverrides = {
   duration?: number;
   endOfStream?: boolean;
-  cueRemoval?: boolean;
 };
 
 export interface BufferOperationQueues {

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -70,6 +70,8 @@ export interface MediaPlaylist {
   url: string;
   videoCodec?: string;
   width?: number;
+  // keep a reference to the track node that is associated with this MediaPlaylist
+  trackNode?: HTMLTrackElement;
 }
 
 export interface MediaAttributes extends AttrList {

--- a/src/utils/media-option-attributes.ts
+++ b/src/utils/media-option-attributes.ts
@@ -47,15 +47,3 @@ export function mediaAttributesIdentical(
       attrs1[subtitleAttribute] !== attrs2[subtitleAttribute],
   );
 }
-
-export function subtitleTrackMatchesTextTrack(
-  subtitleTrack: Pick<MediaPlaylist, 'name' | 'lang' | 'attrs'>,
-  textTrack: TextTrack,
-) {
-  return (
-    textTrack.label.toLowerCase() === subtitleTrack.name.toLowerCase() &&
-    (!textTrack.language ||
-      textTrack.language.toLowerCase() ===
-        (subtitleTrack.lang || '').toLowerCase())
-  );
-}

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -19,9 +19,9 @@ export function createTrackNode(
   }
   // To avoid an issue of the built-in captions menu in Chrome
   // https://github.com/video-dev/hls.js/issues/2198#issuecomment-761614248
-  if (navigator.userAgent.includes('Chrome/')) {
-    el.src = 'data:,WEBVTT';
-  }
+  // It also prevents Safari from removing cues after setting track.mode to `hidden` or `disabled`
+  // https://github.com/video-dev/hls.js/pull/7515#issuecomment-3251091932
+  el.src = 'data:,WEBVTT';
   el.track.mode = mode;
   videoEl.appendChild(el);
   return el;

--- a/tests/index.js
+++ b/tests/index.js
@@ -17,6 +17,7 @@ import './unit/controller/ewma-bandwidth-estimator';
 import './unit/controller/fragment-finders';
 import './unit/controller/fragment-tracker';
 import './unit/controller/gap-controller';
+import './unit/controller/id3-track-controller';
 import './unit/controller/interstitials-controller';
 import './unit/controller/latency-controller';
 import './unit/controller/level-controller';

--- a/tests/unit/controller/id3-track-controller.js
+++ b/tests/unit/controller/id3-track-controller.js
@@ -1,0 +1,28 @@
+import ID3TrackController from '../../../src/controller/id3-track-controller';
+import Hls from '../../../src/hls';
+import { Events } from '../../../src/events';
+
+describe('TimelineController', function () {
+  let id3TrackController;
+  let hls;
+  let videoElement;
+
+  beforeEach(function () {
+    videoElement = document.createElement('video');
+    hls = new Hls({ enableID3MetadataCues: true });
+    id3TrackController = new ID3TrackController(hls);
+    id3TrackController.media = videoElement;
+  });
+
+  describe('createCaptionsTrack', function () {
+    it('should create new TextTrack in onFragParsingMetadata() and remove it in onMediaDetaching()', function () {
+      expect(videoElement.textTracks.length).to.equal(0);
+      id3TrackController.onFragParsingMetadata(Events.FRAG_PARSING_METADATA, {
+        samples: [],
+      });
+      expect(videoElement.textTracks.length).to.equal(1);
+      id3TrackController.onMediaDetaching(Events.MEDIA_DETACHING, {});
+      expect(videoElement.textTracks.length).to.equal(0);
+    });
+  });
+});

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1112,6 +1112,7 @@ fileSequence5.mp4`;
         Events.INTERSTITIAL_STARTED,
         Events.INTERSTITIAL_ASSET_STARTED,
         Events.MEDIA_DETACHING,
+        Events.MEDIA_DETACHED,
       ];
       expect(callsWithPrerollAfterAttach).to.deep.equal(
         expectedEvents,
@@ -1346,6 +1347,7 @@ fileSequence6.mp4`;
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );
@@ -1460,6 +1462,7 @@ fileSequence6.mp4`;
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );
@@ -1839,6 +1842,7 @@ fileSequence6.mp4
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );
@@ -2012,6 +2016,7 @@ fileSequence6.mp4`;
           Events.INTERSTITIAL_ASSET_PLAYER_CREATED,
           Events.INTERSTITIAL_ASSET_STARTED,
           Events.MEDIA_DETACHING,
+          Events.MEDIA_DETACHED,
         ],
         `Actual events after asset-list`,
       );

--- a/tests/unit/controller/timeline-controller.ts
+++ b/tests/unit/controller/timeline-controller.ts
@@ -10,177 +10,25 @@ const expect = chai.expect;
 describe('TimelineController', function () {
   let timelineController;
   let hls;
+  let videoElement;
 
   beforeEach(function () {
+    videoElement = document.createElement('video');
     hls = new Hls();
     hls.config.enableWebVTT = true;
-    hls.config.renderNatively = true;
+    hls.config.renderTextTracksNatively = true;
     timelineController = new TimelineController(hls);
-    timelineController.media = document.createElement('video');
+    timelineController.config.renderTextTracksNatively = true;
+    timelineController.media = videoElement;
   });
 
-  describe('reuse text track', function () {
-    it('should reuse text track when track order is same between manifests', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(
-        Events.SUBTITLE_TRACKS_UPDATED,
-        {
-          subtitleTracks: [
-            { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
-            { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
-          ],
-        },
-      );
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].label).to.equal('en');
-      expect(timelineController.textTracks[1].label).to.equal('ru');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-
-      timelineController.onSubtitleTracksUpdated(
-        Events.SUBTITLE_TRACKS_UPDATED,
-        {
-          subtitleTracks: [
-            { id: 0, name: 'en', attrs: { LANGUAGE: 'en', NAME: 'en' } },
-            { id: 1, name: 'ru', attrs: { LANGUAGE: 'ru', NAME: 'ru' } },
-          ],
-        },
-      );
-
-      // text tracks model contain only newly added manifest tracks, in same order
-      expect(timelineController.textTracks[0].label).to.equal('en');
-      expect(timelineController.textTracks[1].label).to.equal('ru');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the previously added text tracks, in same order as the manifest order
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-    });
-
-    it('should reuse text track when track order is not same between manifests', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            lang: 'en',
-            attrs: { LANGUAGE: 'en', NAME: 'en' },
-          },
-          {
-            id: 1,
-            name: 'ru',
-            lang: 'ru',
-            attrs: { LANGUAGE: 'ru', NAME: 'ru' },
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].label).to.equal('en');
-      expect(timelineController.textTracks[1].label).to.equal('ru');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'ru',
-            lang: 'ru',
-            attrs: { LANGUAGE: 'ru', NAME: 'ru' },
-          },
-          {
-            id: 1,
-            name: 'en',
-            lang: 'en',
-            attrs: { LANGUAGE: 'en', NAME: 'en' },
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order
-      expect(timelineController.textTracks[0].label).to.equal('ru');
-      expect(timelineController.textTracks[1].label).to.equal('en');
-      expect(timelineController.textTracks.length).to.equal(2);
-      // text tracks of the media contain the previously added text tracks).to.equal(in opposite order to the manifest order
-      expect(timelineController.media.textTracks[0].label).to.equal('en');
-      expect(timelineController.media.textTracks[1].label).to.equal('ru');
-      expect(timelineController.media.textTracks.length).to.equal(2);
-    });
-  });
-
-  describe('text track kind', function () {
-    it('should be kind captions when there is both transcribes-spoken-dialog and describes-music-and-sound', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-      const characteristics =
-        'public.accessibility.transcribes-spoken-dialog,public.accessibility.describes-music-and-sound';
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            characteristics,
-            attrs: {
-              CHARACTERISTICS: characteristics,
-            },
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].kind).to.equal('captions');
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].kind).to.equal('captions');
-    });
-
-    it('should be kind subtitles when there is no describes-music-and-sound', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            attrs: {
-              CHARACTERISTICS: 'public.accessibility.transcribes-spoken-dialog',
-            },
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].kind).to.equal('subtitles');
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].kind).to.equal('subtitles');
-    });
-
-    it('should be kind subtitles when there is no CHARACTERISTICS', function () {
-      hls.subtitleTrackController = { subtitleDisplay: false };
-
-      timelineController.onSubtitleTracksUpdated(Events.MANIFEST_LOADED, {
-        subtitleTracks: [
-          {
-            id: 0,
-            name: 'en',
-            attrs: {},
-          },
-        ],
-      });
-
-      // text tracks model contain only newly added manifest tracks, in same order as in manifest
-      expect(timelineController.textTracks[0].kind).to.equal('subtitles');
-      // text tracks of the media contain the newly added text tracks
-      expect(timelineController.media.textTracks[0].kind).to.equal('subtitles');
+  describe('createCaptionsTrack', function () {
+    it('should create new TextTrack after calling and remove it when detaching', function () {
+      expect(videoElement.textTracks.length).to.equal(0);
+      timelineController.createCaptionsTrack('textTrack1');
+      expect(videoElement.textTracks.length).to.equal(1);
+      timelineController.onMediaDetaching(Events.MEDIA_DETACHING, {});
+      expect(videoElement.textTracks.length).to.equal(0);
     });
   });
 });

--- a/tests/unit/utils/texttrack-utils.js
+++ b/tests/unit/utils/texttrack-utils.js
@@ -1,8 +1,4 @@
-import {
-  sendAddTrackEvent,
-  clearCurrentCues,
-} from '../../../src/utils/texttrack-utils';
-import sinon from 'sinon';
+import { removeCuesInRange } from '../../../src/utils/texttrack-utils';
 
 describe('text track utils', function () {
   const cues = [
@@ -29,42 +25,14 @@ describe('text track utils', function () {
     });
   });
 
-  describe('synthetic addtrack event', function () {
-    it('should have the provided track as data', function (done) {
-      const dispatchSpy = sinon.spy(video, 'dispatchEvent');
-      video.addEventListener('addtrack', function (e) {
-        expect(e.track).to.equal(track);
-        done();
-      });
-
-      sendAddTrackEvent(track, video);
-      expect(dispatchSpy.calledOnce).to.be.true;
-    });
-
-    it('should fallback to document.createEvent if window.Event constructor throws', function (done) {
-      const stub = sinon.stub(self, 'Event');
-      stub.throws();
-
-      const spy = sinon.spy(document, 'createEvent');
-
-      video.addEventListener('addtrack', function (e) {
-        expect(e.track).to.equal(track);
-        done();
-      });
-
-      sendAddTrackEvent(track, video);
-      expect(spy.calledOnce).to.be.true;
-    });
-  });
-
   describe('clear current cues', function () {
     it('should not fail with empty cue list', function () {
       const emptyTrack = video.addTextTrack('subtitles', 'empty');
-      expect(clearCurrentCues(emptyTrack)).to.not.throw;
+      expect(removeCuesInRange(emptyTrack, 0, 10)).to.not.throw;
     });
 
     it('should clear the cues from track', function () {
-      clearCurrentCues(track);
+      removeCuesInRange(track, 0, 10);
       expect(track.cues.length).to.equal(0);
     });
   });


### PR DESCRIPTION
Allow removing TextTracks created by hls.js
### This PR will...

- use `appendChild` instead of `addTextTrack` to allow reverse operation
- replace track flush and reuse workflow with simple removal
- add `trackNode` field in `MediaPlaylist` to indicate associated `TextTrack`
- fix `MEDIA_DETACHED` event in wrong order and sometimes not triggering

### Why is this Pull Request needed?

This PR allows video elements to have the same lifecycle as hls.js instances. After detaching, you may attach them to new hls.js instances with nothing to worry about. It also fixed a bug caused by track reuse, where content overlapping occurs if a video contains multiple captions sharing the same language and label. eg: https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8

### Are there any points in the code the reviewer needs to double check?

Yes. Since the changes involve more than one place, extensive testing from multiple aspects may be necessary to ensure no issues are left behind. Especially I'm not sure whether it works well with `transferMedia()`

### Resolves issues:
https://github.com/video-dev/hls.js/issues/2198

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md