### PR TITLE
Fix issue where manifest parsing end time is 0

### DIFF
--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -375,6 +375,7 @@ export default class LevelController extends BasePlaylistController {
     const altAudioEnabled = !!(
       config.audioStreamController && config.audioTrackController
     );
+    statsParsing.end = performance.now();
     const edata: ManifestParsedData = {
       levels,
       audioTracks,
@@ -388,7 +389,6 @@ export default class LevelController extends BasePlaylistController {
       altAudio:
         altAudioEnabled && !audioOnly && audioTracks.some((t) => !!t.url),
     };
-    statsParsing.end = performance.now();
     this.hls.trigger(Events.MANIFEST_PARSED, edata);
   }
 


### PR DESCRIPTION
### This PR will fix an issue where the calculated end time for parsing the manifest is always 0.

### Why is this Pull Request needed? To ensure correct reporting of LoaderStats for Manifest parsing.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues: N/A

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] API or design changes are documented in API.md
