### PR TITLE
Fix links for API Docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ An overview of this project's design, it's modules, events, and error handling c
 ## API docs and usage guide
 
 - [API and usage docs, with code examples](./docs/API.md)
-- [Auto-Generated API Docs (Latest Release)](https://hlsjs.video-dev.org/api-docs)
-- [Auto-Generated API Docs (Development Branch)](https://hlsjs-dev.video-dev.org/api-docs)
+- [Auto-Generated API Docs (Latest Release)](https://hlsjs.video-dev.org/api-docs/)
+- [Auto-Generated API Docs (Development Branch)](https://hlsjs-dev.video-dev.org/api-docs/)
 
 _Note you can access the docs for a particular version using "[https://github.com/video-dev/hls.js/tree/deployments](https://github.com/video-dev/hls.js/tree/deployments)"_
 


### PR DESCRIPTION
### This PR will...

Fix the latest and development API docs links in the README.md. They're currently going to a 404 pages. 

### Why is this Pull Request needed?

Fix broken links and ensure users can reach the API docs.

### Are there any points in the code the reviewer needs to double check?

Links will redirect to https://hlsjs.video-dev.org/api-docs/hls.js.hls (similar to the feature branch links). However, should they redirect to https://hlsjs.video-dev.org/api-docs/hls.js?

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
