### PR TITLE
Do not update initPTS in streams with some amount of drift caused by …

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1946,9 +1946,14 @@ export default class BaseStreamController
   }
 
   protected get playhead(): number {
-    return this.hls?.hasEnoughToStart
-      ? this.media?.currentTime || this.lastCurrentTime
-      : this.getLoadPosition();
+    if (this.hls?.hasEnoughToStart) {
+      const currentTime = this.media?.currentTime as number;
+      if (Number.isFinite(currentTime)) {
+        return currentTime;
+      }
+      return this.lastCurrentTime;
+    }
+    return this.getLoadPosition();
   }
 
   protected get iframesOnly(): boolean | undefined {

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -252,10 +252,10 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     }
 
     const syncOnAudio =
-      audioSampleTimestamps &&
+      !!audioSampleTimestamps &&
       (!videoSampleTimestamps ||
         (!initPTS && audioStartTime < videoStartTime) ||
-        (initPTS && initPTS.trackId === initData.audio!.id));
+        (!!initPTS && initPTS.trackId === initData.audio!.id));
     const baseOffsetSamples = syncOnAudio
       ? audioSampleTimestamps
       : videoSampleTimestamps;
@@ -346,23 +346,28 @@ class PassThroughRemuxer extends Logger implements Remuxer {
         (isInvalidInitPts(initPTS, decodeTime, timeOffset, duration) ||
           timescale !== initPTS.timescale)
       ) {
+        let detectedDrift = false;
+        const trackType = syncOnAudio ? 'audio' : 'video';
         if (initPTS) {
-          this.warn(
-            `Timestamps at playlist time: ${accurateTimeOffset ? '' : '~'}${timeOffset} ${baseTime / timescale} != initPTS: ${initPTS.baseTime / initPTS.timescale} (${
+          const driftEstimate =
+            timeOffset !== 0 ? decodeTime / timeOffset : 1 + decodeTime / 1;
+          detectedDrift =
+            decodeTime >= 0 && Math.abs(1 - driftEstimate) < 0.001;
+          this.log(
+            `${trackType} timestamps in track ${trackId} at playlist time: ${accurateTimeOffset ? '' : '~'}${timeOffset} maps to ${decodeTime} with initPTS: ${initPTS.baseTime / initPTS.timescale} (${
               baseTime / timescale - initPTS.baseTime / initPTS.timescale
-            }s diff) (${type}) trackId: ${initPTS.trackId}`,
-            initData,
-            videoSampleTimestamps,
-            audioSampleTimestamps,
+            }s diff) (${type}) drift estimate: ${driftEstimate} ${detectedDrift ? '(ignoring drift)' : 'remapping timestamps (initPTS)'}`,
           );
         }
-        this.log(
-          `Found initPTS at playlist time: ${timeOffset} offset: ${decodeTime - timeOffset} (${baseTime}/${timescale}) trackId: ${trackId}`,
-        );
-        initPTS = null;
-        initSegment.initPTS = baseTime;
-        initSegment.timescale = timescale;
-        initSegment.trackId = trackId;
+        if (!detectedDrift) {
+          this.log(
+            `Found initPTS in ${trackType} track ${trackId} at playlist time: ${timeOffset} offset: ${decodeTime - timeOffset} (${baseTime}/${timescale})`,
+          );
+          initPTS = null;
+          initSegment.initPTS = baseTime;
+          initSegment.timescale = timescale;
+          initSegment.trackId = trackId;
+        }
       }
     } else {
       this.warn(


### PR DESCRIPTION
### This PR will...
Do not update initPTS in streams with some amount of drift caused by playlist segment duration rounding.
Also fixes an issue with the wrong playhead time used when seeking back to 0.

### Why is this Pull Request needed?
Long form VOD or live DVR with drift can result in unwanted timestamp offset remapping. Maintaining the same timestamp offset ensures that hls.js updates the playlist fragments model accordingly.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7677

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
