### PR TITLE
Verify byte-range responses

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -576,7 +576,7 @@ export default class BaseStreamController
 
         if ('payload' in data) {
           this.log(
-            `Loaded ${frag.type} sn: ${frag.sn} of ${this.playlistLabel()} ${frag.level}`,
+            `Loaded ${frag.type} sn: ${frag.sn} of ${this.playlistLabel()} ${frag.level} (bytes ${frag.stats.loaded})`,
           );
           this.hls.trigger(Events.FRAG_LOADED, data);
         }
@@ -936,7 +936,9 @@ export default class BaseStreamController
               frag.cc
             } [${details.startSN}-${details.endSN}], target: ${parseFloat(
               targetBufferTime.toFixed(3),
-            )}`,
+            )}${
+              part.byteRange.length ? ` range:${part.byteRange.join('-')}` : ''
+            }`,
           );
           this.nextLoadPosition = part.start + part.duration;
           this.state = State.FRAG_LOADING;
@@ -1004,7 +1006,9 @@ export default class BaseStreamController
     this.log(
       `Loading ${frag.type} sn: ${frag.sn} of ${this.fragInfo(frag, false)}) cc: ${frag.cc} ${
         '[' + details.startSN + '-' + details.endSN + ']'
-      }, target: ${parseFloat(targetBufferTime.toFixed(3))}`,
+      }, target: ${parseFloat(targetBufferTime.toFixed(3))}${
+        frag.byteRange.length ? ` range:${frag.byteRange.join('-')}` : ''
+      }`,
     );
     // Don't update nextLoadPosition for fragments which are not buffered
     if (Number.isFinite(frag.sn as number) && !this.bitrateTest) {

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -146,7 +146,7 @@ class XhrLoader implements Loader<LoaderContext> {
     if (context.rangeEnd) {
       xhr.setRequestHeader(
         'Range',
-        'bytes=' + context.rangeStart + '-' + (context.rangeEnd - 1),
+        `bytes=${context.rangeStart}-${context.rangeEnd - 1}`,
       );
     }
 
@@ -229,6 +229,14 @@ class XhrLoader implements Loader<LoaderContext> {
               data: data,
               code: status,
             };
+            if (
+              context.rangeEnd &&
+              len !== context.rangeEnd - context.rangeStart!
+            ) {
+              logger.warn(
+                `Payload length ${len} does not match requested Range: bytes=${context.rangeStart}-${context.rangeEnd - 1}`,
+              );
+            }
             this.callbacks?.onSuccess(response, stats, context, xhr);
             return;
           }

--- a/tests/unit/loader/fragment.ts
+++ b/tests/unit/loader/fragment.ts
@@ -77,12 +77,14 @@ describe('Fragment class tests', function () {
       frag.setByteRange('1000@10000');
       expect(frag.byteRangeStartOffset).to.equal(10000);
       expect(frag.byteRangeEndOffset).to.equal(11000);
+      expect(frag.byteRange).to.deep.equal([10000, 11000]);
     });
 
     it('set byte range with no offset and uses 0 as offset', function () {
       frag.setByteRange('5000');
       expect(frag.byteRangeStartOffset).to.equal(0);
       expect(frag.byteRangeEndOffset).to.equal(5000);
+      expect(frag.byteRange).to.deep.equal([0, 5000]);
     });
 
     it('set byte range with no offset and uses 0 as offset', function () {
@@ -91,6 +93,7 @@ describe('Fragment class tests', function () {
       frag.setByteRange('5000', prevFrag);
       expect(frag.byteRangeStartOffset).to.equal(11000);
       expect(frag.byteRangeEndOffset).to.equal(16000);
+      expect(frag.byteRange).to.deep.equal([11000, 16000]);
     });
   });
 

--- a/tests/unit/loader/m3u8-parser.ts
+++ b/tests/unit/loader/m3u8-parser.ts
@@ -864,6 +864,7 @@ lo008ts`;
     expect(result.fragments[9].url).to.equal('http://dummy.com/lo008ts');
     expect(result.fragments[9].byteRangeStartOffset).to.equal(684508);
     expect(result.fragments[9].byteRangeEndOffset).to.equal(817988);
+    expect(result.fragments[9].byteRange).to.deep.equal([684508, 817988]);
   });
 
   it('parse level with #EXT-X-BYTERANGE after #EXTINF', function () {
@@ -921,6 +922,7 @@ lo008ts`;
     expect(result.fragments[9].url).to.equal('http://dummy.com/lo008ts');
     expect(result.fragments[9].byteRangeStartOffset).to.equal(684508);
     expect(result.fragments[9].byteRangeEndOffset).to.equal(817988);
+    expect(result.fragments[9].byteRange).to.deep.equal([684508, 817988]);
   });
 
   it('parse level with #EXT-X-BYTERANGE before #EXT-X-MAP tag', function () {
@@ -968,6 +970,7 @@ lo007.m4v
     expect(result.fragments[2].url).to.equal('http://dummy.com/lo007.m4v');
     expect(result.fragments[2].byteRangeStartOffset).to.equal(64000, '3 start');
     expect(result.fragments[2].byteRangeEndOffset).to.equal(104000, '3 end');
+    expect(result.fragments[2].byteRange).to.deep.equal([64000, 104000]);
   });
 
   it('parse level with #EXT-X-BYTERANGE without offset', function () {
@@ -1003,6 +1006,7 @@ lo007ts`;
     expect(result.fragments[1].byteRangeEndOffset).to.equal(1039452);
     expect(result.fragments[2].byteRangeStartOffset).to.equal(1039452);
     expect(result.fragments[2].byteRangeEndOffset).to.equal(1182520);
+    expect(result.fragments[2].byteRange).to.deep.equal([1039452, 1182520]);
   });
 
   it('parses discontinuity and maintains continuity counter', function () {
@@ -1311,6 +1315,7 @@ main.mp4`;
     );
     expect(initSegment?.byteRangeStartOffset).to.equal(0);
     expect(initSegment?.byteRangeEndOffset).to.equal(718);
+    expect(initSegment?.byteRange).to.deep.equal([0, 718]);
     expect(initSegment?.sn).to.equal('initSegment');
   });
 


### PR DESCRIPTION
### This PR will...
Verify that responses from byte-range requests match the requested length.

### Why is this Pull Request needed?
Servers can ignore range headers and return the entire resource or an incorrect range. In this case, the client should at least log a warning. (#6191)

### Are there any points in the code that the reviewer needs to double-check?
After reviewing the draft and considering this change further, I think the client should reject the response and emit an error. 

There could be a case for handling responses that appear to contain a complete resource, but that requires comparing the bytes to the full range of segment ranges and caching them to pull those bytes as the segments are requested - not expected or valid behavior.

### Resolves issues:
- #7246 

- Related to #6191

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
