### PR TITLE
Do not reset interstitial when seeking between assets

### DIFF
--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -967,7 +967,8 @@ export default class InterstitialsController
       currentTime >= start + duration
     ) {
       if (playingItem.event?.appendInPlace) {
-        this.clearInterstitial(playingItem.event, playingItem);
+        // Return SourceBuffer(s) to primary player and flush
+        this.clearAssetPlayers(playingItem.event, playingItem);
         this.flushFrontBuffer(currentTime);
       }
       this.setScheduleToAssetAtTime(currentTime, playingAsset);
@@ -2478,11 +2479,18 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     interstitial: InterstitialEvent,
     toSegment: InterstitialScheduleItem | null,
   ) {
+    this.clearAssetPlayers(interstitial, toSegment);
+    // Remove asset list and resolved duration
+    interstitial.reset();
+  }
+
+  private clearAssetPlayers(
+    interstitial: InterstitialEvent,
+    toSegment: InterstitialScheduleItem | null,
+  ) {
     interstitial.assetList.forEach((asset) => {
       this.clearAssetPlayer(asset.identifier, toSegment);
     });
-    // Remove asset list and resolved duration
-    interstitial.reset();
   }
 
   private resetAssetPlayer(assetId: InterstitialAssetId) {


### PR DESCRIPTION
### This PR will...
Do not reset interstitial when seeking between assets

### Why is this Pull Request needed?
Asset players are reset to return the SourceBuffers to the primary player for flushing the buffer in case of scheduled asset change. This was done by resetting the interstitial, but that inadvertently reset the loaded asset-list as well.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7640

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
