### PR TITLE
Resolve end-of-stream with empty or gap segments at end of playlist

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2155,11 +2155,15 @@ export default class BaseStreamController
       false,
     );
     if (!parsed) {
-      if (level.fragmentError === 0) {
-        // Mark and track the odd empty segment as a gap to avoid reloading
+      const mediaNotFound = this.transmuxer?.error === null;
+      if (
+        level.fragmentError === 0 ||
+        (mediaNotFound && (level.fragmentError < 2 || frag.endList))
+      ) {
+        // Mark and track the odd (or last) empty segment as a gap to avoid reloading
         this.treatAsGap(frag, level);
       }
-      if (this.transmuxer?.error === null) {
+      if (mediaNotFound) {
         const error = new Error(
           `Found no media in fragment ${frag.sn} of ${this.playlistLabel()} ${frag.level} resetting transmuxer to fallback to playlist timing`,
         );

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -231,12 +231,7 @@ export class FragmentTracker implements ComponentAPI {
     });
     fragmentEntity.loaded = null;
     if (Object.keys(fragmentEntity.range).length) {
-      fragmentEntity.buffered = true;
-      const endList = (fragmentEntity.body.endList =
-        frag.endList || fragmentEntity.body.endList);
-      if (endList) {
-        this.endListFragments[fragmentEntity.body.type] = fragmentEntity;
-      }
+      this.bufferedEnd(fragmentEntity, frag);
       if (!isPartial(fragmentEntity)) {
         // Remove older fragment parts from lookup after frag is tracked as buffered
         this.removeParts(frag.sn - 1, frag.type);
@@ -244,6 +239,15 @@ export class FragmentTracker implements ComponentAPI {
     } else {
       // remove fragment if nothing was appended
       this.removeFragment(fragmentEntity.body);
+    }
+  }
+
+  private bufferedEnd(fragmentEntity: FragmentEntity, frag: MediaFragment) {
+    fragmentEntity.buffered = true;
+    const endList = (fragmentEntity.body.endList =
+      frag.endList || fragmentEntity.body.endList);
+    if (endList) {
+      this.endListFragments[fragmentEntity.body.type] = fragmentEntity;
     }
   }
 
@@ -275,7 +279,7 @@ export class FragmentTracker implements ComponentAPI {
     }
     if (fragmentEntity) {
       fragmentEntity.loaded = null;
-      fragmentEntity.buffered = true;
+      this.bufferedEnd(fragmentEntity, frag);
     }
   }
 


### PR DESCRIPTION
### This PR will...
Resolve end-of-stream with empty or gap segments at end of playlist.

### Why is this Pull Request needed?
Publishers have streams with empty segment at the end of their playlist. They expect that when the client has attempted to load all segments up to the end that EOS will be resolved even if the end segments are bad and they don't want to remove them from the content they publish.

On the plus side this should address handling of EOS when actual GAP tags are used at the end of a playlist (as should be the case in media described in linked issues).

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
- Fixes #7572
- and maybe #7564 (no reproduction sample provided)

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
