### PR TITLE
Multivariant Playlist parsing fixes

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1533,6 +1533,9 @@ export default class InterstitialsController
       return;
     }
     const main = this.hls.levels[data.level];
+    if (!main.details) {
+      return;
+    }
     const currentSelection = {
       ...(this.mediaSelection || this.altSelection),
       main,

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -8,7 +8,6 @@ import {
   codecsSetSelectionPreferenceValue,
   convertAVC1ToAVCOTI,
   getCodecCompatibleName,
-  sampleEntryCodesISO,
   videoCodecPreferenceValue,
 } from '../utils/codecs';
 import { reassignFragmentLevelIndexes } from '../utils/level-helper';
@@ -133,29 +132,8 @@ export default class LevelController extends BasePlaylistController {
 
       // only keep levels with supported audio/video codecs
       const { width, height, unknownCodecs } = levelParsed;
-      let unknownUnsupportedCodecCount = unknownCodecs
-        ? unknownCodecs.length
-        : 0;
-      if (unknownCodecs) {
-        // Treat unknown codec as audio or video codec based on passing `isTypeSupported` check
-        // (allows for playback of any supported codec even if not indexed in utils/codecs)
-        for (let i = unknownUnsupportedCodecCount; i--; ) {
-          const unknownCodec = unknownCodecs[i];
-          if (this.isAudioSupported(unknownCodec)) {
-            levelParsed.audioCodec = audioCodec = audioCodec
-              ? `${audioCodec},${unknownCodec}`
-              : unknownCodec;
-            unknownUnsupportedCodecCount--;
-            sampleEntryCodesISO.audio[audioCodec.substring(0, 4)] = 2;
-          } else if (this.isVideoSupported(unknownCodec)) {
-            levelParsed.videoCodec = videoCodec = videoCodec
-              ? `${videoCodec},${unknownCodec}`
-              : unknownCodec;
-            unknownUnsupportedCodecCount--;
-            sampleEntryCodesISO.video[videoCodec.substring(0, 4)] = 2;
-          }
-        }
-      }
+      const unknownUnsupportedCodecCount = unknownCodecs?.length || 0;
+
       resolutionFound ||= !!(width && height);
       videoCodecFound ||= !!videoCodec;
       audioCodecFound ||= !!audioCodec;

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -230,6 +230,7 @@ export default class LevelController extends BasePlaylistController {
     let audioTracks: MediaPlaylist[] = [];
     let subtitleTracks: MediaPlaylist[] = [];
     let levels = filteredLevels;
+    const statsParsing = data.stats?.parsing || {};
 
     // remove audio-only and invalid video-range levels if we also have levels with video codecs or RESOLUTION signalled
     if ((resolutionFound || videoCodecFound) && audioCodecFound) {
@@ -268,6 +269,7 @@ export default class LevelController extends BasePlaylistController {
           });
         }
       });
+      statsParsing.end = performance.now();
       return;
     }
 
@@ -386,6 +388,7 @@ export default class LevelController extends BasePlaylistController {
       altAudio:
         altAudioEnabled && !audioOnly && audioTracks.some((t) => !!t.url),
     };
+    statsParsing.end = performance.now();
     this.hls.trigger(Events.MANIFEST_PARSED, edata);
   }
 

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -428,6 +428,7 @@ class PlaylistLoader implements NetworkComponentAPI {
     const parsedResult = M3U8Parser.parseMasterPlaylist(string, url);
 
     if (parsedResult.playlistParsingError) {
+      stats.parsing.end = performance.now();
       this.handleManifestParsingError(
         response,
         context,

--- a/tests/index.js
+++ b/tests/index.js
@@ -35,6 +35,7 @@ import './unit/loader/fragment-loader';
 import './unit/loader/fragment';
 import './unit/loader/level';
 import './unit/loader/m3u8-parser';
+import './unit/loader/playlist-loader';
 import './unit/remux/mp4-remuxer';
 import './unit/utils/attr-list';
 import './unit/utils/binary-search';

--- a/tests/unit/controller/content-steering-controller.ts
+++ b/tests/unit/controller/content-steering-controller.ts
@@ -54,7 +54,7 @@ type ConentSteeringControllerTestable = Omit<
   audioTracks: MediaPlaylist[] | null;
   subtitleTracks: MediaPlaylist[] | null;
   onManifestLoading: () => void;
-  onManifestLoaded: (event: string, data: Partial<ManifestLoadedData>) => void;
+  onManifestLoaded: (event: string, data: ManifestLoadedData) => void;
 };
 
 describe('ContentSteeringController', function () {
@@ -100,6 +100,16 @@ describe('ContentSteeringController', function () {
           uri: 'http://example.com/manifest.json',
           pathwayId: 'pathway-2',
         },
+        levels: [],
+        audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       expect(contentSteeringController.uri).to.equal(
         'http://example.com/manifest.json',
@@ -114,6 +124,16 @@ describe('ContentSteeringController', function () {
           uri: 'http://example.com/manifest.json',
           pathwayId: 'pathway-2',
         },
+        levels: [],
+        audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       contentSteeringController.stopLoad();
       expect(contentSteeringController).to.have.property('loader').that.is.null;
@@ -128,6 +148,16 @@ describe('ContentSteeringController', function () {
           uri: 'http://example.com/manifest.json',
           pathwayId: 'pathway-2',
         },
+        levels: [],
+        audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       expect(contentSteeringController.stopLoad).to.be.a('function');
       contentSteeringController.stopLoad();
@@ -149,6 +179,16 @@ describe('ContentSteeringController', function () {
           uri: 'http://example.com/manifest.json',
           pathwayId: 'pathway-2',
         },
+        levels: [],
+        audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       expect(contentSteeringController.loader)
         .to.have.property('context')
@@ -166,6 +206,16 @@ describe('ContentSteeringController', function () {
           uri: 'http://example.com/manifest.json',
           pathwayId: 'pathway-2',
         },
+        levels: [],
+        audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       expect(contentSteeringController.uri).to.equal(
         'http://example.com/manifest.json',
@@ -209,11 +259,18 @@ http://a.example.com/md/prog_index.m3u8`;
         'http://example.com/main.m3u8',
         parsedMultivariant,
       );
-      const manifestLoadedData = {
+      const manifestLoadedData: ManifestLoadedData = {
         contentSteering: parsedMultivariant.contentSteering,
         levels: parsedMultivariant.levels,
-        audioTracks: parsedMediaOptions.AUDIO,
+        audioTracks: parsedMediaOptions.AUDIO!,
         subtitles: parsedMediaOptions.SUBTITLES,
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       };
       const levelController: any = (hls.levelController = new LevelController(
         hls as any,
@@ -310,11 +367,18 @@ http://a.example.com/md/prog_index.m3u8`;
         'http://example.com/main.m3u8',
         parsedMultivariant,
       );
-      const manifestLoadedData = {
+      const manifestLoadedData: ManifestLoadedData = {
         contentSteering: parsedMultivariant.contentSteering,
         levels: parsedMultivariant.levels,
-        audioTracks: parsedMediaOptions.AUDIO,
+        audioTracks: parsedMediaOptions.AUDIO!,
         subtitles: parsedMediaOptions.SUBTITLES,
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        startTimeOffset: null,
+        variableList: null,
       };
       levelController = hls.levelController = new LevelController(
         hls as any,

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -4,6 +4,7 @@ import sinonChai from 'sinon-chai';
 import LevelController from '../../../src/controller/level-controller';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import { Events } from '../../../src/events';
+import { LoadStats } from '../../../src/loader/load-stats';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
 import { Level } from '../../../src/types/level';
 import { PlaylistLevelType } from '../../../src/types/loader';
@@ -29,7 +30,7 @@ chai.use(sinonChai);
 const expect = chai.expect;
 
 type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
-  onManifestLoaded: (event: string, data: Partial<ManifestLoadedData>) => void;
+  onManifestLoaded: (event: string, data: ManifestLoadedData) => void;
   onAudioTrackSwitched: (event: string, data: { id: number }) => void;
   onError: (
     event: string,
@@ -123,7 +124,7 @@ describe('LevelController', function () {
       contentSteering: null,
       startTimeOffset: null,
       variableList: null,
-      stats: {} as any,
+      stats: new LoadStats(),
       subtitles: [],
       url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
     };
@@ -189,6 +190,12 @@ describe('LevelController', function () {
         networkDetails: new Response('ok'),
         subtitles: [],
         url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        contentSteering: null,
+        startTimeOffset: null,
+        variableList: null,
       });
 
       return Promise.resolve().then(() => {
@@ -204,6 +211,7 @@ describe('LevelController', function () {
     });
 
     it('emits MANIFEST_PARSED when levels are found in the manifest', function () {
+      const stats = new LoadStats();
       const data: ManifestLoadedData = {
         audioTracks: [],
         levels: [
@@ -239,7 +247,7 @@ describe('LevelController', function () {
         contentSteering: null,
         startTimeOffset: null,
         variableList: null,
-        stats: {} as any,
+        stats,
         url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
       };
 
@@ -252,7 +260,7 @@ describe('LevelController', function () {
         sessionData: null,
         sessionKeys: null,
         firstLevel: 0,
-        stats: {},
+        stats,
         audio: false,
         video: false,
         altAudio: false,
@@ -280,6 +288,15 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
       levelController.onManifestLoaded(Events.MANIFEST_LOADED, {
         levels: parsedLevels,
         audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        contentSteering: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       const {
         name,
@@ -304,6 +321,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
 
   describe('Manifest Parsed Alt-Audio', function () {
     it('emits MANIFEST_PARSED with `altAudio = true` when there are no codec attributes in MANIFEST_LOADED', function () {
+      const stats = new LoadStats();
       const data: ManifestLoadedData = {
         audioTracks: [
           mediaPlaylist({
@@ -324,7 +342,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         contentSteering: null,
         startTimeOffset: null,
         variableList: null,
-        stats: {} as any,
+        stats,
         url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
       };
 
@@ -335,7 +353,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         sessionData: null,
         sessionKeys: null,
         firstLevel: 0,
-        stats: {} as any,
+        stats,
         audio: false,
         video: false,
         altAudio: true,
@@ -349,6 +367,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
     });
 
     it('emits MANIFEST_PARSED with `altAudio = true` when there are codec attributes in MANIFEST_LOADED', function () {
+      const stats = new LoadStats();
       const data: ManifestLoadedData = {
         audioTracks: [
           mediaPlaylist({ audioCodec: 'mp4a.40.5', url: 'audio-track.m3u8' }),
@@ -368,7 +387,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         contentSteering: null,
         startTimeOffset: null,
         variableList: null,
-        stats: {} as any,
+        stats,
         url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
       };
 
@@ -380,7 +399,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         sessionData: null,
         sessionKeys: null,
         firstLevel: 0,
-        stats: {},
+        stats,
         audio: true,
         video: true,
         altAudio: true,
@@ -388,6 +407,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
     });
 
     it('emits MANIFEST_PARSED with `altAudio = false` when Variant(s) are audio-only with audio Media Playlists in MANIFEST_LOADED', function () {
+      const stats = new LoadStats();
       const data: ManifestLoadedData = {
         audioTracks: [
           mediaPlaylist({ audioCodec: 'mp4a.40.5', name: 'main' }),
@@ -407,7 +427,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         contentSteering: null,
         startTimeOffset: null,
         variableList: null,
-        stats: {} as any,
+        stats,
         url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
       };
 
@@ -419,7 +439,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         sessionData: null,
         sessionKeys: null,
         firstLevel: 0,
-        stats: {},
+        stats,
         audio: true,
         video: false,
         altAudio: false,
@@ -445,7 +465,7 @@ http://bar.example.com/audio-only/prog_index.m3u8`,
         contentSteering: null,
         startTimeOffset: null,
         variableList: null,
-        stats: {} as any,
+        stats: new LoadStats(),
         url: 'foo',
       };
     });
@@ -664,6 +684,15 @@ http://bar.example.com/md/prog_index.m3u8`,
       levelController.onManifestLoaded(Events.MANIFEST_LOADED, {
         levels: parsedLevels,
         audioTracks: [],
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        contentSteering: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       const {
         name,
@@ -718,7 +747,16 @@ http://bar.example.com/md/prog_index.m3u8`;
       expect(parsedSubs).to.be.undefined;
       levelController.onManifestLoaded(Events.MANIFEST_LOADED, {
         levels: parsedLevels,
-        audioTracks: parsedAudio,
+        audioTracks: parsedAudio!,
+        subtitles: [],
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        contentSteering: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       const {
         name,
@@ -774,6 +812,14 @@ http://bar.example.com/md/prog_index.m3u8`;
           levels: parsedLevels,
           audioTracks: parsedAudio,
           subtitles: parsedSubs,
+          networkDetails: new Response('ok'),
+          url: 'https://example.com/prog.m3u8',
+          stats: new LoadStats(),
+          sessionData: null,
+          sessionKeys: null,
+          contentSteering: null,
+          startTimeOffset: null,
+          variableList: null,
         });
         const { name, payload } = hls.getEventData(0) as {
           name: string;
@@ -909,6 +955,14 @@ http://bar.example.com/md/prog_index.m3u8`;
         levels: parsedLevels,
         audioTracks: parsedAudio,
         subtitles: parsedSubs,
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        contentSteering: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       const { name, payload } = hls.getEventData(0) as {
         name: string;
@@ -995,6 +1049,14 @@ http://bar.example.com/md/prog_index.m3u8`;
         levels: parsedLevels,
         audioTracks: parsedAudio,
         subtitles: parsedSubs,
+        networkDetails: new Response('ok'),
+        url: 'https://example.com/prog.m3u8',
+        stats: new LoadStats(),
+        sessionData: null,
+        sessionKeys: null,
+        contentSteering: null,
+        startTimeOffset: null,
+        variableList: null,
       });
       const { name, payload } = hls.getEventData(0) as {
         name: string;

--- a/tests/unit/loader/playlist-loader.ts
+++ b/tests/unit/loader/playlist-loader.ts
@@ -1,0 +1,91 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import LevelController from '../../../src/controller/level-controller';
+import { Events } from '../../../src/events';
+import { LoadStats } from '../../../src/loader/load-stats';
+import PlaylistLoader from '../../../src/loader/playlist-loader';
+import HlsMock from '../../mocks/hls.mock';
+import { multivariantPlaylistWithPathways } from '../controller/level-controller';
+import type Hls from '../../../src/hls';
+import type {
+  LoaderCallbacks,
+  LoaderConfiguration,
+  PlaylistLoaderContext,
+} from '../../../src/types/loader';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('PlaylistLoader tests', function () {
+  const sandbox = sinon.createSandbox();
+  let hls: Hls; // HlsMock
+  let playlistLoader: PlaylistLoader;
+  let levelController: LevelController; // level-controller finishes manifest parsing
+  let response;
+
+  beforeEach(function () {
+    hls = new HlsMock({}) as unknown as Hls;
+    playlistLoader = new PlaylistLoader(hls);
+    levelController = new LevelController(hls, null);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    playlistLoader.destroy();
+    levelController.destroy();
+  });
+
+  it('handles multivariant playlist loading and parsing (with level-controller) on MANIFEST_LOADING', function () {
+    return new Promise<void>((resolve, reject) => {
+      const stats = new LoadStats();
+      const networkDetails = new Response('ok');
+      sinon.stub(playlistLoader as any, 'createInternalLoader').returns({
+        load: (
+          context: PlaylistLoaderContext,
+          config: LoaderConfiguration,
+          callback: LoaderCallbacks<PlaylistLoaderContext>,
+        ) => {
+          expect(context.type).eq('manifest');
+          Promise.resolve()
+            .then(() => {
+              response = { data: multivariantPlaylistWithPathways };
+              callback.onSuccess(response, stats, context, networkDetails);
+            })
+            .catch(reject);
+        },
+        abort: () => {},
+      });
+
+      hls.on(Events.MANIFEST_LOADED, (type, data) => {
+        expect(data).includes({
+          url: 'http://example.cpm/program.m3u8',
+          stats,
+          networkDetails,
+          captions: undefined,
+          sessionData: null,
+          sessionKeys: null,
+          startTimeOffset: null,
+          variableList: null,
+        });
+        expect(data.levels, 'levels.length').to.have.lengthOf(30);
+        expect(data.audioTracks, 'audioTracks.length').to.have.lengthOf(6);
+        expect(data.subtitles, 'subtitles.length').to.have.lengthOf(6);
+        expect(data.contentSteering, 'contentSteering').to.includes({
+          uri: 'http://example.com/manifest.json',
+          pathwayId: 'Bar',
+        });
+        expect(stats.parsing.start, 'parsing.start').to.be.greaterThan(0);
+        expect(stats.parsing.end, 'parsing.end').to.be.greaterThanOrEqual(
+          stats.parsing.start,
+        );
+
+        resolve();
+      });
+
+      hls.trigger(Events.MANIFEST_LOADING, {
+        url: 'http://example.cpm/program.m3u8',
+      });
+    });
+  });
+});


### PR DESCRIPTION
### This PR will...
1. Add `stats.parsing.end` timing prior to emitting `MANIFEST_PARSED` on `MANIFEST_LOADED` and `MANIFEST_PARSING_ERROR`
2. Move unknown codecs handling to playlist-loader

### Why is this Pull Request needed?
1. Ensures time to parse Multivariant Playlist is measures and available in HLS.js events.
2. Unknown codecs that are supported as audio and video mime times need to be added to parsed levels before parsing media options so that `audioCodec` is set on audio tracks and audio `levelCodec` is set on levels. This ensures creation of SourceBuffers with the full mime type based on the playlists CODECS rather than the incomplete four CC string parse from the segments.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Resolves #7518

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
