### PR TITLE
Fixed exception in interstitial-controller on legacy platforms where media.play() does not return a Promise

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -81,7 +81,7 @@ export type PlayheadTimes = {
 };
 
 function playWithCatch(media: HTMLMediaElement | null) {
-  media?.play().catch(() => {
+  (media?.play() as Promise<void> | undefined)?.catch(() => {
     /* no-op */
   });
 }


### PR DESCRIPTION
### This PR will...
- Guard the result of `media.play()` in `playWithCatch` so that `.catch()` is only called when present.
This avoids a TypeError on legacy engines where `HTMLMediaElement.play()` returns `undefined` (e.g. LG webOS 3 / Chrome 38).

### Why is this Pull Request needed?
- On legacy WebKit/Chromium (webOS 3), `media.play()` may return `undefined`. Chaining `.catch()` throws and breaks playback in the interstitials path. This change is a no-behavior change on modern browsers and simply adds a safe guard.

### Are there any points in the code the reviewer needs to double check?
- Using optional chaining on both the `play` call and the returned value’s `catch`:
  ```ts
  (media?.play?.() as Promise<void> | undefined)?.catch?.(() => { /* no-op */ });
- This keeps the change minimal while handling undefined returns and non-Promise values.
-  No other call sites are affected.

### Resolves issues:
* #7581 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
   - N/A - no API changes 

