### PR TITLE
feat: add frame capture and clipboard helper APIs

### DIFF
--- a/src/hls.ts
+++ b/src/hls.ts
@@ -141,6 +141,76 @@ export default class Hls implements HlsEventEmitter {
     return getMediaSource();
   }
 
+  /**
+   * Capture the currently rendered frame from an `HTMLVideoElement` as an encoded image `Blob`.
+   * This is useful for custom player UIs that support actions such as "copy frame as image".
+   */
+  static captureFrame(
+    media: HTMLMediaElement,
+    type: string = 'image/png',
+    quality?: number,
+  ): Promise<Blob> {
+    if (!(media instanceof HTMLVideoElement)) {
+      return Promise.reject(
+        new Error('captureFrame() requires an HTMLVideoElement'),
+      );
+    }
+
+    if (!media.videoWidth || !media.videoHeight) {
+      return Promise.reject(new Error('No rendered frame is available yet'));
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = media.videoWidth;
+    canvas.height = media.videoHeight;
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return Promise.reject(new Error('Failed to acquire 2D canvas context'));
+    }
+
+    context.drawImage(media, 0, 0, canvas.width, canvas.height);
+
+    return new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('Failed to encode frame image'));
+          return;
+        }
+        resolve(blob);
+      }, type, quality);
+    });
+  }
+
+  /**
+   * Capture the currently rendered frame and write it to the Clipboard as an image.
+   */
+  static copyFrameToClipboard(
+    media: HTMLMediaElement,
+    type: string = 'image/png',
+    quality?: number,
+  ): Promise<void> {
+    if (
+      typeof ClipboardItem === 'undefined' ||
+      !navigator.clipboard ||
+      typeof navigator.clipboard.write !== 'function'
+    ) {
+      return Promise.reject(
+        new Error(
+          'Clipboard image writing is not supported in this environment',
+        ),
+      );
+    }
+
+    return Hls.captureFrame(media, type, quality).then((frame) =>
+      navigator.clipboard.write([
+        new ClipboardItem({
+          [type]: frame,
+        }),
+      ]),
+    );
+  }
+
   static get Events(): typeof Events {
     return Events;
   }

--- a/tests/unit/hls.ts
+++ b/tests/unit/hls.ts
@@ -29,6 +29,105 @@ describe('Hls', function () {
     });
   });
 
+  describe('static frame helpers', function () {
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('captureFrame should reject non-video elements', async function () {
+      const media = document.createElement('audio');
+
+      try {
+        await Hls.captureFrame(media);
+        expect.fail('Expected captureFrame() to reject');
+      } catch (error) {
+        expect((error as Error).message).to.equal(
+          'captureFrame() requires an HTMLVideoElement',
+        );
+      }
+    });
+
+    it('captureFrame should render a video frame to canvas', async function () {
+      const media = document.createElement('video');
+      Object.defineProperty(media, 'videoWidth', { value: 640 });
+      Object.defineProperty(media, 'videoHeight', { value: 360 });
+
+      const frame = new Blob(['frame'], { type: 'image/png' });
+      const drawImage = sinon.stub();
+      const toBlob = sinon
+        .stub()
+        .callsFake((callback: BlobCallback) => callback(frame));
+      const fakeCanvas = {
+        width: 0,
+        height: 0,
+        getContext: sinon.stub().withArgs('2d').returns({ drawImage }),
+        toBlob,
+      } as unknown as HTMLCanvasElement;
+      const createElement = document.createElement.bind(document);
+
+      sinon
+        .stub(document, 'createElement')
+        .callsFake((tagName: string): HTMLElement => {
+          if (tagName === 'canvas') {
+            return fakeCanvas as unknown as HTMLElement;
+          }
+          return createElement(tagName);
+        });
+
+      const blob = await Hls.captureFrame(media);
+      expect(blob).to.equal(frame);
+      expect(drawImage).to.have.been.calledOnceWithExactly(media, 0, 0, 640, 360);
+    });
+
+    it('copyFrameToClipboard should write the captured frame to clipboard', async function () {
+      const media = document.createElement('video');
+      const frame = new Blob(['frame'], { type: 'image/png' });
+
+      const captureFrame = sinon.stub(Hls, 'captureFrame').resolves(frame);
+      const write = sinon.stub().resolves();
+      const clipboardItem = sinon
+        .stub()
+        .callsFake(function (this: { data: Record<string, Blob> }, data) {
+          this.data = data;
+        });
+
+      const previousClipboard = Object.getOwnPropertyDescriptor(
+        navigator,
+        'clipboard',
+      );
+      const previousClipboardItem = (globalThis as any).ClipboardItem;
+
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { write },
+        configurable: true,
+      });
+      (globalThis as any).ClipboardItem = clipboardItem;
+
+      try {
+        await Hls.copyFrameToClipboard(media);
+      } finally {
+        if (previousClipboard) {
+          Object.defineProperty(navigator, 'clipboard', previousClipboard);
+        }
+        if (typeof previousClipboardItem === 'undefined') {
+          delete (globalThis as any).ClipboardItem;
+        } else {
+          (globalThis as any).ClipboardItem = previousClipboardItem;
+        }
+      }
+
+      expect(captureFrame).to.have.been.calledOnceWithExactly(
+        media,
+        'image/png',
+        undefined,
+      );
+      expect(clipboardItem).to.have.been.calledOnceWithExactly({
+        'image/png': frame,
+      });
+      expect(write).to.have.been.calledOnce;
+    });
+  });
+
   describe('attachMedia and detachMedia', function () {
     function detachTest(hls: Hls, media: HTMLMediaElement, refCount: number) {
       const components = (hls as any).coreComponents


### PR DESCRIPTION
## Summary
- add `Hls.captureFrame(media, type?, quality?)` to capture current video frame as an image Blob
- add `Hls.copyFrameToClipboard(media, type?, quality?)` to write captured frame to Clipboard
- add unit tests for non-video rejection, canvas capture flow, and clipboard write flow

## Motivation
Our dashboard player supports pausing and a right-click action to copy the current frame as an image. These helper APIs make this use-case reusable upstream for hls.js consumers.

## Testing
- `npx eslint src/hls.ts tests/unit/hls.ts`
- `npm run test:unit -- --grep "static frame helpers"`

## Notes
- Clipboard image writes are subject to browser permission/user-gesture constraints.