### PR TITLE
Fix api-extractor output for dependency update

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -49,7 +49,7 @@ export class AbrController extends Logger implements AbrComponentAPI {
     // (undocumented)
     protected onFragBuffered(event: Events.FRAG_BUFFERED, data: FragBufferedData): void;
     // (undocumented)
-    protected onFragLoaded(event: Events.FRAG_LOADED, { frag, part }: FragLoadedData): void;
+    protected onFragLoaded(event: Events.FRAG_LOADED, data: FragLoadedData): void;
     // (undocumented)
     protected onFragLoading(event: Events.FRAG_LOADING, data: FragLoadingData): void;
     // (undocumented)
@@ -206,7 +206,7 @@ export class AudioStreamController extends BaseStreamController implements Netwo
     // (undocumented)
     protected onHandlerDestroying(): void;
     // (undocumented)
-    onInitPtsFound(event: Events.INIT_PTS_FOUND, { frag, id, initPTS, timescale, trackId, timestampOffsets, }: InitPTSFoundData): void;
+    onInitPtsFound(event: Events.INIT_PTS_FOUND, data: InitPTSFoundData): void;
     // (undocumented)
     protected onManifestLoading(): void;
     // (undocumented)
@@ -5093,7 +5093,7 @@ export class TimelineController implements ComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
-    onBufferFlushing(event: Events.BUFFER_FLUSHING, { startOffset, endOffset, endOffsetSubtitles, type }: BufferFlushingData): void;
+    onBufferFlushing(event: Events.BUFFER_FLUSHING, data: BufferFlushingData): void;
 }
 
 // Warning: (ae-missing-release-tag) "TimelineControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -461,10 +461,8 @@ class AbrController extends Logger implements AbrComponentAPI {
     hls.trigger(Events.FRAG_LOAD_EMERGENCY_ABORTED, { frag, part, stats });
   };
 
-  protected onFragLoaded(
-    event: Events.FRAG_LOADED,
-    { frag, part }: FragLoadedData,
-  ) {
+  protected onFragLoaded(event: Events.FRAG_LOADED, data: FragLoadedData) {
+    const { frag, part } = data;
     const stats = part ? part.stats : frag.stats;
     if (frag.type === PlaylistLevelType.MAIN) {
       this.bwEstimator.sampleTTFB(stats.loading.first - stats.loading.start);

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -139,17 +139,8 @@ class AudioStreamController
   }
 
   // INIT_PTS_FOUND is triggered when the video track parsed in the stream-controller has a new PTS value
-  onInitPtsFound(
-    event: Events.INIT_PTS_FOUND,
-    {
-      frag,
-      id,
-      initPTS,
-      timescale,
-      trackId,
-      timestampOffsets,
-    }: InitPTSFoundData,
-  ) {
+  onInitPtsFound(event: Events.INIT_PTS_FOUND, data: InitPTSFoundData) {
+    const { frag, id, initPTS, timescale, trackId, timestampOffsets } = data;
     // Always update the new INIT PTS
     // Can change due level switch
     if (id === PlaylistLevelType.MAIN) {

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -637,10 +637,8 @@ export class TimelineController implements ComponentAPI {
     }
   }
 
-  onBufferFlushing(
-    event: Events.BUFFER_FLUSHING,
-    { startOffset, endOffset, endOffsetSubtitles, type }: BufferFlushingData,
-  ) {
+  onBufferFlushing(event: Events.BUFFER_FLUSHING, data: BufferFlushingData) {
+    const { startOffset, endOffset, endOffsetSubtitles, type } = data;
     const { media } = this;
     if (!media || media.currentTime < endOffset) {
       return;


### PR DESCRIPTION
### This PR will...
Move destructuring out of function arguments changed in api signature with #7824.

### Why is this Pull Request needed?
The dependency update in #7824 replaces destructuring in the updated function signature arguments, causing the build to fail.