### PR TITLE
Fix Pathway Cloning PARAMS applied after PER-VARIANT-URIS

### DIFF
--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -593,20 +593,18 @@ function performUriReplacement(
   perOptionKey: 'PER-VARIANT-URIS' | 'PER-RENDITION-URIS',
   uriReplacement: UriReplacement,
 ): string {
-  const {
-    HOST: host,
-    PARAMS: params,
-    [perOptionKey]: perOptionUris,
-  } = uriReplacement;
-  let perVariantUri;
   if (stableId) {
-    perVariantUri = perOptionUris?.[stableId];
-    if (perVariantUri) {
-      uri = perVariantUri;
+    const { [perOptionKey]: perOptionUris } = uriReplacement;
+    if (perOptionUris) {
+      const perVariantUri = perOptionUris[stableId];
+      if (perVariantUri) {
+        return perVariantUri;
+      }
     }
   }
+  const { HOST: host, PARAMS: params } = uriReplacement;
   const url = new self.URL(uri);
-  if (host && !perVariantUri) {
+  if (host) {
     url.hostname = host;
   }
   if (params) {


### PR DESCRIPTION
### This PR will...
Perform Pathway Cloning based on PER-VARIANT-URIS and PER-RENDITION-URIS, which supersede HOST and PARAMS replacement.

### Why is this Pull Request needed?
Pathway Cloning is described in the HLS spec with PER-VARIANT-URIS and PER-RENDITION-URIS being applied last, completely replacing the URI of the media playlist it applies to. This change aligns with behavior in other HLS clients.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
