### PR TITLE
Use GitHub `release` env for npm publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,6 +279,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release_npm:
+    # npm oidc is configured for this environment
+    # https://docs.npmjs.com/trusted-publishers#for-github-actions
+    environment: release
     needs: [config, test_unit]
     if: needs.config.outputs.tag || needs.config.outputs.isMainBranch == 'true'
     runs-on: ubuntu-latest
@@ -323,7 +326,6 @@ jobs:
           ./scripts/publish-npm.sh
         env:
           CI: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ needs.config.outputs.tag }}
 
   test_functional_required:

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -2,9 +2,6 @@
 set -e
 
 if [[ $(node ./scripts/check-already-published.js) = "not published" ]]; then
-  # write the token to config
-  # see https://docs.npmjs.com/private-modules/ci-server-config
-  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
   if [[  -z "$TAG" ]]; then
     npm publish --provenance --tag canary
     echo "Published canary."


### PR DESCRIPTION
### This PR will...
Use the new release environment and stop providing the npm token. Publishes will then use the OIDC flow which is configured on npm and more secure as we can restrict all publishes to come from this workflow.

### Why is this Pull Request needed?
Help mitigate against attacks like https://thehackernews.com/2025/09/40-npm-packages-compromised-in-supply.html
