### PR TITLE
Only emit FRAG_PARSING_USERDATA when text samples are found

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -164,7 +164,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     const result: RemuxerResult = {
       audio: undefined,
       video: undefined,
-      text: textTrack,
+      text: undefined,
       id3: id3Track,
       initSegment: undefined,
     };


### PR DESCRIPTION
  ## Summary

  Fixes a bug in `PassThroughRemuxer` where the `FRAG_PARSING_USERDATA` event is incorrectly triggered even when
  there are no text samples.

  ## Problem

  Previously, `PassThroughRemuxer` would set `result.text` to the `textTrack` object unconditionally. This caused
  issues when:

  1. SEI NAL units with unsupported payload types (e.g., type 1 - `pic_timing`) are encountered
  2. These SEI messages are parsed but ignored, resulting in empty `textTrack.samples`
  3. However, because `result.text` was set to the `textTrack` object (not `undefined`), the condition in
  `stream-controller.ts:1404` evaluates to `true`
  4. This triggers the `FRAG_PARSING_USERDATA` event with empty samples

  ## Solution

  Aligns `PassThroughRemuxer` behavior with `MP4Remuxer` by:
  - Initializing `result.text` to `undefined` instead of `textTrack`
  - Only setting `result.text` when `textTrack.samples.length > 0`

  ## Changes

  - **File**: `src/remux/passthrough-remuxer.ts`
  - **Line 167**: Changed `text: textTrack` to `text: undefined`

  ## Test plan

  - [x] Type checking passes
  - [x] Linting passes
  - [x] Build succeeds
  - [x] Pre-commit hooks pass