### PR TITLE
Fix Low-Latency HLS VTT subtitle part loading

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -4674,6 +4674,8 @@ export interface SubtitleFragProcessedData {
     // (undocumented)
     frag: Fragment;
     // (undocumented)
+    part: Part | null;
+    // (undocumented)
     success: boolean;
 }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1161,10 +1161,6 @@ export default class BaseStreamController
         // Buffer must be ahead of first part + duration of parts after last segment
         // and playback must be at or past segment adjacent to part list
         const firstPart = details.partList[0];
-        // Loading of VTT subtitle parts is not implemented in subtitle-stream-controller (#7460)
-        if (firstPart.fragment.type === PlaylistLevelType.SUBTITLE) {
-          return false;
-        }
         const safePartStart =
           firstPart.end + (details.fragmentHint?.duration || 0);
         if (bufferEnd >= safePartStart) {

--- a/src/controller/subtitle-track-controller.ts
+++ b/src/controller/subtitle-track-controller.ts
@@ -526,7 +526,6 @@ class SubtitleTrackController extends BasePlaylistController {
     // and we'll set subtitleTrack when onMediaAttached is triggered
     if (!this.media) {
       this.queuedDefaultTrack = newId;
-      return;
     }
 
     // exit if track id as already set or invalid

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -1,11 +1,11 @@
 import { buildAbsoluteURL } from 'url-toolkit';
 import { LoadStats } from './load-stats';
+import { PlaylistLevelType } from '../types/loader';
 import type { LevelKey } from './level-key';
 import type {
   FragmentLoaderContext,
   KeyLoaderContext,
   Loader,
-  PlaylistLevelType,
 } from '../types/loader';
 import type { AttrList } from '../utils/attr-list';
 import type { KeySystemFormats } from '../utils/mediakeys-helper';
@@ -453,7 +453,8 @@ export class Part extends BaseSegment {
     return !!(
       elementaryStreams.audio ||
       elementaryStreams.video ||
-      elementaryStreams.audiovideo
+      elementaryStreams.audiovideo ||
+      (this.fragment.type === PlaylistLevelType.SUBTITLE && this.stats.loaded)
     );
   }
 }

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -662,7 +662,7 @@ export default class M3U8Parser {
             if (!partList) {
               partList = level.partList = [];
             }
-            const previousFragmentPart =
+            const previousPart =
               currentPart > 0 ? partList[partList.length - 1] : undefined;
             const index = currentPart++;
             const partAttrs = new AttrList(value1, level);
@@ -671,7 +671,7 @@ export default class M3U8Parser {
               frag as MediaFragment,
               base,
               index,
-              previousFragmentPart,
+              previousPart,
             );
             partList.push(part);
             frag.duration += part.duration;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -286,6 +286,7 @@ export interface TrackSwitchedData {
 export interface SubtitleFragProcessed {
   success: boolean;
   frag: Fragment;
+  part: Part | null;
 }
 
 export interface FragChangedData {
@@ -351,6 +352,7 @@ export interface ErrorData {
 export interface SubtitleFragProcessedData {
   success: boolean;
   frag: Fragment;
+  part: Part | null;
   error?: Error;
 }
 

--- a/src/types/vtt.ts
+++ b/src/types/vtt.ts
@@ -1,9 +1,11 @@
 export type VTTCCs = {
   ccOffset: number;
   presentationOffset: number;
-  [key: number]: {
-    start: number;
-    prevCC: number;
-    new: boolean;
-  };
+  [key: number]:
+    | {
+        start: number;
+        prevCC: number;
+        new: boolean;
+      }
+    | undefined;
 };

--- a/tests/unit/controller/subtitle-track-controller.ts
+++ b/tests/unit/controller/subtitle-track-controller.ts
@@ -52,6 +52,7 @@ describe('SubtitleTrackController', function () {
     subtitleTrackController = new SubtitleTrackController(
       hls as unknown as Hls,
     );
+    (hls as any).subtitleTrackController = subtitleTrackController;
     hls.networkControllers.push(subtitleTrackController);
     hls.levelController = {
       levels: [
@@ -654,8 +655,13 @@ describe('SubtitleTrackController', function () {
 
       expect(subtitleTracks[1].details).not.to.be.undefined;
       expect((subtitleTrackController as any).timer).to.equal(-1);
-      // We will still emit playlist loaded since we did load and store the details
-      expect(playlistLoadedSpy).to.have.been.called;
+      // hls.js will not emit playlist loaded since the trackId does not match the loaded event id
+      expect(playlistLoadedSpy).to.have.not.been.called;
+
+      expect((subtitleTrackController as any).tracksInGroup[1]).not.to.be
+        .undefined;
+      expect((subtitleTrackController as any).tracksInGroup[1].details).not.to
+        .be.undefined;
     });
 
     it('does not set the reload timer if loading has not started', function () {


### PR DESCRIPTION
### This PR will...
- Fix LL-HLS VTT subtitle part loading
- Fix fragment selection when live subtitle playlist does not overlap with position
- Fix subtitle selection in asset players while primary is detached
- Remove dead code in VTT parser, and remove redundant code in subtitle-stream-controller

### Why is this Pull Request needed?
These changes unify subtitle segment finding with audio and video, fixing issues with subtitle part and segment loading.

### Are there any points in the code the reviewer needs to double check?
Low-latency live with VTT parts https://llhls-demo.ovenmediaengine.com/app/stream/llhls.m3u8

### Resolves issues:
- #7460
- #7522
- #7557


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
