### PR TITLE
Use Widevine KEYID or parse PlayReady when level keys are present

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -3359,7 +3359,9 @@ export class LevelKey implements DecryptData {
     // (undocumented)
     readonly encrypted: boolean;
     // (undocumented)
-    getDecryptData(sn: number | 'initSegment'): LevelKey | null;
+    getDecryptData(sn: number | 'initSegment', levelKeys?: {
+        [key: string]: LevelKey | undefined;
+    }): LevelKey | null;
     // (undocumented)
     readonly isCommonEncryption: boolean;
     // (undocumented)

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -273,7 +273,7 @@ export class Fragment extends BaseSegment {
           const levelKey = (this._decryptdata =
             this.levelkeys[keyFormats[0]] || null);
           if (levelKey) {
-            return levelKey.getDecryptData(this.sn);
+            return levelKey.getDecryptData(this.sn, this.levelkeys);
           }
         } else {
           // Multiple keys. key-loader to call Fragment.setKeyFormat based on selected key-system.
@@ -364,10 +364,11 @@ export class Fragment extends BaseSegment {
   }
 
   setKeyFormat(keyFormat: KeySystemFormats) {
-    if (this.levelkeys) {
-      const key = this.levelkeys[keyFormat];
+    const levelkeys = this.levelkeys;
+    if (levelkeys) {
+      const key = levelkeys[keyFormat];
       if (key && !this._decryptdata) {
-        this._decryptdata = key.getDecryptData(this.sn);
+        this._decryptdata = key.getDecryptData(this.sn, this.levelkeys);
       }
     }
   }

--- a/src/loader/level-key.ts
+++ b/src/loader/level-key.ts
@@ -100,7 +100,10 @@ export class LevelKey implements DecryptData {
     return false;
   }
 
-  public getDecryptData(sn: number | 'initSegment'): LevelKey | null {
+  public getDecryptData(
+    sn: number | 'initSegment',
+    levelKeys?: { [key: string]: LevelKey | undefined },
+  ): LevelKey | null {
     if (!this.encrypted || !this.uri) {
       return null;
     }
@@ -135,10 +138,19 @@ export class LevelKey implements DecryptData {
       return this;
     }
 
-    if (this.pssh && this.keyId) {
-      return this;
+    if (this.keyId) {
+      // Handle case where key id is changed in KEY_LOADING event handler #7542#issuecomment-3305203929
+      const assignedKeyId = keyUriToKeyIdMap[this.uri];
+      if (assignedKeyId && !arrayValuesMatch(this.keyId, assignedKeyId)) {
+        LevelKey.setKeyIdForUri(this.uri, this.keyId);
+      }
+
+      if (this.pssh) {
+        return this;
+      }
     }
 
+    // Key bytes are signalled the KEYID attribute, typically only found on WideVine KEY tags
     // Initialize keyId if possible
     const keyBytes = convertDataUriToArrayBytes(this.uri);
     if (keyBytes) {
@@ -156,8 +168,11 @@ export class LevelKey implements DecryptData {
             }
           }
           if (!this.keyId) {
-            const offset = keyBytes.length - 22;
-            this.keyId = keyBytes.subarray(offset, offset + 16);
+            this.keyId = getKeyIdFromPlayReadyKey(levelKeys);
+            if (!this.keyId) {
+              const offset = keyBytes.length - 22;
+              this.keyId = keyBytes.subarray(offset, offset + 16);
+            }
           }
           break;
         case KeySystemFormats.PLAYREADY: {
@@ -189,13 +204,20 @@ export class LevelKey implements DecryptData {
 
     // Default behavior: assign a new keyId for each uri
     if (!this.keyId || this.keyId.byteLength !== 16) {
-      let keyId = keyUriToKeyIdMap[this.uri];
+      let keyId: Uint8Array<ArrayBuffer> | null | undefined =
+        keyUriToKeyIdMap[this.uri];
       if (!keyId) {
-        const val =
-          Object.keys(keyUriToKeyIdMap).length % Number.MAX_SAFE_INTEGER;
-        keyId = new Uint8Array(16);
-        const dv = new DataView(keyId.buffer, 12, 4); // Just set the last 4 bytes
-        dv.setUint32(0, val);
+        keyId = getKeyIdFromWidevineKey(levelKeys);
+        if (!keyId) {
+          keyId = getKeyIdFromPlayReadyKey(levelKeys);
+          if (!keyId) {
+            const val =
+              Object.keys(keyUriToKeyIdMap).length % Number.MAX_SAFE_INTEGER;
+            keyId = new Uint8Array(16);
+            const dv = new DataView(keyId.buffer, 12, 4); // Just set the last 4 bytes
+            dv.setUint32(0, val);
+          }
+        }
         LevelKey.setKeyIdForUri(this.uri, keyId);
       }
       this.keyId = keyId;
@@ -203,6 +225,29 @@ export class LevelKey implements DecryptData {
 
     return this;
   }
+}
+
+function getKeyIdFromWidevineKey(
+  levelKeys: { [key: string]: LevelKey | undefined } | undefined,
+) {
+  const widevineKey = levelKeys?.[KeySystemFormats.WIDEVINE];
+  if (widevineKey) {
+    return widevineKey.keyId;
+  }
+  return null;
+}
+
+function getKeyIdFromPlayReadyKey(
+  levelKeys: { [key: string]: LevelKey | undefined } | undefined,
+) {
+  const playReadyKey = levelKeys?.[KeySystemFormats.PLAYREADY];
+  if (playReadyKey) {
+    const playReadyKeyBytes = convertDataUriToArrayBytes(playReadyKey.uri);
+    if (playReadyKeyBytes) {
+      return parsePlayReadyWRM(playReadyKeyBytes);
+    }
+  }
+  return null;
 }
 
 function createInitializationVector(segmentNumber: number) {


### PR DESCRIPTION
### This PR will...

- Use Widevine KEYID or parse PlayReady when level keys are present
- Update `keyUriToKeyIdMap` set after KEY_LOADING

### Why is this Pull Request needed?
This works around shortcoming in keyID parsing for FPS and WV key tags by reading them from key tags in other formats that apply to the same segment. Example: use the value found from WV KEYID attribute rather than generate a new id which would require patching the media, or parse the PR id rather than assume the WV key can be found 22 bytes from the end of the parsed URI.

The second change is an enhancement to add some level of support for replacing a keyId on KEY_LOADING as attempted here https://github.com/video-dev/hls.js/issues/7542#issuecomment-3305203929

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7542


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
