### PR TITLE
Fix remuxing of encrypted I-Frame segments

### DIFF
--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -1,5 +1,6 @@
 import { State } from './base-stream-controller';
 import StreamController from './stream-controller';
+import { Events } from '../events';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper } from '../utils/buffer-helper';
 import type { Fragment, MediaFragment, Part } from '../loader/fragment';
@@ -88,9 +89,8 @@ export class IFrameStreamController extends StreamController {
     if (currentOp?.[1].seekOnAppend) {
       this.seekTo(currentOp[0]);
       if (!nextOp && !this.gotNext) {
-        // repeat op to get next segment (Chrome may require two HEVC frame appends, or one with EoS, before rendering)
-        this.gotNext = true;
-        this.loadMediaAt.apply(this, currentOp);
+        // Mark end of stream to force rendering immediately
+        this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       }
     }
     if (nextOp) {

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -6,7 +6,11 @@ import {
 import { ElementaryStreamTypes } from '../loader/fragment';
 import { getCodecCompatibleName } from '../utils/codecs';
 import { type ILogger, Logger } from '../utils/logger';
-import { patchEncyptionData, writeUint32 } from '../utils/mp4-tools';
+import {
+  patchEncyptionData,
+  truncateIFrameMoofToSamples,
+  writeUint32,
+} from '../utils/mp4-tools';
 import { getSampleData, parseInitSegment } from '../utils/mp4-tools';
 import type { HlsEventEmitter } from '../events';
 import type { TrackFragmentSample } from './mp4-generator';
@@ -283,65 +287,124 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     if (
       __USE_IFRAMES__ &&
       videoSampleTimestamps &&
-      (videoSampleTimestamps.sampleCount > 1 ||
-        (videoSampleTimestamps.sampleCount === 1 &&
-          !syncOnAudio &&
-          chunkMeta.duration / (videoEndTime - videoStartTime) > 1.5)) &&
+      videoSampleTimestamps.sampleCount >= 1 &&
       initData.video &&
       chunkMeta.iframe
     ) {
-      duration = chunkMeta.duration;
-      const { trun, start, duration: sampleDuration } = videoSampleTimestamps;
+      const { trun, start } = videoSampleTimestamps;
       if (trun.length === 1 && trun[0].samples.length) {
-        const sampleOffset = trun[0].sampleOffset;
-        let totalSize = 0;
-        const samples = trun[0].samples.map((sample): TrackFragmentSample => {
-          const { cts, size, flags } = sample;
-          const { dependsOn, isNonSync } = Object.assign(
-            { dependsOn: 2, isNonSync: 0 },
-            flags,
-          );
-          totalSize += size;
-          return {
-            cts: cts || 0,
-            duration: sampleDuration,
-            size,
-            flags: {
-              isLeading: 0,
-              isDependedOn: 0,
-              hasRedundancy: 0,
-              degradPrio: 0,
-              dependsOn,
-              isNonSync,
-              paddingValue: 0,
-            },
-          };
-        });
-        if (samples.length) {
-          const lastSample = samples[samples.length - 1];
-          let lastSampleDuration = duration * initData.video.timescale;
-          for (let i = samples.length - 1; i--; ) {
-            lastSampleDuration -= samples[i].duration;
+        const fragRun = trun[0];
+        const samples = fragRun.samples;
+        const { lastSampleDurationOffset, defaultSampleDurationOffset } =
+          fragRun;
+        // Stretch samples to playlist time when the moof's
+        // sample timing is off by more than 1/20s.
+        const needsDurationAdjustment =
+          Math.abs(chunkMeta.duration - (videoEndTime - videoStartTime)) > 0.05;
+        const partialMdat = samples.length < videoSampleTimestamps.sampleCount;
+        const needsRemux = needsDurationAdjustment || partialMdat;
+        const canRewriteInPlace =
+          lastSampleDurationOffset !== undefined ||
+          defaultSampleDurationOffset !== undefined;
+        if (!needsRemux) {
+          // MP4 timing already spans EXTINF and every declared sample's
+          // data is in the slice — pass through unchanged.
+          duration = videoEndTime - videoStartTime;
+        } else if (initData.video.encrypted && canRewriteInPlace) {
+          // Encrypted I-Frame: mutate the moof in place so senc /
+          // saiz / saio (and any other moof/traf children) survive intact.
+          if (partialMdat) {
+            const totalSize = samples.reduce(
+              (sum, sample) => sum + sample.size,
+              0,
+            );
+            truncateIFrameMoofToSamples(data, samples.length, totalSize);
           }
-          lastSample.duration = lastSampleDuration;
-
-          // Remux Iframe segments reporting more than one sample (mp4 byte-range contains moof for playback segment)
-          data1 = MP4.moof(chunkMeta.sn, start, {
-            type: 'video',
-            id: videoTrack.id,
-            samples, //: [samples[0]],
+          // adjust duration
+          duration = needsDurationAdjustment
+            ? chunkMeta.duration
+            : videoEndTime - videoStartTime;
+          if (lastSampleDurationOffset !== undefined) {
+            let lastSampleDuration = duration * initData.video.timescale;
+            for (let i = 0; i < samples.length - 1; i++) {
+              lastSampleDuration -= samples[i].duration;
+            }
+            writeUint32(data, lastSampleDurationOffset, lastSampleDuration);
+          } else {
+            writeUint32(
+              data,
+              defaultSampleDurationOffset!,
+              Math.round(
+                (duration * initData.video.timescale) / samples.length,
+              ),
+            );
+          }
+        } else if (!initData.video.encrypted) {
+          // Unencrypted: regenerate the moof from the in-range samples.
+          // The in-place truncation path the encrypted branch uses doesn't
+          // preserve enough structure for some unencrypted codecs
+          duration = needsDurationAdjustment
+            ? chunkMeta.duration
+            : videoEndTime - videoStartTime;
+          const sampleOffset = fragRun.sampleOffset;
+          const sampleDuration = videoSampleTimestamps.duration;
+          let totalSize = 0;
+          const remuxedSamples = samples.map((sample): TrackFragmentSample => {
+            const { cts, size, flags } = sample;
+            const { dependsOn, isNonSync } = Object.assign(
+              { dependsOn: 2, isNonSync: 0 },
+              flags,
+            );
+            totalSize += size;
+            return {
+              cts: cts || 0,
+              duration: sampleDuration,
+              size,
+              flags: {
+                isLeading: 0,
+                isDependedOn: 0,
+                hasRedundancy: 0,
+                degradPrio: 0,
+                dependsOn,
+                isNonSync,
+                paddingValue: 0,
+              },
+            };
           });
-          data2 = data.subarray(sampleOffset - 8, sampleOffset + totalSize);
-          writeUint32(data2, 0, totalSize + 8);
+          if (remuxedSamples.length) {
+            const lastSample = remuxedSamples[remuxedSamples.length - 1];
+            let lastSampleDuration = duration * initData.video.timescale;
+            for (let i = remuxedSamples.length - 1; i--; ) {
+              lastSampleDuration -= remuxedSamples[i].duration;
+            }
+            lastSample.duration = lastSampleDuration;
+
+            data1 = MP4.moof(chunkMeta.sn, start, {
+              type: 'video',
+              id: videoTrack.id,
+              samples: remuxedSamples,
+            });
+            data2 = data.subarray(sampleOffset - 8, sampleOffset + totalSize);
+            writeUint32(data2, 0, totalSize + 8);
+          } else {
+            this.warn(
+              `Could not remux IFrame track fragment (sampleOffset ${sampleOffset}: totalSize: ${totalSize} bytes: ${data})`,
+            );
+            duration = videoEndTime - videoStartTime;
+          }
         } else {
+          // Encrypted, but neither trun nor tfhd carries a duration we
+          // can rewrite (encoder relies on moov trex defaults).
           this.warn(
-            `Could not remux IFrame track fragment (sampleOffset ${sampleOffset}: totalSize: ${totalSize} bytes: ${data})`,
+            `IFrame remux skipped for encrypted segment without trun or tfhd sample_duration (sn ${chunkMeta.sn}); using native sample duration`,
           );
+          duration = videoEndTime - videoStartTime;
         }
       } else {
         this.warn(
           `Could not remux IFrame track fragment (trun count ${trun.length})`,
         );
+        duration = videoEndTime - videoStartTime;
       }
     } else {
       duration = syncOnAudio

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -106,6 +106,52 @@ export function writeUint32(buffer: Uint8Array, offset: number, value: number) {
   buffer[offset + 3] = value & 0xff;
 }
 
+export function truncateIFrameMoofToSamples(
+  data: Uint8Array<ArrayBuffer>,
+  keepSampleCount: number,
+  keepTotalSize: number,
+): void {
+  const moofs = findBox(data, ['moof']);
+  if (moofs.length !== 1) {
+    return;
+  }
+  const moof = moofs[0];
+  const trafs = findBox(moof, ['traf']);
+  for (let i = 0; i < trafs.length; i++) {
+    const traf = trafs[i];
+    const trun = findBox(traf, ['trun'])[0];
+    if (trun) {
+      writeUint32(data, trun.byteOffset - data.byteOffset + 4, keepSampleCount);
+    }
+    const senc = findBox(traf, ['senc'])[0];
+    if (senc) {
+      writeUint32(data, senc.byteOffset - data.byteOffset + 4, keepSampleCount);
+    }
+    const saiz = findBox(traf, ['saiz'])[0];
+    if (saiz) {
+      const saizFlags = (saiz[1] << 16) | (saiz[2] << 8) | saiz[3];
+      let off = 4;
+      if (saizFlags & 0x01) {
+        off += 8;
+      }
+      off += 1;
+      writeUint32(
+        data,
+        saiz.byteOffset - data.byteOffset + off,
+        keepSampleCount,
+      );
+    }
+  }
+  const mdats = findBox(data, ['mdat']);
+  if (mdats.length === 1) {
+    writeUint32(
+      data,
+      mdats[0].byteOffset - data.byteOffset - 8,
+      8 + keepTotalSize,
+    );
+  }
+}
+
 export function hasBoxData(data: Uint8Array, type: BoxType): boolean {
   const end = data.byteLength;
   for (let i = 0; i < end; ) {
@@ -698,6 +744,7 @@ export function parseSinf(sinf: Uint8Array): BoxDataOrUndefined {
 
 type TrackFragmentRunSample = {
   cts?: number;
+  duration: number;
   size: number;
   flags?: {
     dependsOn: 1 | 2;
@@ -707,6 +754,8 @@ type TrackFragmentRunSample = {
 type TrackFragmentRun = {
   sampleOffset: number;
   samples: TrackFragmentRunSample[];
+  lastSampleDurationOffset?: number;
+  defaultSampleDurationOffset?: number;
 };
 export type TrackTimes = {
   duration: number;
@@ -789,6 +838,7 @@ export function getSampleData(
       // each present only when its flag is set. Walk them so default_sample_size
       // is read at the correct offset regardless of which earlier fields exist.
       let defaultSampleDuration = trackDefault?.duration || 0;
+      let defaultSampleDurationOffset: number | undefined;
       let defaultSampleSize = trackDefault?.sampleSize || 0;
       let tfhdOptOffset = 8;
       if (tfhdFlags & 0x000001) {
@@ -802,6 +852,8 @@ export function getSampleData(
       if (tfhdFlags & 0x000008) {
         // default_sample_duration
         defaultSampleDuration = readUint32(tfhd, tfhdOptOffset);
+        defaultSampleDurationOffset =
+          tfhd.byteOffset - data.byteOffset + tfhdOptOffset;
         tfhdOptOffset += 4;
       }
       if (tfhdFlags & 0x000010) {
@@ -854,16 +906,20 @@ export function getSampleData(
         }
         let sampleOffset = baseDataOffset + dataOffset;
         const samples: TrackFragmentRunSample[] = [];
+        const fragRun: TrackFragmentRun = {
+          sampleOffset,
+          samples,
+          defaultSampleDurationOffset,
+        };
         if (sampleOffset <= eof) {
-          const fragRun: TrackFragmentRun = {
-            sampleOffset,
-            samples,
-          };
           trackTimes.trun.push(fragRun);
         }
         let size;
         for (let ix = 0; ix < sampleCount; ix++) {
+          let thisSampleDurationOffset: number | undefined;
           if (sampleDurationPresent) {
+            thisSampleDurationOffset =
+              trun.byteOffset - data.byteOffset + offset;
             sampleDuration = readUint32(trun, offset);
             offset += 4;
           } else {
@@ -877,6 +933,11 @@ export function getSampleData(
           }
           sampleOffset += size;
           if (sampleOffset <= eof) {
+            // Capture only fitting samples so a partial-mdat truncation
+            // can still rewrite the right uint32 to balance EXTINF.
+            if (thisSampleDurationOffset !== undefined) {
+              fragRun.lastSampleDurationOffset = thisSampleDurationOffset;
+            }
             let flags;
             let cts = 0;
             if (sampleFlagsPresent) {
@@ -916,6 +977,7 @@ export function getSampleData(
             }
             samples[ix] = {
               cts,
+              duration: sampleDuration,
               flags,
               size,
             };

--- a/tests/unit/remux/passthrough-remuxer.ts
+++ b/tests/unit/remux/passthrough-remuxer.ts
@@ -68,45 +68,35 @@ describe('passthrough-remuxer', function () {
     );
   }
 
-  it('remuxes a single-keyframe iframe segment whose native sample duration is far short of EXTINF', function () {
-    // Dedicated i-frame segment: one keyframe carrying ~one-frame duration
-    // (3003/90000 ≈ 0.033s) while the playlist advertises a multi-second EXTINF.
-    // The duration ratio is well above the 1.5 heuristic, so the remuxer rewrites
-    // the moof, stretching the keyframe to the EXTINF window.
+  it('remuxes moof+mdat to stretch a single-keyframe iframe to the EXTINF duration', function () {
     const extinfDuration = 4;
     const fragmentData = mp4Fragment([sample(3003, 4, 0)]);
 
     const result = remuxIFrameFragment(fragmentData, extinfDuration);
 
     expect(result.video, 'video track').to.exist;
-    // data2 is only populated when the iframe moof is rewritten (remuxed)
-    expect(result.video!.data2, 'remuxed mdat').to.exist;
+    // regenerated: a fresh moof in data1 and a separate mdat in data2
+    expect(result.video!.data1, 'data1').to.not.equal(fragmentData);
+    expect(result.video!.data2, 'data2').to.exist;
     expect(result.video!.endDTS - result.video!.startDTS).to.equal(
       extinfDuration,
     );
-    // track.nb stays an informative parse count, not forced to 1
     expect(result.video!.nb).to.equal(1);
   });
 
   it('does not remux a byte-range iframe segment whose sample duration already matches EXTINF', function () {
-    // Byte-range addressed iframe (single sample spanning the whole playback
-    // segment): sample duration == EXTINF, so the ratio is ~1 and the heuristic
-    // keeps the more-accurate sample-based timing instead of remuxing.
+    // Byte-range addressed iframe (single sample spanning the whole playback segment)
     const extinfDuration = 4;
     const fragmentData = mp4Fragment([sample(extinfDuration * 90000, 4, 0)]);
 
     const result = remuxIFrameFragment(fragmentData, extinfDuration);
 
     expect(result.video, 'video track').to.exist;
-    // not remuxed: the original fragment is passed through and no mdat is split out
-    expect(result.video!.data2, 'remuxed mdat').to.not.exist;
+    expect(result.video!.data2, 'data2').to.not.exist;
     expect(result.video!.data1).to.equal(fragmentData);
   });
 
-  it('remuxes a multi-sample in-range iframe fragment, preserving every sample', function () {
-    // Several samples fully present in the mdat (e.g. a byte-range that spans a
-    // multi-sample moof). The sampleCount > 1 branch must still emit all samples,
-    // back-loading the EXTINF remainder onto the last sample's duration.
+  it('regenerates moof+mdat for a multi-sample iframe fragment, keeping every sample', function () {
     const extinfDuration = 4;
     const fragmentData = mp4Fragment([
       sample(3003, 4, 0),
@@ -117,7 +107,8 @@ describe('passthrough-remuxer', function () {
     const result = remuxIFrameFragment(fragmentData, extinfDuration);
 
     expect(result.video, 'video track').to.exist;
-    expect(result.video!.data2, 'remuxed mdat').to.exist;
+    expect(result.video!.data1, 'data1').to.not.equal(fragmentData);
+    expect(result.video!.data2, 'data2').to.exist;
     // all three parsed samples are reported, not collapsed to one
     expect(result.video!.nb).to.equal(3);
     expect(result.video!.endDTS - result.video!.startDTS).to.equal(


### PR DESCRIPTION
### This PR will...
Fix remuxing of encrypted I-Frame segments so that they retain encryption boxes.

### Why is this Pull Request needed?
Support for Widevine decryption of I-Frames.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
