### PR TITLE
Increase minimum Windows test version for saucelabs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,9 +352,9 @@ jobs:
             ua: chrome
             os: OS X 10.11
             uaVersion: '79.0'
-          - config: chrome-win_7-75.0
+          - config: chrome-win_8-75.0
             ua: chrome
-            os: Windows 7
+            os: Windows 8
             uaVersion: '75.0'
 
     steps:


### PR DESCRIPTION
### This PR will...
Increase minimum Windows test version for saucelabs from Windows 7 to Windows 8.

### Why is this Pull Request needed?
Automated functional tests are failing to start because Windows 7 is no longer a supported platform configuration:
https://github.com/video-dev/hls.js/actions/runs/18847073929/job/53774146538
