### PR TITLE
Fix mapPartIntersection loop bounds

### DIFF
--- a/src/utils/level-helper.ts
+++ b/src/utils/level-helper.ts
@@ -388,7 +388,7 @@ export function mapPartIntersection(
 ) {
   if (oldParts && newParts) {
     let delta = 0;
-    for (let i = 0, len = oldParts.length; i <= len; i++) {
+    for (let i = 0, len = oldParts.length; i < len; i++) {
       const oldPart = oldParts[i];
       const newPart = newParts[i + delta];
       if (

--- a/tests/unit/controller/level-helper.ts
+++ b/tests/unit/controller/level-helper.ts
@@ -155,6 +155,28 @@ describe('LevelHelper Tests', function () {
         newParts[2],
       );
     });
+
+    it('does not read beyond the old parts array', function () {
+      const oldFrags = generatePlaylist([1]).fragments;
+      const attr = new AttrList('DURATION=1');
+      const oldParts: Part[] = [new Part(attr, oldFrags[0], '', 0)];
+      const newParts: Part[] = [new Part(attr, oldFrags[0], '', 0)];
+
+      const guardedOldParts = new Proxy(oldParts, {
+        get(target, property, receiver) {
+          if (property === String(target.length)) {
+            throw new Error('Out-of-bounds part access');
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+
+      const intersectionFn = sinon.spy();
+      expect(() =>
+        mapPartIntersection(guardedOldParts, newParts, intersectionFn),
+      ).not.to.throw();
+      expect(intersectionFn).to.have.been.calledOnce;
+    });
   });
 
   describe('adjustSliding', function () {


### PR DESCRIPTION
Fixes #7855.

This updates `mapPartIntersection` so the loop stops before `oldParts.length` instead of reading one past the end. It also adds a focused regression test that fails if the helper tries to access `oldParts[oldParts.length]`.

Verification:
- `npm run lint:quiet -- src/utils/level-helper.ts tests/unit/controller/level-helper.ts`
- `npm run type-check`
- `./node_modules/.bin/karma start karma.conf.js --client.mocha.grep='mapPartIntersection'`