### PR TITLE
Introduce `MEDIA_SOURCE_REQUIRES_RESET` error event (MediaSource closed while attached or ended on append error)

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1427,6 +1427,8 @@ export enum ErrorDetails {
     // (undocumented)
     MANIFEST_PARSING_ERROR = "manifestParsingError",
     // (undocumented)
+    MEDIA_SOURCE_REQUIRES_RESET = "mediaSourceRequiresReset",
+    // (undocumented)
     REMUX_ALLOC_ERROR = "remuxAllocError",
     // (undocumented)
     SUBTITLE_LOAD_ERROR = "subtitleTrackLoadError",
@@ -4200,9 +4202,11 @@ export const enum NetworkErrorAction {
     // (undocumented)
     RemoveAlternatePermanently = 3,
     // (undocumented)
+    ResetMediaSource = 6,// Reserved for future use
+    // (undocumented)
     RetryRequest = 5,// Reserved for future use
     // (undocumented)
-    SendAlternateToPenaltyBox = 2,// Reserved for future use
+    SendAlternateToPenaltyBox = 2,
     // (undocumented)
     SendEndCallback = 1
 }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1,5 +1,9 @@
 import BufferOperationQueue from './buffer-operation-queue';
-import { createDoNothingErrorAction } from './error-controller';
+import {
+  createDoNothingErrorAction,
+  ErrorActionFlags,
+  NetworkErrorAction,
+} from './error-controller';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
 import { ElementaryStreamTypes } from '../loader/fragment';
@@ -1584,7 +1588,16 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       this.warn(
         'MediaSource closed while media attached - triggering recovery',
       );
-      this.hls.recoverMediaError();
+      this.hls.trigger(Events.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.MEDIA_SOURCE_REQUIRES_RESET,
+        fatal: false,
+        error: new Error('MediaSource closed while media is still attached'),
+        errorAction: {
+          action: NetworkErrorAction.ResetMediaSource,
+          flags: ErrorActionFlags.None,
+        },
+      });
     }
   };
 
@@ -1636,7 +1649,19 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       this.warn(
         `MediaSource readyState "ended" during SourceBuffer error - triggering recovery`,
       );
-      this.hls.recoverMediaError();
+      this.hls.trigger(Events.ERROR, {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.MEDIA_SOURCE_REQUIRES_RESET,
+        fatal: false,
+        sourceBufferName: type,
+        error: new Error(
+          `${type} SourceBuffer error. MediaSource readyState: ended`,
+        ),
+        errorAction: {
+          action: NetworkErrorAction.ResetMediaSource,
+          flags: ErrorActionFlags.None,
+        },
+      });
       return;
     }
 

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -28,6 +28,7 @@ export const enum NetworkErrorAction {
   RemoveAlternatePermanently = 3, // Reserved for future use
   InsertDiscontinuity = 4, // Reserved for future use
   RetryRequest = 5,
+  ResetMediaSource = 6,
 }
 
 export const enum ErrorActionFlags {
@@ -479,6 +480,9 @@ export default class ErrorController
         break;
       case NetworkErrorAction.RetryRequest:
         // handled by stream and playlist/level controllers
+        break;
+      case NetworkErrorAction.ResetMediaSource:
+        this.hls.recoverMediaError();
         break;
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -98,6 +98,8 @@ export enum ErrorDetails {
   INTERNAL_ABORTED = 'aborted',
   // Triggered when attachMedia fails
   ATTACH_MEDIA_ERROR = 'attachMediaError',
+  // Triggered when MediaSource enters an invalid state that requires a reset
+  MEDIA_SOURCE_REQUIRES_RESET = 'mediaSourceRequiresReset',
   // Uncategorized error
   UNKNOWN = 'unknown',
 }

--- a/tests/unit/controller/error-controller.ts
+++ b/tests/unit/controller/error-controller.ts
@@ -3,6 +3,10 @@ import { fakeServer } from 'nise';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { multivariantPlaylistWithRedundantFallbacks } from './level-controller';
+import {
+  ErrorActionFlags,
+  NetworkErrorAction,
+} from '../../../src/controller/error-controller';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
@@ -542,6 +546,26 @@ segment.mp4
           'Offset is outside the bounds of the DataView',
         ),
       );
+    });
+  });
+
+  describe('Media Error Handling', function () {
+    it('treats MEDIA_SOURCE_REQUIRES_RESET as recoverable and calls recoverMediaError', function () {
+      const recoverSpy = sinon.spy(hls, 'recoverMediaError');
+      const data: any = {
+        type: ErrorTypes.MEDIA_ERROR,
+        details: ErrorDetails.MEDIA_SOURCE_REQUIRES_RESET,
+        fatal: false,
+        error: new Error(
+          'MediaSource requires reset while media is still attached',
+        ),
+        errorAction: {
+          action: NetworkErrorAction.ResetMediaSource,
+          flags: ErrorActionFlags.None,
+        },
+      };
+      hls.trigger(Events.ERROR, data);
+      expect(recoverSpy).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
### This PR will...
Refactor the MediaSource close handler to emit a new error event instead of directly calling recovery, allowing applications to intercept and handle the error before automatic recovery occurs. 

**Changes:**
1. Buffer controller now emits `MEDIA_SOURCE_REQUIRES_RESET` error when MediaSource closes unexpectedly
2. Buffer controller now emits `MEDIA_SOURCE_REQUIRES_RESET` error from SourceBuffer update error when MediaSource is ended
3. Error controller handles the error in `onErrorOut` and calls `recoverMediaError()` if needed
4. Adds new error detail: `ErrorDetails.MEDIA_SOURCE_REQUIRES_RESET`

### Why is this Pull Request needed?
When MediaSource closes unexpectedly with media attached (on Safari bfcache restore), the buffer controller directly calls `this.hls.recoverMediaError()`, bypassing the normal error handling flow. This change allows the media to recover through the full error handling route, where `recoverMediaError` would end up getting called in error-controller, instead of directly in buffer-controller.

### Resolves issues:
N/A - This is a refactor, not fixing a specific reported bug. Related discussion in #7693 (comment): https://github.com/video-dev/hls.js/pull/7693#issuecomment-37620677, and a follow-up to #7683

**Manual testing:**
1. Open demo page
2. Trigger bfcache restore (navigate away and use browser back button)
3. Verify `MEDIA_SOURCE_REQUIRES_RESET` error is logged
5. Verify playback recovers

### Checklist
- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md