### PR TITLE
Add subtitleTrack and closedCaptions properties to `CUES_PARSED` event

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1084,7 +1084,11 @@ export interface CuesInterface {
 // @public (undocumented)
 export interface CuesParsedData {
     // (undocumented)
+    closedCaptions?: MediaPlaylist | undefined;
+    // (undocumented)
     cues: any;
+    // (undocumented)
+    subtitleTrack?: MediaPlaylist;
     // (undocumented)
     track: string;
     // (undocumented)
@@ -4443,20 +4447,14 @@ export const enum NetworkErrorAction {
 // Warning: (ae-missing-release-tag) "NonNativeTextTrack" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export interface NonNativeTextTrack {
-    // (undocumented)
-    closedCaptions?: MediaPlaylist;
-    // (undocumented)
-    default: boolean;
-    // (undocumented)
+export type NonNativeTextTrack = {
     _id?: string;
-    // (undocumented)
+    label: string;
     kind: string;
-    // (undocumented)
-    label: any;
-    // (undocumented)
+    default: boolean;
+    closedCaptions?: MediaPlaylist;
     subtitleTrack?: MediaPlaylist;
-}
+};
 
 // Warning: (ae-missing-release-tag) "NonNativeTextTracksData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -26,6 +26,7 @@ import type {
   ManifestLoadedData,
   MediaAttachingData,
   MediaDetachingData,
+  NonNativeTextTrack,
   SubtitleTracksUpdatedData,
 } from '../types/events';
 import type { MediaPlaylist } from '../types/media-playlist';
@@ -40,15 +41,6 @@ type TrackProperties = {
   media?: MediaPlaylist;
 };
 
-type NonNativeCaptionsTrack = {
-  _id?: string;
-  label: string;
-  kind: string;
-  default: boolean;
-  closedCaptions?: MediaPlaylist;
-  subtitleTrack?: MediaPlaylist;
-};
-
 export class TimelineController implements ComponentAPI {
   private hls: Hls;
   private media: HTMLMediaElement | null = null;
@@ -60,7 +52,7 @@ export class TimelineController implements ComponentAPI {
   private unparsedVttFrags: Array<FragLoadedData | FragDecryptedData> = [];
   private captionsTracks: Record<string, HTMLTrackElement> = {};
   private cueCache: Record<string, VTTCue[]> = {};
-  private nonNativeCaptionsTracks: Record<string, NonNativeCaptionsTrack> = {};
+  private nonNativeCaptionsTracks: Record<string, NonNativeTextTrack> = {};
   private cea608Parser1?: Cea608Parser;
   private cea608Parser2?: Cea608Parser;
   private lastCc: number = -1; // Last video (CEA-608) fragment CC
@@ -187,10 +179,12 @@ export class TimelineController implements ComponentAPI {
       }
     } else {
       const cues = this.Cues.newCue(null, startTime, endTime, screen);
+      const closedCaptions = this.captionsProperties[trackName]?.media;
       this.hls.trigger(Events.CUES_PARSED, {
         type: 'captions',
         cues,
         track: trackName,
+        closedCaptions,
       });
     }
   }
@@ -567,7 +561,12 @@ export class TimelineController implements ComponentAPI {
         return;
       }
       const track = currentTrack.default ? 'default' : 'subtitles' + fragLevel;
-      hls.trigger(Events.CUES_PARSED, { type: 'subtitles', cues, track });
+      hls.trigger(Events.CUES_PARSED, {
+        type: 'subtitles',
+        cues,
+        track,
+        subtitleTrack: currentTrack,
+      });
     }
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -368,16 +368,18 @@ export interface CuesParsedData {
   type: 'captions' | 'subtitles';
   cues: any;
   track: string;
+  closedCaptions?: MediaPlaylist | undefined;
+  subtitleTrack?: MediaPlaylist;
 }
 
-export interface NonNativeTextTrack {
+export type NonNativeTextTrack = {
   _id?: string;
-  label: any;
+  label: string;
   kind: string;
   default: boolean;
   closedCaptions?: MediaPlaylist;
   subtitleTrack?: MediaPlaylist;
-}
+};
 
 export interface NonNativeTextTracksData {
   tracks: Array<NonNativeTextTrack>;


### PR DESCRIPTION
### This PR will...
Add `subtitleTrack` and `closedCaptions` properties to `CUES_PARSED` event. 

### Why is this Pull Request needed?
Provides detailed track information like subtitles language or captions instream-id with `CUES_PARSED` otherwise not available outside of `NON_NATIVE_TEXT_TRACKS_FOUND` event. 

### Are there any points in the code the reviewer needs to double check?
New property names align with those already present in `NON_NATIVE_TEXT_TRACKS_FOUND`.

### Resolves issues:
Resolves #6680

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
