### PR TITLE
fix: set HEVC sync samples from IRAP VCL NALs

### DIFF
--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -61,11 +61,13 @@ class HevcVideoParser extends BaseVideoParser {
           push = true;
           break;
 
-        // CRA, BLA (random access picture)
+        // IRAP - CRA, BLA, reserved IRAP (random access picture)
         case 16:
         case 17:
         case 18:
         case 21:
+        case 22:
+        case 23:
           push = true;
           if (spsfound) {
             // handle PES not starting with AUD
@@ -83,7 +85,7 @@ class HevcVideoParser extends BaseVideoParser {
           VideoSample.frame = true;
           break;
 
-        // IDR
+        // IRAP - IDR
         case 19:
         case 20:
           push = true;
@@ -154,9 +156,10 @@ class HevcVideoParser extends BaseVideoParser {
           }
           this.pushParameterSet(track.sps, unit.data, track.vps);
           if (!VideoSample) {
-            VideoSample = createVideoSample(true);
+            // Parameter sets may prefix either IRAP or non-IRAP pictures.
+            // Only IRAP VCL NALs should mark an HEVC sample as sync/key.
+            VideoSample = createVideoSample(false);
           }
-          VideoSample.key = true;
           break;
 
         // PPS


### PR DESCRIPTION
### This PR will...

Fix a HEVC fMP4 sync sample regression introduced by #7854, where parameter-set NALs could mark samples as keyframes.

A HEVC sample is now marked as sync only when its access unit contains an IRAP VCL picture, such as BLA, IDR, or CRA.

Test stream:

```text
https://sf1-cdn-tos.huoshanstatic.com/obj/media-fe/badcase/hls-hevc-au-testset/hls-hevc-sync/index.m3u8
```

### Why is this Pull Request needed?


Some HEVC TS streams place parameter sets before regular non-IRAP pictures:

```text
VPS/SPS/PPS/SEI/AUD + TRAIL
```

This issue was introduced by #7854. After access-unit boundary handling groups those prefix NALs with the following picture, the old SPS path could still mark the sample as key:

```ts
VideoSample.key = true;
```

That can produce an invalid fMP4 sync sample:

```text
wrong:   K__ [VPS, SPS, PPS, prefix SEI, AUD, TRAIL]
correct: ___ [VPS, SPS, PPS, prefix SEI, AUD, TRAIL]
```

`TRAIL` is not a random access picture. On Chrome/macOS, VideoToolbox may fail decoding when such a sample is incorrectly marked as sync:

```text
PIPELINE_ERROR_DECODE
NSOSStatusErrorDomain Code=-12909
VTDecompressionOutputCallback
```

Real IRAP pictures remain sync samples:

```text
K__ [SPS, PPS, prefix SEI, prefix SEI, AUD, IDR]
```


### Are there any points in the code the reviewer needs to double check?


Please check the HEVC sync-sample rule:

```text
VPS/SPS/PPS/AUD/SEI do not make a sample sync.
Only IRAP VCL pictures, such as BLA/IDR/CRA, make a sample sync.
```

Also note that `VideoSample.key = true` is still needed in IRAP branches because a sample may already have been opened by prefix NALs before the IRAP VCL NAL is parsed.

### Resolves issues:

N/A

### Checklist

- [ x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md



Validation performed:

- [x] `npm run build:debug`
- [x] `npx prettier --check src/demux/video/hevc-video-parser.ts`
- [x] `git diff --check`
- [x] Manual Safari/Chrome/Firefox macOS/Window playback verification with the affected HEVC stream
