### PR TITLE
Resolve setMediaKeys only once media is attached

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -83,6 +83,7 @@ class EMEController extends Logger implements ComponentAPI {
     keyLoadPolicy: LoadPolicy;
   };
   private media: HTMLMediaElement | null = null;
+  private mediaResolved?: () => void;
   private keyFormatPromise: Promise<KeySystemFormats> | null = null;
   private keySystemAccessPromises: {
     [keysystem: string]: KeySystemAccessPromises | undefined;
@@ -704,6 +705,7 @@ class EMEController extends Logger implements ComponentAPI {
     keySystem: KeySystems,
     mediaKeys: MediaKeys,
   ): Promise<void> {
+    this.mediaResolved = undefined;
     if (this.mediaKeys === mediaKeys) {
       return Promise.resolve();
     }
@@ -714,10 +716,20 @@ class EMEController extends Logger implements ComponentAPI {
     // can be queued for execution for multiple key sessions.
     const setMediaKeysPromise = Promise.all(queue).then(() => {
       if (!this.media) {
-        this.mediaKeys = null;
-        throw new Error(
-          'Attempted to set mediaKeys without media element attached',
-        );
+        return new Promise((resolve: (value?: void) => void, reject) => {
+          this.mediaResolved = () => {
+            this.mediaResolved = undefined;
+            if (!this.media) {
+              return reject(
+                new Error(
+                  'Attempted to set mediaKeys without media element attached',
+                ),
+              );
+            }
+            this.mediaKeys = mediaKeys;
+            this.media.setMediaKeys(mediaKeys).then(resolve).catch(reject);
+          };
+        });
       }
       return this.media.setMediaKeys(mediaKeys);
     });
@@ -1344,6 +1356,13 @@ class EMEController extends Logger implements ComponentAPI {
 
     addEventListener(media, 'encrypted', this.onMediaEncrypted);
     addEventListener(media, 'waitingforkey', this.onWaitingForKey);
+
+    const mediaResolved = this.mediaResolved;
+    if (mediaResolved) {
+      mediaResolved();
+    } else {
+      this.mediaKeys = media.mediaKeys;
+    }
   }
 
   private onMediaDetached() {
@@ -1361,6 +1380,10 @@ class EMEController extends Logger implements ComponentAPI {
     this._requestLicenseFailureCount = 0;
     this.keyIdToKeySessionPromise = {};
     this.bannedKeyIds = {};
+    const mediaResolved = this.mediaResolved;
+    if (mediaResolved) {
+      mediaResolved();
+    }
     if (!this.mediaKeys && !this.mediaKeySessions.length) {
       return;
     }
@@ -1414,8 +1437,7 @@ class EMEController extends Logger implements ComponentAPI {
   }
 
   private onManifestLoading() {
-    this.keyFormatPromise = null;
-    this.bannedKeyIds = {};
+    this._clear();
   }
 
   private onManifestLoaded(


### PR DESCRIPTION
### This PR will...
Resolve `setMediaKeys` only once media is attached.

### Why is this Pull Request needed?
Prevents failure to establish key-session while media is attached to an interstitial asset player.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7608

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
