### PR TITLE
Fix switching back to main audio(-only) after end-of-stream buffered

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -876,7 +876,7 @@ export default class StreamController
   ) {
     const hls = this.hls;
     // if any URL found on new audio track, it is an alternate audio track
-    const fromAltAudio = this.altAudio === AlternateAudio.SWITCHED;
+    const fromAltAudio = this.altAudio !== AlternateAudio.DISABLED;
     const altAudio = useAlternateAudio(data.url, hls);
     // if we switch on main audio, ensure that main fragment scheduling is synced with media.buffered
     // don't do anything if we switch to alt audio: audio stream controller is handling it.
@@ -904,6 +904,7 @@ export default class StreamController
       }
       // If switching from alt to main audio, flush all audio and trigger track switched
       if (fromAltAudio) {
+        this.altAudio = AlternateAudio.DISABLED;
         this.fragmentTracker.removeAllFragments();
         hls.once(Events.BUFFER_FLUSHED, () => {
           if (!this.hls as any) {


### PR DESCRIPTION
### This PR will...
Set `StreamController.altAudio` to `AlternateAudio.DISABLED` on `AUDIO_TRACK_SWITCHING`, rather than waiting until `AUDIO_TRACK_SWITCHED` like when changing from `AlternateAudio.SWITCHING` to `AlternateAudio.SWITCHED`.

### Why is this Pull Request needed?

The `StreamController` ignores audio buffer flush events when alternate audio is active. Immediately switching the `altAudio` to disabled ensures that `afterBufferFlushed` is called after the buffer is flushed and the controller state is reset from ENDED to IDLE. This is required to load audio-only from the main playlist after having switched to alternate audio which is handled by the audio-stream-controller.

Previously, `altAudio` was only ever set in `AUDIO_TRACK_SWITCHED`. This issue was introduced in v1.6.0 when the timing of `AUDIO_TRACK_SWITCHED` was changed to trigger after segment append instead of synchronously on `AUDIO_TRACK_SWITCHING` with `altAudio` going from a boolean to an enum (DISABLED > SWITCHING > SWITCHED).

### Are there any points in the code the reviewer needs to double check?
There is no need to go from SWITCHING to DISABLED. Immediately setting alt audio to DISABLED restores expected behavior.

### Resolves issues:
Fixes #7643

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
