### PR TITLE
fix: detect stream ended after live-to-VOD transition when endListFra…

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -297,9 +297,22 @@ export default class BaseStreamController
       return lastPartBuffered;
     }
 
-    const playlistType =
-      levelDetails.fragments[levelDetails.fragments.length - 1].type;
-    return this.fragmentTracker.isEndListAppended(playlistType);
+    const lastFragment =
+      levelDetails.fragments[levelDetails.fragments.length - 1];
+    const playlistType = lastFragment.type;
+    if (this.fragmentTracker.isEndListAppended(playlistType)) {
+      return true;
+    }
+    // When a live playlist transitions to VOD (ENDLIST added), the last
+    // fragment in the updated playlist has endList=true but the fragment
+    // tracker entity was created before ENDLIST was known. Check if the
+    // last fragment is actually buffered even though endListFragments
+    // was never populated for it.
+    if (lastFragment.endList) {
+      const state = this.fragmentTracker.getState(lastFragment);
+      return state === FragmentState.OK || state === FragmentState.PARTIAL;
+    }
+    return false;
   }
 
   public getLevelDetails(): LevelDetails | undefined {


### PR DESCRIPTION
### This PR will...

Add a fallback check in `_streamEnded()` to correctly detect end-of-stream when a live HLS playlist transitions to VOD (`#EXT-X-ENDLIST` is added after segments have already been buffered).

### Why is this Pull Request needed?

When an HLS stream starts as live and later transitions to VOD (e.g., a server-side transcode that adds `#EXT-X-ENDLIST` upon completion), `_streamEnded()` never returns `true`, preventing `BUFFER_EOS` and `mediaSource.endOfStream()` from being called. This causes the player to stall at the end of the video with `bufferStalledError` and `bufferNudgeOnStall` errors instead of cleanly ending playback.

The root cause is a race condition in `fragment-tracker.ts`: when the last fragment is buffered during the live phase, `bufferedEnd()` is called with `frag.endList = false`, so `endListFragments` is never populated. When the playlist later reloads with `#EXT-X-ENDLIST`, the parser sets `endList = true` on the new playlist's fragment objects, but the fragment tracker's existing entity is never retroactively updated. As a result, `isEndListAppended()` returns `false` indefinitely.

This fix adds a fallback in `_streamEnded()`: when `isEndListAppended()` returns `false`, it checks whether the last fragment in the current (updated) playlist has `endList = true` and is tracked as buffered by the fragment tracker. Since fragment keys (`type_level_sn`) are stable across playlist reloads, this correctly identifies that the end-list fragment has been buffered even though `endListFragments` was never populated for it.

### Are there any points in the code the reviewer needs to double check?

- The fallback accepts `FragmentState.PARTIAL` in addition to `FragmentState.OK`, consistent with the existing behavior of `isEndListAppended()` which also treats partial fragments as "appended". Verify this is desired for all cases.
- The `isMediaFragment()` guard ensures we don't call `getState()` on init segments (whose `sn` is `'initSegment'` rather than a number). This should always be true for the last fragment in a playlist, but the guard is there for type safety.

### Resolves issues:

Resolves playback stalling at end-of-stream for any HLS source that starts as a live playlist and transitions to VOD mid-playback (common with server-side transcoding workflows such as Jellyfin, Plex, Emby, etc.).

### Checklist

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] API or design changes are documented in API.md

