### PR TITLE
fix(eme-controller): unhandled type error depending on promise state

### DIFF
--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -303,6 +303,7 @@ class EMEController extends Logger implements ComponentAPI {
         );
       });
       return keySystemAccess.then((mediaKeySystemAccess) => {
+        this.throwIfDestroyed();
         this.log(
           `Access for key-system "${mediaKeySystemAccess.keySystem}" obtained`,
         );
@@ -1703,6 +1704,9 @@ class EMEController extends Logger implements ComponentAPI {
         `Selecting key-system from session-keys ${keyFormats.join(', ')}`,
       );
       this.keyFormatPromise = this.getKeyFormatPromise(keyFormats);
+      // Until onMediaEncrypted is called this promise is unhandled, add a catch to prevent unhandled rejection
+      // when result is not used.
+      this.keyFormatPromise.catch(() => {});
     }
   }
 

--- a/tests/unit/controller/eme-controller.ts
+++ b/tests/unit/controller/eme-controller.ts
@@ -33,7 +33,12 @@ type EMEControllerTestable = Omit<EMEController, 'hls' | 'mediaKeySessions'> & {
     data: MediaAttachedData,
   ) => void;
   onMediaDetached: () => void;
+  onManifestLoaded: (
+    event: Events.MANIFEST_LOADED,
+    data: { sessionKeys: LevelKey[] },
+  ) => void;
   media: HTMLMediaElement | null;
+  keyFormatPromise: Promise<KeySystemFormats> | null;
   getKeyStatuses: (mediaKeySessionContext: MediaKeySessionContext) => {
     [keyId: string]: MediaKeyStatus;
   };
@@ -579,6 +584,112 @@ describe('EMEController', function () {
         expect(emeController.hls.trigger.args[0][1].details).to.equal(
           ErrorDetails.KEY_SYSTEM_SERVER_CERTIFICATE_REQUEST_FAILED,
         );
+      });
+  });
+
+  it('should reject pending session-key key-system selection with invalid state when destroyed', function () {
+    let resolveKeySystemAccess!: (value: MediaKeySystemAccess) => void;
+    const keySystemAccessPromise = new Promise<MediaKeySystemAccess>(
+      (resolve) => {
+        resolveKeySystemAccess = resolve;
+      },
+    );
+    const createMediaKeysSpy = sinon.spy(() =>
+      Promise.resolve(new MediaKeysMock()),
+    );
+    const reqMediaKsAccessSpy = sinon.spy(() => keySystemAccessPromise);
+
+    setupEach({
+      emeEnabled: true,
+      requestMediaKeySystemAccessFunc: reqMediaKsAccessSpy,
+      drmSystems: {
+        'com.apple.fps': {},
+      },
+    });
+
+    const levelKey = getParsedLevelKey();
+
+    emeController.onManifestLoaded(Events.MANIFEST_LOADED, {
+      sessionKeys: [levelKey],
+    });
+
+    const keyFormatPromise = emeController.keyFormatPromise;
+    if (!keyFormatPromise) {
+      throw new Error('Expected pending key-system selection');
+    }
+
+    emeController.destroy();
+    const mediaKeySystemAccess: MediaKeySystemAccess = {
+      keySystem: KeySystems.FAIRPLAY,
+      createMediaKeys: createMediaKeysSpy,
+      getConfiguration: () => ({}),
+    };
+    resolveKeySystemAccess(mediaKeySystemAccess);
+
+    return keyFormatPromise.then(
+      () => {
+        throw new Error('Expected key-system selection to reject');
+      },
+      (error) => {
+        expect(error).to.be.instanceOf(Error);
+        expect(error.message).to.equal('invalid state');
+        expect(createMediaKeysSpy).not.to.have.been.called;
+      },
+    );
+  });
+
+  it('should handle unused session-key key-system selection rejections', function () {
+    let rejectKeySystemAccess!: (error: Error) => void;
+    const keySystemAccessPromise = new Promise<MediaKeySystemAccess>(
+      (resolve, reject) => {
+        rejectKeySystemAccess = reject;
+      },
+    );
+    let unhandledRejection: PromiseRejectionEvent | null = null;
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      unhandledRejection = event;
+      event.preventDefault();
+    };
+
+    self.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    setupEach({
+      emeEnabled: true,
+      requestMediaKeySystemAccessFunc: () => keySystemAccessPromise,
+      drmSystems: {
+        'com.apple.fps': {},
+      },
+    });
+
+    emeController.onManifestLoaded(Events.MANIFEST_LOADED, {
+      sessionKeys: [getParsedLevelKey()],
+    });
+
+    const keyFormatPromise = emeController.keyFormatPromise;
+    if (!keyFormatPromise) {
+      throw new Error('Expected key-system selection promise');
+    }
+
+    rejectKeySystemAccess(new Error('key-system access failed'));
+
+    return new Promise<void>((resolve) => {
+      self.setTimeout(resolve, 0);
+    })
+      .then(() => {
+        expect(unhandledRejection).to.equal(null);
+        expect(emeController.hls.trigger).not.to.have.been.called;
+        return keyFormatPromise.then(
+          () => {
+            throw new Error('Expected key-system selection to reject');
+          },
+          (error) => {
+            expect(error).to.be.instanceOf(Error);
+            expect(error.message).to.equal('key-system access failed');
+          },
+        );
+      })
+      .finally(() => {
+        self.removeEventListener('unhandledrejection', onUnhandledRejection);
       });
   });
 


### PR DESCRIPTION
### This PR will...

Add missing `throwIfDestroyed()` after keySystemAccess has resolved, this prevents the promise chain to continue in an invalid state resulting in type errors due to expectation of `this.config` to exist.

I also added a catch to the `this.keyFormatPromise` that is "cached" until `onMediaEncrypted` is called, this prevents an unhandled promise rejection from surfacing to the consumer if it occurs before `﻿onMediaEncrypted` is called. 

It's fairly easy to reproduce when playing any DRM protected media with a #EXT-X-SESSION-KEY in the manster manifest, just add the following to your code ( I haven't seen it myself for real but can see it in bugsnag ).

```
hlsjs.on(Events.MANIFEST_LOADED, () => {
  hlsjs.destroy();
});
```

### Why is this Pull Request needed?

Unhandled promise rejection surfaces to the consumer of hls.js eg. to bugsnag/sentry etc unnecessarily as the rejection thrown after the hls.js has been destroyed.

### Are there any points in the code the reviewer needs to double check?

The `this.keyFormatPromise.catch(() => {});` silents an error until the media element detects the media is encrypted, a nicer solution might be to handle the error but not consider it fatal, but that has more impact on the API.

### Resolves issues:

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md **N/A**
