### PR TITLE
Treat un-demuxable fragments as a gap to prevent infinite reloading

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2380,18 +2380,24 @@ export default class BaseStreamController
       false,
     );
     if (!parsed) {
+      // mediaNotFound: probed successfully but contained no elementary streams
+      // (e.g. an empty segment). couldNotDemux: the demuxer probe failed, so the
+      // bytes could not be demuxed at all (for example encrypted media served
+      // without an EXT-X-KEY tag). The two are mutually exclusive, and both are
+      // false when there is no transmuxer (so neither triggers a gap in that case).
       const mediaNotFound = this.transmuxer?.error === null;
+      const couldNotDemux = this.transmuxer?.error != null;
+      const hasAlternateLevels = (this.levels?.length ?? 0) > 1;
       if (
         level.fragmentError === 0 ||
         (mediaNotFound && (level.fragmentError < 2 || frag.endList)) ||
-        (this.transmuxer?.error != null && (this.levels?.length ?? 0) > 1)
+        (couldNotDemux && hasAlternateLevels)
       ) {
-        // Mark and track the empty or undecodable segment as a gap to avoid reloading.
-        // A non-null transmuxer error means the fragment could not be demuxed (for
-        // example encrypted media served without an EXT-X-KEY tag). When alternate
-        // levels are available, gap it so playback advances instead of repeatedly
-        // switching levels and reloading the same undecodable segment; with a single
-        // level the error is left to escalate (fatal after retries).
+        // Mark and track the empty or undecodable segment as a gap to avoid
+        // reloading. When the fragment could not be demuxed and alternate levels
+        // are available, gap it so playback advances instead of repeatedly switching
+        // levels and reloading the same undecodable segment; with a single level the
+        // error is left to escalate (fatal after retries).
         this.treatAsGap(frag, level);
       }
       if (mediaNotFound) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2383,9 +2383,15 @@ export default class BaseStreamController
       const mediaNotFound = this.transmuxer?.error === null;
       if (
         level.fragmentError === 0 ||
-        (mediaNotFound && (level.fragmentError < 2 || frag.endList))
+        (mediaNotFound && (level.fragmentError < 2 || frag.endList)) ||
+        (this.transmuxer?.error != null && (this.levels?.length ?? 0) > 1)
       ) {
-        // Mark and track the odd (or last) empty segment as a gap to avoid reloading
+        // Mark and track the empty or undecodable segment as a gap to avoid reloading.
+        // A non-null transmuxer error means the fragment could not be demuxed (for
+        // example encrypted media served without an EXT-X-KEY tag). When alternate
+        // levels are available, gap it so playback advances instead of repeatedly
+        // switching levels and reloading the same undecodable segment; with a single
+        // level the error is left to escalate (fatal after retries).
         this.treatAsGap(frag, level);
       }
       if (mediaNotFound) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -2118,13 +2118,16 @@ export default class BaseStreamController
       couldRetry &&
       !errorAction.resolved &&
       flags & ErrorActionFlags.MoveAllAlternatesMatchingHost;
-    const live = this.hls.latestLevelDetails?.live;
+    const levelDetails = this.hls.latestLevelDetails;
+    const live = levelDetails?.live;
+    // Errors on the last live fragment fall through to retry and escalate to
+    // fatal once retries are exhausted, as they do for VOD.
     if (
       !retry &&
       noAlternate &&
       isMediaFragment(frag) &&
-      !frag.endList &&
       live &&
+      frag.sn < levelDetails.endSN &&
       !isUnusableKeyError(data)
     ) {
       this.resetFragmentErrors(filterType);
@@ -2380,24 +2383,22 @@ export default class BaseStreamController
       false,
     );
     if (!parsed) {
-      // mediaNotFound: probed successfully but contained no elementary streams
-      // (e.g. an empty segment). couldNotDemux: the demuxer probe failed, so the
-      // bytes could not be demuxed at all (for example encrypted media served
-      // without an EXT-X-KEY tag). The two are mutually exclusive, and both are
-      // false when there is no transmuxer (so neither triggers a gap in that case).
+      // The transmuxer error is null when transmuxing completed without error
+      // but found no elementary streams (e.g. an empty segment), and non-null
+      // when an error occurred before any media samples were found.
       const mediaNotFound = this.transmuxer?.error === null;
-      const couldNotDemux = this.transmuxer?.error != null;
+      const transmuxerError = this.transmuxer?.error != null;
       const hasAlternateLevels = (this.levels?.length ?? 0) > 1;
       if (
         level.fragmentError === 0 ||
         (mediaNotFound && (level.fragmentError < 2 || frag.endList)) ||
-        (couldNotDemux && hasAlternateLevels)
+        (transmuxerError && hasAlternateLevels)
       ) {
-        // Mark and track the empty or undecodable segment as a gap to avoid
-        // reloading. When the fragment could not be demuxed and alternate levels
-        // are available, gap it so playback advances instead of repeatedly switching
-        // levels and reloading the same undecodable segment; with a single level the
-        // error is left to escalate (fatal after retries).
+        // Mark and track the empty or errored segment as a gap to avoid
+        // reloading. A fragment with a transmuxer error is only gapped when
+        // alternate levels exist, so playback advances instead of reloading
+        // the same segment after each level switch; with a single level the
+        // error is left to escalate through error-controller retries.
         this.treatAsGap(frag, level);
       }
       if (mediaNotFound) {


### PR DESCRIPTION
## Why this change is needed

We hit a stream issue where **AES-128 encrypted content was served without an `#EXT-X-KEY` tag** in the media playlist (the key tag was dropped before it reached the player). Because the playlist declares no encryption, hls.js treats the encrypted bytes as clear media and passes them to the transmuxer, where the demuxer probe fails:

```
[transmuxer] Failed to find demuxer by probing fragment data
```

In this state hls.js **re-requests the same segment indefinitely** — in our captures the identical segment was reloaded **every ~180–200 ms, hundreds of times** (a single segment reached tens of thousands of reloads in the worst real incident). The player makes no forward progress and floods the network with requests for one undecodable segment.

## Root cause

In `BaseStreamController.updateLevelTiming()`, when a fragment is parsed but yields no elementary streams (`!parsed`), the gap-marking guard only handles the "no media, **no** transmuxer error" case:

```ts
const mediaNotFound = this.transmuxer?.error === null;
if (
  level.fragmentError === 0 ||
  (mediaNotFound && (level.fragmentError < 2 || frag.endList))
) {
  this.treatAsGap(frag, level);
}
```

When the demuxer probe *fails*, `this.transmuxer.error` is **non-null**, so `mediaNotFound` is `false`. After the very first error (`fragmentError === 0`) the fragment is no longer marked as a gap. Without `frag.gap`, the `FRAG_PARSING_ERROR` path in `error-controller` keeps retrying / switching levels — and because every level carries the same undecodable bytes, the controller loops forever re-requesting the segment.

## What this PR does

Extend the guard so a fragment the transmuxer **could not demux** is also marked as a gap — but **only when alternate levels exist**. Intermediate booleans keep the three cases explicit:

```ts
// mediaNotFound: probed OK but no elementary streams (e.g. an empty segment).
// couldNotDemux: the demuxer probe failed — the bytes could not be demuxed at all
// (for example encrypted media served without an EXT-X-KEY tag). The two are
// mutually exclusive, and both are false when there is no transmuxer.
const mediaNotFound = this.transmuxer?.error === null;
const couldNotDemux = this.transmuxer?.error != null;
const hasAlternateLevels = (this.levels?.length ?? 0) > 1;
if (
  level.fragmentError === 0 ||
  (mediaNotFound && (level.fragmentError < 2 || frag.endList)) ||
  (couldNotDemux && hasAlternateLevels)
) {
  this.treatAsGap(frag, level);
}
```

- **Multiple renditions** (`hasAlternateLevels`): gapping lets playback advance instead of endlessly switching levels and reloading the same undecodable segment.
- **Single rendition**: the fragment is deliberately **not** gapped, so the error is left to escalate (fatal after retries) rather than silently skipping the whole stream.
- `couldNotDemux` is `transmuxer?.error != null` (not `!mediaNotFound`) so that a missing transmuxer — where `error` is `undefined`, not a real demux failure — does not trigger a gap.

Once the fragment is gapped (`frag.gap = true`), `error-controller`'s `FRAG_PARSING_ERROR` handler short-circuits (`if (data.frag?.gap) { … }`) and the stream advances to the next fragment. The **first** parse error per fragment still reaches the error controller before the gap is set, so normal level-switch recovery (when an alternate level *can* be demuxed) is preserved — only the infinite reload of an undecodable segment is stopped.

## Scope / known limitation

This stops the **network flood** (the filed incident). When *every* rendition carries undecodable media (the AES-without-key case), playback advances through gaps at playlist cadence instead of erroring out; surfacing a terminal error for a fully-undecodable stream is intentionally left as a follow-up.

## Reproduction

1. Serve an AES-128 live playlist whose segments are encrypted but **omit** `#EXT-X-KEY`.
2. Load it in hls.js.
3. **Before:** the same segment is requested every ~180–200 ms and never advances.
   **After:** each undecodable segment is requested ~once and the player advances at playlist cadence.

Sanitized logs (domains, keys and IDs redacted):

**Before** — one segment, reloaded indefinitely
```
[stream-controller] Loading main sn: 1234 of level 1 (frag:[6.000-8.000]), target: 6
[transmuxer]        Failed to find demuxer by probing fragment data
[stream-controller] FRAG_LOADING->IDLE
[error-controller]  switching to level 0 after fragParsingError
[stream-controller] Loading main sn: 1234 of level 0 (frag:[6.000-8.000]), target: 6
... sn 1234 requested again ~180 ms later — repeated hundreds of times, no progress
```

**After** — segment is gapped, playback advances
```
[stream-controller] Loading main sn: 1234 of level 1 (frag:[6.000-8.000]), target: 6
[transmuxer]        Failed to find demuxer by probing fragment data
[stream-controller] Loading main sn: 1235 of level 0 (frag:[8.000-10.000])   <- advances
... each segment requested ~1–2x, paced by the live playlist refresh (~2 s)
```

Measured in an end-to-end test that strips `#EXT-X-KEY` from an AES-128 stream: of 53 parse errors on the undecodable segment, only **1** triggered a level switch (46 were absorbed as gaps), versus a per-error level-switch thrash without the change.

## Checklist

- [x] No public API change
- [x] Builds clean (`npm run build`)
