### PR TITLE
Pad initial PTS of remuxed MPEGTS to avoid video rendering issues in Chrome

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -801,13 +801,25 @@ export default class MP4Remuxer extends Logger implements Remuxer {
           mp4SampleDuration = lastFrameDuration;
         }
       }
-      const compositionTimeOffset = Math.round(
-        VideoSample.pts - VideoSample.dts,
-      );
+      let compositionTimeOffset = Math.round(VideoSample.pts - VideoSample.dts);
       minDtsDelta = Math.min(minDtsDelta, mp4SampleDuration);
       maxDtsDelta = Math.max(maxDtsDelta, mp4SampleDuration);
       minPtsDelta = Math.min(minPtsDelta, ptsDelta);
       maxPtsDelta = Math.max(maxPtsDelta, ptsDelta);
+
+      // Increase composition time by one frame tick to avoid pts overlap frame eviction in Chrome
+      // Fixes https://github.com/video-dev/hls.js/issues/6374 (https://issues.chromium.org/u/1/issues/336839131)
+      if (!contiguous && i === 0 && compositionTimeOffset > mp4SampleDuration) {
+        const tickPaddedCompositionTime =
+          Math.round(compositionTimeOffset / averageSampleDuration) *
+          averageSampleDuration;
+        if (tickPaddedCompositionTime - compositionTimeOffset === 1) {
+          this.log(
+            `pad first CTS ${compositionTimeOffset} -> ${tickPaddedCompositionTime} of sn: ${chunkMeta.sn}`,
+          );
+          compositionTimeOffset = tickPaddedCompositionTime;
+        }
+      }
 
       outputSamples.push(
         createMp4Sample(


### PR DESCRIPTION
### This PR will...
Pad initial PTS of remuxed TS segments by only 1 tick at most to prevent PTS overlap from rounding errors. 

### Why is this Pull Request needed?
When segments are appended out of order, by seeking backwards for example, any PTS overlap between the end of the last segment and the start of a previously appended one, will result in the overlapped coded frames failing to render. I'd assume they were evicted, but the buffered range is not updated and playback does not stall. Instead video rendering freezes until the next keyframe is reached. 

Ex: append init, append segment 8, append segment 7, where the last pts + sample duration of segment 7 is 1 greater than the min pts of segment 8. After playing through 7, the video will freeze for all or part of 8. See #6374 for steps to repro.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #6374

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
