### PR TITLE
Multi-key handling #7474

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1104,7 +1104,7 @@ export const enum DecrypterAesMode {
 export type DRMSystemConfiguration = {
     licenseUrl: string;
     serverCertificateUrl?: string;
-    generateRequest?: (this: Hls, initDataType: string, initData: ArrayBuffer | null, keyContext: MediaKeySessionContext) => {
+    generateRequest?: (this: Hls, initDataType: string, initData: ArrayBuffer | null, keyContext: MediaKeySessionContextAndLevelKey) => {
         initDataType: string;
         initData: ArrayBuffer | null;
     } | undefined | never;
@@ -1172,6 +1172,8 @@ export class EMEController extends Logger implements ComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
+    getKeyStatus(decryptdata: LevelKey): MediaKeyStatus | undefined;
+    // (undocumented)
     getKeySystemAccess(keySystemsToAttempt: KeySystems[]): Promise<void>;
     // (undocumented)
     getSelectedKeySystemFormats(): KeySystemFormats[];
@@ -1187,8 +1189,8 @@ export class EMEController extends Logger implements ComponentAPI {
 //
 // @public (undocumented)
 export type EMEControllerConfig = {
-    licenseXhrSetup?: (this: Hls, xhr: XMLHttpRequest, url: string, keyContext: MediaKeySessionContext, licenseChallenge: Uint8Array) => void | Uint8Array | Promise<Uint8Array | void>;
-    licenseResponseCallback?: (this: Hls, xhr: XMLHttpRequest, url: string, keyContext: MediaKeySessionContext) => ArrayBuffer;
+    licenseXhrSetup?: (this: Hls, xhr: XMLHttpRequest, url: string, keyContext: MediaKeySessionContextAndLevelKey, licenseChallenge: Uint8Array) => void | Uint8Array | Promise<Uint8Array | void>;
+    licenseResponseCallback?: (this: Hls, xhr: XMLHttpRequest, url: string, keyContext: MediaKeySessionContextAndLevelKey) => ArrayBuffer;
     emeEnabled: boolean;
     widevineLicenseUrl?: string;
     drmSystems: DRMSystemsConfiguration | undefined;
@@ -3381,6 +3383,8 @@ export class LevelKey implements DecryptData {
     // (undocumented)
     pssh: Uint8Array<ArrayBuffer> | null;
     // (undocumented)
+    static setKeyIdForUri(uri: string, keyId: Uint8Array<ArrayBuffer>): void;
+    // (undocumented)
     readonly uri: string;
 }
 
@@ -3992,11 +3996,13 @@ export type MediaKeyFunc = (keySystem: KeySystems, supportedConfigurations: Medi
 // @public (undocumented)
 export interface MediaKeySessionContext {
     // (undocumented)
-    decryptdata: LevelKey;
-    // (undocumented)
-    keyStatus: MediaKeyStatus;
+    keyStatuses: {
+        [keyId: string]: MediaKeyStatus;
+    };
     // (undocumented)
     keySystem: KeySystems;
+    // (undocumented)
+    levelKeys: LevelKey[];
     // (undocumented)
     licenseXhr?: XMLHttpRequest;
     // (undocumented)
@@ -5005,6 +5011,10 @@ export class XhrLoader implements Loader<LoaderContext> {
     // (undocumented)
     stats: LoaderStats;
 }
+
+// Warnings were encountered during analysis:
+//
+// src/config.ts:91:3 - (ae-forgotten-export) The symbol "MediaKeySessionContextAndLevelKey" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ import FetchLoader, { fetchSupported } from './utils/fetch-loader';
 import { requestMediaKeySystemAccess } from './utils/mediakeys-helper';
 import { stringify } from './utils/safe-json-stringify';
 import XhrLoader from './utils/xhr-loader';
-import type { MediaKeySessionContext } from './controller/eme-controller';
+import type { MediaKeySessionContextAndLevelKey } from './controller/eme-controller';
 import type Hls from './hls';
 import type {
   FragmentLoaderContext,
@@ -92,7 +92,7 @@ export type DRMSystemConfiguration = {
     this: Hls,
     initDataType: string,
     initData: ArrayBuffer | null,
-    keyContext: MediaKeySessionContext,
+    keyContext: MediaKeySessionContextAndLevelKey,
   ) =>
     | { initDataType: string; initData: ArrayBuffer | null }
     | undefined
@@ -108,14 +108,14 @@ export type EMEControllerConfig = {
     this: Hls,
     xhr: XMLHttpRequest,
     url: string,
-    keyContext: MediaKeySessionContext,
+    keyContext: MediaKeySessionContextAndLevelKey,
     licenseChallenge: Uint8Array,
   ) => void | Uint8Array | Promise<Uint8Array | void>;
   licenseResponseCallback?: (
     this: Hls,
     xhr: XMLHttpRequest,
     url: string,
-    keyContext: MediaKeySessionContext,
+    keyContext: MediaKeySessionContextAndLevelKey,
   ) => ArrayBuffer;
   emeEnabled: boolean;
   widevineLicenseUrl?: string;

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -55,14 +55,25 @@ interface KeySystemAccessPromises {
 
 export interface MediaKeySessionContext {
   keySystem: KeySystems;
+  levelKeys: LevelKey[];
   mediaKeys: MediaKeys;
-  decryptdata: LevelKey; // FIXME: LevelKey has a URI which should be bound to the session, but is dependent one KeyId specifically. Session context should be allowed to adopt multiple level keys.
   mediaKeysSession: MediaKeySession;
-  keyStatus: MediaKeyStatus; // FIXME: MediaKeySession can manage multiple keys with each with its own status
+  keyStatuses: { [keyId: string]: MediaKeyStatus };
   licenseXhr?: XMLHttpRequest;
   _onmessage?: (this: MediaKeySession, ev: MediaKeyMessageEvent) => any;
   _onkeystatuseschange?: (this: MediaKeySession, ev: Event) => any;
 }
+
+// TODO: move to config?
+export type MediaKeySessionContextAndLevelKey = {
+  decryptdata: LevelKey; // soft-deprecated
+  keySystem: KeySystems;
+  levelKeys: LevelKey[];
+  mediaKeys: MediaKeys;
+  mediaKeysSession: MediaKeySession;
+  keyStatuses: { [keyId: string]: MediaKeyStatus };
+  licenseXhr?: XMLHttpRequest;
+};
 
 /**
  * Controller to deal with encrypted media extensions (EME)
@@ -87,14 +98,16 @@ class EMEController extends Logger implements ComponentAPI {
   } = {};
   private _requestLicenseFailureCount: number = 0;
   private mediaKeySessions: MediaKeySessionContext[] = [];
-  private keyIdToKeySessionPromise: {
-    [keyId: string]: Promise<MediaKeySessionContext> | undefined;
+  private keyUriToSessionPromise: {
+    [keyUri: string]: Promise<MediaKeySessionContext> | undefined;
+  } = {};
+  private keyUriToLevelKeys: {
+    [keyUri: string]: LevelKey[] | undefined;
   } = {};
   private mediaKeys: MediaKeys | null = null;
   private setMediaKeysQueue: Promise<void>[] = EMEController.CDMCleanupPromise
     ? [EMEController.CDMCleanupPromise]
     : [];
-  private bannedKeyIds: { [keyId: string]: MediaKeyStatus | undefined } = {};
 
   constructor(hls: Hls) {
     super('eme', hls.logger);
@@ -112,7 +125,9 @@ class EMEController extends Logger implements ComponentAPI {
     config.licenseXhrSetup = config.licenseResponseCallback = undefined;
     config.drmSystems = config.drmSystemOptions = {};
     // @ts-ignore
-    this.hls = this.config = this.keyIdToKeySessionPromise = null;
+    this.hls = this.config = null;
+    // @ts-ignore
+    this.keyUriToSessionPromise = this.keyUriToLevelKeys = null;
     // @ts-ignore
     this.onMediaEncrypted = this.onWaitingForKey = null;
   }
@@ -310,29 +325,32 @@ class EMEController extends Logger implements ComponentAPI {
     return keySystemAccess.then(() => keySystemAccessPromises!.mediaKeys!);
   }
 
-  private createMediaKeySessionContext({
-    decryptdata,
-    keySystem,
-    mediaKeys,
-  }: {
-    decryptdata: LevelKey;
-    keySystem: KeySystems;
-    mediaKeys: MediaKeys;
-  }): MediaKeySessionContext {
+  private createMediaKeySessionContext(
+    {
+      levelKeys,
+      keySystem,
+      mediaKeys,
+    }: {
+      levelKeys: LevelKey[];
+      keySystem: KeySystems;
+      mediaKeys: MediaKeys;
+    },
+    decryptdata: LevelKey,
+  ): MediaKeySessionContext {
     this.log(
       `Creating key-system session "${keySystem}" keyId: ${arrayToHex(
         decryptdata.keyId || ([] as number[]),
-      )}`,
+      )} keyUri: ${decryptdata.uri}`,
     );
 
     const mediaKeysSession = mediaKeys.createSession();
 
     const mediaKeySessionContext: MediaKeySessionContext = {
-      decryptdata,
+      levelKeys,
       keySystem,
       mediaKeys,
       mediaKeysSession,
-      keyStatus: 'status-pending',
+      keyStatuses: {},
     };
 
     this.mediaKeySessions.push(mediaKeySessionContext);
@@ -340,20 +358,24 @@ class EMEController extends Logger implements ComponentAPI {
     return mediaKeySessionContext;
   }
 
-  private renewKeySession(mediaKeySessionContext: MediaKeySessionContext) {
-    const decryptdata = mediaKeySessionContext.decryptdata;
-    if (decryptdata.pssh) {
+  private renewKeySession(
+    mediaKeySessionContext: MediaKeySessionContext,
+    levelKey: LevelKey,
+  ) {
+    if (levelKey.pssh) {
       const keySessionContext = this.createMediaKeySessionContext(
         mediaKeySessionContext,
+        levelKey,
       );
-      const keyId = this.getKeyIdString(decryptdata);
+      const keyUri = levelKey.uri;
       const scheme = 'cenc';
-      this.keyIdToKeySessionPromise[keyId] =
+      this.keyUriToSessionPromise[keyUri] =
         this.generateRequestWithPreferredKeySession(
           keySessionContext,
           scheme,
-          decryptdata.pssh.buffer,
+          levelKey.pssh.buffer,
           'expired',
+          levelKey,
         );
     } else {
       this.warn(`Could not renew expired session. Missing pssh initData.`);
@@ -374,12 +396,13 @@ class EMEController extends Logger implements ComponentAPI {
 
   private updateKeySession(
     mediaKeySessionContext: MediaKeySessionContext,
+    decryptdata: LevelKey,
     data: Uint8Array<ArrayBuffer>,
   ): Promise<void> {
     const keySession = mediaKeySessionContext.mediaKeysSession;
     this.log(
       `Updating key-session "${keySession.sessionId}" for keyId ${arrayToHex(
-        mediaKeySessionContext.decryptdata.keyId || [],
+        decryptdata.keyId || [],
       )}
       } (data length: ${data.byteLength})`,
     );
@@ -450,25 +473,50 @@ class EMEController extends Logger implements ComponentAPI {
     return this.selectKeySystem(keySystemsToAttempt);
   }
 
-  public loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext> {
-    const decryptdata = data.keyInfo.decryptdata;
+  public getKeyStatus(decryptdata: LevelKey): MediaKeyStatus | undefined {
+    const { mediaKeySessions } = this;
+    for (let i = 0; i < mediaKeySessions.length; i++) {
+      if (mediaKeySessions[i].levelKeys[0].uri === decryptdata.uri) {
+        return decryptdata.keyId
+          ? mediaKeySessions[i].mediaKeysSession.keyStatuses.get(
+              decryptdata.keyId,
+            )
+          : mediaKeySessions[i].keyStatuses[this.getKeyIdString(decryptdata)];
+      }
+    }
+    return undefined;
+  }
 
-    const keyId = this.getKeyIdString(decryptdata);
-    const badStatus = this.bannedKeyIds[keyId];
-    if (badStatus) {
-      const error = getKeyStatusError(badStatus, decryptdata);
+  public loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext> {
+    const levelKey = data.keyInfo.decryptdata;
+
+    // Error immediately when encountering a key ID with this status again
+    const status = this.getKeyStatus(levelKey);
+    if (status === 'internal-error') {
+      const error = getKeyStatusError(status, levelKey);
       this.handleError(error, data.frag);
       return Promise.reject(error);
     }
-    const keyDetails = `(keyId: ${keyId} format: "${decryptdata.keyFormat}" method: ${decryptdata.method} uri: ${decryptdata.uri})`;
 
-    this.log(`Starting session for key ${keyDetails}`);
+    const keyUri = levelKey.uri;
 
-    const keyContextPromise = this.keyIdToKeySessionPromise[keyId];
+    // Keep collection of level-keys associated with Key URI and key-session context
+    let levelKeys = this.keyUriToLevelKeys[keyUri];
+    if (!levelKeys) {
+      levelKeys = this.keyUriToLevelKeys[keyUri] = [levelKey];
+    } else if (
+      !levelKeys.some((decryptdata) => decryptdata.matches(levelKey))
+    ) {
+      levelKeys.push(levelKey);
+    }
+
+    // Get key-session context async
+    const keyContextPromise = this.keyUriToSessionPromise[keyUri];
     if (!keyContextPromise) {
-      const keySessionContextPromise = this.getKeySystemForKeyPromise(
-        decryptdata,
-      )
+      const keyId = this.getKeyIdString(levelKey);
+      const keyDetails = `(keyId: ${keyId} URI: ${keyUri} format: "${levelKey.keyFormat}" method: ${levelKey.method})`;
+      this.log(`Starting session for key ${keyDetails}`);
+      const keySessionContextPromise = this.getKeySystemForKeyPromise(levelKey)
         .then(({ keySystem, mediaKeys }) => {
           this.throwIfDestroyed();
           this.log(
@@ -477,28 +525,32 @@ class EMEController extends Logger implements ComponentAPI {
 
           return this.attemptSetMediaKeys(keySystem, mediaKeys).then(() => {
             this.throwIfDestroyed();
-            return this.createMediaKeySessionContext({
-              keySystem,
-              mediaKeys,
-              decryptdata,
-            });
+            return this.createMediaKeySessionContext(
+              {
+                keySystem,
+                mediaKeys,
+                levelKeys,
+              },
+              levelKey,
+            );
           });
         })
         .then((keySessionContext) => {
           const scheme = 'cenc';
-          const initData = decryptdata.pssh ? decryptdata.pssh.buffer : null;
+          const initData = levelKey.pssh ? levelKey.pssh.buffer : null;
           return this.generateRequestWithPreferredKeySession(
             keySessionContext,
             scheme,
             initData,
             'playlist-key',
+            levelKey,
           );
         });
 
       keySessionContextPromise.catch((error) =>
         this.handleError(error, data.frag),
       );
-      this.keyIdToKeySessionPromise[keyId] = keySessionContextPromise;
+      this.keyUriToSessionPromise[keyUri] = keySessionContextPromise;
 
       return keySessionContextPromise;
     }
@@ -535,8 +587,8 @@ class EMEController extends Logger implements ComponentAPI {
   private getKeySystemForKeyPromise(
     decryptdata: LevelKey,
   ): Promise<{ keySystem: KeySystems; mediaKeys: MediaKeys }> {
-    const keyId = this.getKeyIdString(decryptdata);
-    const mediaKeySessionContext = this.keyIdToKeySessionPromise[keyId];
+    const keyUri = decryptdata.uri;
+    const mediaKeySessionContext = this.keyUriToSessionPromise[keyUri];
     if (!mediaKeySessionContext) {
       const keySystem = keySystemFormatToKeySystemDomain(
         decryptdata.keyFormat as KeySystemFormats,
@@ -621,42 +673,50 @@ class EMEController extends Logger implements ComponentAPI {
         }
 
         const keyIdHex = arrayToHex(keyId);
-        const { keyIdToKeySessionPromise, mediaKeySessions } = this;
-        let keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex];
+        const { keyUriToSessionPromise, mediaKeySessions } = this;
+        let keySessionContextPromise:
+          | Promise<MediaKeySessionContext>
+          | undefined;
 
+        // Match `tenc` box keyId to playlist key in session
         for (let i = 0; i < mediaKeySessions.length; i++) {
-          // Match playlist key
           const keyContext = mediaKeySessions[i];
-          const decryptdata = keyContext.decryptdata;
-          if (!decryptdata.keyId) {
-            continue;
-          }
-          const oldKeyIdHex = arrayToHex(decryptdata.keyId);
-          if (
-            keyIdHex === oldKeyIdHex ||
-            decryptdata.uri.replace(/-/g, '').indexOf(keyIdHex) !== -1
-          ) {
-            keySessionContextPromise = keyIdToKeySessionPromise[oldKeyIdHex];
-            if (!keySessionContextPromise) {
+          for (let j = 0; j < keyContext.levelKeys.length; j++) {
+            const decryptdata = keyContext.levelKeys[j];
+            if (!decryptdata.keyId) {
               continue;
             }
-            if (decryptdata.pssh) {
+            const sessionKeyUri = decryptdata.uri;
+            const sessionKeyId = arrayToHex(decryptdata.keyId);
+            if (
+              keyIdHex === sessionKeyId ||
+              sessionKeyUri.replace(/-/g, '').indexOf(keyIdHex) !== -1
+            ) {
+              keySessionContextPromise = keyUriToSessionPromise[sessionKeyUri];
+              if (!keySessionContextPromise) {
+                continue;
+              }
+              if (decryptdata.pssh) {
+                break;
+              }
+              decryptdata.pssh = new Uint8Array(initData);
+              decryptdata.keyId = keyId;
+              LevelKey.setKeyIdForUri(sessionKeyUri, keyId);
+              keySessionContextPromise = keyUriToSessionPromise[sessionKeyUri] =
+                keySessionContextPromise.then(() => {
+                  return this.generateRequestWithPreferredKeySession(
+                    keyContext,
+                    initDataType,
+                    initData,
+                    'encrypted-event-key-match',
+                    decryptdata,
+                  );
+                });
+              keySessionContextPromise.catch((error) =>
+                this.handleError(error),
+              );
               break;
             }
-            delete keyIdToKeySessionPromise[oldKeyIdHex];
-            decryptdata.pssh = new Uint8Array(initData);
-            decryptdata.keyId = keyId;
-            keySessionContextPromise = keyIdToKeySessionPromise[keyIdHex] =
-              keySessionContextPromise.then(() => {
-                return this.generateRequestWithPreferredKeySession(
-                  keyContext,
-                  initDataType,
-                  initData,
-                  'encrypted-event-key-match',
-                );
-              });
-            keySessionContextPromise.catch((error) => this.handleError(error));
-            break;
           }
         }
 
@@ -716,13 +776,23 @@ class EMEController extends Logger implements ComponentAPI {
       | 'encrypted-event-key-match'
       | 'encrypted-event-no-match'
       | 'expired',
+    levelKey: LevelKey,
   ): Promise<MediaKeySessionContext> | never {
     const generateRequestFilter =
       this.config.drmSystems?.[context.keySystem]?.generateRequest;
     if (generateRequestFilter) {
+      const contextWithLevelKey: MediaKeySessionContextAndLevelKey = {
+        decryptdata: levelKey,
+        ...context,
+      };
       try {
         const mappedInitData: ReturnType<typeof generateRequestFilter> =
-          generateRequestFilter.call(this.hls, initDataType, initData, context);
+          generateRequestFilter.call(
+            this.hls,
+            initDataType,
+            initData,
+            contextWithLevelKey,
+          );
         if (!mappedInitData) {
           throw new Error(
             'Invalid response from configured generateRequest filter',
@@ -730,7 +800,7 @@ class EMEController extends Logger implements ComponentAPI {
         }
         initDataType = mappedInitData.initDataType;
         initData = mappedInitData.initData ? mappedInitData.initData : null;
-        context.decryptdata.pssh = initData ? new Uint8Array(initData) : null;
+        levelKey.pssh = initData ? new Uint8Array(initData) : null;
       } catch (error) {
         this.warn(error.message);
         if ((this.hls as any) && this.hls.config.debug) {
@@ -744,9 +814,10 @@ class EMEController extends Logger implements ComponentAPI {
       return Promise.resolve(context);
     }
 
-    const keyId = this.getKeyIdString(context.decryptdata);
+    const keyId = this.getKeyIdString(levelKey);
+    const keyUri = levelKey.uri;
     this.log(
-      `Generating key-session request for "${reason}": ${keyId} (init data type: ${initDataType} length: ${
+      `Generating key-session request for "${reason}" keyId: ${keyId} URI: ${keyUri} (init data type: ${initDataType} length: ${
         initData.byteLength
       })`,
     );
@@ -767,17 +838,23 @@ class EMEController extends Logger implements ComponentAPI {
         messageType === 'license-request' ||
         messageType === 'license-renewal'
       ) {
-        this.renewLicense(context, message).catch((error) => {
+        this.renewLicense(context, levelKey, message).catch((error) => {
           if (licenseStatus.eventNames().length) {
             licenseStatus.emit('error', error);
           } else {
             this.handleError(error);
           }
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          this.removeSession(context);
         });
       } else if (messageType === 'license-release') {
         if (context.keySystem === KeySystems.FAIRPLAY) {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          this.updateKeySession(context, strToUtf8array('acknowledged'));
+          this.updateKeySession(
+            context,
+            levelKey,
+            strToUtf8array('acknowledged'),
+          );
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.removeSession(context);
         }
@@ -794,14 +871,72 @@ class EMEController extends Logger implements ComponentAPI {
         licenseStatus.emit('error', new Error('invalid state'));
         return;
       }
-      const initialStatus = context.keyStatus;
+
+      // populate/update context.keyStatuses
       this.onKeyStatusChange(context);
-      const status = context.keyStatus;
-      if (status !== initialStatus) {
-        licenseStatus.emit('keyStatus', status, context);
-        if (status === 'expired') {
-          this.log(`${context.keySystem} expired for key ${keyId}`);
-          this.renewKeySession(context);
+
+      // renew when a key status comes back expired
+      const keyIds = Object.keys(context.keyStatuses);
+      if (keyIds.some((id) => context.keyStatuses[id] === 'expired')) {
+        this.log(
+          `${context.keySystem} expired for key ${stringify(context.keyStatuses)}`,
+        );
+        this.renewKeySession(context, levelKey);
+      }
+
+      // handle status of current key
+      let keyStatus = context.keyStatuses[keyId] as MediaKeyStatus | undefined;
+      let keyError: EMEKeyError | Error | undefined;
+      if (!keyStatus) {
+        // Handle case where no keyIds matched but all have the same status
+        const keyIds = Object.keys(context.keyStatuses);
+        if (keyIds.length) {
+          const keyStatuses = keyIds.map((id) => context.keyStatuses[id]);
+          const firstStatus = keyStatuses[0];
+          const allSameStatus = !keyStatuses.some(
+            (status) => status.substring(0, 6) !== firstStatus.substring(0, 6),
+          );
+          if (allSameStatus) {
+            keyStatus = firstStatus;
+          } else if (keyStatuses.some((status) => status === 'expired')) {
+            keyStatus = 'expired';
+          } else if (keyStatuses.some((status) => status === 'released')) {
+            keyStatus = 'released';
+          }
+        }
+        if (!keyStatus) {
+          keyStatus = 'internal-error';
+        }
+        this.log(
+          `No status for keyId ${keyId}. Using session key-status ${keyStatus} (${stringify(context.keyStatuses)}).`,
+        );
+      }
+      if (keyStatus.startsWith('usable')) {
+        licenseStatus.emit('resolved');
+      } else if (
+        keyStatus === 'internal-error' ||
+        keyStatus === 'output-restricted' ||
+        keyStatus === 'output-downscaled'
+      ) {
+        keyError = getKeyStatusError(keyStatus, levelKey);
+      } else if (keyStatus === 'expired') {
+        keyError = new Error(
+          `key expired while generating request (keyId: ${keyId})`,
+        );
+      } else if (keyStatus === 'released') {
+        keyError = new Error(`key released`);
+      } else if (keyStatus === 'status-pending') {
+        /* no-op */
+      } else {
+        this.warn(
+          `unhandled key status change "${keyStatus}" (keyId: ${keyId})`,
+        );
+      }
+      if (keyError) {
+        if (licenseStatus.eventNames().length) {
+          licenseStatus.emit('error', keyError);
+        } else {
+          this.handleError(keyError);
         }
       }
     });
@@ -816,33 +951,7 @@ class EMEController extends Logger implements ComponentAPI {
     const keyUsablePromise = new Promise(
       (resolve: (value?: void) => void, reject) => {
         licenseStatus.on('error', reject);
-
-        licenseStatus.on(
-          'keyStatus',
-          (
-            keyStatus: MediaKeyStatus,
-            { decryptdata }: MediaKeySessionContext,
-          ) => {
-            if (keyStatus.startsWith('usable')) {
-              resolve();
-            } else if (
-              keyStatus === 'internal-error' ||
-              keyStatus === 'output-restricted'
-            ) {
-              reject(getKeyStatusError(keyStatus, decryptdata));
-            } else if (keyStatus === 'expired') {
-              reject(
-                new Error(
-                  `key expired while generating request (keyId: ${keyId})`,
-                ),
-              );
-            } else {
-              this.warn(
-                `unhandled key status change "${keyStatus}" (keyId: ${keyId})`,
-              );
-            }
-          },
-        );
+        licenseStatus.on('resolved', resolve);
       },
     );
 
@@ -850,7 +959,7 @@ class EMEController extends Logger implements ComponentAPI {
       .generateRequest(initDataType, initData)
       .then(() => {
         this.log(
-          `Request generated for key-session "${context.mediaKeysSession.sessionId}" keyId: ${keyId}`,
+          `Request generated for key-session "${context.mediaKeysSession.sessionId}" keyId: ${keyId} URI: ${keyUri}`,
         );
       })
       .catch((error) => {
@@ -859,7 +968,7 @@ class EMEController extends Logger implements ComponentAPI {
             type: ErrorTypes.KEY_SYSTEM_ERROR,
             details: ErrorDetails.KEY_SYSTEM_NO_SESSION,
             error,
-            decryptdata: context.decryptdata,
+            decryptdata: levelKey,
             fatal: false,
           },
           `Error generating key-session request: ${error}`,
@@ -879,13 +988,8 @@ class EMEController extends Logger implements ComponentAPI {
   }
 
   private onKeyStatusChange(mediaKeySessionContext: MediaKeySessionContext) {
-    const sessionLevelKeyId = arrayToHex(
-      new Uint8Array(mediaKeySessionContext.decryptdata.keyId || []),
-    );
-
-    let hasMatchedKey = false;
-    const keyStatuses: { status: MediaKeyStatus; keyId: string }[] = [];
-
+    const keyStatuses = {};
+    mediaKeySessionContext.keyStatuses = keyStatuses;
     mediaKeySessionContext.mediaKeysSession.keyStatuses.forEach(
       (status: MediaKeyStatus, keyId: BufferSource) => {
         // keyStatuses.forEach is not standard API so the callback value looks weird on xboxone
@@ -895,79 +999,23 @@ class EMEController extends Logger implements ComponentAPI {
           keyId = status;
           status = temp;
         }
-
-        const keyIdArray: Uint8Array =
+        const keyIdArray =
           'buffer' in keyId
             ? new Uint8Array(keyId.buffer, keyId.byteOffset, keyId.byteLength)
             : new Uint8Array(keyId);
-
-        // Handle PlayReady little-endian key ID conversion for status comparison only
-        // Don't modify the original key ID from playlist parsing
         if (
           mediaKeySessionContext.keySystem === KeySystems.PLAYREADY &&
           keyIdArray.length === 16
         ) {
           changeEndianness(keyIdArray);
         }
-
-        const keyIdWithStatusChange = arrayToHex(
-          keyIdArray as Uint8Array<ArrayBuffer>,
+        const keyIdWithStatusChange = arrayToHex(keyIdArray);
+        this.log(
+          `key status change "${status}" for keyStatuses keyId: ${keyIdWithStatusChange}`,
         );
-
-        // Store all key statuses for processing
-        keyStatuses.push({ status, keyId: keyIdWithStatusChange });
-
-        // Error immediately when encountering a key ID with this status again
-        if (status === 'internal-error') {
-          this.bannedKeyIds[keyIdWithStatusChange] = status;
-        }
-
-        // Check if this key matches the session-level key ID
-        const matched = keyIdWithStatusChange === sessionLevelKeyId;
-        if (matched) {
-          hasMatchedKey = true;
-          mediaKeySessionContext.keyStatus = status;
-          this.log(
-            `matched key status change "${status}" for keyStatuses keyId: ${keyIdWithStatusChange} session keyId: ${sessionLevelKeyId} uri: ${mediaKeySessionContext.decryptdata.uri}`,
-          );
-        } else {
-          this.log(
-            `unmatched key status change "${status}" for keyStatuses keyId: ${keyIdWithStatusChange} session keyId: ${sessionLevelKeyId} uri: ${mediaKeySessionContext.decryptdata.uri}`,
-          );
-        }
+        keyStatuses[keyIdWithStatusChange] = status;
       },
     );
-
-    // Handle case where no keys matched but all have the same status
-    // This can happen with PlayReady when key IDs don't align properly
-    if (!hasMatchedKey && keyStatuses.length > 0) {
-      const firstStatus = keyStatuses[0].status;
-      const allSameStatus = !keyStatuses.some(
-        ({ status }) => status !== firstStatus,
-      );
-
-      if (
-        allSameStatus &&
-        (firstStatus === 'usable' || firstStatus.startsWith('usable'))
-      ) {
-        this.log(
-          `No key matched session keyId ${sessionLevelKeyId}, but all keys have usable status "${firstStatus}". Treating as usable.`,
-        );
-        mediaKeySessionContext.keyStatus = firstStatus;
-      } else if (
-        allSameStatus &&
-        (firstStatus === 'internal-error' || firstStatus === 'expired')
-      ) {
-        this.log(
-          `No key matched session keyId ${sessionLevelKeyId}, but all keys have error status "${firstStatus}". Applying to session.`,
-        );
-        mediaKeySessionContext.keyStatus = firstStatus;
-      } else {
-        this.log(
-          `No key matched session keyId ${sessionLevelKeyId}. Key statuses: ${keyStatuses.map(({ keyId, status }) => `${keyId}:${status}`).join(', ')}`,
-        );
-      }
-    }
   }
 
   private fetchServerCertificate(
@@ -1078,26 +1126,34 @@ class EMEController extends Logger implements ComponentAPI {
 
   private renewLicense(
     context: MediaKeySessionContext,
+    levelKey: LevelKey,
     keyMessage: ArrayBuffer,
   ): Promise<void> {
-    return this.requestLicense(context, new Uint8Array(keyMessage)).then(
-      (data: ArrayBuffer) => {
-        return this.updateKeySession(context, new Uint8Array(data)).catch(
-          (error) => {
-            throw new EMEKeyError(
-              {
-                type: ErrorTypes.KEY_SYSTEM_ERROR,
-                details: ErrorDetails.KEY_SYSTEM_SESSION_UPDATE_FAILED,
-                decryptdata: context.decryptdata,
-                error,
-                fatal: false,
-              },
-              error.message,
-            );
+    const contextWithLevelKey: MediaKeySessionContextAndLevelKey = {
+      decryptdata: levelKey,
+      ...context,
+    };
+    return this.requestLicense(
+      contextWithLevelKey,
+      new Uint8Array(keyMessage),
+    ).then((data: ArrayBuffer) => {
+      return this.updateKeySession(
+        context,
+        levelKey,
+        new Uint8Array(data),
+      ).catch((error) => {
+        throw new EMEKeyError(
+          {
+            type: ErrorTypes.KEY_SYSTEM_ERROR,
+            details: ErrorDetails.KEY_SYSTEM_SESSION_UPDATE_FAILED,
+            decryptdata: levelKey,
+            error,
+            fatal: false,
           },
+          error.message,
         );
-      },
-    );
+      });
+    });
   }
 
   private unpackPlayReadyKeyMessage(
@@ -1149,7 +1205,7 @@ class EMEController extends Logger implements ComponentAPI {
   private setupLicenseXHR(
     xhr: XMLHttpRequest,
     url: string,
-    keysListItem: MediaKeySessionContext,
+    contextWithLevelKey: MediaKeySessionContextAndLevelKey,
     licenseChallenge: Uint8Array<ArrayBuffer>,
   ): Promise<{
     xhr: XMLHttpRequest;
@@ -1165,19 +1221,19 @@ class EMEController extends Logger implements ComponentAPI {
 
     return Promise.resolve()
       .then(() => {
-        if (!keysListItem.decryptdata as any) {
-          throw new Error('Key removed');
+        if (contextWithLevelKey.levelKeys.length === 0) {
+          throw new Error('Keys removed');
         }
         return licenseXhrSetup.call(
           this.hls,
           xhr,
           url,
-          keysListItem,
+          contextWithLevelKey,
           licenseChallenge,
         );
       })
       .catch((error: Error) => {
-        if (!keysListItem.decryptdata as any) {
+        if (contextWithLevelKey.levelKeys.length === 0) {
           // Key session removed. Cancel license request.
           throw error;
         }
@@ -1188,7 +1244,7 @@ class EMEController extends Logger implements ComponentAPI {
           this.hls,
           xhr,
           url,
-          keysListItem,
+          contextWithLevelKey,
           licenseChallenge,
         );
       })
@@ -1205,19 +1261,21 @@ class EMEController extends Logger implements ComponentAPI {
   }
 
   private requestLicense(
-    keySessionContext: MediaKeySessionContext,
+    contextWithLevelKey: MediaKeySessionContextAndLevelKey,
     licenseChallenge: Uint8Array<ArrayBuffer>,
   ): Promise<ArrayBuffer> {
     const keyLoadPolicy = this.config.keyLoadPolicy.default;
     return new Promise((resolve, reject) => {
-      const url = this.getLicenseServerUrlOrThrow(keySessionContext.keySystem);
+      const url = this.getLicenseServerUrlOrThrow(
+        contextWithLevelKey.keySystem,
+      );
       this.log(`Sending license request to URL: ${url}`);
       const xhr = new XMLHttpRequest();
       xhr.responseType = 'arraybuffer';
       xhr.onreadystatechange = () => {
         if (
           (!this.hls as any) ||
-          (!keySessionContext.mediaKeysSession as any)
+          (!contextWithLevelKey.mediaKeysSession as any)
         ) {
           return reject(new Error('invalid state'));
         }
@@ -1237,7 +1295,7 @@ class EMEController extends Logger implements ComponentAPI {
                   this.hls,
                   xhr,
                   url,
-                  keySessionContext,
+                  contextWithLevelKey,
                 );
               } catch (error) {
                 this.error(error);
@@ -1257,7 +1315,7 @@ class EMEController extends Logger implements ComponentAPI {
                   {
                     type: ErrorTypes.KEY_SYSTEM_ERROR,
                     details: ErrorDetails.KEY_SYSTEM_LICENSE_REQUEST_FAILED,
-                    decryptdata: keySessionContext.decryptdata,
+                    decryptdata: contextWithLevelKey.decryptdata,
                     fatal: true,
                     networkDetails: xhr,
                     response: {
@@ -1276,7 +1334,7 @@ class EMEController extends Logger implements ComponentAPI {
               this.warn(
                 `Retrying license request, ${attemptsLeft} attempts left`,
               );
-              this.requestLicense(keySessionContext, licenseChallenge).then(
+              this.requestLicense(contextWithLevelKey, licenseChallenge).then(
                 resolve,
                 reject,
               );
@@ -1285,16 +1343,16 @@ class EMEController extends Logger implements ComponentAPI {
         }
       };
       if (
-        keySessionContext.licenseXhr &&
-        keySessionContext.licenseXhr.readyState !== XMLHttpRequest.DONE
+        contextWithLevelKey.licenseXhr &&
+        contextWithLevelKey.licenseXhr.readyState !== XMLHttpRequest.DONE
       ) {
-        keySessionContext.licenseXhr.abort();
+        contextWithLevelKey.licenseXhr.abort();
       }
-      keySessionContext.licenseXhr = xhr;
+      contextWithLevelKey.licenseXhr = xhr;
 
-      this.setupLicenseXHR(xhr, url, keySessionContext, licenseChallenge)
+      this.setupLicenseXHR(xhr, url, contextWithLevelKey, licenseChallenge)
         .then(({ xhr, licenseChallenge }) => {
-          if (keySessionContext.keySystem == KeySystems.PLAYREADY) {
+          if (contextWithLevelKey.keySystem == KeySystems.PLAYREADY) {
             licenseChallenge = this.unpackPlayReadyKeyMessage(
               xhr,
               licenseChallenge,
@@ -1341,8 +1399,8 @@ class EMEController extends Logger implements ComponentAPI {
 
   private _clear() {
     this._requestLicenseFailureCount = 0;
-    this.keyIdToKeySessionPromise = {};
-    this.bannedKeyIds = {};
+    this.keyUriToSessionPromise = {};
+    this.keyUriToLevelKeys = {};
     if (!this.mediaKeys && !this.mediaKeySessions.length) {
       return;
     }
@@ -1397,7 +1455,6 @@ class EMEController extends Logger implements ComponentAPI {
 
   private onManifestLoading() {
     this.keyFormatPromise = null;
-    this.bannedKeyIds = {};
   }
 
   private onManifestLoaded(
@@ -1429,11 +1486,10 @@ class EMEController extends Logger implements ComponentAPI {
   private removeSession(
     mediaKeySessionContext: MediaKeySessionContext,
   ): Promise<void> | void {
-    const { mediaKeysSession, licenseXhr, decryptdata } =
-      mediaKeySessionContext;
+    const { mediaKeysSession, licenseXhr, levelKeys } = mediaKeySessionContext;
     if (mediaKeysSession as MediaKeySession | undefined) {
       this.log(
-        `Remove licenses and keys and close session "${mediaKeysSession.sessionId}" keyId: ${arrayToHex((decryptdata as LevelKey | undefined)?.keyId || [])}`,
+        `Remove licenses and keys and close session "${mediaKeysSession.sessionId}" keyIds: ${levelKeys.map(({ keyId }) => arrayToHex(keyId || []))} URI: ${levelKeys[0]?.uri}`,
       );
       if (mediaKeySessionContext._onmessage) {
         mediaKeysSession.removeEventListener(
@@ -1454,9 +1510,8 @@ class EMEController extends Logger implements ComponentAPI {
         licenseXhr.abort();
       }
       mediaKeySessionContext.mediaKeysSession =
-        mediaKeySessionContext.decryptdata =
-        mediaKeySessionContext.licenseXhr =
-          undefined!;
+        mediaKeySessionContext.licenseXhr = undefined!;
+      mediaKeySessionContext.levelKeys = [];
       const index = this.mediaKeySessions.indexOf(mediaKeySessionContext);
       if (index > -1) {
         this.mediaKeySessions.splice(index, 1);
@@ -1499,7 +1554,7 @@ class EMEController extends Logger implements ComponentAPI {
   }
 }
 
-class EMEKeyError extends Error {
+export class EMEKeyError extends Error {
   public readonly data: ErrorData;
   constructor(
     data: Omit<ErrorData, 'error'> & { error?: Error },

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -509,7 +509,9 @@ export default class ErrorController
           'HDCP-LEVEL'
         ];
         errorAction.hdcpLevel = restrictedHdcpLevel;
-        if (restrictedHdcpLevel) {
+        if (restrictedHdcpLevel === 'NONE') {
+          this.warn(`HDCP policy resticted output with HDCP-LEVEL=NONE`);
+        } else if (restrictedHdcpLevel) {
           hls.maxHdcpLevel =
             HdcpLevels[HdcpLevels.indexOf(restrictedHdcpLevel) - 1];
           errorAction.resolved = true;

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -7,10 +7,14 @@ import {
   getKeySystemsForConfig,
   keySystemFormatToKeySystemDomain,
 } from '../utils/mediakeys-helper';
+import { KeySystemFormats } from '../utils/mediakeys-helper';
 import type { LevelKey } from './level-key';
 import type { HlsConfig } from '../config';
 import type EMEController from '../controller/eme-controller';
-import type { MediaKeySessionContext } from '../controller/eme-controller';
+import type {
+  EMEKeyError,
+  MediaKeySessionContext,
+} from '../controller/eme-controller';
 import type { ComponentAPI } from '../types/component-api';
 import type { KeyLoadedData } from '../types/events';
 import type {
@@ -24,7 +28,6 @@ import type {
 } from '../types/loader';
 import type { NullableNetworkDetails } from '../types/network-details';
 import type { ILogger } from '../utils/logger';
-import type { KeySystemFormats } from '../utils/mediakeys-helper';
 
 export interface KeyLoaderInfo {
   decryptdata: LevelKey;
@@ -198,8 +201,8 @@ export default class KeyLoader extends Logger implements ComponentAPI {
       return Promise.resolve({ frag, keyInfo });
     }
     // Return key load promise once it has a mediakey session with an usable key status
-    if (keyInfo?.keyLoadPromise) {
-      const keyStatus = keyInfo.mediaKeySessionContext?.keyStatus;
+    if (this.emeController && keyInfo?.keyLoadPromise) {
+      const keyStatus = this.emeController.getKeyStatus(keyInfo.decryptdata);
       switch (keyStatus) {
         case 'usable':
         case 'usable-in-future':
@@ -216,7 +219,7 @@ export default class KeyLoader extends Logger implements ComponentAPI {
 
     // Load the key or return the loading promise
     this.log(
-      `Loading key ${arrayToHex(decryptdata.keyId || [])} from ${frag.type} ${frag.level}`,
+      `${this.keyIdToKeyInfo[id] ? 'Rel' : 'L'}oading keyId: ${arrayToHex(decryptdata.keyId || [])} URI: ${decryptdata.uri} from ${frag.type} ${frag.level}`,
     );
 
     keyInfo = this.keyIdToKeyInfo[id] = {
@@ -262,10 +265,10 @@ export default class KeyLoader extends Logger implements ComponentAPI {
           keyInfo.mediaKeySessionContext = keySessionContext;
           return keyLoadedData;
         },
-      )).catch((error) => {
+      )).catch((error: EMEKeyError | Error) => {
         // Remove promise for license renewal or retry
         keyInfo.keyLoadPromise = null;
-        if (error.data) {
+        if ('data' in error) {
           error.data.frag = frag;
         }
         throw error;
@@ -307,8 +310,8 @@ export default class KeyLoader extends Logger implements ComponentAPI {
           context: KeyLoaderContext,
           networkDetails: NullableNetworkDetails,
         ) => {
-          const { frag, keyInfo, url: uri } = context;
-          const id = getKeyId(keyInfo.decryptdata) || uri;
+          const { frag, keyInfo } = context;
+          const id = getKeyId(keyInfo.decryptdata);
           if (!frag.decryptdata || keyInfo !== this.keyIdToKeyInfo[id]) {
             return reject(
               this.createKeyLoadError(
@@ -403,9 +406,11 @@ export default class KeyLoader extends Logger implements ComponentAPI {
 }
 
 function getKeyId(decryptdata: LevelKey) {
-  const keyId = decryptdata.keyId;
-  if (keyId) {
-    return arrayToHex(keyId);
+  if (decryptdata.keyFormat !== KeySystemFormats.FAIRPLAY) {
+    const keyId = decryptdata.keyId;
+    if (keyId) {
+      return arrayToHex(keyId);
+    }
   }
   return decryptdata.uri;
 }

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -37,6 +37,10 @@ export class LevelKey implements DecryptData {
     keyUriToKeyIdMap = {};
   }
 
+  static setKeyIdForUri(uri: string, keyId: Uint8Array<ArrayBuffer>) {
+    keyUriToKeyIdMap[uri] = keyId;
+  }
+
   constructor(
     method: string,
     uri: string,
@@ -142,11 +146,11 @@ export class LevelKey implements DecryptData {
           this.pssh = keyBytes;
           // In case of Widevine, if KEYID is not in the playlist, assume only two fields in the pssh KEY tag URI.
           if (!this.keyId) {
-            const [psshData] = parseMultiPssh(keyBytes.buffer);
-            this.keyId =
-              psshData && 'kids' in psshData && psshData.kids?.[0]
-                ? psshData.kids[0]
-                : null;
+            const results = parseMultiPssh(keyBytes.buffer);
+            if (results.length) {
+              const psshData = results[0];
+              this.keyId = psshData.kids?.length ? psshData.kids[0] : null;
+            }
           }
           if (!this.keyId) {
             const offset = keyBytes.length - 22;
@@ -189,7 +193,7 @@ export class LevelKey implements DecryptData {
         keyId = new Uint8Array(16);
         const dv = new DataView(keyId.buffer, 12, 4); // Just set the last 4 bytes
         dv.setUint32(0, val);
-        keyUriToKeyIdMap[this.uri] = keyId;
+        LevelKey.setKeyIdForUri(this.uri, keyId);
       }
       this.keyId = keyId;
     }

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -1361,6 +1361,7 @@ export type PsshData = {
 
 export type PsshInvalidResult = {
   systemId?: undefined;
+  kids?: undefined;
   offset: number;
   size: number;
 };

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -5,7 +5,11 @@ import sinonChai from 'sinon-chai';
 import EMEController from '../../../src/controller/eme-controller';
 import { ErrorDetails } from '../../../src/errors';
 import { Events } from '../../../src/events';
-import { KeySystemFormats } from '../../../src/utils/mediakeys-helper';
+import { LevelKey } from '../../../src/loader/level-key';
+import {
+  KeySystemFormats,
+  KeySystems,
+} from '../../../src/utils/mediakeys-helper';
 import HlsMock from '../../mocks/hls.mock';
 import type { MediaKeySessionContext } from '../../../src/controller/eme-controller';
 import type { MediaAttachedData } from '../../../src/types/events';
@@ -15,13 +19,16 @@ const expect = chai.expect;
 
 type EMEControllerTestable = Omit<
   EMEController,
-  'hls' | 'keyIdToKeySessionPromise' | 'mediaKeySessions'
+  'hls' | 'keyUriToSessionPromise' | 'mediaKeySessions' | 'keyUriToLevelKeys'
 > & {
   hls: HlsMock;
-  keyIdToKeySessionPromise: {
-    [keyId: string]: Promise<MediaKeySessionContext>;
-  };
   mediaKeySessions: MediaKeySessionContext[];
+  keyUriToSessionPromise: {
+    [keyUri: string]: Promise<MediaKeySessionContext> | undefined;
+  };
+  keyUriToLevelKeys: {
+    [keyUri: string]: LevelKey[] | undefined;
+  };
   onMediaAttached: (
     event: Events.MEDIA_ATTACHED,
     data: MediaAttachedData,
@@ -45,15 +52,64 @@ class MediaMock extends EventEmitter {
   }
 }
 
-class MediaKeySessionMock extends EventEmitter {
+class MediaKeysMock implements MediaKeys {
+  createSession(/* sessionType?: MediaKeySessionType */) {
+    return new MediaKeySessionMock();
+  }
+  getStatusForPolicy(/* policy?: MediaKeysPolicy */) {
+    // "output-restricted" | "released" | "status-pending" | "usable" | "usable-in-future"
+    return Promise.resolve('usable' as MediaKeyStatus);
+  }
+  setServerCertificate(/* serverCertificate: BufferSource */) {
+    return Promise.resolve(true);
+  }
+}
+
+class MediaKeySessionMock extends EventEmitter implements MediaKeySession {
   addEventListener: any;
   removeEventListener: any;
-  keyStatuses: Map<Uint8Array, string>;
+  private _resolveClose: (reason: MediaKeySessionClosedReason) => void =
+    () => {};
+  protected _keyStatuses: Map<Uint8Array, string>;
+  readonly closed: Promise<MediaKeySessionClosedReason>;
+  readonly keyStatuses: MediaKeyStatusMap;
+  readonly expiration: number;
+  readonly onkeystatuseschange = null; // use add/removeEventListener
+  readonly onmessage = null; // use add/removeEventListener
+  readonly sessionId: string;
+
   constructor() {
     super();
-    this.keyStatuses = new Map();
     this.addEventListener = this.addListener.bind(this);
     this.removeEventListener = this.removeListener.bind(this);
+    this.closed = new Promise((resolve) => {
+      this._resolveClose = resolve;
+    });
+    this.expiration = NaN;
+    this.sessionId = '';
+
+    const keyStatuses = (this._keyStatuses = new Map());
+    this.keyStatuses = {
+      get size() {
+        return keyStatuses.size;
+      },
+      get(keyId) {
+        return keyStatuses.get(keyId);
+      },
+      has(keyId) {
+        return keyStatuses.has(keyId);
+      },
+      forEach(callbackfn, thisArg?) {
+        return keyStatuses.forEach(callbackfn, thisArg);
+      },
+    };
+  }
+  dispatchEvent() {
+    return true;
+  }
+  close() {
+    this._resolveClose('release-acknoledged' as MediaKeySessionClosedReason);
+    return this.closed.then(() => {});
   }
   generateRequest() {
     return Promise.resolve().then(() => {
@@ -61,9 +117,12 @@ class MediaKeySessionMock extends EventEmitter {
         messageType: 'license-request',
         message: new Uint8Array(0),
       });
-      this.keyStatuses.set(new Uint8Array(16), 'usable');
+      this._keyStatuses.set(new Uint8Array(16), 'usable');
       this.emit('keystatuseschange', {});
     });
+  }
+  load(sessionId: string) {
+    return Promise.reject(new Error('not supported'));
   }
   remove() {
     return Promise.resolve();
@@ -94,6 +153,16 @@ const setupEach = function (config) {
   sinonFakeXMLHttpRequestStatic = sinon.useFakeXMLHttpRequest();
 };
 
+const getParsedLevelKey = (
+  uri: string = 'data://key-uri',
+  format: string = 'com.apple.streamingkeydelivery',
+) => {
+  const levelKey = new LevelKey('SAMPLE-AES', uri, format);
+  levelKey.keyId = new Uint8Array(16);
+  levelKey.pssh = new Uint8Array(16);
+  return levelKey;
+};
+
 describe('EMEController', function () {
   beforeEach(function () {
     setupEach({});
@@ -104,16 +173,12 @@ describe('EMEController', function () {
   });
 
   it('should request keysystem access based on key format when `emeEnabled` is true', function () {
+    const mediaKeys = new MediaKeysMock();
     const reqMediaKsAccessSpy = sinon.spy(function () {
       return Promise.resolve({
         // Media-keys mock
         keySystem: 'com.apple.fps',
-        createMediaKeys: sinon.spy(() =>
-          Promise.resolve({
-            setServerCertificate: () => Promise.resolve(),
-            createSession: () => new MediaKeySessionMock(),
-          }),
-        ),
+        createMediaKeys: sinon.spy(() => Promise.resolve(mediaKeys)),
       });
     });
 
@@ -143,19 +208,16 @@ describe('EMEController', function () {
     expect(media.setMediaKeys).callCount(0);
     expect(reqMediaKsAccessSpy).callCount(0);
 
+    const levelKey = getParsedLevelKey();
     const emePromise = emeController.loadKey({
-      frag: {},
+      frag: {} as any,
       keyInfo: {
-        decryptdata: {
-          encrypted: true,
-          method: 'SAMPLE-AES',
-          keyFormat: 'com.apple.streamingkeydelivery',
-          uri: 'data://key-uri',
-          keyId: new Uint8Array(16),
-          pssh: new Uint8Array(16),
-        },
+        decryptdata: levelKey,
+        keyLoadPromise: null,
+        loader: null,
+        mediaKeySessionContext: null,
       },
-    } as any);
+    });
 
     expect(emePromise).to.be.a('Promise');
     return emePromise.finally(() => {
@@ -306,9 +368,9 @@ describe('EMEController', function () {
         type: 'main',
       } as any)
       .then(() => {
-        expect(emeController.keyIdToKeySessionPromise).to.deep.equal(
+        expect(emeController.keyUriToSessionPromise).to.deep.equal(
           {},
-          '`keyIdToKeySessionPromise` should be an empty dictionary when no key IDs are found',
+          '`keyUriToSessionPromise` should be an empty dictionary when no key IDs are found',
         );
       });
   });
@@ -317,7 +379,7 @@ describe('EMEController', function () {
     class MediaKeySessionMock2 extends MediaKeySessionMock {
       constructor() {
         super();
-        this.keyStatuses.set(new Uint8Array(16), 'usable');
+        this._keyStatuses.set(new Uint8Array(16), 'usable');
       }
     }
 
@@ -331,24 +393,20 @@ describe('EMEController', function () {
       },
     });
 
+    const levelKey = getParsedLevelKey();
     const keySession = new MediaKeySessionMock2();
-    const mockMediaKeySessionContext = {
+    const mockMediaKeySessionContext: MediaKeySessionContext = {
+      keySystem: KeySystems.FAIRPLAY,
+      levelKeys: [levelKey],
+      mediaKeys: new MediaKeysMock(),
       mediaKeysSession: keySession,
-      decryptdata: {
-        encrypted: true,
-        method: 'SAMPLE-AES',
-        keyFormat: 'com.apple.streamingkeydelivery',
-        uri: 'data://key-uri',
-        keyId: new Uint8Array(16),
-        pssh: new Uint8Array(16),
-      },
-      keyStatus: 'status-pending',
+      keyStatuses: {},
     };
 
-    emeController.onKeyStatusChange(
-      mockMediaKeySessionContext as unknown as MediaKeySessionContext,
-    );
-    expect(mockMediaKeySessionContext.keyStatus).to.be.equal('usable');
+    emeController.onKeyStatusChange(mockMediaKeySessionContext);
+    expect(mockMediaKeySessionContext.keyStatuses)
+      .to.have.property('00000000000000000000000000000000')
+      .which.equals('usable');
   });
 
   it('should fetch the server certificate and set it into the session', function () {
@@ -404,19 +462,17 @@ describe('EMEController', function () {
         },
       } as any)
       .then(() => {
-        expect(
-          emeController.keyIdToKeySessionPromise[
-            '00000000000000000000000000000000'
-          ],
-        ).to.be.a('Promise');
-        return emeController.keyIdToKeySessionPromise[
-          '00000000000000000000000000000000'
-        ].finally(() => {
-          expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
-          expect(mediaKeysSetServerCertificateSpy).to.have.been.calledWith(
-            sinon.match({ byteLength: 6 }),
-          );
-        });
+        expect(emeController.keyUriToSessionPromise['data://key-uri']).to.be.a(
+          'Promise',
+        );
+        return emeController.keyUriToSessionPromise['data://key-uri']!.finally(
+          () => {
+            expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
+            expect(mediaKeysSetServerCertificateSpy).to.have.been.calledWith(
+              sinon.match({ byteLength: 6 }),
+            );
+          },
+        );
       });
   });
 
@@ -485,26 +541,22 @@ describe('EMEController', function () {
         // expected?
       });
 
-    expect(
-      emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ],
-    ).to.be.a('Promise');
-    return emeController.keyIdToKeySessionPromise[
-      '00000000000000000000000000000000'
-    ]
-      .catch(() => {})
-      .finally(() => {
-        expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
-        expect((mediaKeysSetServerCertificateSpy.args[0] as any)[0]).to.equal(
-          xhrInstance.response,
-        );
+    expect(emeController.keyUriToSessionPromise['data://key-uri']).to.be.a(
+      'Promise',
+    );
+    return emeController.keyUriToSessionPromise['data://key-uri']!.catch(
+      () => {},
+    ).finally(() => {
+      expect(mediaKeysSetServerCertificateSpy).to.have.been.calledOnce;
+      expect((mediaKeysSetServerCertificateSpy.args[0] as any)[0]).to.equal(
+        xhrInstance.response,
+      );
 
-        expect(emeController.hls.trigger).to.have.been.calledOnce;
-        expect(emeController.hls.trigger.args[0][1].details).to.equal(
-          ErrorDetails.KEY_SYSTEM_SERVER_CERTIFICATE_UPDATE_FAILED,
-        );
-      });
+      expect(emeController.hls.trigger).to.have.been.calledOnce;
+      expect(emeController.hls.trigger.args[0][1].details).to.equal(
+        ErrorDetails.KEY_SYSTEM_SERVER_CERTIFICATE_UPDATE_FAILED,
+      );
+    });
   });
 
   it('should fetch the server certificate and trigger request failed error', function () {
@@ -565,21 +617,17 @@ describe('EMEController', function () {
         // expected?
       });
 
-    expect(
-      emeController.keyIdToKeySessionPromise[
-        '00000000000000000000000000000000'
-      ],
-    ).to.be.a('Promise');
-    return emeController.keyIdToKeySessionPromise[
-      '00000000000000000000000000000000'
-    ]
-      .catch(() => {})
-      .finally(() => {
-        expect(emeController.hls.trigger).to.have.been.calledOnce;
-        expect(emeController.hls.trigger.args[0][1].details).to.equal(
-          ErrorDetails.KEY_SYSTEM_SERVER_CERTIFICATE_REQUEST_FAILED,
-        );
-      });
+    expect(emeController.keyUriToSessionPromise['data://key-uri']).to.be.a(
+      'Promise',
+    );
+    return emeController.keyUriToSessionPromise['data://key-uri']!.catch(
+      () => {},
+    ).finally(() => {
+      expect(emeController.hls.trigger).to.have.been.calledOnce;
+      expect(emeController.hls.trigger.args[0][1].details).to.equal(
+        ErrorDetails.KEY_SYSTEM_SERVER_CERTIFICATE_REQUEST_FAILED,
+      );
+    });
   });
 
   it('should remove media property  when media is detached', function () {
@@ -602,8 +650,6 @@ describe('EMEController', function () {
         ),
       });
     });
-    const keySessionRemoveSpy = sinon.spy(() => Promise.resolve());
-    const keySessionCloseSpy = sinon.spy(() => Promise.resolve());
 
     setupEach({
       emeEnabled: true,
@@ -613,14 +659,20 @@ describe('EMEController', function () {
     emeController.onMediaAttached(Events.MEDIA_ATTACHED, {
       media: media as any as HTMLMediaElement,
     });
-    emeController.mediaKeySessions = [
-      {
-        mediaKeysSession: {
-          remove: keySessionRemoveSpy,
-          close: keySessionCloseSpy,
-        },
-      } as any,
-    ];
+
+    const levelKey = getParsedLevelKey();
+    const keySession = new MediaKeySessionMock();
+    const mockMediaKeySessionContext: MediaKeySessionContext = {
+      keySystem: KeySystems.FAIRPLAY,
+      levelKeys: [levelKey],
+      mediaKeys: new MediaKeysMock(),
+      mediaKeysSession: keySession,
+      keyStatuses: {},
+    };
+    sinon.stub(keySession, 'remove');
+    sinon.stub(keySession, 'close');
+
+    emeController.mediaKeySessions = [mockMediaKeySessionContext];
     emeController.destroy();
 
     expect(emeController.media).to.equal(null);
@@ -646,8 +698,6 @@ describe('EMEController', function () {
         ),
       });
     });
-    const keySessionRemoveSpy = sinon.spy(() => Promise.resolve());
-    const keySessionCloseSpy = sinon.spy(() => Promise.resolve());
 
     setupEach({
       emeEnabled: true,
@@ -657,14 +707,20 @@ describe('EMEController', function () {
     emeController.onMediaAttached(Events.MEDIA_ATTACHED, {
       media: media as any as HTMLMediaElement,
     });
-    emeController.mediaKeySessions = [
-      {
-        mediaKeysSession: {
-          remove: keySessionRemoveSpy,
-          close: keySessionCloseSpy,
-        },
-      } as any,
-    ];
+
+    const levelKey = getParsedLevelKey();
+    const keySession = new MediaKeySessionMock();
+    const mockMediaKeySessionContext: MediaKeySessionContext = {
+      keySystem: KeySystems.FAIRPLAY,
+      levelKeys: [levelKey],
+      mediaKeys: new MediaKeysMock(),
+      mediaKeysSession: keySession,
+      keyStatuses: {},
+    };
+    sinon.stub(keySession, 'remove');
+    const keySessionCloseSpy = sinon.stub(keySession, 'close');
+
+    emeController.mediaKeySessions = [mockMediaKeySessionContext];
     emeController.destroy();
 
     expect(EMEController.CDMCleanupPromise).to.be.a('Promise');
@@ -698,8 +754,6 @@ describe('EMEController', function () {
         ),
       });
     });
-    const keySessionRemoveSpy = sinon.spy(() => Promise.resolve());
-    const keySessionCloseSpy = sinon.spy(() => Promise.resolve());
 
     setupEach({
       emeEnabled: true,
@@ -712,14 +766,20 @@ describe('EMEController', function () {
     emeController.onMediaAttached(Events.MEDIA_ATTACHED, {
       media: media as any as HTMLMediaElement,
     });
-    emeController.mediaKeySessions = [
-      {
-        mediaKeysSession: {
-          remove: keySessionRemoveSpy,
-          close: keySessionCloseSpy,
-        },
-      } as any,
-    ];
+
+    const levelKey = getParsedLevelKey();
+    const keySession = new MediaKeySessionMock();
+    const mockMediaKeySessionContext: MediaKeySessionContext = {
+      keySystem: KeySystems.FAIRPLAY,
+      levelKeys: [levelKey],
+      mediaKeys: new MediaKeysMock(),
+      mediaKeysSession: keySession,
+      keyStatuses: {},
+    };
+    sinon.stub(keySession, 'remove');
+    const keySessionCloseSpy = sinon.stub(keySession, 'close');
+
+    emeController.mediaKeySessions = [mockMediaKeySessionContext];
     emeController.destroy();
 
     expect(EMEController.CDMCleanupPromise).to.be.a('Promise');


### PR DESCRIPTION
### This PR will...
- Group media key sessions by key tag (EXT-X-KEY) URI, and group all parsed key tags (`LevelKey` instances) and their key-ids in eme-controller session-context objects.
- Fixes key-status errors being ignored after key is usable.
- Warn when "output-restricted" key status is received on level with HDCP-LEVEL=NONE

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

- @hongfeih-es (#7413)
- @ShubhamSharma2311 (#7510)
- @mudit2108 (#7469)

### Resolves issues:
Resolves #7474

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
