### PR TITLE
Setup as audio-only when main segment has no video

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -664,6 +664,18 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     if (this.sourceBufferCount) {
       return;
     }
+
+    if (
+      this.bufferCodecEventsTotal > 1 &&
+      !this.tracks.video &&
+      !data.video &&
+      data.audio?.id === 'main'
+    ) {
+      // MVP is missing CODECS and only audio was found in main segment (#7524)
+      this.log(`Main audio-only`);
+      this.bufferCodecEventsTotal = 1;
+    }
+
     if (this.mediaSourceOpenOrEnded) {
       this.checkPendingTracks();
     }


### PR DESCRIPTION
### This PR will...
Stops waiting for video track when main segment is parsed containing only audio.

### Why is this Pull Request needed?
Handles audio-only content in multivariant playlists missing CODECS attribute.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7524

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
