### PR TITLE
Do not request video buffer flush or EOS when the main playlist is audio-only

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -808,7 +808,7 @@ export type BufferCreatedTrackSet = Partial<Record<SourceBufferName, BufferCreat
 // @public (undocumented)
 export interface BufferEOSData {
     // (undocumented)
-    type?: SourceBufferName;
+    type: SourceBufferName | null;
 }
 
 // Warning: (ae-missing-release-tag) "BufferFlushedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1179,7 +1179,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
   }
 
   // on BUFFER_EOS mark matching sourcebuffer(s) as "ending" and "ended" and queue endOfStream after remaining operations(s)
-  // an undefined data.type will mark all buffers as EOS.
+  // a nullish data.type will mark all buffers as EOS.
   private onBufferEos(event: Events.BUFFER_EOS, data: BufferEOSData) {
     this.sourceBuffers.forEach(([type]) => {
       if (type) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -270,10 +270,9 @@ export default class StreamController
 
     const lastDetails = this.getLevelDetails();
     if (lastDetails && this._streamEnded(bufferInfo, lastDetails)) {
-      const data: BufferEOSData = {};
-      if (this.altAudio === AlternateAudio.SWITCHED) {
-        data.type = 'video';
-      }
+      const data: BufferEOSData = {
+        type: this.targetBufferType(),
+      };
 
       this.hls.trigger(Events.BUFFER_EOS, data);
       this.state = State.ENDED;
@@ -489,11 +488,13 @@ export default class StreamController
   }
 
   protected flushMainBuffer(startOffset: number, endOffset: number) {
-    super.flushMainBuffer(
-      startOffset,
-      endOffset,
-      this.altAudio === AlternateAudio.SWITCHED ? 'video' : null,
-    );
+    super.flushMainBuffer(startOffset, endOffset, this.targetBufferType());
+  }
+
+  private targetBufferType(): 'video' | null {
+    return this.altAudio === AlternateAudio.SWITCHED && !this.audioOnly
+      ? 'video'
+      : null;
   }
 
   protected onMediaAttached(

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -106,7 +106,7 @@ export interface BufferAppendedData {
 }
 
 export interface BufferEOSData {
-  type?: SourceBufferName;
+  type: SourceBufferName | null;
 }
 
 export interface BufferFlushingData {

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -1092,7 +1092,7 @@ describe('BufferController with attached media', function () {
   describe('onBufferEos', function () {
     it('marks the ExtendedSourceBuffer as ended', function () {
       // No type arg ends both SourceBuffers
-      hls.trigger(Events.BUFFER_EOS, {});
+      hls.trigger(Events.BUFFER_EOS, { type: null });
       queueNames.forEach((type) => {
         const track = getSourceBufferTrack(bufferController, type);
         const buffer = track?.buffer;


### PR DESCRIPTION
### This PR will...
Do not request video buffer flush or EOS when the main playlist is audio-only.

### Why is this Pull Request needed?
Prevents error in flush operation with audio-only content when setting `hls.currentLevel`.