### PR TITLE
Clear Fragment and Part resolved url cache

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -382,7 +382,7 @@ export class BaseSegment {
     set stats(value: LoadStats);
     // (undocumented)
     get url(): string;
-    set url(value: string);
+    set url(value: string | null);
 }
 
 // Warning: (ae-missing-release-tag) "BaseStreamController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -306,6 +306,7 @@ export default class FragmentLoader {
 
   private resetLoader(frag: Fragment, loader: Loader<FragmentLoaderContext>) {
     frag.loader = null;
+    frag.url = null;
     if (this.loader === loader) {
       self.clearTimeout(this.partLoadTimeout);
       this.loader = null;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -120,7 +120,7 @@ export class BaseSegment {
   }
 
   get url(): string {
-    if (!this._url && this.baseurl && this.relurl) {
+    if (!this._url && this.relurl) {
       this._url = buildAbsoluteURL(this.baseurl, this.relurl, {
         alwaysNormalize: true,
       });
@@ -128,7 +128,7 @@ export class BaseSegment {
     return this._url || '';
   }
 
-  set url(value: string) {
+  set url(value: string | null) {
     this._url = value;
   }
 
@@ -137,6 +137,7 @@ export class BaseSegment {
     elementaryStreams[ElementaryStreamTypes.AUDIO] = null;
     elementaryStreams[ElementaryStreamTypes.VIDEO] = null;
     elementaryStreams[ElementaryStreamTypes.AUDIOVIDEO] = null;
+    this.url = null;
   }
 }
 

--- a/tests/unit/loader/fragment-loader.ts
+++ b/tests/unit/loader/fragment-loader.ts
@@ -10,24 +10,25 @@ import { LoadStats } from '../../../src/loader/load-stats';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import { logger } from '../../../src/utils/logger';
 import { MockXhr } from '../../mocks/loader.mock';
+import type { MediaFragment } from '../../../src/loader/fragment';
 
 use(sinonChai);
 
 describe('FragmentLoader tests', function () {
   let fragmentLoader: FragmentLoader;
-  let frag;
-  let levelDetails;
+  let frag: MediaFragment;
+  let levelDetails: LevelDetails;
   let response;
   let context;
-  let stats;
+  let stats: LoadStats;
   let networkDetails;
 
   beforeEach(function () {
     fragmentLoader = new FragmentLoader(
       mergeConfig(hlsDefaultConfig, { loader: MockXhr }, logger),
     );
-    frag = new Fragment(PlaylistLevelType.MAIN, '');
-    frag.url = 'foo';
+    frag = new Fragment(PlaylistLevelType.MAIN, '') as MediaFragment;
+    frag.relurl = 'foo';
     levelDetails = new LevelDetails('');
     levelDetails.fragments.push(frag);
     response = {};
@@ -88,9 +89,9 @@ describe('FragmentLoader tests', function () {
 
   it('should reject with a LoadError if the fragment does not have a url', function () {
     return new Promise<void>((resolve, reject) => {
-      frag.url = null;
+      frag.relurl = undefined;
       fragmentLoader
-        .load(frag, levelDetails)
+        .load(frag)
         .then(() => {
           reject(new Error('Fragment loader should not have resolved'));
         })
@@ -104,7 +105,7 @@ describe('FragmentLoader tests', function () {
     const fragmentLoaderPrivates = fragmentLoader as any;
     return new Promise<LoadError>((resolve, reject) => {
       fragmentLoader
-        .load(frag, levelDetails)
+        .load(frag)
         .then(() => {
           reject(new Error('Fragment loader should not have resolved'));
         })
@@ -143,7 +144,7 @@ describe('FragmentLoader tests', function () {
     const fragmentLoaderPrivates = fragmentLoader as any;
     return new Promise<LoadError>((resolve, reject) => {
       fragmentLoader
-        .load(frag, levelDetails)
+        .load(frag)
         .then(() => {
           reject(new Error('Fragment loader should not have resolved'));
         })


### PR DESCRIPTION
### This PR will...
Clear Fragment and Part resolved url cache when done loading or ejected from the buffer.

### Why is this Pull Request needed?
Reduce memory usage in long playback sessions.

### Are there any points in the code the reviewer needs to double check?
Reading `frag.url` without loading or buffering the fragment can repopulate the cache (`frag._url`) without it being cleared with the loader or elementary stream data (ex: cmcd-controller next object url). Most of the time, these are still loaded and cleared. At this point, I'm not looking to do more expensive sweeps.

This could be a breaking change if developers are setting segment.url to change what is loaded. This can still be done, but the value will later be reset. Anyone doing this should instead set `relurl` and/or the shared `base.url`.
### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
