### PR TITLE
fix: correct computeInitPts rollover condition causing segment 0 loop 

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -357,11 +357,11 @@ export default class MP4Remuxer extends Logger implements Remuxer {
   ): number {
     const offset = Math.round(presentationTime * timescale);
     let timestamp = normalizePts(basetime, offset);
-    if (timestamp < offset + timescale) {
+    if (timestamp < 0) {
       this.log(
         `Adjusting PTS for rollover in timeline near ${(offset - timestamp) / timescale} ${type}`,
       );
-      while (timestamp < offset + timescale) {
+      while (timestamp < 0) {
         timestamp += 8589934592;
       }
     }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -358,11 +358,11 @@ export default class MP4Remuxer extends Logger implements Remuxer {
   ): number {
     const offset = Math.round(presentationTime * timescale);
     let timestamp = normalizePts(basetime, offset);
-    if (timestamp < 0) {
+    if (timestamp < offset) {
       this.log(
         `Adjusting PTS for rollover in timeline near ${(offset - timestamp) / timescale} ${type}`,
       );
-      while (timestamp < 0) {
+      while (timestamp < offset) {
         timestamp += MPEG_TS_PTS_ROLLOVER;
       }
     }

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -39,6 +39,7 @@ const MAX_SILENT_FRAME_DURATION = 10 * 1000; // 10 seconds
 const AAC_SAMPLES_PER_FRAME = 1024;
 const MPEG_AUDIO_SAMPLE_PER_FRAME = 1152;
 const AC3_SAMPLES_PER_FRAME = 1536;
+const MPEG_TS_PTS_ROLLOVER = 8589934592; // 2^33
 
 let chromeVersion: number | null = null;
 let safariWebkitVersion: number | null = null;
@@ -362,7 +363,7 @@ export default class MP4Remuxer extends Logger implements Remuxer {
         `Adjusting PTS for rollover in timeline near ${(offset - timestamp) / timescale} ${type}`,
       );
       while (timestamp < 0) {
-        timestamp += 8589934592;
+        timestamp += MPEG_TS_PTS_ROLLOVER;
       }
     }
     return timestamp - offset;
@@ -1180,10 +1181,10 @@ export function normalizePts(value: number, reference: number | null): number {
 
   if (reference < value) {
     // - 2^33
-    offset = -8589934592;
+    offset = -MPEG_TS_PTS_ROLLOVER;
   } else {
     // + 2^33
-    offset = 8589934592;
+    offset = MPEG_TS_PTS_ROLLOVER;
   }
   /* PTS is 33bit (from 0 to 2^33 -1)
     if diff between value and reference is bigger than half of the amplitude (2^32) then it means that

--- a/tests/unit/remux/mp4-remuxer.ts
+++ b/tests/unit/remux/mp4-remuxer.ts
@@ -73,6 +73,22 @@ describe('mp4-remuxer', function () {
     const minPts = mp4Remuxer.getVideoStartPts(videoSamples);
     expect(minPts).to.eq(8589928347);
   });
+
+  it('computeInitPts() returns 0 for basetime 0 at presentationTime 0', function () {
+    expect(mp4Remuxer.computeInitPts(0, 90000, 0, 'video')).to.eq(0);
+  });
+
+  it('computeInitPts() rolls forward when basetime has wrapped past 2^33', function () {
+    const basetime = 8589000000; // near 2^33, pre-rollover segment
+    const timeOffset = 583.595; // seek target after rollover
+    const result = mp4Remuxer.computeInitPts(
+      basetime,
+      90000,
+      timeOffset,
+      'audio',
+    );
+    expect(result).to.be.gt(0);
+  });
 });
 
 function ptsDts(pts: number, dts: number): VideoSample {

--- a/tests/unit/remux/mp4-remuxer.ts
+++ b/tests/unit/remux/mp4-remuxer.ts
@@ -89,6 +89,19 @@ describe('mp4-remuxer', function () {
     );
     expect(result).to.be.gt(0);
   });
+
+  it('computeInitPts() rolls forward when offset exceeds 2^33 and normalizePts does not wrap to negative', function () {
+    const basetime = 100000;
+    const timeOffset = 95600; // ~26.5 hours, offset = ~8604000000 > 2^33
+    const timescale = 90000;
+    const result = mp4Remuxer.computeInitPts(
+      basetime,
+      timescale,
+      timeOffset,
+      'audio',
+    );
+    expect(result).to.be.gt(0);
+  });
 });
 
 function ptsDts(pts: number, dts: number): VideoSample {


### PR DESCRIPTION
### This PR will...

Fix a bug introduced in #7537 in `computeInitPts()` that caused segment 0 to be fetched in an infinite loop (Firefox).

### Why is this Pull Request needed?

`computeInitPts()` was introduced in #7537 to handle PTS rollover in long-running live streams. When the 90kHz PTS counter exceeds 2^33 (~26.5 hours), seeking back to segments from before the rollover point causes `normalizePts()` to wrap their large PTS values down to negative numbers, which get filtered out and result in "Found no media in fragment" errors.

The rollover condition used was `timestamp < offset + timescale`. When `EXT-X-START:TIME-OFFSET=0` and video PTS starts at exactly 0, both `basetime` and `offset` are 0, so after `normalizePts(0, 0) = 0` the condition evaluates to `0 < 90000, which evaluates to `true` even though no rollover has occurred. `computeInitPts` returns 8589934592 (2^33) instead of 0. Since initPTS is set to the minimum across both tracks via `Math.min`, the inflated video value loses to audio's 287730, leaving initPTS anchored to the late-starting audio PTS rather than the video PTS of 0. The resulting `timestampOffset` mismatch causes the stream controller to loop on segment 0. On Firefox this loop never recovers.

Changing the condition to `timestamp < 0` would address this. Since `normalizePts()` only produces a negative value when it has wrapped a large PTS down past zero, a negative timestamp appears to be a more precise signal that a genuine rollover has occurred. A legitimately zero-valued timestamp will never be negative. This should preserve the #7536 fix while resolving #7674, though verification against a real long-running stream with PTS rollover would be valuable.

### Are there any points in the code the reviewer needs to double check?

Whether `timestamp < 0` is fully correct for all rollover scenarios, or whether there are edge cases where `normalizePts()` could return a small positive value that still needs rolling forward and that the `original + timescale` tolerance was intentionally guarding against.

The #7536 scenario has not been verified against a real long-running stream. The fix is validated by unit tests.

### Resolves issues:
Fixes #7674

Stream with issue: https://live1.greeblesoftware.com/228541993686314.m3u8

https://compute-init-pts-rollover-regression.pages.dev/ - test in Firefox!

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
