### PR TITLE
fix: ADTS channel config for 5.1

### DIFF
--- a/src/demux/audio/adts.ts
+++ b/src/demux/audio/adts.ts
@@ -51,7 +51,7 @@ export function getAudioConfig(
   }
   // MPEG-4 Audio Object Type (profile_ObjectType+1)
   const adtsObjectType = ((byte2 >> 6) & 0x3) + 1;
-  const channelCount = ((data[offset + 3] >> 6) & 0x3) | ((byte2 & 1) << 2);
+  const channelCount = (data[offset + 3] >> 3) & 0x07;
   const codec = 'mp4a.40.' + adtsObjectType;
   /* refer to http://wiki.multimedia.cx/index.php?title=MPEG-4_Audio#Audio_Specific_Config
       ISO/IEC 14496-3 - Table 1.13 — Syntax of AudioSpecificConfig()

--- a/tests/unit/demuxer/adts.js
+++ b/tests/unit/demuxer/adts.js
@@ -74,7 +74,7 @@ describe('getAudioConfig', function () {
     data[0] = 0xff;
     data[1] = 0xf1; // ID = 0 (MPEG-4), layer = 00
     data[2] = 0x5c; // sampling_frequency_index = 7
-    data[3] = 0x80; // stereo channels
+    data[3] = 0x10; // stereo channels (channel config = 2)
 
     const result = getAudioConfig(observer, data, 0, undefined);
     expect(result, JSON.stringify(result)).to.deep.equal({
@@ -93,7 +93,7 @@ describe('getAudioConfig', function () {
     data[0] = 0xff;
     data[1] = 0xf1; // ID = 0 (MPEG-4), layer = 00
     data[2] = 0x50; // sampling_frequency_index = 4
-    data[3] = 0x40; // mono channels
+    data[3] = 0x08; // mono channels (channel config = 1)
 
     const result = getAudioConfig(observer, data, 0, undefined);
     expect(result, JSON.stringify(result)).to.deep.equal({


### PR DESCRIPTION
Fixes #7739

Correct ADTS channel configuration parsing to support 5.1 audio.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*