### PR TITLE
Drop bad mp4 data

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2316,7 +2316,9 @@ export default class BaseStreamController
       }
       if (mediaNotFound) {
         const error = new Error(
-          `Found no media in fragment ${frag.sn} of ${this.playlistLabel()} ${frag.level} resetting transmuxer to fallback to playlist timing`,
+          `Found no media in ${this.playlistLabel()} ${frag.level} ${
+            part ? `part: ${part.index} of ` : ''
+          }sn: ${frag.sn} at playlist time: ${frag.start}. Resetting transmuxer to fallback to playlist timing`,
         );
         this.warn(error.message);
         this.hls.trigger(Events.ERROR, {

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1124,8 +1124,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     };
 
     if (buffersAppendedTo.length === 0) {
-      this.warn(
-        `Fragments must have at least one ElementaryStreamType set. type: ${frag.type} level: ${frag.level} sn: ${frag.sn}`,
+      this.log(
+        `Fragments must have at least one ElementaryStreamType set. ${frag.type} ${frag.level} ${
+          part ? `part: ${part.index} of ` : ''
+        }sn: ${frag.sn}`,
       );
     }
 

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -215,6 +215,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     }
     if (this.emitInitSegment) {
       initSegment.tracks = this.initTracks;
+      result.initSegment = initSegment;
       this.emitInitSegment = false;
     }
 
@@ -267,6 +268,13 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     const baseOffsetSamples = syncOnAudio
       ? audioSampleTimestamps
       : videoSampleTimestamps;
+
+    if (!baseOffsetSamples) {
+      this.warn(
+        `No audio or video samples found for initPTS at playlist time: ${timeOffset}`,
+      );
+      return result;
+    }
 
     let data1 = data;
     let data2: Uint8Array<ArrayBuffer> | undefined;
@@ -336,46 +344,40 @@ class PassThroughRemuxer extends Logger implements Remuxer {
         : videoEndTime - videoStartTime;
     }
 
-    if (baseOffsetSamples) {
-      const timescale = baseOffsetSamples.timescale;
-      const baseTime = baseOffsetSamples.start - timeOffset * timescale;
-      const trackId = syncOnAudio ? initData.audio!.id : initData.video!.id;
+    const timescale = baseOffsetSamples.timescale;
+    const baseTime = baseOffsetSamples.start - timeOffset * timescale;
+    const trackId = syncOnAudio ? initData.audio!.id : initData.video!.id;
 
-      decodeTime = baseOffsetSamples.start / timescale;
+    decodeTime = baseOffsetSamples.start / timescale;
 
-      if (
-        (accurateTimeOffset || !initPTS) &&
-        (isInvalidInitPts(initPTS, decodeTime, timeOffset, duration) ||
-          timescale !== initPTS.timescale)
-      ) {
-        let detectedDrift = false;
-        const trackType = syncOnAudio ? 'audio' : 'video';
-        if (initPTS) {
-          const driftEstimate =
-            timeOffset !== 0 ? decodeTime / timeOffset : 1 + decodeTime / 1;
-          detectedDrift =
-            decodeTime >= 0 && Math.abs(1 - driftEstimate) < 0.001;
-          this.log(
-            `${trackType} timestamps in track ${trackId} at playlist time: ${accurateTimeOffset ? '' : '~'}${timeOffset} maps to ${decodeTime} with initPTS: ${initPTS.baseTime / initPTS.timescale} (${
-              baseTime / timescale - initPTS.baseTime / initPTS.timescale
-            }s diff) (${type}) drift estimate: ${driftEstimate} ${detectedDrift ? '(ignoring drift)' : 'remapping timestamps (initPTS)'}`,
-          );
-        }
-        if (!detectedDrift) {
-          this.log(
-            `Found initPTS in ${trackType} track ${trackId} at playlist time: ${timeOffset} offset: ${decodeTime - timeOffset} (${baseTime}/${timescale})`,
-          );
-          initPTS = null;
-          initSegment.initPTS = baseTime;
-          initSegment.timescale = timescale;
-          initSegment.trackId = trackId;
-        }
+    if (
+      (accurateTimeOffset || !initPTS) &&
+      (isInvalidInitPts(initPTS, decodeTime, timeOffset, duration) ||
+        timescale !== initPTS.timescale)
+    ) {
+      let detectedDrift = false;
+      const trackType = syncOnAudio ? 'audio' : 'video';
+      if (initPTS) {
+        const driftEstimate =
+          timeOffset !== 0 ? decodeTime / timeOffset : 1 + decodeTime / 1;
+        detectedDrift = decodeTime >= 0 && Math.abs(1 - driftEstimate) < 0.001;
+        this.log(
+          `${trackType} timestamps in track ${trackId} at playlist time: ${accurateTimeOffset ? '' : '~'}${timeOffset} maps to ${decodeTime} with initPTS: ${initPTS.baseTime / initPTS.timescale} (${
+            baseTime / timescale - initPTS.baseTime / initPTS.timescale
+          }s diff) (${type}) drift estimate: ${driftEstimate} ${detectedDrift ? '(ignoring drift)' : 'remapping timestamps (initPTS)'}`,
+        );
       }
-    } else {
-      this.warn(
-        `No audio or video samples found for initPTS at playlist time: ${timeOffset}`,
-      );
+      if (!detectedDrift) {
+        this.log(
+          `Found initPTS in ${trackType} track ${trackId} at playlist time: ${timeOffset} offset: ${decodeTime - timeOffset} (${baseTime}/${timescale})`,
+        );
+        initPTS = null;
+        initSegment.initPTS = baseTime;
+        initSegment.timescale = timescale;
+        initSegment.trackId = trackId;
+      }
     }
+
     if (!initPTS) {
       if (
         !initSegment.timescale ||

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -270,8 +270,10 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       : videoSampleTimestamps;
 
     if (!baseOffsetSamples) {
-      this.warn(
-        `No audio or video samples found for initPTS at playlist time: ${timeOffset}`,
+      this.log(
+        `No media samples found in ${playlistType} ${chunkMeta.level} ${
+          chunkMeta.part === -1 ? '' : `part: ${chunkMeta.part} of`
+        } sn: ${chunkMeta.sn} at playlist time: ${timeOffset}`,
       );
       return result;
     }


### PR DESCRIPTION
### This PR will...
Drop bad mp4 data in the passthrough-remuxer before media timestamp calculation

### Why is this Pull Request needed?
https://github.com/video-dev/hls.js/issues/7811#issuecomment-4306170831

### Are there any points in the code the reviewer needs to double check?
I didn't use a proxy to reproduce the issue. I injected empty bytes in the place of random LL-Part responses and then stepped through passthrough-remuxer `remux` to identify the issue:

```ts
        onSuccess: (response, stats, context, networkDetails) => {
          this.resetLoader(frag, loader);
          this.updateStatsFromPart(frag, part);
          let payload = response.data as ArrayBuffer;
          const indexToCorrupt = Math.floor(Math.random() * 6) - 2;
          if (part.index === indexToCorrupt) {
            console.log(
              `Emptying bytes for ${frag.type} ${frag.level} sn: ${frag.sn} part ${part.index}${part.independent ? '-i' : ''}`,
            );
            payload = new Uint8Array(payload.byteLength).buffer;
          }
```

### Resolves issues:
Related to #7811
Follow up to #7814

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
