### PR TITLE
Fix initial reload time of live media playlist loaded with `hls.loadSource()`

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -236,7 +236,7 @@ export default class BasePlaylistController
       );
       if (details.requestScheduled + reloadInterval < now) {
         details.requestScheduled = now;
-      } else {
+      } else if (details.requestScheduled <= now) {
         details.requestScheduled += reloadInterval;
       }
       this.log(


### PR DESCRIPTION
### This PR will...
Fix initial reload time of live media playlist loaded with `hls.loadSource()`

### Why is this Pull Request needed?
Scheduled reload time is doubled when loading a media playlist (once on "manifest" load and again on level load. The media playlist or "level" is the manifest in this case.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #7556
Closes #7453


### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
