### PR TITLE
Restart loading in `recoverMediaError` when `autoStartLoad` is disabled

### DIFF
--- a/src/hls.ts
+++ b/src/hls.ts
@@ -665,12 +665,17 @@ export default class Hls implements HlsEventEmitter {
   recoverMediaError() {
     this.logger.log('recoverMediaError');
     const media = this._media;
+    const started = this.started;
     const time = media?.currentTime;
     this.detachMedia();
     if (media) {
       this.attachMedia(media);
-      if (time) {
-        this.startLoad(time);
+      if (started) {
+        if (time) {
+          this.startLoad(time);
+        } else if (!this.config.autoStartLoad) {
+          this.startLoad();
+        }
       }
     }
   }


### PR DESCRIPTION
### This PR will...
Restart loading in `recoverMediaError` when `autoStartLoad` is disabled.

### Why is this Pull Request needed?
Because otherwise, `detachMedia` will stop all loading, and `attachMedia` will not restart it when `autoStartLoad` is set to `false`.

The problem when testing the fix in #7683 (call `recoverMediaError` when MediaSource of attached media element is closed) for the steps in #7687 is that with `autoStartLoad: false`, loading is not automatically restarted.  This change ensures that loading is restarted when `hls.started` is `true` (meaning `hls.stopLoad()` was never called).

### Resolves issues:
Fixes #7687

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
