### PR TITLE
Task: improve transmuxer teardown

### DIFF
--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -52,7 +52,7 @@ if (__USE_M2TS_ADVANCED_CODECS__) {
 export default class Transmuxer {
   private asyncResult: boolean = false;
   private logger: ILogger;
-  private observer: HlsEventEmitter;
+  private observer: HlsEventEmitter | undefined;
   private typeSupported: TypeSupported;
   private config: HlsConfig;
   private id: PlaylistLevelType;
@@ -92,6 +92,9 @@ export default class Transmuxer {
     chunkMeta: ChunkMetadata,
     state?: TransmuxState,
   ): TransmuxerResult | Promise<TransmuxerResult> {
+    if (!this.observer) {
+      return emptyResult(chunkMeta);
+    }
     const stats = chunkMeta.transmuxing;
     stats.executeStart = now();
 
@@ -136,14 +139,10 @@ export default class Transmuxer {
           aesMode,
           plainTextLength,
         )
-        .then((decryptedData): TransmuxerResult => {
+        .then((decryptedData) => {
           // Calling push here is important; if flush() is called while this is still resolving, this ensures that
           // the decrypted data has been transmuxed
-          const result = this.push(
-            decryptedData,
-            null,
-            chunkMeta,
-          ) as TransmuxerResult;
+          const result = this.push(decryptedData, null, chunkMeta);
           this.decryptionPromise = null;
           return result;
         });
@@ -280,6 +279,9 @@ export default class Transmuxer {
     demuxResult: DemuxerResult,
     chunkMeta: ChunkMetadata,
   ) {
+    if (!this.remuxer) {
+      return;
+    }
     const { audioTrack, videoTrack, id3Track, textTrack } = demuxResult;
     const { accurateTimeOffset, timeOffset } = this.currentTransmuxState;
     this.logger.log(
@@ -287,7 +289,7 @@ export default class Transmuxer {
         chunkMeta.part > -1 ? ' part: ' + chunkMeta.part : ''
       } of ${this.id} playlist ${chunkMeta.level}`,
     );
-    const remuxResult = this.remuxer!.remux(
+    const remuxResult = this.remuxer.remux(
       audioTrack,
       videoTrack,
       id3Track,
@@ -361,6 +363,10 @@ export default class Transmuxer {
       this.remuxer.destroy();
       this.remuxer = undefined;
     }
+    this.decryptionPromise = null;
+    this.decrypter = this.observer = undefined;
+    //@ts-ignore
+    this.logger = this.config = this.probe = undefined;
   }
 
   private transmux(
@@ -396,10 +402,18 @@ export default class Transmuxer {
     accurateTimeOffset: boolean,
     chunkMeta: ChunkMetadata,
   ): TransmuxerResult {
-    const { audioTrack, videoTrack, id3Track, textTrack } = (
-      this.demuxer as Demuxer
-    ).demux(data, timeOffset, chunkMeta, false, !this.config.progressive);
-    const remuxResult = this.remuxer!.remux(
+    const { demuxer, remuxer } = this;
+    if (!demuxer || !remuxer) {
+      return emptyResult(chunkMeta);
+    }
+    const { audioTrack, videoTrack, id3Track, textTrack } = demuxer.demux(
+      data,
+      timeOffset,
+      chunkMeta,
+      false,
+      !this.config.progressive,
+    );
+    const remuxResult = remuxer.remux(
       audioTrack,
       videoTrack,
       id3Track,
@@ -423,7 +437,10 @@ export default class Transmuxer {
     accurateTimeOffset: boolean,
     chunkMeta: ChunkMetadata,
   ): Promise<TransmuxerResult> {
-    return (this.demuxer as Demuxer)
+    if (!this.demuxer) {
+      return Promise.reject(new Error('no demuxer'));
+    }
+    return this.demuxer
       .demuxSampleAes(data, decryptData, timeOffset, chunkMeta)
       .then((demuxResult) => {
         const remuxResult = this.remuxer!.remux(
@@ -446,6 +463,9 @@ export default class Transmuxer {
 
   private configureTransmuxer(data: Uint8Array): undefined | Error {
     const { config, observer, typeSupported } = this;
+    if (!observer) {
+      return;
+    }
     // probe for content type
     let mux: MuxConfig | undefined;
     for (let i = 0, len = muxConfig.length; i < len; i++) {


### PR DESCRIPTION
Improve transmuxer teardown so that async callback subroutines exit silently after the instance is destroyed.

### Resolves issues:
Resolves #7856
