### PR TITLE
fix: handle page restoration from bfcache in Safari

### DIFF
--- a/tests/unit/controller/buffer-controller.ts
+++ b/tests/unit/controller/buffer-controller.ts
@@ -57,8 +57,7 @@ type BufferControllerTestable = Omit<
   sourceBuffers: SourceBuffersTuple;
   tracks: SourceBufferTrackSet;
   tracksReady: boolean;
-  _handleSafariMediaSourceClose: () => void;
-  safariSourceCloseHandler: () => void;
+  _onMediaSourceClose: () => void;
 };
 
 describe('BufferController', function () {
@@ -561,25 +560,23 @@ describe('BufferController', function () {
   });
 
   describe('Safari MediaSource bfcache close recovery', function () {
-    it('triggers recoverMediaError when MediaSource closes with media attached', function () {
+    it('triggers recoverMediaError when sourceclose fires with media attached', function () {
       const media = new MockMediaElement() as unknown as HTMLMediaElement;
       const mediaSource = new MockMediaSource() as unknown as MediaSource;
       const recoverMediaErrorSpy = sandbox.spy(hls, 'recoverMediaError');
       bufferController.media = media;
       bufferController.mediaSource = mediaSource;
-      bufferController._handleSafariMediaSourceClose();
+      bufferController._onMediaSourceClose();
       expect(recoverMediaErrorSpy).to.have.been.calledOnce;
     });
 
-    it('removes handler on media detaching', function () {
+    it('does not trigger recovery when sourceclose fires without media attached', function () {
       const mediaSource = new MockMediaSource() as unknown as MediaSource;
-      const spy = sandbox.spy(mediaSource, 'removeEventListener');
-      const handler = () => {};
+      const recoverMediaErrorSpy = sandbox.spy(hls, 'recoverMediaError');
+      bufferController.media = null;
       bufferController.mediaSource = mediaSource;
-      bufferController.safariSourceCloseHandler = handler;
-      hls.trigger(Events.MEDIA_DETACHING, {});
-      expect(spy).to.have.been.calledWith('sourceclose', handler);
-      expect(bufferController.safariSourceCloseHandler).to.be.null;
+      bufferController._onMediaSourceClose();
+      expect(recoverMediaErrorSpy).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
### This PR will...
This PR fixes an issue where video playback fails to resume after navigating back and forth between pages in Safari. The problem manifests as buffer append errors when reinitializing the player after a page navigation.

### Why is this Pull Request needed?
The issue affects users who navigate away from a page with a playing HLS.js video and then return to it on Safari.

### Are there any points in the code the reviewer needs to double check?
- [ ] The solution should be tested across different browsers, with particular attention to Safari's behavior. Should we set these event listeners only for Safari?

### Resolves issues:
Fixes #7578 - Unable to resume video playback after navigating back and forth between two pages

Demo of issue: 
https://github.com/user-attachments/assets/d87ab24b-9774-474a-bbc1-a096d4d70009

Demo of fix:

https://github.com/user-attachments/assets/f73c99be-ae6e-4226-bfe5-c5f9d02a4e96

### Checklist

- [x] Changes have been done against master branch, and PR does not conflict
- [x] New unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
