### PR TITLE
Add audio forward buffer info via top-level API

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -193,6 +193,8 @@ export class AudioStreamController extends BaseStreamController implements Netwo
     // (undocumented)
     protected getBufferOutput(): Bufferable | null;
     // (undocumented)
+    getFwdBufferInfo(): BufferInfo | null;
+    // (undocumented)
     protected getLoadPosition(): number;
     // (undocumented)
     protected _handleFragmentLoadComplete(fragLoadedData: FragLoadedData): void;
@@ -2168,6 +2170,8 @@ class Hls implements HlsEventEmitter {
     get allAudioTracks(): MediaPlaylist[];
     get allSubtitleTracks(): MediaPlaylist[];
     attachMedia(data: HTMLMediaElement | MediaAttachingData): void;
+    // (undocumented)
+    get audioForwardBufferInfo(): BufferInfo | null;
     get audioTrack(): number;
     // Warning: (ae-setter-with-docs) The doc comment for the property "audioTrack" must appear on the getter, not the setter.
     set audioTrack(audioTrackId: number);

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -44,6 +44,7 @@ import type {
 import type { MediaPlaylist } from '../types/media-playlist';
 import type { TrackSet } from '../types/track';
 import type { TransmuxerResult } from '../types/transmuxer';
+import type { BufferInfo } from '../utils/buffer-helper';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
 
@@ -344,16 +345,13 @@ class AudioStreamController
       return;
     }
 
-    const bufferable = this.mediaBuffer ? this.mediaBuffer : this.media;
+    const bufferable = this.getBufferOutput();
     if (this.bufferFlushed && bufferable) {
       this.bufferFlushed = false;
       this.afterBufferFlushed(bufferable, ElementaryStreamTypes.AUDIO);
     }
 
-    const bufferInfo = this.getFwdBufferInfo(
-      bufferable,
-      PlaylistLevelType.AUDIO,
-    );
+    const bufferInfo = this.getFwdBufferInfo();
     if (bufferInfo === null) {
       return;
     }
@@ -773,6 +771,11 @@ class AudioStreamController
     }
   }
 
+  public getFwdBufferInfo(): BufferInfo | null {
+    const bufferable = this.getBufferOutput();
+    return super.getFwdBufferInfo(bufferable, PlaylistLevelType.AUDIO);
+  }
+
   protected getBufferOutput(): Bufferable | null {
     return this.mediaBuffer ? this.mediaBuffer : this.media;
   }
@@ -869,7 +872,7 @@ class AudioStreamController
       if (this.state === State.ENDED) {
         this.state = State.IDLE;
       }
-      const mediaBuffer = this.mediaBuffer || this.media;
+      const mediaBuffer = this.getBufferOutput();
       if (mediaBuffer) {
         this.afterBufferFlushed(mediaBuffer, type);
         this.tick();

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1035,6 +1035,10 @@ export default class Hls implements HlsEventEmitter {
     return this.streamController.getMainFwdBufferInfo();
   }
 
+  public get audioForwardBufferInfo(): BufferInfo | null {
+    return this.audioStreamController?.getFwdBufferInfo() || null;
+  }
+
   public get maxBufferLength(): number {
     return this.streamController.maxBufferLength;
   }


### PR DESCRIPTION
### This PR will...
Add audio forward buffer info via top-level API.

### Are there any points in the code the reviewer needs to double check?
Both main and audio buffer info getters remain undocumented. They will remain supported for hls.js@v1 but deserve better naming in a major update.

### Resolves issues:
Resolves #7858
