### PR TITLE
Fix uncaught init segment abort errors

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -601,7 +601,9 @@ export default class BaseStreamController
         if (this.state === State.STOPPED || this.state === State.ERROR) {
           return;
         }
-        this.warn(`Frag error: ${reason?.message || reason}`);
+        this.log(
+          `Frag error ${fragment.type} sn:${fragment.sn} cc:${fragment.cc}: ${reason?.message || reason}`,
+        );
         this.resetFragmentLoading(fragment);
       });
   }
@@ -813,7 +815,6 @@ export default class BaseStreamController
           this.fragmentLoader.abort();
           this.handleFragLoadError(reason);
         }
-        this.warn(reason);
         this.resetFragmentLoading(mediaFrag);
         throw reason;
       });
@@ -1100,6 +1101,8 @@ export default class BaseStreamController
       this.log(
         `Context changed in KEY_LOADING sn: ${frag.sn} ${frag.relurl} > ${this.fragCurrent?.relurl}`,
       );
+      initDataPromise?.catch(() => null);
+      keyLoadingPromise?.catch(() => null);
       return Promise.resolve(null);
     }
     this.log(

--- a/tests/unit/controller/base-stream-controller.ts
+++ b/tests/unit/controller/base-stream-controller.ts
@@ -965,7 +965,6 @@ describe('BaseStreamController', function () {
         baseStreamController as any,
         'resetFragmentLoading',
       );
-      const warnStub = sinon.stub(baseStreamController as any, 'warn');
 
       const result = (baseStreamController as any).loadInitSegmentIfNeeded(
         mediaFrag,
@@ -989,13 +988,11 @@ describe('BaseStreamController', function () {
           expect(resetFragmentLoadingStub).to.have.been.calledOnceWith(
             mediaFrag,
           );
-          expect(warnStub).to.have.been.calledOnceWith(loadError);
         })
         .finally(() => {
           abortStub.restore();
           handleFragLoadErrorStub.restore();
           resetFragmentLoadingStub.restore();
-          warnStub.restore();
         });
     });
   });


### PR DESCRIPTION
### This PR will...
Fix uncaught init segment network errors.
Removes warning (abort errors are expected, error handler covers logging).

### Why is this Pull Request needed?
Fixes internal exception caught by e2e tests:
https://github.com/video-dev/hls.js/actions/runs/27314625048/job/80898805659#step:8:361

Uncaught init segment promise is a recent regression introduced in v1.7.0-beta.1 with #7879.
