### PR TITLE
Fix seeking back in live with timestamp wrapping (1.6.6 regression)

### DIFF
--- a/src/utils/timescale-conversion.ts
+++ b/src/utils/timescale-conversion.ts
@@ -39,3 +39,8 @@ export function toMpegTsClockFromTimescale(
 ): number {
   return toTimescaleFromBase(baseTime, MPEG_TS_CLOCK_FREQ_HZ, 1 / srcScale);
 }
+
+export function timestampToString(timestamp: TimestampOffset): string {
+  const { baseTime, timescale, trackId } = timestamp;
+  return `${baseTime / timescale} (${baseTime}/${timescale}) trackId: ${trackId}`;
+}


### PR DESCRIPTION
### This PR will...
Advance initPTS to accommodate timestamps in earlier segments when starting late in the timeline.

### Why is this Pull Request needed?
When starting long running live streams without discontinuities, timestamps may have already wrapped in the past. This change anticipates that so that initPTS is not set to a value that would result in earlier segments timestamps getting unwrapped backwards to a value less than zero.

This issue did not occur prior to v1.6.6 with #7311, since in those older versions PTS was always remapped to the timeline. Now that PTS is preserved, it needs to be unwrapped if the timeline is long enough that a low starting "initPTS" would result in negative timestamps when seeking back.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7536

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] changes cherry-picked into patch/v1.6.x branch
- [ ] new unit / functional tests have been added (whenever applicable)
