### PR TITLE
Reject remux results with implausible timestamps to prevent initPTS ping-pong

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2037,6 +2037,8 @@ export class FragmentTracker implements ComponentAPI {
     // (undocumented)
     addAsGap(frag: MediaFragment): void;
     // (undocumented)
+    addPartAsGap(frag: MediaFragment, part: Part): void;
+    // (undocumented)
     destroy(): void;
     detectEvictedFragments(elementaryStream: SourceBufferName, timeRange: TimeRanges, playlistType: PlaylistLevelType, appendedFrag?: MediaFragment | null, appendedPart?: Part | null, removeAppending?: boolean): void;
     detectPartialFragments(data: FragBufferedData): void;
@@ -4517,7 +4519,7 @@ export class Part extends BaseSegment {
     // (undocumented)
     readonly fragOffset: number;
     // (undocumented)
-    readonly gap: boolean;
+    gap: boolean;
     // (undocumented)
     readonly independent: boolean;
     // (undocumented)
@@ -4713,6 +4715,8 @@ export interface RemuxerResult {
     independent?: boolean;
     // (undocumented)
     initSegment?: InitSegmentData;
+    // (undocumented)
+    parseError?: string;
     // (undocumented)
     text?: RemuxedUserdata;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -908,6 +908,27 @@ class AudioStreamController
       return;
     }
 
+    // #7811: mirror the main stream-controller handling. When the
+    // audio remuxer rejects a segment or part on implausible initPTS,
+    // mark it as a gap and drop back to IDLE instead of feeding
+    // poisoned timings into the audio SourceBuffer.
+    if (remuxResult.parseError) {
+      this.warn(
+        `Audio transmux of ${
+          part ? `part ${part.index} of ` : ''
+        }sn: ${frag.sn} cc: ${frag.cc} level: ${
+          frag.level
+        } rejected: ${remuxResult.parseError}. Marking as gap and skipping.`,
+      );
+      if (part) {
+        this.fragmentTracker.addPartAsGap(frag as MediaFragment, part);
+      } else {
+        this.fragmentTracker.addAsGap(frag as MediaFragment);
+      }
+      this.resetLoadingState();
+      return;
+    }
+
     this.state = State.PARSING;
     if (audio && this.switchingTrack && !this.switchingTrack.flushImmediate) {
       const { config } = this;

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -271,6 +271,10 @@ export class FragmentTracker implements ComponentAPI {
         this.removeParts(frag.sn - 1, frag.type);
       }
       // Detect nothing buffered for segment append (open-GOP issue #7774)
+      // and for part append (#7811 part-aware extension). For a part we
+      // inspect only the part's own playlist-declared time window — a
+      // later corrupt part would otherwise be masked by earlier healthy
+      // parts of the same SN.
       if (!part) {
         const minPartialAppend = Math.min(0.004, frag.duration);
         trackNames.some((elementaryStream) => {
@@ -285,6 +289,31 @@ export class FragmentTracker implements ComponentAPI {
           }
           return bufferedGap;
         });
+      } else {
+        const minPartialAppend = Math.min(0.004, part.duration);
+        const partStart = part.start;
+        const partEnd = part.end;
+        trackNames.some((elementaryStream) => {
+          const times = fragmentEntity.range[elementaryStream]?.time ?? [];
+          let coveredInPart = 0;
+          for (let i = 0; i < times.length; i++) {
+            const overlapStart = Math.max(times[i].startPTS, partStart);
+            const overlapEnd = Math.min(times[i].endPTS, partEnd);
+            if (overlapEnd > overlapStart) {
+              coveredInPart += overlapEnd - overlapStart;
+            }
+          }
+          const partBufferedGap = coveredInPart < minPartialAppend;
+          if (partBufferedGap) {
+            // Part append produced no usable buffer contribution within
+            // its own time window. Mark only this part as a gap so that
+            // fragment-loader's `part.gap` check short-circuits future
+            // re-requests, without invalidating other healthy parts of
+            // the same SN.
+            this.addPartAsGap(frag, part);
+          }
+          return partBufferedGap;
+        });
       }
     } else {
       // remove fragment if nothing was appended
@@ -296,6 +325,18 @@ export class FragmentTracker implements ComponentAPI {
     frag.gap = true;
     this.removeFragment(frag);
     this.fragBuffered(frag, true);
+  }
+
+  /**
+   * Part-aware variant of {@link addAsGap}. Marks a single part of a
+   * fragment as a gap without invalidating the fragment's other parts
+   * or its tracking entry. Used when the remuxer rejects a part with a
+   * parse error (issue #7811) or when a part's append is silently
+   * dropped by the SourceBuffer.
+   */
+  public addPartAsGap(frag: MediaFragment, part: Part) {
+    part.gap = true;
+    this.hasGaps = true;
   }
 
   private bufferedEnd(fragmentEntity: FragmentEntity, frag: MediaFragment) {

--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -327,13 +327,11 @@ export class FragmentTracker implements ComponentAPI {
     this.fragBuffered(frag, true);
   }
 
-  /**
-   * Part-aware variant of {@link addAsGap}. Marks a single part of a
-   * fragment as a gap without invalidating the fragment's other parts
-   * or its tracking entry. Used when the remuxer rejects a part with a
-   * parse error (issue #7811) or when a part's append is silently
-   * dropped by the SourceBuffer.
-   */
+  // Part-aware variant of addAsGap. Marks a single part of a fragment as
+  // a gap without invalidating the fragment's other parts or its tracking
+  // entry. Used when the remuxer rejects a part with a parse error
+  // (issue #7811) or when a part's append is silently dropped by the
+  // SourceBuffer.
   public addPartAsGap(frag: MediaFragment, part: Part) {
     part.gap = true;
     this.hasGaps = true;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1221,6 +1221,29 @@ export default class StreamController
       return;
     }
 
+    // #7811: the remuxer may reject a segment or part whose timestamps
+    // are implausibly far from the playlist-declared time. When that
+    // happens it returns with `parseError` and no audio/video/initSegment
+    // payload. Mark the target as a gap and drop back to IDLE rather
+    // than running the rest of this handler, which would try to buffer
+    // empty tracks and re-load indefinitely.
+    if (remuxResult.parseError) {
+      this.warn(
+        `Transmux of ${
+          part ? `part ${part.index} of ` : ''
+        }sn: ${frag.sn} cc: ${frag.cc} level: ${
+          frag.level
+        } rejected: ${remuxResult.parseError}. Marking as gap and skipping.`,
+      );
+      if (part) {
+        this.fragmentTracker.addPartAsGap(frag as MediaFragment, part);
+      } else {
+        this.fragmentTracker.addAsGap(frag as MediaFragment);
+      }
+      this.resetLoadingState();
+      return;
+    }
+
     this.state = State.PARSING;
 
     if (initSegment) {

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -433,7 +433,10 @@ export class Fragment extends BaseSegment {
 export class Part extends BaseSegment {
   public readonly fragOffset: number = 0;
   public readonly duration: number = 0;
-  public readonly gap: boolean = false;
+  // `gap` is not readonly: a remuxer may detect corruption at runtime
+  // (issue #7811) and mark the part as a gap so fragment-loader's
+  // `part.gap` check rejects re-requests.
+  public gap: boolean = false;
   public readonly independent: boolean = false;
   public readonly relurl: string;
   public readonly fragment: MediaFragment;

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -168,6 +168,13 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     chunkMeta: ChunkMetadata,
   ): RemuxerResult {
     let { initPTS, lastEndTime } = this;
+    // Snapshot mutable session state so the #7811 rollback below can
+    // restore it if the computed startDTS ends up implausibly far from
+    // timeOffset (a sign that a corrupt tfdt or stale anchor would
+    // otherwise poison the session).
+    const priorInitPTS = this.initPTS;
+    const priorEmitInitSegment = this.emitInitSegment;
+    const priorLastEndTime = this.lastEndTime;
     const result: RemuxerResult = {
       audio: undefined,
       video: undefined,
@@ -401,6 +408,44 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       ? baseOffsetSamples.ptsMax / baseOffsetSamples.timescale -
         initPTS.baseTime / initPTS.timescale
       : endDTS;
+
+    // #7811: reject implausible initPTS changes before they poison the
+    // session. Under normal playback the computed startDTS should be
+    // approximately equal to the playlist-declared `timeOffset`. A
+    // corrupt tfdt — or a stale anchor that `isInvalidInitPts` did not
+    // catch — can leave us with a wildly off startDTS. Propagating that
+    // downstream corrupts `fragment.start` via updateFragPTSDTS, which
+    // then feeds back as a negative timeOffset on the next remux() and
+    // produces an initPTS ping-pong between two mutually-invalid
+    // anchors.
+    //
+    // The tolerance accommodates legitimate drift (e.g. #5452 audio-
+    // leads-video ~3s) while still catching the many-seconds shifts
+    // observed in #7811. When the check trips we roll back the mutable
+    // session state this remux() has already touched (this.initPTS /
+    // this.emitInitSegment / this.lastEndTime) and return parseError so
+    // the caller can mark the segment or part as a gap.
+    const startDTSDeviation = Math.abs(startDTS - timeOffset);
+    const startDTSTolerance = Math.max(2 * duration, 5);
+    if (Number.isFinite(startDTS) && startDTSDeviation > startDTSTolerance) {
+      const reason =
+        `remux startDTS ${startDTS.toFixed(3)}s deviates ` +
+        `${startDTSDeviation.toFixed(3)}s from timeOffset ` +
+        `${timeOffset.toFixed(3)}s ` +
+        `(tolerance ${startDTSTolerance.toFixed(3)}s)`;
+      this.warn(
+        `Rejecting implausible initPTS — ${reason}. ` +
+          `initPTS ${initPTS.baseTime}/${initPTS.timescale} ` +
+          `(≈${(initPTS.baseTime / initPTS.timescale).toFixed(3)}s), ` +
+          `decodeTime ${decodeTime.toFixed(3)}s. ` +
+          `Restoring prior session anchor to prevent ping-pong.`,
+      );
+      this.initPTS = priorInitPTS;
+      this.emitInitSegment = priorEmitInitSegment;
+      this.lastEndTime = priorLastEndTime;
+      result.parseError = reason;
+      return result;
+    }
 
     // For troubleshooting duplicates of https://github.com/video-dev/hls.js/issues/6777
     // if (videoSampleTimestamps) {

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -97,6 +97,12 @@ export interface RemuxerResult {
   id3?: RemuxedMetadata;
   initSegment?: InitSegmentData;
   independent?: boolean;
+  // Set by a remuxer when it detects a segment or part whose timestamps
+  // are implausible enough to be treated as corrupt (issue #7811).
+  // Downstream consumers (stream-controller, fragment-tracker) mark the
+  // fragment or part as a gap and skip buffering rather than propagating
+  // the poisoned timing.
+  parseError?: string;
 }
 
 export interface InitSegmentData {


### PR DESCRIPTION
### This PR will...

- Add a validity check in `passthrough-remuxer.ts` that rejects a remux result whose computed `startDTS` deviates from the playlist-declared `timeOffset` by more than `max(2 * duration, 5)` seconds, rolling back the mutable session state (`this.initPTS`, `this.emitInitSegment`, `this.lastEndTime`) before returning.
- Add a new `RemuxerResult.parseError?: string` signal so the remuxer can tell `stream-controller` / `audio-stream-controller` to treat the segment or part as a gap instead of buffering empty data.
- Add `FragmentTracker.addPartAsGap(frag, part)` plus a part-aware branch in `detectPartialFragments` so a single corrupt part can be marked as a gap without invalidating the fragment's other healthy parts.
- Drop `readonly` from `Part.gap` so the tracker can mark a part as a gap at runtime (`fragment-loader.ts` already honours `part.gap`).

### Why is this Pull Request needed?

Closes #7811.

A malformed fMP4 segment (reproduced by injecting an empty `moof`/`mdat` with Proxyman, seen in production streams) can make `passthrough-remuxer` produce a `startDTS` that is many multiples of `fragment.duration` away from the playlist-declared `timeOffset`. For example, a corrupt segment whose tfdt was rewritten to encode playlist time directly, combined with a healthy session anchor of ~22594s, yields `startDTS = 52.017 - 22594.751 = -22542.734s` for a playlist fragment at `[52-54]`.

Once that negative `startDTS` is written, it propagates through `_handleTransmuxComplete` → `frag.setElementaryStreamInfo` → `updateFragPTSDTS` → `frag.setStart`, so the fragment's own `frag.start` becomes `-22542s`. On the next retry / re-load, stream-controller passes that poisoned `frag.start` back in as `timeOffset`, which makes `isInvalidInitPts` fire again and the remuxer keeps flipping `this.initPTS` between two mutually-invalid anchors. This is the "initPTS ping-pong" reported in #7811 — on live streams it eventually exits via the `\"too far from the end of live sliding playlist\"` safety-net (~20–25s of black screen), on VOD it would stall indefinitely.

PR #7797 already closed the \"SourceBuffer silently dropped the append\" half of this loop, but the remuxer-side anchor poisoning was still open. Rob noted in the issue thread:

> If the pts is completely invalid, init PTS should not have been changed in the first place. Ignoring the part or raising a parsing error would be the right thing to do.

This PR implements that: the remuxer detects the implausible result, rolls back its own session state, and returns `parseError` so downstream can gap-mark the segment or part.

### Are there any points in the code the reviewer needs to double check?

1. **Tolerance value**: `Math.max(2 * duration, 5)`. Picked to comfortably accommodate legitimate drift — e.g. #5452 audio-leads-video (~3s), #5195 variant-boundary realignment (handled upstream of this check by `emitInitSegment` resetting the anchor cleanly), #7310 CMAF tfdt adjustment (which is sub-sample) — while still rejecting the many-thousand-second shifts observed in #7811. Happy to tune.
2. **Part-aware gap handling in `FragmentTracker.detectPartialFragments`**: the existing `if (!part)` branch skipped gap detection entirely when a part was being processed, so a corrupt part could slip through. The new `else` branch inspects only the part's own `[partStart, partEnd]` window rather than the whole fragment's cumulative range — otherwise an earlier healthy part of the same SN would mask a later corrupt part.
3. **`addPartAsGap` intentionally does NOT call `removeFragment` or `fragBuffered(frag, true)`** (unlike `addAsGap`). Marking the whole fragment as buffered / gap from a single bad part regressed behaviour in testing: it invalidated the fragment's earlier healthy parts and blocked `stream-controller` from advancing. Only `part.gap = true` + `hasGaps = true` is needed; `fragment-loader.ts:186` already honours `part.gap` to reject re-requests.
4. **`Part.gap` is no longer `readonly`**: this is the runtime-mutation hook that `addPartAsGap` uses. The constructor still initialises it from the manifest's `#EXT-X-PART GAP` attribute exactly as before.

### Reproduction & verification

Proxyman MITM injection of a corrupted LL-HLS `.m4s` part in the middle of live playback; same technique as the #7797 repro.

**Before this PR** — repeat injection produces the ping-pong loop reported in #7811:


```
22:08:25.366 [passthrough-remuxer]: No audio or video samples found for initPTS at playlist time: 48.016008
22:08:31.698 [passthrough-remuxer]: Timestamps at playlist time: -15589.958... 31275.958... != initPTS: 15637.974... (750622798.792/48000)
22:08:31.812 [passthrough-remuxer]: Found initPTS at playlist time: 52.014... offset: 15637.975... (750622799.792/48000)
22:08:31.862 [passthrough-remuxer]: Timestamps at playlist time: -15589.958... 31275.958... != initPTS: 15637.975...
22:08:31.912 [passthrough-remuxer]: Timestamps at playlist time:  52.014...     15637.974... != initPTS: 31275.958... (1501246013.408/48000)
...
22:08:51.356 [stream-controller]: Playback: 47.944 is located too far from the end of live sliding playlist: 80.028, reset currentTime to : 74.979
```


`initPTS` oscillates between two values exactly 2× apart (`1501246013.408 ≈ 2 × 750622798.792`); `fragment.startPTS` for sn 7841 is written back as `[-15589.959-50.009]` for a playlist fragment declared at `[50-52]`; recovery only via the live-edge safety-net at ~20s.

**After this PR** — same injection, ping-pong is gone:

```
14:16:37.631 [passthrough-remuxer]: Rejecting implausible initPTS — remux startDTS -22544.736s deviates 22594.751s from timeOffset 50.015s (tolerance 5.000s). initPTS 1084548063.112/48000 (≈22594.751s), decodeTime 50.015s. Restoring prior session anchor to prevent ping-pong.
14:16:37.631 [stream-controller]: Transmux of sn: 11241 cc: 0 level: 4 rejected: remux startDTS -22544.736s deviates 22594.751s from timeOffset 50.015s (tolerance 5.000s). Marking as gap and skipping.
14:16:37.631 [stream-controller]: Reset loading state
14:16:37.631 [stream-controller]: FRAG_LOADING->IDLE
...
14:16:48.101 [gap-controller]: skipping hole, adjusting currentTime from 49.915... to 52.071
14:16:48.202 [gap-controller]: playback not stuck anymore @52.079..., after 6460ms
```

Across the full verification session (two corruption injections, 60 `remux()` calls):

| metric | before | after |
|---|---|---|
| `this.initPTS` anchor shifts across session | multiple | 0 (stays at 22594.751s) |
| `fragment.start` corruption (`frag:[-<negative>-...]`) | many | 0 |
| `Timestamps at playlist time: ... != initPTS: ...` ping-pong log lines | many | 0 |
| `Nothing buffered for ... retries N` cascade | many | 0 |
| recovery latency per injection | ~20–25s (live-edge reset) | ~6–7s (gap-controller) |
| VOD recovery | stalls permanently | works via gap-controller |

### Resolves issues:

Fixes #7811
Builds on #7797 (closes the half of the loop that #7797 did not cover)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable) — happy to add; the ideal test exercises the remuxer with a crafted fMP4 fixture whose tfdt produces an implausible `startDTS`, plus a `FragmentTracker` test for the new part-aware `detectPartialFragments` branch. Advice on the preferred shape welcome.
- [x] API or design changes are documented in API.md — the only public-surface addition is `RemuxerResult.parseError?: string`; inline comments cover the rationale. Happy to add API.md entries if preferred.