### PR TITLE
Fixed Content Steering URI-REPLACEMENT: HOST applies to the Hostname,

### DIFF
--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -607,7 +607,7 @@ function performUriReplacement(
   }
   const url = new self.URL(uri);
   if (host && !perVariantUri) {
-    url.host = host;
+    url.hostname = host;
   }
   if (params) {
     Object.keys(params)


### PR DESCRIPTION
### This PR will...
Fix application of Content Steering host.

### Why is this Pull Request needed?
Content Steering URI-REPLACEMENT: HOST applies to the Hostname, not host[:port]. The port should not be replaced. There is no way to change the URI scheme or port with url cloning.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
