### PR TITLE
Fix error handling of empty media playlists

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -119,7 +119,10 @@ export default class M3U8Parser {
     const levelsWithKnownCodecs: LevelParsed[] = [];
 
     MASTER_PLAYLIST_REGEX.lastIndex = 0;
-
+    if (!string.startsWith('#EXTM3U')) {
+      parsed.playlistParsingError = new Error('no EXTM3U delimiter');
+      return parsed;
+    }
     let result: RegExpExecArray | null;
     while ((result = MASTER_PLAYLIST_REGEX.exec(string)) != null) {
       if (result[1]) {
@@ -710,9 +713,7 @@ export default class M3U8Parser {
       }
     }
     if (!level.targetduration) {
-      level.playlistParsingError = new Error(
-        `#EXT-X-TARGETDURATION is required`,
-      );
+      level.playlistParsingError = new Error(`Missing Target Duration`);
     }
     const fragmentLength = fragments.length;
     const firstFragment = fragments[0];

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -345,18 +345,6 @@ class PlaylistLoader implements NetworkComponentAPI {
 
         const string = response.data as string;
 
-        // Validate if it is an M3U8 at all
-        if (string.indexOf('#EXTM3U') !== 0) {
-          this.handleManifestParsingError(
-            response,
-            context,
-            new Error('no EXTM3U delimiter'),
-            networkDetails || null,
-            stats,
-          );
-          return;
-        }
-
         stats.parsing.start = performance.now();
         if (
           M3U8Parser.isMediaPlaylist(string) ||
@@ -734,29 +722,6 @@ class PlaylistLoader implements NetworkComponentAPI {
       typeof context.level === 'number' && parent === PlaylistLevelType.MAIN
         ? (level as number)
         : undefined;
-    if (!levelDetails.fragments.length) {
-      const error = (levelDetails.playlistParsingError = new Error(
-        'No Segments found in Playlist',
-      ));
-      hls.trigger(Events.ERROR, {
-        type: ErrorTypes.NETWORK_ERROR,
-        details: ErrorDetails.LEVEL_EMPTY_ERROR,
-        fatal: false,
-        url,
-        error,
-        reason: error.message,
-        response,
-        context,
-        level: levelIndex,
-        parent,
-        networkDetails,
-        stats,
-      });
-      return;
-    }
-    if (!levelDetails.targetduration) {
-      levelDetails.playlistParsingError = new Error('Missing Target Duration');
-    }
     const error = levelDetails.playlistParsingError;
     if (error) {
       this.hls.logger.warn(`${error} ${levelDetails.url}`);
@@ -778,6 +743,26 @@ class PlaylistLoader implements NetworkComponentAPI {
         return;
       }
       levelDetails.playlistParsingError = null;
+    }
+    if (!levelDetails.fragments.length) {
+      const error = (levelDetails.playlistParsingError = new Error(
+        'No Segments found in Playlist',
+      ));
+      hls.trigger(Events.ERROR, {
+        type: ErrorTypes.NETWORK_ERROR,
+        details: ErrorDetails.LEVEL_EMPTY_ERROR,
+        fatal: false,
+        url,
+        error,
+        reason: error.message,
+        response,
+        context,
+        level: levelIndex,
+        parent,
+        networkDetails,
+        stats,
+      });
+      return;
     }
 
     if (levelDetails.live && loader) {

--- a/tests/unit/loader/m3u8-parser.ts
+++ b/tests/unit/loader/m3u8-parser.ts
@@ -19,11 +19,11 @@ describe('M3U8Parser', function () {
     );
     expect(result.levels).to.deep.equal([]);
     expect(result.sessionData).to.equal(null);
-    expectPlaylistParsingError(result, 'no levels found in manifest');
+    expectPlaylistParsingError(result, 'no EXTM3U delimiter');
   });
 
   it('manifest with broken syntax returns empty array', function () {
-    const manifest = `#EXTXSTREAMINF:PROGRAM-ID=1,BANDWIDTH=836280,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=848x360,NAME="480"
+    const manifest = `#EXTM3U#EXTXSTREAMINF:PROGRAM-ID=1,BANDWIDTH=836280,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=848x360,NAME="480"
 http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core`;
     const result = M3U8Parser.parseMasterPlaylist(
       manifest,


### PR DESCRIPTION
### This PR will...
1. Handles #EXTM3U playlist parsing errors according to the request type (manifest vs level parsing error)
2. Removes some redundant playlist parsing error handling (~'#EXT-X-TARGETDURATION is required'~ > 'Missing Target Duration')

### Why is this Pull Request needed?
1. Fixes Live reload "giving up" after an empty response because it is handles as a manifest (multivariant playlist) error rather than a level (media playlist) error.
2. Removes unused '#EXT-X-TARGETDURATION is required' error message and redundant code from src

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7531

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
