### PR TITLE
Fix endless while loop in gap controller with bad streams

### DIFF
--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -582,8 +582,9 @@ export default class GapController extends TaskLoop {
             let pos = appended.end;
             while (pos < startTime) {
               const provisioned = appendedFragAtPosition(pos, fragmentTracker);
-              if (provisioned) {
-                pos += provisioned.duration;
+              const duration = provisioned ? provisioned.duration : 0;
+              if (duration > 0) {
+                pos += duration;
               } else {
                 moreToLoad = true;
                 break;

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -394,10 +394,10 @@ function isInvalidInitPts(
   if (initPTS === null) {
     return true;
   }
-  // InitPTS is invalid when distance from program would be more than segment duration or a minimum of one second
+  // InitPTS is invalid when distance from program would be more than or equal to segment duration or a minimum of one second
   const minDuration = Math.max(duration, 1);
   const startTime = startDTS - initPTS.baseTime / initPTS.timescale;
-  return Math.abs(startTime - timeOffset) > minDuration;
+  return Math.abs(startTime - timeOffset) >= minDuration;
 }
 
 function getParsedTrackCodec(


### PR DESCRIPTION
### This PR will...
Fix endless while loop in gap controller with bad streams where segment duration is calculated as 0
Adjust initPTS when segments have the same start time

### Why is this Pull Request needed?
JS should not lock up the page when there are unmarked discontinuities and out of sync audio and video segments that result in buffer gaps or otherwise unplayable timelines.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
- #7656

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
