### PR TITLE
fix: split large appendBuffer to stop QuotaExceededError on high-bitrate segments

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -786,6 +786,7 @@ export type BufferControllerConfig = {
     loopBackBufferFlush?: boolean;
     liveDurationInfinity: boolean;
     liveBackBufferLength: number | null;
+    maxAppendSize: number;
 };
 
 // Warning: (ae-missing-release-tag) "BufferCreatedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,6 +32,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`frontBufferFlushThreshold`](#frontbufferflushthreshold)
   - [`loopBackBufferFlush`](#loopbackbufferflush)
   - [`startOnSegmentBoundary`](#startonsegmentboundary)
+  - [`maxAppendSize`](#maxappendsize)
   - [`maxBufferSize`](#maxbuffersize)
   - [`maxBufferHole`](#maxbufferhole)
   - [`maxStarvationDelay`](#maxstarvationdelay)
@@ -462,6 +463,7 @@ var config = {
   maxMaxBufferLength: 600,
   backBufferLength: Infinity,
   frontBufferFlushThreshold: Infinity,
+  maxAppendSize: Infinity,
   maxBufferSize: 60 * 1000 * 1000,
   maxBufferHole: 0.1,
   highBufferWatchdogPeriod: 2,
@@ -661,6 +663,14 @@ Controls back-buffer flushing on quality upgrades when the underlying `HTMLMedia
 
 When set to `true`, the player will align the live start position with the closest video segment boundary when preparing playback. This ensures playback starts at a clean segment boundary rather than potentially in the middle of a segment, which can prevent some segment skipping. This is helpful for when liveSyncDurationCount or liveSyncDuration, do not calculate start position to be the start position of a segment.
 Setting this to `true` may increase initial live playback latency slightly, but can provide more stable playback start. When set to `false`, playback will start at the exact position determined by the player's live sync calculations, which could be in the middle of a segment.
+
+### `maxAppendSize`
+
+(default: `Infinity`)
+
+The maximum number of bytes passed to one `SourceBuffer.appendBuffer()` call. A finite value must be a positive safe integer. `Infinity` disables splitting.
+
+When enabled, larger append payloads are submitted as ordered zero-copy views, and each view waits for the preceding append to finish. This limits the input size used by each browser append and quota preflight. It does not reduce the total bytes appended, release the original JavaScript `ArrayBuffer`, increase the browser's total coded-frame capacity, or replace `maxBufferSize` and `backBufferLength`.
 
 ### `maxBufferSize`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,7 @@ export type BufferControllerConfig = {
    * @deprecated use backBufferLength
    */
   liveBackBufferLength: number | null;
+  maxAppendSize: number;
 };
 
 export type CapLevelControllerConfig = {
@@ -456,6 +457,7 @@ export const hlsDefaultConfig: HlsConfig = {
   backBufferLength: Infinity, // used by buffer-controller
   frontBufferFlushThreshold: Infinity,
   loopBackBufferFlush: undefined, // used by buffer-controller
+  maxAppendSize: Infinity, // used by buffer-controller
   startOnSegmentBoundary: false, // used by stream-controller
   nextAudioTrackBufferFlushForwardOffset: 0.25, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,10 @@ export type BufferControllerConfig = {
    * @deprecated use backBufferLength
    */
   liveBackBufferLength: number | null;
+  /**
+   * Maximum number of bytes passed to one SourceBuffer.appendBuffer call.
+   * Set to Infinity to disable append splitting.
+   */
   maxAppendSize: number;
 };
 
@@ -721,6 +725,17 @@ export function mergeConfig(
   userConfig: Partial<HlsConfig>,
   logger: ILogger,
 ): HlsConfig {
+  if (
+    userConfig.maxAppendSize !== undefined &&
+    userConfig.maxAppendSize !== Infinity &&
+    (!Number.isSafeInteger(userConfig.maxAppendSize) ||
+      userConfig.maxAppendSize <= 0)
+  ) {
+    throw new Error(
+      'Illegal hls.js config: "maxAppendSize" must be a positive safe integer or Infinity',
+    );
+  }
+
   if (
     (userConfig.liveSyncDurationCount ||
       userConfig.liveMaxLatencyDurationCount) &&

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -6,7 +6,6 @@ import { ElementaryStreamTypes, isMediaFragment } from '../loader/fragment';
 import { DEFAULT_TARGET_DURATION } from '../loader/level-details';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper, type BufferTimeRange } from '../utils/buffer-helper';
-import { readUint32 } from '../utils/mp4-tools';
 import {
   areCodecsMediaSourceSupported,
   getCodecCompatibleName,
@@ -23,6 +22,7 @@ import {
   isCompatibleTrackChange,
   isManagedMediaSource,
 } from '../utils/mediasource-helper';
+import { splitAppendData } from '../utils/mp4-tools';
 import { stringify } from '../utils/safe-json-stringify';
 import { timeRangesToString } from '../utils/time-ranges';
 import type { FragmentTracker } from './fragment-tracker';
@@ -88,120 +88,6 @@ class HlsJsTrackRemovedError extends Error {
     super(message);
     this.name = TRACK_REMOVED_ERROR_NAME;
   }
-}
-
-// Maximum bytes per appendBuffer() call. Chromium's per-SourceBuffer quota is
-// ~150MB; keeping each append well under this prevents QuotaExceededError when
-// a single fMP4 segment is very large (common with high-bitrate remuxed streams).
-const MAX_APPEND_SIZE = 16 * 1024 * 1024; // 16MB
-
-/**
- * Read an unsigned 32-bit big-endian integer from a Uint8Array.
- */
-function readBoxSize(data: Uint8Array, offset: number): number {
-  return readUint32(data, offset);
-}
-
-/**
- * Create a view into `data` from `start` to `start + length`.
- */
-function sliceView(
-  data: Uint8Array<ArrayBuffer>,
-  start: number,
-  length: number,
-): Uint8Array<ArrayBuffer> {
-  return new Uint8Array(data.buffer, data.byteOffset + start, length);
-}
-
-/**
- * Read the size of an fMP4 box at the given offset, handling both standard
- * and 64-bit extended sizes. Returns the box size in bytes, or 0 if the
- * box header is invalid or truncated.
- */
-function readMp4BoxSize(data: Uint8Array, pos: number, end: number): number {
-  if (pos + 8 > end) {
-    return 0;
-  }
-  const size = readBoxSize(data, pos);
-  if (size === 0) {
-    return end - pos;
-  }
-  if (size === 1 && pos + 16 <= end) {
-    const hi = readBoxSize(data, pos + 8);
-    return hi > 0 ? end - pos : readBoxSize(data, pos + 12);
-  }
-  if (size < 8 || pos + size > end) {
-    return 0;
-  }
-  return size;
-}
-
-/**
- * Try to split data at fMP4 top-level box boundaries into chunks of at
- * most maxBytes. Returns null if box-boundary splitting cannot produce
- * chunks that all fit within maxBytes (e.g. a single giant mdat box).
- */
-function splitAtBoxBoundaries(
-  data: Uint8Array<ArrayBuffer>,
-  maxBytes: number,
-): Uint8Array<ArrayBuffer>[] | null {
-  if (data.byteLength < 8) {
-    return null;
-  }
-  const chunks: Uint8Array<ArrayBuffer>[] = [];
-  const end = data.byteLength;
-  let chunkStart = 0;
-  let pos = 0;
-
-  while (pos < end) {
-    const boxSize = readMp4BoxSize(data, pos, end);
-    if (boxSize === 0) {
-      break;
-    }
-    if (pos > chunkStart && pos - chunkStart + boxSize > maxBytes) {
-      chunks.push(sliceView(data, chunkStart, pos - chunkStart));
-      chunkStart = pos;
-    }
-    pos += boxSize;
-  }
-
-  if (chunkStart < end) {
-    chunks.push(sliceView(data, chunkStart, end - chunkStart));
-  }
-
-  const allFit =
-    chunks.length > 1 && chunks.every((c) => c.byteLength <= maxBytes);
-  return allFit ? chunks : null;
-}
-
-/**
- * Split a large buffer into chunks of at most maxBytes.
- * Tries to split at fMP4 top-level box boundaries first. If the data
- * contains a single box larger than maxBytes (e.g. a giant mdat), falls
- * back to naive byte splitting — MSE SourceBuffer handles reassembly of
- * partial boxes internally.
- */
-function splitAppendData(
-  data: Uint8Array<ArrayBuffer>,
-  maxBytes: number,
-): Uint8Array<ArrayBuffer>[] {
-  if (data.byteLength <= maxBytes) {
-    return [data];
-  }
-
-  const boxChunks = splitAtBoxBoundaries(data, maxBytes);
-  if (boxChunks) {
-    return boxChunks;
-  }
-
-  // Fallback: naive byte splitting. MSE SourceBuffer handles partial box
-  // reassembly across sequential appendBuffer() calls.
-  const chunks: Uint8Array<ArrayBuffer>[] = [];
-  const end = data.byteLength;
-  for (let offset = 0; offset < end; offset += maxBytes) {
-    chunks.push(sliceView(data, offset, Math.min(maxBytes, end - offset)));
-  }
-  return chunks;
 }
 
 export default class BufferController extends Logger implements ComponentAPI {
@@ -910,11 +796,12 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     eventData: BufferAppendingData,
   ) {
     const { data, type } = eventData;
+    const { maxAppendSize } = this.hls.config;
 
     // Split large fMP4 segments into smaller chunks to avoid QuotaExceededError.
     // Each chunk becomes a separate operation with full error handling.
-    if (data.byteLength > MAX_APPEND_SIZE) {
-      const chunks = splitAppendData(data, MAX_APPEND_SIZE);
+    if (isFinite(maxAppendSize) && data.byteLength > maxAppendSize) {
+      const chunks = splitAppendData(data, maxAppendSize);
       if (chunks.length > 1) {
         this.log(
           `Splitting large ${type} append (sn:${eventData.frag.sn}, ` +

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -6,6 +6,7 @@ import { ElementaryStreamTypes, isMediaFragment } from '../loader/fragment';
 import { DEFAULT_TARGET_DURATION } from '../loader/level-details';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper, type BufferTimeRange } from '../utils/buffer-helper';
+import { readUint32 } from '../utils/mp4-tools';
 import {
   areCodecsMediaSourceSupported,
   getCodecCompatibleName,
@@ -87,6 +88,120 @@ class HlsJsTrackRemovedError extends Error {
     super(message);
     this.name = TRACK_REMOVED_ERROR_NAME;
   }
+}
+
+// Maximum bytes per appendBuffer() call. Chromium's per-SourceBuffer quota is
+// ~150MB; keeping each append well under this prevents QuotaExceededError when
+// a single fMP4 segment is very large (common with high-bitrate remuxed streams).
+const MAX_APPEND_SIZE = 16 * 1024 * 1024; // 16MB
+
+/**
+ * Read an unsigned 32-bit big-endian integer from a Uint8Array.
+ */
+function readBoxSize(data: Uint8Array, offset: number): number {
+  return readUint32(data, offset);
+}
+
+/**
+ * Create a view into `data` from `start` to `start + length`.
+ */
+function sliceView(
+  data: Uint8Array<ArrayBuffer>,
+  start: number,
+  length: number,
+): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(data.buffer, data.byteOffset + start, length);
+}
+
+/**
+ * Read the size of an fMP4 box at the given offset, handling both standard
+ * and 64-bit extended sizes. Returns the box size in bytes, or 0 if the
+ * box header is invalid or truncated.
+ */
+function readMp4BoxSize(data: Uint8Array, pos: number, end: number): number {
+  if (pos + 8 > end) {
+    return 0;
+  }
+  const size = readBoxSize(data, pos);
+  if (size === 0) {
+    return end - pos;
+  }
+  if (size === 1 && pos + 16 <= end) {
+    const hi = readBoxSize(data, pos + 8);
+    return hi > 0 ? end - pos : readBoxSize(data, pos + 12);
+  }
+  if (size < 8 || pos + size > end) {
+    return 0;
+  }
+  return size;
+}
+
+/**
+ * Try to split data at fMP4 top-level box boundaries into chunks of at
+ * most maxBytes. Returns null if box-boundary splitting cannot produce
+ * chunks that all fit within maxBytes (e.g. a single giant mdat box).
+ */
+function splitAtBoxBoundaries(
+  data: Uint8Array<ArrayBuffer>,
+  maxBytes: number,
+): Uint8Array<ArrayBuffer>[] | null {
+  if (data.byteLength < 8) {
+    return null;
+  }
+  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  const end = data.byteLength;
+  let chunkStart = 0;
+  let pos = 0;
+
+  while (pos < end) {
+    const boxSize = readMp4BoxSize(data, pos, end);
+    if (boxSize === 0) {
+      break;
+    }
+    if (pos > chunkStart && pos - chunkStart + boxSize > maxBytes) {
+      chunks.push(sliceView(data, chunkStart, pos - chunkStart));
+      chunkStart = pos;
+    }
+    pos += boxSize;
+  }
+
+  if (chunkStart < end) {
+    chunks.push(sliceView(data, chunkStart, end - chunkStart));
+  }
+
+  const allFit =
+    chunks.length > 1 && chunks.every((c) => c.byteLength <= maxBytes);
+  return allFit ? chunks : null;
+}
+
+/**
+ * Split a large buffer into chunks of at most maxBytes.
+ * Tries to split at fMP4 top-level box boundaries first. If the data
+ * contains a single box larger than maxBytes (e.g. a giant mdat), falls
+ * back to naive byte splitting — MSE SourceBuffer handles reassembly of
+ * partial boxes internally.
+ */
+function splitAppendData(
+  data: Uint8Array<ArrayBuffer>,
+  maxBytes: number,
+): Uint8Array<ArrayBuffer>[] {
+  if (data.byteLength <= maxBytes) {
+    return [data];
+  }
+
+  const boxChunks = splitAtBoxBoundaries(data, maxBytes);
+  if (boxChunks) {
+    return boxChunks;
+  }
+
+  // Fallback: naive byte splitting. MSE SourceBuffer handles partial box
+  // reassembly across sequential appendBuffer() calls.
+  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  const end = data.byteLength;
+  for (let offset = 0; offset < end; offset += maxBytes) {
+    chunks.push(sliceView(data, offset, Math.min(maxBytes, end - offset)));
+  }
+  return chunks;
 }
 
 export default class BufferController extends Logger implements ComponentAPI {
@@ -794,8 +909,29 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     event: Events.BUFFER_APPENDING,
     eventData: BufferAppendingData,
   ) {
+    const { data, type } = eventData;
+
+    // Split large fMP4 segments into smaller chunks to avoid QuotaExceededError.
+    // Each chunk becomes a separate operation with full error handling.
+    if (data.byteLength > MAX_APPEND_SIZE) {
+      const chunks = splitAppendData(data, MAX_APPEND_SIZE);
+      if (chunks.length > 1) {
+        this.log(
+          `Splitting large ${type} append (sn:${eventData.frag.sn}, ` +
+            `${(data.byteLength / 1e6).toFixed(1)}MB) into ${chunks.length} chunks`,
+        );
+        for (let i = 0; i < chunks.length; i++) {
+          this.onBufferAppending(event, {
+            ...eventData,
+            data: chunks[i],
+          });
+        }
+        return;
+      }
+    }
+
     const { tracks } = this;
-    const { data, type, parent, frag, part, chunkMeta, offset } = eventData;
+    const { parent, frag, part, chunkMeta, offset } = eventData;
     const chunkStats = chunkMeta.buffering[type];
     const trackProgress =
       isMediaFragment(frag) &&

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -5,6 +5,7 @@ import { Events } from '../events';
 import { ElementaryStreamTypes, isMediaFragment } from '../loader/fragment';
 import { DEFAULT_TARGET_DURATION } from '../loader/level-details';
 import { PlaylistLevelType } from '../types/loader';
+import { ChunkMetadata } from '../types/transmuxer';
 import { BufferHelper, type BufferTimeRange } from '../utils/buffer-helper';
 import {
   areCodecsMediaSourceSupported,
@@ -60,7 +61,6 @@ import type {
   MediaAttachingData,
   MediaDetachingData,
 } from '../types/events';
-import type { ChunkMetadata } from '../types/transmuxer';
 
 interface BufferedChangeEvent extends Event {
   readonly addedRanges?: TimeRanges;
@@ -81,6 +81,16 @@ type FragmentAppendProgress = {
   progressed: boolean;
   errored: boolean;
   fullyBuffered: Partial<Record<SourceBufferName, boolean>>;
+};
+
+type ChunkedAppendGroup = {
+  chunks: Uint8Array<ArrayBuffer>[];
+  sourceData: BufferAppendingData;
+  nextChunkIndex: number;
+  completedChunkCount: number;
+  failed: boolean;
+  quotaRetryChunkIndex: number | null;
+  quotaRetrySucceeded: boolean;
 };
 
 class HlsJsTrackRemovedError extends Error {
@@ -615,6 +625,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     if (this.operationQueue) {
       this.operationQueue.destroy();
     }
+    this._quotaEvictionPending = {};
     this.operationQueue = new BufferOperationQueue(this.tracks);
   }
 
@@ -792,34 +803,122 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   }
 
   private onBufferAppending(
-    event: Events.BUFFER_APPENDING,
+    _event: Events.BUFFER_APPENDING,
     eventData: BufferAppendingData,
-  ) {
+  ): void {
     const { data, type } = eventData;
     const { maxAppendSize } = this.hls.config;
 
-    // Split large fMP4 segments into smaller chunks to avoid QuotaExceededError.
-    // Each chunk becomes a separate operation with full error handling.
-    if (isFinite(maxAppendSize) && data.byteLength > maxAppendSize) {
+    if (
+      Number.isSafeInteger(maxAppendSize) &&
+      maxAppendSize > 0 &&
+      data.byteLength > maxAppendSize
+    ) {
       const chunks = splitAppendData(data, maxAppendSize);
       if (chunks.length > 1) {
         this.log(
           `Splitting large ${type} append (sn:${eventData.frag.sn}, ` +
             `${(data.byteLength / 1e6).toFixed(1)}MB) into ${chunks.length} chunks`,
         );
-        for (let i = 0; i < chunks.length; i++) {
-          this.onBufferAppending(event, {
-            ...eventData,
-            data: chunks[i],
-          });
-        }
+        const appendGroup: ChunkedAppendGroup = {
+          chunks,
+          sourceData: eventData,
+          nextChunkIndex: 1,
+          completedChunkCount: 0,
+          failed: false,
+          quotaRetryChunkIndex: null,
+          quotaRetrySucceeded: false,
+        };
+        this.queueBufferAppend(
+          this.createChunkedAppendData(appendGroup, 0),
+          appendGroup,
+          0,
+        );
         return;
       }
     }
 
+    this.queueBufferAppend(eventData, null, 0);
+  }
+
+  private createChunkedAppendData(
+    appendGroup: ChunkedAppendGroup,
+    chunkIndex: number,
+  ): BufferAppendingData {
+    const { sourceData, chunks } = appendGroup;
+    const sourceMetadata = sourceData.chunkMeta;
+    const chunk = chunks[chunkIndex];
+    const chunkMetadata = new ChunkMetadata(
+      sourceMetadata.level,
+      sourceMetadata.sn,
+      chunkIndex,
+      chunk.byteLength,
+      sourceMetadata.part,
+      sourceMetadata.partial,
+      sourceMetadata.duration,
+      sourceMetadata.iframe,
+      sourceMetadata.decryptRange,
+    );
+    Object.assign(chunkMetadata.transmuxing, sourceMetadata.transmuxing);
+    return {
+      ...sourceData,
+      data: chunk,
+      chunkMeta: chunkMetadata,
+      offset: chunkIndex === 0 ? sourceData.offset : undefined,
+    };
+  }
+
+  private insertNextChunkedAppend(
+    appendGroup: ChunkedAppendGroup,
+    type: SourceBufferName,
+  ): void {
+    if (
+      appendGroup.failed ||
+      appendGroup.nextChunkIndex >= appendGroup.chunks.length
+    ) {
+      return;
+    }
+    const chunkIndex = appendGroup.nextChunkIndex++;
+    this.queueBufferAppend(
+      this.createChunkedAppendData(appendGroup, chunkIndex),
+      appendGroup,
+      chunkIndex,
+      true,
+    );
+  }
+
+  private getAppendRecoverySize(
+    appendGroup: ChunkedAppendGroup | null,
+    chunkIndex: number,
+    currentChunkSize: number,
+  ): number {
+    if (!appendGroup) {
+      return currentChunkSize;
+    }
+    // Reserve the unqueued suffix to avoid one eviction cycle per continuation
+    let remainingSize = 0;
+    for (
+      let remainingIndex = chunkIndex;
+      remainingIndex < appendGroup.chunks.length;
+      remainingIndex++
+    ) {
+      remainingSize += appendGroup.chunks[remainingIndex].byteLength;
+    }
+    return remainingSize;
+  }
+
+  private queueBufferAppend(
+    eventData: BufferAppendingData,
+    appendGroup: ChunkedAppendGroup | null,
+    chunkIndex: number,
+    insertAfterCurrent: boolean = false,
+  ): void {
     const { tracks } = this;
-    const { parent, frag, part, chunkMeta, offset } = eventData;
+    const { data, type, parent, frag, part, chunkMeta, offset } = eventData;
+    const isFirstChunk = appendGroup === null || chunkIndex === 0;
+    const logicalChunkMeta = appendGroup?.sourceData.chunkMeta ?? chunkMeta;
     const chunkStats = chunkMeta.buffering[type];
+    const logicalChunkStats = logicalChunkMeta.buffering[type];
     const trackProgress =
       isMediaFragment(frag) &&
       !part &&
@@ -831,6 +930,9 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const { sn, cc } = frag;
     const bufferAppendingStart = self.performance.now();
     chunkStats.start = bufferAppendingStart;
+    if (logicalChunkStats.start === 0) {
+      logicalChunkStats.start = bufferAppendingStart;
+    }
     const fragBuffering = frag.stats.buffering;
     const partBuffering = part ? part.stats.buffering : null;
     if (fragBuffering.start === 0) {
@@ -847,18 +949,27 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     // More info here: https://github.com/video-dev/hls.js/issues/332#issuecomment-257986486
     const audioTrack = tracks.audio;
     let checkTimestampOffset = false;
-    if (type === 'audio' && audioTrack?.container === 'audio/mpeg') {
+    if (
+      isFirstChunk &&
+      type === 'audio' &&
+      audioTrack?.container === 'audio/mpeg'
+    ) {
       checkTimestampOffset =
         !this.lastMpegAudioChunk ||
-        chunkMeta.id === 1 ||
-        this.lastMpegAudioChunk.sn !== chunkMeta.sn;
-      this.lastMpegAudioChunk = chunkMeta;
+        logicalChunkMeta.id === 1 ||
+        this.lastMpegAudioChunk.sn !== logicalChunkMeta.sn;
+      this.lastMpegAudioChunk = logicalChunkMeta;
     }
 
     // Block audio append until overlapping video append
     const videoTrack = tracks.video;
     const videoSb = videoTrack?.buffer;
-    if (videoSb && sn !== 'initSegment' && offset !== undefined) {
+    if (
+      isFirstChunk &&
+      videoSb &&
+      sn !== 'initSegment' &&
+      offset !== undefined
+    ) {
       const audioSb = audioTrack?.buffer;
       const partOrFrag = part || (frag as MediaFragment);
       if (
@@ -898,7 +1009,11 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const operation: BufferOperation = {
       label: `append-${type}`,
       execute: () => {
-        chunkStats.executeStart = self.performance.now();
+        const executeStart = self.performance.now();
+        chunkStats.executeStart = executeStart;
+        if (logicalChunkStats.executeStart === 0) {
+          logicalChunkStats.executeStart = executeStart;
+        }
         // this.log(
         //   `appending "${type}" sn: ${sn}${part ? ' p: ' + part.index : ''} of ${
         //     parent === PlaylistLevelType.MAIN ? 'level' : 'track'
@@ -932,6 +1047,9 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       },
       onComplete: () => {
         this.clearBufferAppendTimeoutId(this.tracks[type]);
+        if (appendGroup?.failed) {
+          return;
+        }
         // this.log(
         //   `appended "${type}" sn: ${sn}${part ? ' p: ' + part.index : ''} of ${
         //     parent === PlaylistLevelType.MAIN ? 'level' : 'track'
@@ -939,6 +1057,13 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         // );
         const end = self.performance.now();
         chunkStats.executeEnd = chunkStats.end = end;
+        // Complete aggregate timing only after every byte was appended
+        if (!appendGroup || chunkIndex === appendGroup.chunks.length - 1) {
+          logicalChunkStats.executeEnd = logicalChunkStats.end = end;
+        }
+        if (appendGroup) {
+          appendGroup.completedChunkCount++;
+        }
         if (fragBuffering.first === 0) {
           fragBuffering.first = end;
         }
@@ -976,6 +1101,14 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
           }
         }
 
+        if (appendGroup) {
+          if (appendGroup.quotaRetryChunkIndex === chunkIndex) {
+            appendGroup.quotaRetrySucceeded = true;
+          } else {
+            this.insertNextChunkedAppend(appendGroup, type);
+          }
+        }
+
         this.hls.trigger(Events.BUFFER_APPENDED, {
           type,
           frag,
@@ -1004,16 +1137,35 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
           if (!this._quotaEvictionPending[type]) {
             const evictEnd = this.getBackBufferEvictionTarget(
               type,
-              data.byteLength,
+              this.getAppendRecoverySize(
+                appendGroup,
+                chunkIndex,
+                data.byteLength,
+              ),
               frag.type,
             );
             if (evictEnd > 0) {
               this._quotaEvictionPending[type] = true;
+              if (appendGroup) {
+                appendGroup.quotaRetryChunkIndex = chunkIndex;
+                appendGroup.quotaRetrySucceeded = false;
+              }
               this.log(
                 `QuotaExceededError on "${type}" append sn: ${sn} - evicting back buffer to ${evictEnd.toFixed(3)}s and retrying`,
               );
               const removeOp = this.getFlushOp(type, 0, evictEnd);
-              const clearOp = this.getClearEvictionPendingOp(type);
+              const clearOp = this.getClearEvictionPendingOp(type, () => {
+                if (appendGroup?.quotaRetryChunkIndex !== chunkIndex) {
+                  return;
+                }
+                const shouldContinue =
+                  !appendGroup.failed && appendGroup.quotaRetrySucceeded;
+                appendGroup.quotaRetryChunkIndex = null;
+                appendGroup.quotaRetrySucceeded = false;
+                if (shouldContinue) {
+                  this.insertNextChunkedAppend(appendGroup, type);
+                }
+              });
 
               this.insertNext([removeOp, operation, clearOp], type);
               return;
@@ -1022,6 +1174,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
               `QuotaExceededError on "${type}" sn: ${sn} - no back buffer available to evict`,
             );
           }
+        }
+
+        if (appendGroup) {
+          this.failChunkedAppend(appendGroup, type);
         }
 
         // Append exceptions use the existing append-error path.
@@ -1051,7 +1207,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         } else {
           if (isQuotaError) {
             // QuotaExceededError: http://www.w3.org/TR/html5/infrastructure.html#quotaexceedederror
-            // Eviction was already attempted or not possible — report BUFFER_FULL_ERROR
+            // Eviction was already attempted or not possible; report BUFFER_FULL_ERROR
             event.details = ErrorDetails.BUFFER_FULL_ERROR;
           }
           const appendErrorCount = ++this.appendErrors[type];
@@ -1090,14 +1246,48 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         parent
       } playlist ${frag.level} cc: ${cc} offset: ${offset} bytes: ${data.byteLength}`,
     );
+    if (insertAfterCurrent) {
+      this.insertNext([operation], type);
+      return;
+    }
     this.append(operation, type, this.isPending(this.tracks[type]));
   }
 
-  private getClearEvictionPendingOp(type: SourceBufferName): BufferOperation {
+  private failChunkedAppend(
+    appendGroup: ChunkedAppendGroup,
+    type: SourceBufferName,
+  ): void {
+    appendGroup.failed = true;
+    if (appendGroup.completedChunkCount === 0) {
+      return;
+    }
+    const sourceBuffer = this.tracks[type]?.buffer;
+    if (
+      !sourceBuffer ||
+      sourceBuffer.updating ||
+      this.mediaSource?.readyState !== 'open'
+    ) {
+      return;
+    }
+    try {
+      sourceBuffer.abort();
+    } catch (error) {
+      this.warn(
+        `Failed to reset the ${type} SourceBuffer after a chunked append error`,
+        error,
+      );
+    }
+  }
+
+  private getClearEvictionPendingOp(
+    type: SourceBufferName,
+    onClear?: () => void,
+  ): BufferOperation {
     return {
       label: 'clear',
       execute: () => {
         this._quotaEvictionPending[type] = false;
+        onClear?.();
         this.shiftAndExecuteNext(type);
       },
       onStart: () => {},

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -571,7 +571,7 @@ export class FragmentTracker implements ComponentAPI {
       const bytes =
         (frag.hasStats && frag.stats.loaded) ||
         frag.byteLength ||
-        (frag.bitrate && frag.bitrate * 8 * frag.duration);
+        (frag.bitrate && (frag.bitrate * frag.duration) / 8);
       if (frag.end <= beforePosition && bytes) {
         bytesFreed += bytes;
         evictEnd = Math.max(evictEnd, frag.end);

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -84,6 +84,119 @@ function readUint32(buffer: Uint8Array, offset: number): number {
   return val < 0 ? 4294967296 + val : val;
 }
 
+/**
+ * Read the size of an fMP4 box at the given offset, handling both standard
+ * and 64-bit extended sizes. Returns the box size in bytes, or 0 if the
+ * box header is invalid or truncated.
+ */
+export function readMp4BoxSize(
+  data: Uint8Array,
+  pos: number,
+  end: number,
+): number {
+  if (pos + 8 > end) {
+    return 0;
+  }
+  const size = readUint32(data, pos);
+  if (size === 0) {
+    return end - pos;
+  }
+  if (size === 1 && pos + 16 <= end) {
+    const hi = readUint32(data, pos + 8);
+    return hi > 0 ? end - pos : readUint32(data, pos + 12);
+  }
+  if (size < 8 || pos + size > end) {
+    return 0;
+  }
+  return size;
+}
+
+/**
+ * Try to split data at fMP4 top-level box boundaries into chunks of at
+ * most maxBytes. Returns null if box-boundary splitting cannot produce
+ * chunks that all fit within maxBytes (e.g. a single giant mdat box).
+ */
+export function splitAtBoxBoundaries(
+  data: Uint8Array<ArrayBuffer>,
+  maxBytes: number,
+): Uint8Array<ArrayBuffer>[] | null {
+  if (data.byteLength < 8) {
+    return null;
+  }
+  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  const end = data.byteLength;
+  let chunkStart = 0;
+  let pos = 0;
+
+  while (pos < end) {
+    const boxSize = readMp4BoxSize(data, pos, end);
+    if (boxSize === 0) {
+      break;
+    }
+    if (pos > chunkStart && pos - chunkStart + boxSize > maxBytes) {
+      chunks.push(
+        new Uint8Array(
+          data.buffer,
+          data.byteOffset + chunkStart,
+          pos - chunkStart,
+        ),
+      );
+      chunkStart = pos;
+    }
+    pos += boxSize;
+  }
+
+  if (chunkStart < end) {
+    chunks.push(
+      new Uint8Array(
+        data.buffer,
+        data.byteOffset + chunkStart,
+        end - chunkStart,
+      ),
+    );
+  }
+
+  const allFit =
+    chunks.length > 1 && !chunks.some((c) => c.byteLength > maxBytes);
+  return allFit ? chunks : null;
+}
+
+/**
+ * Split a large buffer into chunks of at most maxBytes.
+ * Tries to split at fMP4 top-level box boundaries first. If the data
+ * contains a single box larger than maxBytes (e.g. a giant mdat), falls
+ * back to naive byte splitting — MSE SourceBuffer handles reassembly of
+ * partial boxes internally.
+ */
+export function splitAppendData(
+  data: Uint8Array<ArrayBuffer>,
+  maxBytes: number,
+): Uint8Array<ArrayBuffer>[] {
+  if (data.byteLength <= maxBytes) {
+    return [data];
+  }
+
+  const boxChunks = splitAtBoxBoundaries(data, maxBytes);
+  if (boxChunks) {
+    return boxChunks;
+  }
+
+  // Fallback: naive byte splitting. MSE SourceBuffer handles partial box
+  // reassembly across sequential appendBuffer() calls.
+  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  const end = data.byteLength;
+  for (let offset = 0; offset < end; offset += maxBytes) {
+    chunks.push(
+      new Uint8Array(
+        data.buffer,
+        data.byteOffset + offset,
+        Math.min(maxBytes, end - offset),
+      ),
+    );
+  }
+  return chunks;
+}
+
 function readUint64(buffer: Uint8Array, offset: number) {
   let result = readUint32(buffer, offset);
   result *= Math.pow(2, 32);

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -13,6 +13,10 @@ type BoxDataOrUndefined = Uint8Array<ArrayBuffer> | undefined;
 
 export const UINT32_MAX = Math.pow(2, 32) - 1;
 
+const MP4_BOX_HEADER_SIZE = 8;
+const MP4_EXTENDED_BOX_HEADER_SIZE = 16;
+const UINT32_SIZE_MULTIPLIER = 4294967296;
+
 export const types = {
   avc1: 0x61766331,
   avcC: 0x61766343,
@@ -91,21 +95,39 @@ function readUint32(buffer: Uint8Array, offset: number): number {
  */
 export function readMp4BoxSize(
   data: Uint8Array,
-  pos: number,
-  end: number,
+  offset: number,
+  endOffset: number,
 ): number {
-  if (pos + 8 > end) {
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(endOffset) ||
+    offset < 0 ||
+    endOffset > data.byteLength ||
+    offset + MP4_BOX_HEADER_SIZE > endOffset
+  ) {
     return 0;
   }
-  const size = readUint32(data, pos);
+  const size = readUint32(data, offset);
   if (size === 0) {
-    return end - pos;
+    return endOffset - offset;
   }
-  if (size === 1 && pos + 16 <= end) {
-    const hi = readUint32(data, pos + 8);
-    return hi > 0 ? end - pos : readUint32(data, pos + 12);
+  if (size === 1) {
+    if (offset + MP4_EXTENDED_BOX_HEADER_SIZE > endOffset) {
+      return 0;
+    }
+    const highBits = readUint32(data, offset + MP4_BOX_HEADER_SIZE);
+    const lowBits = readUint32(data, offset + 12);
+    const extendedSize = highBits * UINT32_SIZE_MULTIPLIER + lowBits;
+    if (
+      !Number.isSafeInteger(extendedSize) ||
+      extendedSize < MP4_EXTENDED_BOX_HEADER_SIZE ||
+      offset + extendedSize > endOffset
+    ) {
+      return 0;
+    }
+    return extendedSize;
   }
-  if (size < 8 || pos + size > end) {
+  if (size < MP4_BOX_HEADER_SIZE || offset + size > endOffset) {
     return 0;
   }
   return size;
@@ -118,46 +140,51 @@ export function readMp4BoxSize(
  */
 export function splitAtBoxBoundaries(
   data: Uint8Array<ArrayBuffer>,
-  maxBytes: number,
+  maximumBytes: number,
 ): Uint8Array<ArrayBuffer>[] | null {
-  if (data.byteLength < 8) {
+  if (
+    data.byteLength < 8 ||
+    !Number.isSafeInteger(maximumBytes) ||
+    maximumBytes <= 0
+  ) {
     return null;
   }
   const chunks: Uint8Array<ArrayBuffer>[] = [];
-  const end = data.byteLength;
+  const endOffset = data.byteLength;
   let chunkStart = 0;
-  let pos = 0;
+  let offset = 0;
 
-  while (pos < end) {
-    const boxSize = readMp4BoxSize(data, pos, end);
+  while (offset < endOffset) {
+    const boxSize = readMp4BoxSize(data, offset, endOffset);
     if (boxSize === 0) {
-      break;
+      return null;
     }
-    if (pos > chunkStart && pos - chunkStart + boxSize > maxBytes) {
+    if (offset > chunkStart && offset - chunkStart + boxSize > maximumBytes) {
       chunks.push(
         new Uint8Array(
           data.buffer,
           data.byteOffset + chunkStart,
-          pos - chunkStart,
+          offset - chunkStart,
         ),
       );
-      chunkStart = pos;
+      chunkStart = offset;
     }
-    pos += boxSize;
+    offset += boxSize;
   }
 
-  if (chunkStart < end) {
+  if (chunkStart < endOffset) {
     chunks.push(
       new Uint8Array(
         data.buffer,
         data.byteOffset + chunkStart,
-        end - chunkStart,
+        endOffset - chunkStart,
       ),
     );
   }
 
   const allFit =
-    chunks.length > 1 && !chunks.some((c) => c.byteLength > maxBytes);
+    chunks.length > 1 &&
+    !chunks.some((chunk) => chunk.byteLength > maximumBytes);
   return allFit ? chunks : null;
 }
 
@@ -165,18 +192,22 @@ export function splitAtBoxBoundaries(
  * Split a large buffer into chunks of at most maxBytes.
  * Tries to split at fMP4 top-level box boundaries first. If the data
  * contains a single box larger than maxBytes (e.g. a giant mdat), falls
- * back to naive byte splitting — MSE SourceBuffer handles reassembly of
+ * back to naive byte splitting; MSE SourceBuffer handles reassembly of
  * partial boxes internally.
  */
 export function splitAppendData(
   data: Uint8Array<ArrayBuffer>,
-  maxBytes: number,
+  maximumBytes: number,
 ): Uint8Array<ArrayBuffer>[] {
-  if (data.byteLength <= maxBytes) {
+  if (
+    !Number.isSafeInteger(maximumBytes) ||
+    maximumBytes <= 0 ||
+    data.byteLength <= maximumBytes
+  ) {
     return [data];
   }
 
-  const boxChunks = splitAtBoxBoundaries(data, maxBytes);
+  const boxChunks = splitAtBoxBoundaries(data, maximumBytes);
   if (boxChunks) {
     return boxChunks;
   }
@@ -184,20 +215,20 @@ export function splitAppendData(
   // Fallback: naive byte splitting. MSE SourceBuffer handles partial box
   // reassembly across sequential appendBuffer() calls.
   const chunks: Uint8Array<ArrayBuffer>[] = [];
-  const end = data.byteLength;
-  for (let offset = 0; offset < end; offset += maxBytes) {
+  const endOffset = data.byteLength;
+  for (let offset = 0; offset < endOffset; offset += maximumBytes) {
     chunks.push(
       new Uint8Array(
         data.buffer,
         data.byteOffset + offset,
-        Math.min(maxBytes, end - offset),
+        Math.min(maximumBytes, endOffset - offset),
       ),
     );
   }
   return chunks;
 }
 
-function readUint64(buffer: Uint8Array, offset: number) {
+function readUint64(buffer: Uint8Array, offset: number): number {
   let result = readUint32(buffer, offset);
   result *= Math.pow(2, 32);
   result += readUint32(buffer, offset + 4);

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -2,6 +2,35 @@ import { expect } from 'chai';
 import Hls from '../../src/hls';
 
 describe('Config Validation', function () {
+  describe('maxAppendSize', function () {
+    it('accepts a positive safe integer or Infinity', function () {
+      const finite = new Hls({ maxAppendSize: 65536 });
+      expect(finite.config.maxAppendSize).to.equal(65536);
+      finite.destroy();
+
+      const disabled = new Hls({ maxAppendSize: Infinity });
+      expect(disabled.config.maxAppendSize).to.equal(Infinity);
+      disabled.destroy();
+    });
+
+    it('rejects finite values that cannot be used as byte boundaries', function () {
+      const invalidValues = [
+        0,
+        -1,
+        0.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        NaN,
+        -Infinity,
+      ];
+
+      invalidValues.forEach((maxAppendSize) => {
+        expect(() => new Hls({ maxAppendSize })).to.throw(
+          'Illegal hls.js config: "maxAppendSize" must be a positive safe integer or Infinity',
+        );
+      });
+    });
+  });
+
   describe('liveMaxUnchangedPlaylistRefresh', function () {
     it('clamps values below 2', function () {
       const hls0 = new Hls({ liveMaxUnchangedPlaylistRefresh: 0 });

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -32,7 +32,11 @@ import type {
   ComponentAPI,
   NetworkComponentAPI,
 } from '../../../src/types/component-api';
-import type { BufferAppendingData, ErrorData } from '../../../src/types/events';
+import type {
+  BufferAppendedData,
+  BufferAppendingData,
+  ErrorData,
+} from '../../../src/types/events';
 
 use(sinonChai);
 const sandbox = sinon.createSandbox();
@@ -225,6 +229,17 @@ describe('BufferController with attached media', function () {
     });
   });
 
+  it('clears quota recovery state when resetting the operation queue', function () {
+    (bufferController as any)._quotaEvictionPending.video = true;
+
+    (bufferController as any).resetQueue();
+
+    expect((bufferController as any)._quotaEvictionPending).to.deep.equal({});
+    expect((bufferController as any).operationQueue).to.not.equal(
+      operationQueue,
+    );
+  });
+
   describe('onBufferAppending', function () {
     it('should enqueue and execute an append operation', function () {
       const queueAppendSpy = sandbox.spy(operationQueue, 'append');
@@ -283,6 +298,418 @@ describe('BufferController with attached media', function () {
           'The queue should have been cycled',
         ).to.have.callCount(i + 1);
       });
+    });
+
+    it('splits appends in order with distinct metadata and one timestamp offset update', function () {
+      hls.config.maxAppendSize = 4;
+      const track = getSourceBufferTrack(bufferController, 'video');
+      const buffer = track?.buffer as unknown as MockSourceBuffer;
+      const updateTimestampOffsetSpy = sandbox.spy(
+        bufferController as any,
+        'updateTimestampOffset',
+      );
+      const appendedEvents: BufferAppendedData[] = [];
+      hls.on(Events.BUFFER_APPENDED, (_event, data) => {
+        appendedEvents.push(data);
+      });
+
+      const segmentData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      frag.level = 3;
+      frag.sn = 7;
+      const decryptRange = { start: 16, end: 32 };
+      const sourceMetadata = new ChunkMetadata(
+        3,
+        7,
+        42,
+        segmentData.byteLength,
+        5,
+        true,
+        6,
+        true,
+        decryptRange,
+      );
+      Object.assign(sourceMetadata.transmuxing, {
+        start: 1,
+        executeStart: 2,
+        executeEnd: 3,
+        end: 4,
+      });
+      const data: BufferAppendingData = {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta: sourceMetadata,
+        offset: 12,
+      };
+
+      hls.trigger(Events.BUFFER_APPENDING, data);
+      expect(buffer.appendBuffer).to.have.callCount(1);
+      expect(buffer.appendBuffer.firstCall.args[0]).to.deep.equal(
+        segmentData.subarray(0, 4),
+      );
+      expect(updateTimestampOffsetSpy).to.have.callCount(1);
+
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(buffer.appendBuffer).to.have.callCount(2);
+      expect(buffer.appendBuffer.secondCall.args[0]).to.deep.equal(
+        segmentData.subarray(4, 8),
+      );
+      expect(updateTimestampOffsetSpy).to.have.callCount(1);
+
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(buffer.appendBuffer).to.have.callCount(3);
+      expect(buffer.appendBuffer.thirdCall.args[0]).to.deep.equal(
+        segmentData.subarray(8),
+      );
+      expect(updateTimestampOffsetSpy).to.have.callCount(1);
+
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(appendedEvents).to.have.lengthOf(3);
+      expect(
+        appendedEvents.map((eventData) => eventData.chunkMeta.id),
+      ).to.deep.equal([0, 1, 2]);
+      expect(
+        appendedEvents.map((eventData) => eventData.chunkMeta.size),
+      ).to.deep.equal([4, 4, 2]);
+      appendedEvents.forEach((eventData) => {
+        expect(eventData.chunkMeta).to.not.equal(sourceMetadata);
+        expect(eventData.chunkMeta).to.include({
+          level: 3,
+          sn: 7,
+          part: 5,
+          partial: true,
+          duration: 6,
+          iframe: true,
+        });
+        expect(eventData.chunkMeta.decryptRange).to.equal(decryptRange);
+        expect(eventData.chunkMeta.transmuxing).to.deep.equal(
+          sourceMetadata.transmuxing,
+        );
+        expect(eventData.chunkMeta.transmuxing).to.not.equal(
+          sourceMetadata.transmuxing,
+        );
+      });
+    });
+
+    it('does not repeat MPEG audio timestamp setup for split continuations', function () {
+      hls.config.maxAppendSize = 4;
+      const track = getSourceBufferTrack(bufferController, 'audio');
+      if (!track) {
+        throw new Error('Expected an audio SourceBuffer track');
+      }
+      track.container = 'audio/mpeg';
+      const buffer = track.buffer as unknown as MockSourceBuffer;
+      const updateTimestampOffsetSpy = sandbox.spy(
+        bufferController as any,
+        'updateTimestampOffset',
+      );
+      const segmentData = new Uint8Array(10);
+      const frag = new Fragment(PlaylistLevelType.AUDIO, '');
+      frag.level = 0;
+      frag.sn = 4;
+      const chunkMeta = new ChunkMetadata(0, 4, 1, segmentData.byteLength);
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.AUDIO,
+        type: 'audio',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta,
+      });
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+
+      expect(buffer.appendBuffer).to.have.callCount(3);
+      expect(updateTimestampOffsetSpy).to.have.been.calledOnce;
+    });
+
+    it('keeps the fragment blocker behind every split append', async function () {
+      hls.config.maxAppendSize = 4;
+      const buffer = getSourceBufferTrack(bufferController, 'video')
+        ?.buffer as unknown as MockSourceBuffer;
+      const segmentData = new Uint8Array(10);
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      frag.level = 0;
+      frag.sn = 1;
+      frag.setElementaryStreamInfo(ElementaryStreamTypes.VIDEO, 0, 1, 0, 1);
+      const chunkMeta = new ChunkMetadata(0, 1, 0, segmentData.byteLength);
+      let fragmentBufferedCount = 0;
+      hls.on(Events.FRAG_BUFFERED, () => {
+        fragmentBufferedCount++;
+      });
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta,
+      });
+      hls.trigger(Events.FRAG_PARSED, { frag, part: null, chunkMeta });
+
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(fragmentBufferedCount).to.equal(0);
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(fragmentBufferedCount).to.equal(0);
+      buffer.dispatchEvent(new Event('updateend'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fragmentBufferedCount).to.equal(1);
+      expect(buffer.appendBuffer).to.have.callCount(3);
+    });
+
+    it('keeps later logical appends behind every split continuation', function () {
+      hls.config.maxAppendSize = 4;
+      const buffer = getSourceBufferTrack(bufferController, 'video')
+        ?.buffer as unknown as MockSourceBuffer;
+      const firstSegmentData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const secondSegmentData = new Uint8Array([10, 11, 12]);
+      const firstFragment = new Fragment(PlaylistLevelType.MAIN, '');
+      firstFragment.level = 0;
+      firstFragment.sn = 1;
+      const secondFragment = new Fragment(PlaylistLevelType.MAIN, '');
+      secondFragment.level = 0;
+      secondFragment.sn = 2;
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: firstSegmentData,
+        frag: firstFragment,
+        part: null,
+        chunkMeta: new ChunkMetadata(0, 1, 0, firstSegmentData.byteLength),
+      });
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: secondSegmentData,
+        frag: secondFragment,
+        part: null,
+        chunkMeta: new ChunkMetadata(0, 2, 0, secondSegmentData.byteLength),
+      });
+
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+
+      expect(
+        buffer.appendBuffer.getCalls().map((call) => Array.from(call.args[0])),
+      ).to.deep.equal([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9],
+        [10, 11, 12],
+      ]);
+      buffer.dispatchEvent(new Event('updateend'));
+    });
+
+    it('retries a failed first split chunk before appending its suffix', function () {
+      hls.config.maxAppendSize = 4;
+      const buffer = getSourceBufferTrack(bufferController, 'video')
+        ?.buffer as unknown as MockSourceBuffer;
+      sandbox
+        .stub(bufferController as any, 'getBackBufferEvictionTarget')
+        .returns(5);
+      buffer.appendBuffer
+        .onFirstCall()
+        .throws(
+          new DOMException('Synthetic append limit', 'QuotaExceededError'),
+        );
+      const segmentData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      frag.level = 0;
+      frag.sn = 2;
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta: new ChunkMetadata(0, 2, 0, segmentData.byteLength),
+      });
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+
+      expect(
+        buffer.appendBuffer.getCalls().map((call) => Array.from(call.args[0])),
+      ).to.deep.equal([
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9],
+      ]);
+      expect(buffer.abort).to.not.have.been.called;
+      const errorEvents = triggerSpy
+        .getCalls()
+        .filter((call) => call.args[0] === Events.ERROR);
+      expect(errorEvents).to.have.lengthOf(0);
+    });
+
+    it('retries a failed split chunk before appending its suffix', function () {
+      hls.config.maxAppendSize = 4;
+      const buffer = getSourceBufferTrack(bufferController, 'video')
+        ?.buffer as unknown as MockSourceBuffer;
+      const getEvictionTargetStub = sandbox
+        .stub(bufferController as any, 'getBackBufferEvictionTarget')
+        .returns(5);
+      const quotaError = new DOMException(
+        'Synthetic append limit',
+        'QuotaExceededError',
+      );
+      buffer.appendBuffer.onSecondCall().throws(quotaError);
+      const segmentData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      frag.level = 0;
+      frag.sn = 2;
+      const chunkMeta = new ChunkMetadata(0, 2, 0, segmentData.byteLength);
+      const appendedEvents: BufferAppendedData[] = [];
+      hls.on(Events.BUFFER_APPENDED, (_event, data) => {
+        appendedEvents.push(data);
+      });
+      timers.tick(1);
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta,
+      });
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(buffer.remove).to.have.been.calledOnce;
+
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(buffer.appendBuffer).to.have.callCount(3);
+      buffer.dispatchEvent(new Event('updateend'));
+      expect(buffer.appendBuffer).to.have.callCount(4);
+      buffer.dispatchEvent(new Event('updateend'));
+
+      expect(getEvictionTargetStub).to.have.been.calledWith(
+        'video',
+        6,
+        PlaylistLevelType.MAIN,
+      );
+      expect(
+        buffer.appendBuffer.getCalls().map((call) => Array.from(call.args[0])),
+      ).to.deep.equal([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [4, 5, 6, 7],
+        [8, 9],
+      ]);
+      const errorEvents = triggerSpy
+        .getCalls()
+        .filter((call) => call.args[0] === Events.ERROR);
+      expect(errorEvents).to.have.lengthOf(0);
+      expect(
+        appendedEvents.map((eventData) => eventData.chunkMeta.id),
+      ).to.deep.equal([0, 1, 2]);
+      expect(
+        appendedEvents.map((eventData) => eventData.chunkMeta.size),
+      ).to.deep.equal([4, 4, 2]);
+      expect(chunkMeta.buffering.video).to.include({
+        start: 1,
+        executeStart: 1,
+        executeEnd: 1,
+        end: 1,
+      });
+    });
+
+    it('stops a split group and resets the parser after a terminal error', function () {
+      hls.config.maxAppendSize = 4;
+      const buffer = getSourceBufferTrack(bufferController, 'video')
+        ?.buffer as unknown as MockSourceBuffer;
+      buffer.appendBuffer.onSecondCall().throws(new Error('append failed'));
+      const segmentData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      frag.level = 0;
+      frag.sn = 3;
+      const chunkMeta = new ChunkMetadata(0, 3, 0, segmentData.byteLength);
+      timers.tick(1);
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta,
+      });
+      buffer.dispatchEvent(new Event('updateend'));
+
+      expect(buffer.appendBuffer).to.have.callCount(2);
+      expect(buffer.abort).to.have.been.calledOnce;
+      const errorEvents = triggerSpy
+        .getCalls()
+        .filter((call) => call.args[0] === Events.ERROR);
+      expect(errorEvents).to.have.lengthOf(1);
+      expect(errorEvents[0].args[1]).to.include({
+        details: ErrorDetails.BUFFER_APPEND_ERROR,
+        sourceBufferName: 'video',
+      });
+      expect(errorEvents[0].args[1].chunkMeta.id).to.equal(1);
+      expect(chunkMeta.buffering.video).to.include({
+        start: 1,
+        executeStart: 1,
+        executeEnd: 0,
+        end: 0,
+      });
+    });
+
+    it('stops after a split chunk exhausts quota recovery', function () {
+      hls.config.maxAppendSize = 4;
+      const buffer = getSourceBufferTrack(bufferController, 'video')
+        ?.buffer as unknown as MockSourceBuffer;
+      sandbox
+        .stub(bufferController as any, 'getBackBufferEvictionTarget')
+        .returns(5);
+      const quotaError = new DOMException(
+        'Synthetic append limit',
+        'QuotaExceededError',
+      );
+      buffer.appendBuffer.onSecondCall().throws(quotaError);
+      buffer.appendBuffer.onThirdCall().throws(quotaError);
+      const segmentData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const frag = new Fragment(PlaylistLevelType.MAIN, '');
+      frag.level = 0;
+      frag.sn = 5;
+      const chunkMeta = new ChunkMetadata(0, 5, 0, segmentData.byteLength);
+
+      hls.trigger(Events.BUFFER_APPENDING, {
+        parent: PlaylistLevelType.MAIN,
+        type: 'video',
+        data: segmentData,
+        frag,
+        part: null,
+        chunkMeta,
+      });
+      buffer.dispatchEvent(new Event('updateend'));
+      buffer.dispatchEvent(new Event('updateend'));
+
+      expect(buffer.appendBuffer).to.have.callCount(3);
+      expect(buffer.abort).to.have.been.calledOnce;
+      const errorEvents = triggerSpy
+        .getCalls()
+        .filter((call) => call.args[0] === Events.ERROR);
+      expect(errorEvents).to.have.lengthOf(1);
+      expect(errorEvents[0].args[1]).to.include({
+        details: ErrorDetails.BUFFER_FULL_ERROR,
+        sourceBufferName: 'video',
+      });
+      expect((bufferController as any)._quotaEvictionPending.video).to.equal(
+        false,
+      );
     });
 
     it('should not set timeout during buffer append operation when appendTimeout is Infinity', function () {

--- a/tests/unit/controller/fragment-tracker.ts
+++ b/tests/unit/controller/fragment-tracker.ts
@@ -471,6 +471,54 @@ describe('FragmentTracker', function () {
     removeFragment: (fragment: Fragment) => void;
   };
 
+  describe('getBackBufferEvictionEnd', function () {
+    it('converts bitrate estimates from bits to bytes', function () {
+      const hls = new Hls({});
+      const fragmentTracker = new FragmentTracker(hls);
+      const firstFragment = createMockFragment(
+        {
+          startPTS: 0,
+          endPTS: 2,
+          sn: 1,
+          level: 0,
+          type: PlaylistLevelType.MAIN,
+        },
+        [ElementaryStreamTypes.VIDEO],
+      );
+      const secondFragment = createMockFragment(
+        {
+          startPTS: 2,
+          endPTS: 4,
+          sn: 2,
+          level: 0,
+          type: PlaylistLevelType.MAIN,
+        },
+        [ElementaryStreamTypes.VIDEO],
+      );
+      firstFragment.bitrate = 8_000_000;
+      secondFragment.bitrate = 8_000_000;
+
+      triggerFragLoaded(hls, firstFragment);
+      triggerFragLoaded(hls, secondFragment);
+      hls.trigger(
+        Events.BUFFER_APPENDED,
+        createBufferAppendedData([{ startPTS: 0, endPTS: 4 }]),
+      );
+      hls.trigger(Events.FRAG_BUFFERED, createFragBufferedData(firstFragment));
+      hls.trigger(Events.FRAG_BUFFERED, createFragBufferedData(secondFragment));
+
+      expect(
+        fragmentTracker.getBackBufferEvictionEnd(
+          10,
+          PlaylistLevelType.MAIN,
+          3_000_000,
+        ),
+      ).to.equal(4);
+      fragmentTracker.destroy();
+      hls.destroy();
+    });
+  });
+
   describe('removeFragment', function () {
     let hls: Hls;
     let fragmentTracker: FragmentTrackerTestable;

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -8,7 +8,10 @@ import {
   findBox,
   getSampleData,
   parseInitSegment,
+  readMp4BoxSize,
   remuxVideoOnlyIFrameMoof,
+  splitAppendData,
+  splitAtBoxBoundaries,
   types,
   videoOnlyInitSegment,
 } from '../../../src/utils/mp4-tools';
@@ -16,6 +19,122 @@ import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
 import type { InitData } from '../../../src/utils/mp4-tools';
 
 describe('mp4-tools', function () {
+  describe('splitAppendData', function () {
+    it('returns the original view when the limit is disabled or invalid', function () {
+      const data = new Uint8Array([1, 2, 3, 4]);
+      const invalidLimits = [Infinity, NaN, 0, -1, 0.5];
+
+      invalidLimits.forEach((maximumBytes) => {
+        const chunks = splitAppendData(data, maximumBytes);
+        expect(chunks).to.have.lengthOf(1);
+        expect(chunks[0]).to.equal(data);
+      });
+    });
+
+    it('splits arbitrary data without including bytes outside the input view', function () {
+      const backingData = new Uint8Array([
+        255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 255,
+      ]);
+      const data = backingData.subarray(1, 11) as Uint8Array<ArrayBuffer>;
+      const chunks = splitAppendData(data, 4);
+
+      expect(chunks.map((chunk) => chunk.byteLength)).to.deep.equal([4, 4, 2]);
+      expect(appendBytes(...chunks)).to.deep.equal(data);
+    });
+
+    it('groups complete top-level boxes without exceeding the limit', function () {
+      const firstBox = MP4.box(types.free, new Uint8Array(4));
+      const secondBox = MP4.box(types.free, new Uint8Array(4));
+      const thirdBox = MP4.box(types.free, new Uint8Array(4));
+      const data = appendBytes(firstBox, secondBox, thirdBox);
+      const chunks = splitAppendData(data, firstBox.byteLength * 2);
+
+      expect(chunks.map((chunk) => chunk.byteLength)).to.deep.equal([
+        firstBox.byteLength * 2,
+        thirdBox.byteLength,
+      ]);
+      expect(appendBytes(...chunks)).to.deep.equal(data);
+    });
+
+    it('falls back to fixed-size views when one box exceeds the limit', function () {
+      const data = MP4.mdat(new Uint8Array(25));
+      const chunks = splitAppendData(data, 10);
+
+      expect(chunks.map((chunk) => chunk.byteLength)).to.deep.equal([
+        10, 10, 10, 3,
+      ]);
+      expect(appendBytes(...chunks)).to.deep.equal(data);
+    });
+
+    it('falls back when the complete top-level box sequence is invalid', function () {
+      const validBox = MP4.box(types.free, new Uint8Array(4));
+      const invalidTail = new Uint8Array([0, 0, 0, 16, 0, 0, 0, 0]);
+      const data = appendBytes(validBox, invalidTail);
+
+      expect(splitAtBoxBoundaries(data, validBox.byteLength)).to.equal(null);
+      expect(
+        appendBytes(...splitAppendData(data, validBox.byteLength)),
+      ).to.deep.equal(data);
+    });
+  });
+
+  describe('readMp4BoxSize', function () {
+    it('reads standard, zero, and extended box sizes', function () {
+      const standardBox = MP4.box(types.free, new Uint8Array(4));
+      const zeroSizedBox = appendBytes(
+        uint32(0),
+        uint32(types.free),
+        new Uint8Array(4),
+      );
+      const extendedBox = appendBytes(
+        uint32(1),
+        uint32(types.free),
+        uint64(20),
+        new Uint8Array(4),
+      );
+
+      expect(readMp4BoxSize(standardBox, 0, standardBox.byteLength)).to.equal(
+        standardBox.byteLength,
+      );
+      expect(readMp4BoxSize(zeroSizedBox, 0, zeroSizedBox.byteLength)).to.equal(
+        zeroSizedBox.byteLength,
+      );
+      expect(readMp4BoxSize(extendedBox, 0, extendedBox.byteLength)).to.equal(
+        extendedBox.byteLength,
+      );
+    });
+
+    it('rejects truncated and out-of-range box sizes', function () {
+      const shortHeader = new Uint8Array(7);
+      const undersizedBox = appendBytes(uint32(4), uint32(types.free));
+      const oversizedBox = appendBytes(uint32(32), uint32(types.free));
+      const hugeExtendedBox = appendBytes(
+        uint32(1),
+        uint32(types.free),
+        uint64(2 ** 32 + 16),
+      );
+
+      expect(readMp4BoxSize(shortHeader, 0, shortHeader.byteLength)).to.equal(
+        0,
+      );
+      expect(
+        readMp4BoxSize(undersizedBox, 0, undersizedBox.byteLength),
+      ).to.equal(0);
+      expect(readMp4BoxSize(oversizedBox, 0, oversizedBox.byteLength)).to.equal(
+        0,
+      );
+      expect(
+        readMp4BoxSize(hugeExtendedBox, 0, hugeExtendedBox.byteLength),
+      ).to.equal(0);
+      expect(
+        readMp4BoxSize(oversizedBox, -1, oversizedBox.byteLength),
+      ).to.equal(0);
+      expect(
+        readMp4BoxSize(oversizedBox, 0, oversizedBox.byteLength + 1),
+      ).to.equal(0);
+    });
+  });
+
   it('reads tfhd default sample duration and size in declaration order', function () {
     const sampleData = getSampleData(
       fragmentWithTfhdDefaults(


### PR DESCRIPTION
### This PR will...

Split large HLS fMP4 segments into smaller chunks before appending to MSE SourceBuffer, preventing `QuotaExceededError` with high-bitrate streams.

### Why is this Pull Request needed?

When an HLS fMP4 segment exceeds Chromium's per-SourceBuffer quota (~150MB), `appendBuffer()` throws `QuotaExceededError`. With high-bitrate remuxed streams (80-150+ Mbps), a single segment can easily reach 95-100MB. At playback start there is no back buffer to evict, so hls.js enters an unrecoverable loop: download → append → QuotaExceededError → flush → retry → repeat.

This PR adds `splitAppendData()` to `buffer-controller.ts` that splits large `Uint8Array` buffers into ≤16MB chunks before appending. When `data.byteLength` exceeds 16MB, `onBufferAppending` splits the data and recursively creates separate append operations for each chunk — each with full error handling including QuotaExceeded recovery.

Splitting is attempted first at fMP4 top-level box boundaries. If that can't produce small-enough chunks (e.g. a single giant `mdat` box, which is the typical FFmpeg HLS output: `styp + moof + mdat`), it falls back to naive byte splitting. MSE SourceBuffer natively handles reassembly of partial box data across sequential `appendBuffer()` calls.

### Are there any points in the code the reviewer needs to double check?

- The fMP4 box-boundary splitting logic in `splitAppendData()` — verify it correctly parses top-level box headers and falls back to naive splitting when boxes exceed the chunk size
- The recursive chunk append flow in `onBufferAppending` — each chunk gets its own queued operation with the same frag/part/chunkMeta context and error handling

### Resolves issues:

Fixes #6711, #6776. Related: #5587, #6529.

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] API or design changes are documented in API.md