### PR TITLE
added flushImmediate to audioPreference options

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -178,6 +178,7 @@ export type AudioSelectionOption = {
     audioCodec?: string;
     groupId?: string;
     default?: boolean;
+    flushImmediate?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "AudioStreamController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -244,7 +244,7 @@ class AudioTrackController extends BasePlaylistController {
   set audioTrack(newId: number) {
     // If audio track is selected from API then don't choose from the manifest default track
     this.selectDefaultTrack = false;
-    this.setAudioTrack(newId);
+    this.setAudioTrack(newId, this.hls.config.audioPreference?.flushImmediate);
   }
 
   get nextAudioTrack(): number {

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -32,6 +32,7 @@ export type AudioSelectionOption = {
   audioCodec?: string;
   groupId?: string;
   default?: boolean;
+  flushImmediate?: boolean;
 };
 
 export type SubtitleSelectionOption = {

--- a/tests/unit/controller/audio-track-controller.ts
+++ b/tests/unit/controller/audio-track-controller.ts
@@ -539,7 +539,7 @@ describe('AudioTrackController', function () {
       });
     });
 
-    it('should set audio track with flushImmediate=true by default', function () {
+    it('should set audio track with flushImmediate=true by default (no audioPreference set)', function () {
       const triggerSpy = sinon.spy(hls, 'trigger');
       audioTrackController.audioTrack = 1;
 
@@ -551,6 +551,44 @@ describe('AudioTrackController', function () {
           flushImmediate: true,
         }),
       );
+    });
+
+    it('should set audio track with flushImmediate=true when audioPreference.flushImmediate is true', function () {
+      (hls as unknown as Hls).config.audioPreference = { flushImmediate: true };
+      const triggerSpy = sinon.spy(hls, 'trigger');
+      audioTrackController.audioTrack = 1;
+
+      expect(audioTrackController.trackId).to.equal(1);
+      expect(triggerSpy).to.have.been.calledWith(
+        Events.AUDIO_TRACK_SWITCHING,
+        sinon.match({
+          id: 1,
+          flushImmediate: true,
+        }),
+      );
+    });
+
+    it('should set audio track with flushImmediate=false when audioPreference.flushImmediate is false', function () {
+      (hls as unknown as Hls).config.audioPreference = {
+        flushImmediate: false,
+      };
+      const triggerSpy = sinon.spy(hls, 'trigger');
+      audioTrackController.audioTrack = 1;
+
+      expect(audioTrackController.trackId).to.equal(1);
+      expect(triggerSpy).to.have.been.calledWith(
+        Events.AUDIO_TRACK_SWITCHING,
+        sinon.match({
+          id: 1,
+          flushImmediate: false,
+        }),
+      );
+    });
+
+    it('should set selectDefaultTrack to false when audioTrack is set from API', function () {
+      (audioTrackController as any).selectDefaultTrack = true;
+      audioTrackController.audioTrack = 1;
+      expect((audioTrackController as any).selectDefaultTrack).to.be.false;
     });
   });
 });


### PR DESCRIPTION
### This PR will add the ability to set the default behavior of audio track switching to default to smooth or immediate audio track switching.

### Why is this Pull Request needed?
Without it, you have to conditionally call the setting of nextAudioTrack vs. audioTrack for differentiating between smooth and immediate audio track switching.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
https://github.com/video-dev/hls.js/issues/7692

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
