### PR TITLE
Fix HEVC access-unit video sample boundaries in Safari (fixed #7853)

### DIFF
--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -24,18 +24,24 @@ class HevcVideoParser extends BaseVideoParser {
     // free pes.data to save up some memory
     (pes as any).data = null;
 
-    // if new NAL units found and last sample still there, let's push ...
-    // this helps parsing streams with missing AUD (only do this if AUD never found)
-    if (VideoSample && units.length && !track.audFound) {
-      this.pushAccessUnit(VideoSample, track);
+    const createVideoSample = (key: boolean): ParsedVideoSample => {
       VideoSample = this.VideoSample = this.createVideoSample(
-        false,
+        key,
         pes.pts,
         pes.dts,
       );
-    }
+      return VideoSample;
+    };
 
-    units.forEach((unit) => {
+    units.forEach((unit, index) => {
+      if (this.startsNewAccessUnit(VideoSample, track, unit, index)) {
+        this.pushAccessUnit(VideoSample as ParsedVideoSample, track);
+        // 16..23 are IRAP (IDR/CRA/BLA) NAL types per H.265 Table 7-1.
+        const isIrap = unit.type >= 16 && unit.type <= 23;
+        VideoSample = createVideoSample(isIrap);
+        spsfound = false;
+      }
+
       switch (unit.type) {
         // NON-IDR, NON RANDOM ACCESS SLICE
         case 0:
@@ -49,11 +55,7 @@ class HevcVideoParser extends BaseVideoParser {
         case 8:
         case 9:
           if (!VideoSample) {
-            VideoSample = this.VideoSample = this.createVideoSample(
-              false,
-              pes.pts,
-              pes.dts,
-            );
+            VideoSample = createVideoSample(false);
           }
           VideoSample.frame = true;
           push = true;
@@ -74,11 +76,7 @@ class HevcVideoParser extends BaseVideoParser {
             }
           }
           if (!VideoSample) {
-            VideoSample = this.VideoSample = this.createVideoSample(
-              true,
-              pes.pts,
-              pes.dts,
-            );
+            VideoSample = createVideoSample(true);
           }
 
           VideoSample.key = true;
@@ -96,11 +94,7 @@ class HevcVideoParser extends BaseVideoParser {
             VideoSample = this.VideoSample = null;
           }
           if (!VideoSample) {
-            VideoSample = this.VideoSample = this.createVideoSample(
-              true,
-              pes.pts,
-              pes.dts,
-            );
+            VideoSample = createVideoSample(true);
           }
 
           VideoSample.key = true;
@@ -160,11 +154,7 @@ class HevcVideoParser extends BaseVideoParser {
           }
           this.pushParameterSet(track.sps, unit.data, track.vps);
           if (!VideoSample) {
-            VideoSample = this.VideoSample = this.createVideoSample(
-              true,
-              pes.pts,
-              pes.dts,
-            );
+            VideoSample = createVideoSample(true);
           }
           VideoSample.key = true;
           break;
@@ -193,11 +183,7 @@ class HevcVideoParser extends BaseVideoParser {
             VideoSample = null;
           }
           if (!VideoSample) {
-            VideoSample = this.VideoSample = this.createVideoSample(
-              false,
-              pes.pts,
-              pes.dts,
-            );
+            VideoSample = createVideoSample(false);
           }
           break;
 
@@ -225,6 +211,55 @@ class HevcVideoParser extends BaseVideoParser {
     if ((!!vps && vps[0] === this.initVPS) || (!vps && !parameterSets.length)) {
       parameterSets.push(data);
     }
+  }
+
+  private startsNewAccessUnit(
+    VideoSample: ParsedVideoSample | null,
+    track: DemuxedVideoTrack,
+    unit: { type: number; data: Uint8Array },
+    nalIndex: number,
+  ): boolean {
+    if (!VideoSample) {
+      return false;
+    }
+
+    // if new NAL units found and last sample still there, let's push ...
+    // this helps parsing streams with missing AUD (only do this if AUD never found)
+    if (!track.audFound && nalIndex === 0) {
+      return true;
+    }
+
+    // A sample can be opened by AU prefix NALs such as AUD/VPS/SPS/PPS/SEI
+    // before any VCL slice is appended. Keep those prefix NALs in the same
+    // pending sample; only split once the current sample already contains a
+    // picture and the next NAL indicates another access unit.
+    if (!VideoSample.frame) {
+      return false;
+    }
+
+    const { type, data } = unit;
+    // Per H.265 spec 7.4.2.4.4 the following NAL types must appear before
+    // the first VCL of an access unit; seeing one after a complete picture
+    // means a new AU is starting:
+    //   32..35  VPS / SPS / PPS / AUD
+    //   39      prefix SEI
+    //   41..44  reserved non-VCL prefix
+    //   48..55  unspecified prefix
+    // (36/37 EOS/EOB belong to the previous AU; 38 FD and 40 suffix SEI
+    //  belong to the current AU; both stay attached to the open sample.)
+    const isAuPrefix =
+      (type >= 32 && type <= 35) ||
+      type === 39 ||
+      (type >= 41 && type <= 44) ||
+      (type >= 48 && type <= 55);
+    if (isAuPrefix) {
+      return true;
+    }
+
+    // A VCL slice (NAL types 0..31) whose first_slice_segment_in_pic_flag is
+    // set starts a new coded picture, and therefore a new AU. The flag is
+    // the MSB of the byte after the 2-byte HEVC NAL header (spec 7.3.6.1).
+    return type <= 31 && data.length > 2 && (data[2] & 0x80) !== 0;
   }
 
   protected getNALuType(data: Uint8Array, offset: number): number {


### PR DESCRIPTION
### This PR will...

This change fixes HEVC TS transmuxing so that generated video samples are cut on HEVC access-unit boundaries instead of allowing pre-picture NAL units from the next access unit to remain at the tail of the previous sample.

### Why is this Pull Request needed?


Some HEVC elementary streams repeat VPS / SPS / PPS and prefix SEI before each picture. The current parser only flushes a sample at AUD or at PES boundaries, so it can produce fmp4 samples shaped like:

```text
sample N:
  AUD / VCL slices for picture N
  VPS / SPS / PPS / prefix SEI for picture N+1
sample N+1:
  PPS / AUD / VCL for picture N+1   (VPS/SPS missing -- they leaked into sample N)
```

That sample crosses an access-unit boundary. In fragmented MP4 a video sample must represent exactly one coded picture / access unit. Safari (PC and iOS) is strict about this: when a sample's trailing NAL is an AU-prefix NAL such as VPS(32) or SPS(33), it rejects the buffer and the segment fails to decode. Chrome / Firefox happen to tolerate this layout, which is why the bug only surfaces on Safari.

Real-world evidence from a captured MSE append pair (init + media) on the buggy code path, after `hevc_mp4toannexb` and slicing by the sample sizes reported by `ffprobe -show_packets`:

```
--- sample 0  size=64745  (IDR keyframe) ---
  type=32  VPS
  type=33  SPS
  type=34  PPS
  type=33  SPS
  type=34  PPS
  type=39  prefix SEI
  type=39  prefix SEI
  type=35  AUD
  type=20  IDR_W_RADL          <- this picture's VCL
  type=32  VPS                 <- belongs to next picture
  type=33  SPS                 <- belongs to next picture

--- sample 1  size=1563 ---
  type=34  PPS                 <- VPS/SPS missing
  type=39  prefix SEI
  type=35  AUD
  type=1   TRAIL_N
```

After the fix, sample 0 stops at `type=20` and sample 1 starts at `type=32`, carrying a complete VPS/SPS/PPS/AUD/slice tuple. Safari then decodes the segment.

### Are there any points in the code the reviewer needs to double check?

- `startsNewAccessUnit` is a private method on `HevcVideoParser`; no top-level helpers are introduced. Spec references (H.265 7.4.2.4.4 for AU prefix NAL ordering, Table 7-1 for NAL type ranges, 7.3.6.1 for `first_slice_segment_in_pic_flag`) are inlined as comments next to the magic numbers.
- Behaviour on streams that already use AUD correctly is unchanged: `startsNewAccessUnit` returns `false` when no VCL has been written to the current sample yet.

### Resolves issues:

https://github.com/video-dev/hls.js/issues/7853

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
