### PR TITLE
Added optional flushImmediate argument to setAudioOption

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -178,6 +178,7 @@ export type AudioSelectionOption = {
     audioCodec?: string;
     groupId?: string;
     default?: boolean;
+    flushImmediate?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "AudioStreamController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/controller/audio-track-controller.ts
+++ b/src/controller/audio-track-controller.ts
@@ -282,7 +282,10 @@ class AudioTrackController extends BasePlaylistController {
         );
         if (groupIndex > -1) {
           const track = this.tracksInGroup[groupIndex];
-          this.setAudioTrack(groupIndex);
+          this.setAudioTrack(
+            groupIndex,
+            'flushImmediate' in audioOption && audioOption.flushImmediate,
+          );
           return track;
         } else if (currentTrack) {
           // Find option in nearest level audio group

--- a/src/types/media-playlist.ts
+++ b/src/types/media-playlist.ts
@@ -32,6 +32,7 @@ export type AudioSelectionOption = {
   audioCodec?: string;
   groupId?: string;
   default?: boolean;
+  flushImmediate?: boolean;
 };
 
 export type SubtitleSelectionOption = {

--- a/tests/unit/controller/audio-track-controller.ts
+++ b/tests/unit/controller/audio-track-controller.ts
@@ -523,6 +523,38 @@ describe('AudioTrackController', function () {
     });
   });
 
+  describe('setAudioOption with flushImmediate', function () {
+    beforeEach(function () {
+      hls.levelController = {
+        levels: [
+          {
+            audioGroups: ['1'],
+          },
+        ],
+      };
+      audioTrackController.tracks = tracks;
+      audioTrackController.onLevelLoading(Events.LEVEL_LOADING, {
+        level: 0,
+      });
+    });
+
+    it('should pass flushImmediate=true to AUDIO_TRACK_SWITCHING when specified in AudioSelectionOption', function () {
+      const triggerSpy = sinon.spy(hls, 'trigger');
+      (audioTrackController as any).setAudioOption({
+        name: 'B',
+        flushImmediate: true,
+      });
+
+      expect(triggerSpy).to.have.been.calledWith(
+        Events.AUDIO_TRACK_SWITCHING,
+        sinon.match({
+          id: 1,
+          flushImmediate: true,
+        }),
+      );
+    });
+  });
+
   describe('audioTrack with flushImmediate', function () {
     beforeEach(function () {
       hls.levelController = {


### PR DESCRIPTION
### This PR will add the ability to smoothly switch audio tracks via setAudioOption API.

### Why is this Pull Request needed?
Without it, you can only smoothly switch audio tracks using nextAudioTrack API.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
#7692 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
