### PR TITLE
fix: Tolerate EOF after attribute-only multivariant playlist tags (e.g. EXT-X-I-FRAME-STREAM-INF)

### DIFF
--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -48,7 +48,7 @@ export type ParsedMultivariantMediaOptions = {
 type LevelKeys = { [key: string]: LevelKey | undefined };
 
 const MASTER_PLAYLIST_REGEX =
-  /#EXT-X-STREAM-INF:([^\r\n]*)(?:[\r\n](?:#[^\r\n]*)?)*([^\r\n]+)|#EXT-X-(I-FRAME-STREAM-INF|SESSION-DATA|SESSION-KEY|DEFINE|CONTENT-STEERING|START):([^\r\n]*)[\r\n]+/g;
+  /#EXT-X-STREAM-INF:([^\r\n]*)(?:[\r\n](?:#[^\r\n]*)?)*([^\r\n]+)|#EXT-X-(I-FRAME-STREAM-INF|SESSION-DATA|SESSION-KEY|DEFINE|CONTENT-STEERING|START):([^\r\n]*)(?:[\r\n]+|$)/g;
 const MASTER_PLAYLIST_MEDIA_REGEX = /#EXT-X-MEDIA:(.*)/g;
 
 const IS_MEDIA_PLAYLIST = /^#EXT(?:INF|-X-TARGETDURATION):/m; // Handle empty Media Playlist (first EXTINF not signaled, but TARGETDURATION present)

--- a/tests/unit/loader/m3u8-parser.ts
+++ b/tests/unit/loader/m3u8-parser.ts
@@ -58,6 +58,27 @@ http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/
     expect(result.sessionData).to.equal(null);
   });
 
+  it('parses #EXT-X-I-FRAME-STREAM-INF on the last line without a trailing newline', function () {
+    const manifest = `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=7700000,RESOLUTION=1920x1080,CODECS="avc1.64002a"
+video.m3u8
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=300000,CODECS="avc1.64002a",RESOLUTION=1920x1080,URI="iframe.m3u8"`;
+    const result = M3U8Parser.parseMasterPlaylist(
+      manifest,
+      'http://example.com/master.m3u8',
+    );
+    expect(result.playlistParsingError).to.be.null;
+    expect(result.levels).to.have.lengthOf(1);
+    expect(result.iframeVariants).to.have.lengthOf(1);
+    expect(result.iframeVariants[0].bitrate).to.equal(300000);
+    expect(result.iframeVariants[0].width).to.equal(1920);
+    expect(result.iframeVariants[0].height).to.equal(1080);
+    expect(result.iframeVariants[0].videoCodec).to.equal('avc1.64002a');
+    expect(result.iframeVariants[0].url).to.equal(
+      'http://example.com/iframe.m3u8',
+    );
+  });
+
   it('parses manifest containing comment', function () {
     const manifest = `#EXTM3U
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=836280,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=848x360,NAME="480"


### PR DESCRIPTION
### This PR will...

Recognize `#EXT-X-I-FRAME-STREAM-INF` (and the other tags handled by the same regex alternation: `SESSION-DATA`, `SESSION-KEY`, `DEFINE`, `CONTENT-STEERING`, `START`) when they appear as the final line of a multivariant playlist with no trailing newline.

### Why is this Pull Request needed?

`MASTER_PLAYLIST_REGEX` in `src/loader/m3u8-parser.ts` requires `[\r\n]+` after the attribute capture for those tags, so any one of them on the last line of a manifest with no terminator is silently dropped.

The sibling `STREAM-INF` branch in the same regex already tolerates EOF after its URI line, so this brings the two branches into consistent leniency.

Minimal repro (served without a trailing `\n`):

```
#EXTM3U
#EXT-X-STREAM-INF:BANDWIDTH=7700000,RESOLUTION=1920x1080,CODECS="avc1.64002a"
video.m3u8
#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=300000,CODECS="avc1.64002a",RESOLUTION=1920x1080,URI="iframe.m3u8"
```

Before this PR: `hls.iframeVariants.length === 0`. After this PR: `hls.iframeVariants.length === 1`.

### Are there any points in the code the reviewer needs to double check?

`$` is used without the `m` flag, so it matches only true end-of-input, not end-of-line. `(?:[\r\n]+|$)` preserves existing behavior in every case where `[\r\n]+` previously matched, and additionally matches at EOF.

### Resolves issues:

No prior issue filed — this PR stands as both bug report and fix.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md _(N/A — internal parser regex; no API surface change)_
