### PR TITLE
Fix Low-Latency Live join with interstitial preroll (PRE,ONCE)

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1163,6 +1163,8 @@ export class DateRange {
     // (undocumented)
     get id(): string;
     // (undocumented)
+    get invalidReason(): string | null;
+    // (undocumented)
     get isInterstitial(): boolean;
     // (undocumented)
     get isValid(): boolean;

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -488,7 +488,7 @@ export class BaseStreamController extends TaskLoop implements NetworkComponentAP
     // (undocumented)
     protected exceedsMaxBuffer(bufferInfo: BufferInfo, maxBufLen: number, selected: Fragment): boolean;
     // (undocumented)
-    protected filterReplacedPrimary(frag: MediaFragment | null, details: LevelDetails | undefined): MediaFragment | null;
+    protected filterReplacedPrimary<T extends MediaFragment | Part>(frag: T | null, details: LevelDetails | undefined): T | null;
     // (undocumented)
     protected flushBufferGap(frag: Fragment): void;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -377,11 +377,11 @@ class AudioStreamController
     if (this.switchingTrack && media) {
       const pos = loadPosition;
       // if currentTime (pos) is less than alt audio playlist start time, it means that alt audio is ahead of currentTime
-      if (trackDetails.PTSKnown && pos < start) {
+      if (trackDetails.PTSKnown && pos < start && pos >= this.timelineOffset) {
         // if everything is buffered from pos to start or if audio buffer upfront, let's seek to start
         if (bufferInfo.end > start || bufferInfo.nextStart) {
           this.log(
-            'Alt audio track ahead of main track, seek to start of alt audio track',
+            `Alt audio track ahead of main track, seek to start of alt audio track ${pos} -> ${start} + 0.05`,
           );
           media.currentTime = start + 0.05;
         }

--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -155,7 +155,7 @@ export default class BasePlaylistController
     // Set last updated date-time
     const now = self.performance.now();
     const elapsed = stats.loading.first
-      ? Math.max(0, now - stats.loading.first)
+      ? Math.max(0, Math.floor(now - stats.loading.first))
       : 0;
     details.advancedDateTime = Date.now() - elapsed;
 
@@ -239,13 +239,18 @@ export default class BasePlaylistController
       } else if (details.requestScheduled <= now) {
         details.requestScheduled += reloadInterval;
       }
+      const requestedHls = data.deliveryDirectives;
       this.log(
         `live playlist ${index} ${
           details.advanced
-            ? 'REFRESHED ' + details.lastPartSn + '-' + details.lastPartIndex
+            ? `REFRESHED ${details.lastPartSn} - ${details.lastPartIndex}`
             : details.updated
               ? 'UPDATED'
-              : 'MISSED'
+              : `MISSED (received ${details.lastPartSn} - ${details.lastPartIndex}${
+                  requestedHls
+                    ? ` | requested ${requestedHls.msn} - ${requestedHls.part}`
+                    : ''
+                })`
         }`,
       );
       if (!this.canLoad || !details.live) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1017,6 +1017,9 @@ export default class BaseStreamController
             this.loadingParts = false;
             return Promise.resolve(null);
           }
+          if (!this.filterReplacedPrimary(part, level.details)) {
+            return Promise.resolve(null);
+          }
           const keyLoadingPromise = this.loadKeyFor(frag, details);
           if (this.fragContextChanged(frag)) {
             return Promise.resolve(null);
@@ -1665,16 +1668,17 @@ export default class BaseStreamController
     return false;
   }
 
-  protected filterReplacedPrimary(
-    frag: MediaFragment | null,
+  protected filterReplacedPrimary<T extends MediaFragment | Part>(
+    frag: T | null,
     details: LevelDetails | undefined,
-  ): MediaFragment | null {
+  ): T | null {
     if (!frag) {
       return frag;
     }
     if (
       interstitialsEnabled(this.config) &&
-      frag.type !== PlaylistLevelType.SUBTITLE
+      ('type' in frag ? frag : frag.fragment).type !==
+        PlaylistLevelType.SUBTITLE
     ) {
       // Do not load fragments outside the buffering schedule segment
       const interstitials = this.hls.interstitialsManager;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1571,10 +1571,15 @@ export default class BaseStreamController
           this.startPosition != startPosition ||
           this.nextLoadPosition != startPosition
         ) {
+          const liveDetached =
+            levelDetails.live &&
+            !this.filterReplacedPrimary(frag, levelDetails);
+          const tmpStartPosition = liveDetached ? -1 : startPosition;
           this.log(
-            `Setting startPosition to ${startPosition} ${mainStart === -1 ? '' : `(from ${configValue}) `}based on ${reason}. live edge: ${liveSyncPosition} live frag start: ${fragStart} playlist start: ${playlistStart} buffer pos: ${pos}`,
+            `Setting startPosition to ${tmpStartPosition} next load ${startPosition} ${mainStart === -1 ? '' : `(from ${configValue}) `}based on ${reason}. live edge: ${liveSyncPosition} live frag start: ${fragStart} playlist start: ${playlistStart} buffer pos: ${pos}`,
           );
-          this.startPosition = this.nextLoadPosition = startPosition;
+          this.startPosition = tmpStartPosition;
+          this.nextLoadPosition = startPosition;
         }
       }
     } else if (pos <= playlistStart) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -44,8 +44,9 @@ import {
 import { estimatedAudioBitrate } from '../utils/mediacapabilities-helper';
 import { appendUint8Array } from '../utils/mp4-tools';
 import { timeRangesToString } from '../utils/time-ranges';
-import type { FragmentTracker } from './fragment-tracker';
 import type { HlsConfig } from '../config';
+import type { FragmentTracker } from './fragment-tracker';
+import type { HlsAssetPlayer } from './interstitial-player';
 import type TransmuxerInterface from '../demux/transmuxer-interface';
 import type Hls from '../hls';
 import type {
@@ -1095,6 +1096,9 @@ export default class BaseStreamController
       return Promise.resolve(null);
     }
 
+    if (!this.filterReplacedPrimary(frag, level.details)) {
+      return Promise.resolve(null);
+    }
     // Start the init segment load before the key load so that EME key
     // patching from tenc (KeyLoader.loadKeyEME) has the data it needs
     // before the license request is generated (#7796).
@@ -1596,11 +1600,7 @@ export default class BaseStreamController
     }
     let programFrag = this.filterReplacedPrimary(frag, levelDetails);
     if (!programFrag && frag) {
-      const curSNIdx = frag.sn - levelDetails.startSN;
-      programFrag = this.filterReplacedPrimary(
-        fragments[curSNIdx + 1] || null,
-        levelDetails,
-      );
+      programFrag = fragments[1 + frag.sn - levelDetails.startSN] || null;
     }
     return programFrag;
   }
@@ -1706,7 +1706,7 @@ export default class BaseStreamController
             // this.fragmentTracker.fragBuffered(frag, true);
             return null;
           }
-          if (frag.start > bufferingItem.end && bufferingItem.nextEvent) {
+          if (frag.start >= bufferingItem.end && bufferingItem.nextEvent) {
             // fragment is past schedule item end
             // allow some overflow when not appending in place to prevent stalls
             if (
@@ -1719,18 +1719,14 @@ export default class BaseStreamController
         }
       }
       // Skip loading of fragments that overlap completely with appendInPlace interstitials
-      const playerQueue = interstitials?.playerQueue;
-      if (playerQueue) {
-        for (let i = playerQueue.length; i--; ) {
-          const interstitial = playerQueue[i].interstitial;
-          if (
-            interstitial.appendInPlace &&
-            frag.start >= interstitial.startTime &&
-            frag.end <= interstitial.resumeTime
-          ) {
-            return null;
-          }
-        }
+      if (
+        fragOverlapsQueuedInterstitial(
+          frag,
+          interstitials?.playerQueue,
+          this.playhead,
+        )
+      ) {
+        return null;
       }
     }
     return frag;
@@ -2741,7 +2737,35 @@ export default class BaseStreamController
   }
 }
 
-function interstitialsEnabled(config: Readonly<HlsConfig>): boolean {
+export function fragOverlapsQueuedInterstitial(
+  frag: MediaFragment | Part,
+  playerQueue: HlsAssetPlayer[] | undefined,
+  playhead: number,
+): boolean {
+  if (__USE_INTERSTITIALS__ && playerQueue) {
+    for (let i = playerQueue.length; i--; ) {
+      const interstitial = playerQueue[i].interstitial;
+      if (interstitial.appendInPlace) {
+        if (
+          frag.start >= interstitial.startTime &&
+          frag.end <= interstitial.resumeTime
+        ) {
+          return true;
+        }
+        if (
+          playhead > frag.start &&
+          frag.end > interstitial.startTime &&
+          frag.start < interstitial.resumeTime
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+export function interstitialsEnabled(config: Readonly<HlsConfig>): boolean {
   return (
     __USE_INTERSTITIALS__ &&
     !!config.interstitialsController &&

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1953,6 +1953,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       ? mediaSource.duration
       : Infinity;
     const removeStart = Math.max(0, startOffset);
+    if (removeStart >= msDuration) {
+      this.currentOp(type)?.onComplete();
+      return;
+    }
     const removeEnd = Math.min(endOffset, mediaDuration, msDuration);
     if (removeEnd > removeStart && (!track.ending || track.ended)) {
       track.ended = false;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1034,7 +1034,9 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         this.removeExecutor(type, start, end);
       },
       onStart: () => {
-        // logger.debug(`[buffer-controller]: Started flushing ${start} -> ${end} for ${type} Source Buffer`);
+        // this.log(
+        //   `Started flushing ${start} -> ${end} for ${type} Source Buffer`,
+        // );
       },
       onComplete: () => {
         const sb = this.tracks[type]?.buffer;
@@ -1879,6 +1881,15 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
       return;
     }
     operation.onComplete();
+
+    const updating = this.tracks[type]?.buffer?.updating;
+    if (updating) {
+      this.log(`${type} SourceBuffer updating on "updateend"`);
+      this.blockUntilOpen(() => {
+        this.shiftAndExecuteNext(type);
+      });
+      return;
+    }
     this.shiftAndExecuteNext(type);
   }
 

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -378,13 +378,13 @@ export default class ErrorController
       const isAudioCodecError =
         (fragErrorType === PlaylistLevelType.AUDIO &&
           errorDetails === ErrorDetails.FRAG_PARSING_ERROR) ||
-        (data.sourceBufferName === 'audio' && isCodecRelated(errorDetails));
+        (data.sourceBufferName === 'audio' && isCodecRelated(data));
       const findAudioCodecAlternate =
         isAudioCodecError &&
         levels.some(({ audioCodec }) => level.audioCodec !== audioCodec);
       // Find alternate video codec if available on video codec error
       const isVideoCodecError =
-        data.sourceBufferName === 'video' && isCodecRelated(errorDetails);
+        data.sourceBufferName === 'video' && isCodecRelated(data);
       const findVideoCodecAlternate =
         isVideoCodecError &&
         levels.some(
@@ -482,7 +482,8 @@ export default class ErrorController
         if (
           !data.errorAction.resolved &&
           data.details !== ErrorDetails.FRAG_GAP &&
-          data.details !== ErrorDetails.PLAYLIST_UNCHANGED_ERROR
+          data.details !== ErrorDetails.PLAYLIST_UNCHANGED_ERROR &&
+          !isAppendStateRelated(data)
         ) {
           data.fatal = true;
         }
@@ -614,11 +615,28 @@ export default class ErrorController
   }
 }
 
-function isCodecRelated(errorDetails: ErrorDetails): boolean {
-  return (
+function isCodecRelated(data: ErrorData): boolean {
+  const errorDetails = data.details;
+  if (
     errorDetails === ErrorDetails.BUFFER_ADD_CODEC_ERROR ||
-    errorDetails === ErrorDetails.BUFFER_APPEND_ERROR ||
     errorDetails === ErrorDetails.MEDIA_SOURCE_REQUIRES_RESET
+  ) {
+    return true;
+  }
+  if (errorDetails === ErrorDetails.BUFFER_APPEND_ERROR) {
+    if (!isAppendStateRelated(data)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAppendStateRelated(data: ErrorData): boolean {
+  const errorDetails = data.details;
+  return (
+    errorDetails === ErrorDetails.BUFFER_APPEND_ERROR &&
+    (data.error.name === 'QuotaExceededError' ||
+      data.error.name === 'InvalidStateError')
   );
 }
 

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -154,8 +154,10 @@ export default class GapController extends TaskLoop {
     if (!this.media?.readyState || !this.hasBuffered) {
       return;
     }
-
     const currentTime = this.getCurrentTime();
+    if (this.media.currentTime < currentTime) {
+      return;
+    }
     this.poll(currentTime, this.lastCurrentTime);
     this.lastCurrentTime = currentTime;
   }

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -1,4 +1,8 @@
-import { State } from './base-stream-controller';
+import {
+  fragOverlapsQueuedInterstitial,
+  interstitialsEnabled,
+  State,
+} from './base-stream-controller';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
 import TaskLoop from '../task-loop';
@@ -40,7 +44,7 @@ export default class GapController extends TaskLoop {
   private seeking: boolean = false;
   private buffered: Partial<Record<SourceBufferName, TimeRanges>> = {};
 
-  private lastCurrentTime: number = 0;
+  private lastCurrentTime: number;
   public ended: number = 0;
   public waiting: number = 0;
 
@@ -48,6 +52,7 @@ export default class GapController extends TaskLoop {
     super('gap-controller', hls.logger);
     this.hls = hls;
     this.fragmentTracker = fragmentTracker;
+    this.lastCurrentTime = this.getCurrentTime();
     this.registerListeners();
   }
 
@@ -137,12 +142,20 @@ export default class GapController extends TaskLoop {
     return Object.keys(this.buffered).length > 0;
   }
 
+  private getCurrentTime(): number {
+    const timelineOffset = this.hls?.config.timelineOffset || 0;
+    if (this.media) {
+      return Math.max(this.media.currentTime, timelineOffset);
+    }
+    return timelineOffset;
+  }
+
   public tick() {
     if (!this.media?.readyState || !this.hasBuffered) {
       return;
     }
 
-    const currentTime = this.media.currentTime;
+    const currentTime = this.getCurrentTime();
     this.poll(currentTime, this.lastCurrentTime);
     this.lastCurrentTime = currentTime;
   }
@@ -222,8 +235,16 @@ export default class GapController extends TaskLoop {
 
     // Resolve stalls at buffer holes using the main buffer, whose ranges are the intersections of the A/V sourcebuffers
     const bufferInfo = BufferHelper.bufferInfo(media, currentTime, 0);
-    const nextStart = bufferInfo.nextStart || 0;
     const fragmentTracker = this.fragmentTracker;
+    if (fragmentTracker && this.hls) {
+      withInterstitialBoundary(
+        bufferInfo,
+        currentTime,
+        fragmentTracker,
+        this.hls,
+      );
+    }
+    const nextStart = bufferInfo.nextStart || 0;
 
     if (seeking && fragmentTracker && this.hls) {
       // Is there a fragment loading/parsing/appending before currentTime?
@@ -539,8 +560,8 @@ export default class GapController extends TaskLoop {
    * @private
    */
   private _trySkipBufferHole(appended: MediaFragment | Part | null): number {
-    const { fragmentTracker, media } = this;
-    const config = this.hls?.config;
+    const { fragmentTracker, media, hls } = this;
+    const config = hls?.config;
     if (!media || !fragmentTracker || !config) {
       return 0;
     }
@@ -548,9 +569,11 @@ export default class GapController extends TaskLoop {
     // Check if currentTime is between unbuffered regions of partial fragments
     const currentTime = media.currentTime;
     const bufferInfo = BufferHelper.bufferInfo(media, currentTime, 0);
+    withInterstitialBoundary(bufferInfo, currentTime, fragmentTracker, hls);
     const startTime =
       currentTime < bufferInfo.start ? bufferInfo.start : bufferInfo.nextStart;
-    if (startTime && this.hls) {
+
+    if (startTime) {
       const bufferStarved = bufferInfo.len <= config.maxBufferHole;
       const waiting =
         bufferInfo.len > 0 && bufferInfo.len < 1 && media.readyState < 3;
@@ -570,12 +593,12 @@ export default class GapController extends TaskLoop {
           }
           if (!startGap && appended) {
             // Do not seek when selected variant playlist is unloaded
-            if (!this.hls.loadLevelObj?.details) {
+            if (!hls.loadLevelObj?.details) {
               return 0;
             }
             // Do not seek when required fragments are inflight or appending
             const inFlightDependency = getInFlightDependency(
-              this.hls.inFlightFragments,
+              hls.inFlightFragments,
               startTime,
             );
             if (inFlightDependency) {
@@ -632,7 +655,7 @@ export default class GapController extends TaskLoop {
               errorData.frag = appended;
             }
           }
-          this.hls.trigger(Events.ERROR, errorData);
+          hls.trigger(Events.ERROR, errorData);
         }
         return targetTime;
       }
@@ -720,4 +743,34 @@ function appendedFragAtPosition(pos: number, fragmentTracker: FragmentTracker) {
     fragmentTracker.getAppendedFrag(pos, PlaylistLevelType.MAIN) ||
     fragmentTracker.getPartialFragment(pos)
   );
+}
+
+function withInterstitialBoundary(
+  bufferInfo: BufferInfo,
+  currentTime: number,
+  fragmentTracker: FragmentTracker,
+  hls: Hls,
+) {
+  const levelDetails = hls.latestLevelDetails;
+  const appended = appendedFragAtPosition(currentTime, fragmentTracker);
+  if (
+    interstitialsEnabled(hls.config) &&
+    !bufferInfo.nextStart &&
+    levelDetails &&
+    appended &&
+    hls.interstitialsManager
+  ) {
+    const frag = 'type' in appended ? appended : appended.fragment;
+    const nextFrag = levelDetails.fragments[1 + frag.sn - levelDetails.startSN];
+    if (
+      nextFrag?.level === frag.level &&
+      fragOverlapsQueuedInterstitial(
+        nextFrag,
+        hls.interstitialsManager.playerQueue,
+        currentTime,
+      )
+    ) {
+      bufferInfo.nextStart = nextFrag.start;
+    }
+  }
 }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -2569,6 +2569,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         this.onTimeupdate();
         this.checkBuffer(true);
         return;
+      } else if (data.details === ErrorDetails.BUFFER_SEEK_OVER_HOLE) {
+        return;
       }
       this.handleAssetItemError(
         data,

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -861,21 +861,28 @@ export default class InterstitialsController
       'mediaSource' in attachMediaSourceData &&
       attachMediaSourceData.mediaSource?.readyState !== 'closed';
     const dataToAttach =
-      transferring && attachMediaSourceData ? attachMediaSourceData : media;
+      transferring && attachMediaSourceData ? attachMediaSourceData : { media };
     this.log(
       `${transferring ? 'transfering MediaSource' : 'attaching media'} to ${
         isAssetPlayer ? player : 'Primary'
       } from ${logFromSource} (media.currentTime: ${media.currentTime})`,
     );
+    if (!transferring && !isAssetPlayer) {
+      player.attachMedia(media);
+      return;
+    }
     const schedule = this.schedule;
-    if (dataToAttach === attachMediaSourceData && schedule) {
+    if (schedule) {
       const isAssetAtEndOfSchedule =
         isAssetPlayer &&
         (player as HlsAssetPlayer).assetId === schedule.assetIdAtEnd;
       // Prevent asset players from marking EoS on transferred MediaSource
       dataToAttach.overrides = {
         duration: schedule.duration,
-        endOfStream: !isAssetPlayer || isAssetAtEndOfSchedule,
+        endOfStream:
+          !isAssetPlayer ||
+          isAssetAtEndOfSchedule ||
+          (player as HlsAssetPlayer).appendInPlace === false,
       };
     }
     player.attachMedia(dataToAttach);
@@ -1616,6 +1623,11 @@ export default class InterstitialsController
           timelinePos,
       ) > 0.5
     ) {
+      const details = this.primaryDetails;
+      if (details?.live && timelinePos > details.edge) {
+        this.log(`Resume primary loading when live reaches ${timelinePos}`);
+        return;
+      }
       hls.startLoad(timelinePos, skipSeekToStartPosition);
     } else if (!hls.bufferingEnabled) {
       hls.resumeBuffering();

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -644,7 +644,7 @@ export default class InterstitialsController
           return getMappedDuration('primary');
         },
         get seekableStart() {
-          return c.primaryDetails?.fragmentStart || 0;
+          return c.seekableStart;
         },
       },
       integrated: {
@@ -673,10 +673,7 @@ export default class InterstitialsController
           return getMappedDuration('integrated');
         },
         get seekableStart() {
-          return findMappedTime(
-            c.primaryDetails?.fragmentStart || 0,
-            'integrated',
-          );
+          return findMappedTime(c.seekableStart, 'integrated');
         },
       },
       skip: () => {
@@ -1505,7 +1502,8 @@ export default class InterstitialsController
       let timelinePos = this.timelinePos;
       if (
         timelinePos < scheduledItem.start ||
-        timelinePos >= scheduledItem.end
+        timelinePos >= scheduledItem.end ||
+        timelinePos < this.seekableStart
       ) {
         timelinePos = this.getPrimaryResumption(scheduledItem, index);
         this.log(timelineMessage('resumePrimary', timelinePos));
@@ -1528,6 +1526,10 @@ export default class InterstitialsController
       scheduleIndex: index,
     });
     this.checkBuffer();
+  }
+
+  private get seekableStart(): number {
+    return this.primaryLive ? this.primaryDetails?.fragmentStart || 0 : 0;
   }
 
   private getPrimaryResumption(
@@ -2884,6 +2886,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     // Fallback to Primary by on current or future events by updating schedule to skip errored interstitials/assets
     const flushStart = interstitial.timelineStart;
     const playingItem = this.effectivePlayingItem;
+    const seekableStart = this.seekableStart;
+    const startPosition = this.hls.startPosition;
     let timelinePos = this.timelinePos;
     // Update schedule now that interstitial/assets are flagged with `error` for fallback
     if (playingItem) {
@@ -2892,11 +2896,14 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           flushStart
         } pos: ${timelinePos} playing: ${segmentToString(
           playingItem,
-        )} error: ${interstitial.error}`,
+        )} startPosition: ${startPosition} seekableStart: ${
+          seekableStart
+        } error: ${interstitial.error}`,
       );
       if (timelinePos === -1) {
-        timelinePos = this.hls.startPosition;
+        timelinePos = startPosition;
       }
+      timelinePos = Math.max(timelinePos, seekableStart);
       const newPlayingItem = this.updateItem(playingItem, timelinePos);
       if (this.itemsMatch(playingItem, newPlayingItem)) {
         this.clearInterstitial(interstitial, null);

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -860,8 +860,6 @@ export default class InterstitialsController
       attachMediaSourceData &&
       'mediaSource' in attachMediaSourceData &&
       attachMediaSourceData.mediaSource?.readyState !== 'closed';
-    const dataToAttach =
-      transferring && attachMediaSourceData ? attachMediaSourceData : { media };
     this.log(
       `${transferring ? 'transfering MediaSource' : 'attaching media'} to ${
         isAssetPlayer ? player : 'Primary'
@@ -871,6 +869,8 @@ export default class InterstitialsController
       player.attachMedia(media);
       return;
     }
+    const dataToAttach =
+      transferring && attachMediaSourceData ? attachMediaSourceData : { media };
     const schedule = this.schedule;
     if (schedule) {
       const isAssetAtEndOfSchedule =

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -2325,6 +2325,10 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     if (!requiredTracks) {
       return;
     }
+    const details = this.primaryDetails;
+    if (details && startOffset >= details.edge) {
+      return;
+    }
     this.log(`Removing front buffer starting at ${startOffset}`);
     const sourceBufferNames = Object.keys(requiredTracks);
     sourceBufferNames.forEach((type: SourceBufferName) => {

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1,4 +1,5 @@
 import { createDoNothingErrorAction } from './error-controller';
+import { findFragmentByPTS } from './fragment-finders';
 import { HlsAssetPlayer } from './interstitial-player';
 import {
   type InterstitialScheduleEventItem,
@@ -16,6 +17,7 @@ import {
   eventAssetToString,
   generateAssetIdentifier,
   getNextAssetIndex,
+  getSnapToFragmentTime,
   type InterstitialAssetId,
   type InterstitialAssetItem,
   type InterstitialEvent,
@@ -1088,11 +1090,40 @@ export default class InterstitialsController
     if (!interstitial.isAssetPastPlayoutLimit(nextAssetIndex)) {
       this.bufferedToEvent(item, nextAssetIndex);
     } else if (this.schedule) {
-      const nextItem = this.schedule.items?.[this.findItemIndex(item) + 1];
+      const nextItemIndex = this.getNextItemIndex(item, true);
+      const nextItem = this.schedule.items?.[nextItemIndex];
       if (nextItem) {
         this.bufferedToItem(nextItem);
       }
     }
+  }
+
+  private livePrerollResumption(
+    interstitial: InterstitialEvent,
+  ): number | undefined {
+    if (
+      interstitial.cue.pre &&
+      this.primaryLive &&
+      !Number.isFinite(interstitial.resumeOffset) &&
+      this.hls
+    ) {
+      return this.hls.liveSyncPosition || this.hls.startPosition;
+    }
+  }
+
+  private getNextItemIndex(
+    item: InterstitialScheduleEventItem,
+    buffering?: boolean,
+  ): number {
+    if (this.schedule) {
+      const liveResumptionTime = buffering
+        ? item.end + item.event.duration
+        : this.livePrerollResumption(item.event);
+      if (liveResumptionTime !== undefined) {
+        return this.schedule.findItemIndexAtTime(liveResumptionTime);
+      }
+    }
+    return this.findItemIndex(item) + 1;
   }
 
   private advanceAfterAssetEnded(
@@ -1226,12 +1257,52 @@ export default class InterstitialsController
           scheduleIndex: index,
         });
         // Exiting an Interstitial
-        if (interstitial.cue.once) {
+        if (interstitial.cue.once && this.hls) {
           // Remove interstitial with CUE attribute value of ONCE after it has played
           this.updateSchedule();
           const updatedScheduleItems = this.schedule?.items;
           if (scheduledItem && updatedScheduleItems) {
             const updatedIndex = this.findItemIndex(scheduledItem);
+            const liveResumptionTime = this.livePrerollResumption(interstitial);
+            if (liveResumptionTime !== undefined) {
+              // Join live after preroll (PRE,ONCE) w/o resume-offset removed from schedule
+              let timelinePos = liveResumptionTime;
+              const resumptionIndex = this.getNextItemIndex(currentItem);
+              if (!this.isInterstitial(scheduleItems[resumptionIndex])) {
+                const fragments = this.primaryDetails?.fragments;
+                if (interstitial.snapOptions.in && fragments) {
+                  const resumeAnchor = findFragmentByPTS(
+                    null,
+                    fragments,
+                    liveResumptionTime,
+                  );
+                  if (resumeAnchor) {
+                    timelinePos = Math.min(
+                      Math.max(
+                        scheduleItems[resumptionIndex].start,
+                        getSnapToFragmentTime(timelinePos, resumeAnchor),
+                      ),
+                      scheduleItems[resumptionIndex].end,
+                    );
+                  }
+                }
+              }
+              this.log(timelineMessage('live join (preroll)', timelinePos));
+              this.timelinePos = timelinePos;
+              if (
+                resumptionIndex !== updatedIndex &&
+                (resumptionIndex || resumptionIndex === 0)
+              ) {
+                this.advanceSchedule(
+                  resumptionIndex,
+                  updatedScheduleItems,
+                  undefined,
+                  currentItem,
+                  playingLastItem,
+                );
+                return;
+              }
+            }
             this.advanceSchedule(
               updatedIndex,
               updatedScheduleItems,
@@ -1286,10 +1357,9 @@ export default class InterstitialsController
       const interstitial = scheduledItem.event;
       // find asset index
       if (assetListIndex === undefined) {
-        assetListIndex = schedule.findAssetIndex(
-          interstitial,
-          this.timelinePos,
-        );
+        assetListIndex = interstitial.cue.pre
+          ? 0
+          : schedule.findAssetIndex(interstitial, this.timelinePos);
         const assetIndexCandidate = getNextAssetIndex(
           interstitial,
           assetListIndex - 1,
@@ -2157,7 +2227,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           (this.isInterstitial(playingItem) && playingItem.event.cue.pre)) &&
         this.primaryLive
       ) {
-        liveStartPosition = this.hls.startPosition;
+        liveStartPosition = playingItem
+          ? playingItem.end + playingItem.event.duration
+          : this.hls.startPosition;
         if (liveStartPosition === -1) {
           liveStartPosition = this.hls.liveSyncPosition || 0;
         }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1526,6 +1526,7 @@ export default class InterstitialsController
   private getPrimaryResumption(
     scheduledItem: InterstitialSchedulePrimaryItem,
     index: number,
+    preloading?: boolean,
   ): number {
     const itemStart = scheduledItem.start;
     if (this.primaryLive) {
@@ -1534,9 +1535,23 @@ export default class InterstitialsController
         return this.hls.startPosition;
       } else if (
         details &&
-        (itemStart < details.fragmentStart || itemStart > details.edge)
+        (this.playingItem?.event?.cue.pre ||
+          itemStart < details.fragmentStart ||
+          itemStart > details.edge)
       ) {
-        return this.hls.liveSyncPosition || -1;
+        const liveSync = this.hls.liveSyncPosition;
+        if (liveSync !== null) {
+          if (preloading) {
+            const timeRemaining = this.getBufferingPlayer()?.remaining || 0;
+            return Math.min(
+              liveSync + timeRemaining,
+              details.edge,
+              scheduledItem.end,
+            );
+          }
+          return liveSync;
+        }
+        return -1;
       }
     }
     return itemStart;
@@ -2177,7 +2192,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
 
   private preloadPrimary(item: InterstitialSchedulePrimaryItem) {
     const index = this.findItemIndex(item);
-    const timelinePos = this.getPrimaryResumption(item, index);
+    const timelinePos = this.getPrimaryResumption(item, index, true);
     this.startLoadingPrimaryAt(timelinePos);
   }
 
@@ -2245,8 +2260,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       }
       this.log(
         `Load interstitial asset ${assetListIndex + 1}/${uri ? 1 : assetListLength} ${interstitial}${
-          hlsStartOffset
-            ? ` live-start: ${liveStartPosition} start-offset: ${hlsStartOffset}`
+          liveStartPosition
+            ? ` live-start: ${liveStartPosition} start-offset: ${hlsStartOffset} (timeline-start: ${timelineStart})`
             : ''
         }`,
       );
@@ -2384,7 +2399,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     const assetId = assetItem.identifier;
     const playerConfig: HlsAssetPlayerConfig = {
       ...userConfig,
-      maxMaxBufferLength: Math.min(180, primary.config.maxMaxBufferLength),
+      maxMaxBufferLength: Math.min(15, primary.config.maxMaxBufferLength),
       autoStartLoad: true,
       startFragPrefetch: true,
       primarySessionId: primary.sessionId,
@@ -2402,7 +2417,6 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         (selectedSubtitle as MediaPlaylist | undefined) ||
         userConfig.subtitlePreference,
     };
-    // TODO: limit maxMaxBufferLength in asset players to prevent QEE
     if (interstitial.appendInPlace) {
       interstitial.appendInPlaceStarted = true;
       if (assetItem.timelineStart) {

--- a/src/loader/date-range.ts
+++ b/src/loader/date-range.ts
@@ -92,10 +92,10 @@ export class DateRange {
     } else {
       this._startDate = new Date(dateRangeAttr[DateRangeAttribute.START_DATE]);
     }
-    if (DateRangeAttribute.END_DATE in this.attr) {
+    if (DateRangeAttribute.END_DATE in dateRangeAttr) {
       const endDate =
         dateRangeWithSameId?.endDate ||
-        new Date(this.attr[DateRangeAttribute.END_DATE]);
+        new Date(dateRangeAttr[DateRangeAttribute.END_DATE]);
       if (Number.isFinite(endDate.getTime())) {
         this._endDate = endDate;
       }
@@ -203,5 +203,27 @@ export class DateRange {
         'X-ASSET-URI' in this.attr ||
         'X-ASSET-LIST' in this.attr)
     );
+  }
+
+  get invalidReason(): string | null {
+    if (!this.id) {
+      return 'Missing ID';
+    }
+    if (this._badValueForSameId) {
+      return `Date range ${this._badValueForSameId} mismatch`;
+    }
+    if (!Number.isFinite(this.startDate.getTime())) {
+      return 'Date range invalid start date';
+    }
+    if (
+      this.isInterstitial &&
+      !('X-ASSET-URI' in this.attr || 'X-ASSET-LIST' in this.attr)
+    ) {
+      return 'Interstitial Date range missing X-ASSET-(LIST|URI)';
+    }
+    if (!this.isValid) {
+      return 'Unknown (check DURATION(|END|NEXT), CLASS, and CUE)';
+    }
+    return null;
   }
 }

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -294,7 +294,7 @@ export class InterstitialEvent {
   }
 }
 
-function getSnapToFragmentTime(time: number, frag: MediaFragmentRef) {
+export function getSnapToFragmentTime(time: number, frag: MediaFragmentRef) {
   return time - frag.start < frag.duration / 2 &&
     !(
       Math.abs(time - (frag.start + frag.duration)) <

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -577,7 +577,9 @@ export default class M3U8Parser {
             if (dateRange.isValid || level.skippedSegments) {
               level.dateRanges[dateRange.id] = dateRange;
             } else {
-              logger.warn(`Ignoring invalid DATERANGE tag: "${value1}"`);
+              logger.log(
+                `Ignoring invalid DATERANGE tag: ${dateRange.invalidReason}: ${value1}`,
+              );
             }
             // Add to fragment tag list for backwards compatibility (< v1.2.0)
             frag.tagList.push(['EXT-X-DATERANGE', value1]);

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1,6 +1,7 @@
 import { config as chaiConfig, expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { findFragmentByPTS } from '../../../src/controller/fragment-finders';
 import InterstitialsController from '../../../src/controller/interstitials-controller';
 import {
   type InterstitialScheduleItem,
@@ -2217,7 +2218,7 @@ media_w507366714_268.ts`;
     });
   });
 
-  describe('#7845 Live start folloing preroll', function () {
+  describe('#7845 Live start following preroll', function () {
     describe('resumes at live-edge', function () {
       const playlist = `#EXTM3U
 #EXT-X-TARGETDURATION:6
@@ -2540,6 +2541,419 @@ fileSequence-60.s
         expect(interstitials.playingIndex).to.equal(1, 'playingIndex b');
         expect(interstitials.primary.currentTime).to.equal(40, 'timelinePos b');
       });
+    });
+  });
+
+  describe('#7906 Live start following preroll (PRE,ONCE) w/o resume-offset', function () {
+    const playlist1 = `#EXTM3U
+#EXT-X-VERSION:8
+#EXT-X-TARGETDURATION:12
+#EXT-X-MEDIA-SEQUENCE:278327900
+#EXT-X-DISCONTINUITY-SEQUENCE:3
+#EXT-X-DATERANGE:ID="preroll",CLASS="com.apple.hls.interstitial",START-DATE="1970-01-01T00:00:00.000Z",CUE="PRE,ONCE",X-ASSET-LIST="preroll.json",X-PLAYOUT-LIMIT=30.0,X-SNAP="OUT,IN",X-CONTENT-MAY-VARY="YES",X-TIMELINE-STYLE="HIGHLIGHT",X-TIMELINE-OCCUPIES="RANGE"
+#EXT-X-PROGRAM-DATE-TIME:2026-06-12T21:09:18.000Z
+#EXT-X-MAP:URI="276476833_init.mp4"
+#EXTINF:6.5,
+278327900.mp4
+#EXTINF:6.5,
+278327901.mp4
+#EXTINF:6.5,
+278327902.mp4
+#EXTINF:0.5,
+278327903.mp4
+#EXT-X-DATERANGE:ID="1781298578033-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:09:38.500Z",PLANNED-DURATION=15.0,X-ASSET-LIST="1781298578033-101-270F",X-SNAP="OUT,IN"
+#EXTINF:12.0,
+278327904.mp4
+#EXTINF:2.75,
+278327905.mp4
+#EXT-X-DATERANGE:ID="1781298578033-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:09:38.500Z",END-DATE="2026-06-12T21:09:53.500Z",DURATION=15.0,X-PLAYOUT-LIMIT=16.0
+#EXTINF:10.25,
+278327906.mp4
+#EXTINF:6.5,
+278327907.mp4
+#EXTINF:6.5,
+278327908.mp4
+#EXTINF:6.5,
+278327909.mp4
+#EXTINF:6.5,
+278327910.mp4
+#EXTINF:6.5,
+278327911.mp4
+#EXTINF:2.75,
+278327912.mp4
+#EXT-X-DATERANGE:ID="1781298637933-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:10:39.000Z",PLANNED-DURATION=15.0,X-ASSET-LIST="1781298637933-101-270F",X-SNAP="OUT,IN"
+#EXTINF:10.25,
+278327913.mp4
+#EXTINF:4.75,
+278327914.mp4
+#EXT-X-DATERANGE:ID="1781298637933-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:10:39.000Z",END-DATE="2026-06-12T21:10:54.000Z",DURATION=15.0,X-PLAYOUT-LIMIT=16.0
+#EXTINF:7.75,
+278327915.mp4
+#EXTINF:6.5,
+278327916.mp4
+#EXTINF:6.5,
+278327917.mp4
+#EXTINF:6.5,
+278327918.mp4`;
+    const playlist2 = `#EXTM3U
+#EXT-X-VERSION:8
+#EXT-X-TARGETDURATION:12
+#EXT-X-MEDIA-SEQUENCE:278327902
+#EXT-X-DISCONTINUITY-SEQUENCE:3
+#EXT-X-DATERANGE:ID="preroll",CLASS="com.apple.hls.interstitial",START-DATE="1970-01-01T00:00:00.000Z",CUE="PRE,ONCE",X-ASSET-LIST="preroll.json",X-PLAYOUT-LIMIT=30.0,X-SNAP="OUT,IN",X-CONTENT-MAY-VARY="YES",X-TIMELINE-STYLE="HIGHLIGHT",X-TIMELINE-OCCUPIES="RANGE"
+#EXT-X-PROGRAM-DATE-TIME:2026-06-12T21:09:31.000Z
+#EXT-X-MAP:URI="276476833_init.mp4"
+#EXTINF:6.5,
+278327902.mp4
+#EXTINF:0.5,
+278327903.mp4
+#EXT-X-DATERANGE:ID="1781298578033-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:09:38.500Z",PLANNED-DURATION=15.0,X-ASSET-LIST="1781298578033-101-270F",X-SNAP="OUT,IN"
+#EXTINF:12.0,
+278327904.mp4
+#EXTINF:2.75,
+278327905.mp4
+#EXT-X-DATERANGE:ID="1781298578033-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:09:38.500Z",END-DATE="2026-06-12T21:09:53.500Z",DURATION=15.0,X-PLAYOUT-LIMIT=16.0
+#EXTINF:10.25,
+278327906.mp4
+#EXTINF:6.5,
+278327907.mp4
+#EXTINF:6.5,
+278327908.mp4
+#EXTINF:6.5,
+278327909.mp4
+#EXTINF:6.5,
+278327910.mp4
+#EXTINF:6.5,
+278327911.mp4
+#EXTINF:2.75,
+278327912.mp4
+#EXT-X-DATERANGE:ID="1781298637933-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:10:39.000Z",PLANNED-DURATION=15.0,X-ASSET-LIST="1781298637933-101-270F",X-SNAP="OUT,IN"
+#EXTINF:10.25,
+278327913.mp4
+#EXTINF:4.75,
+278327914.mp4
+#EXT-X-DATERANGE:ID="1781298637933-101-270F",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:10:39.000Z",END-DATE="2026-06-12T21:10:54.000Z",DURATION=15.0,X-PLAYOUT-LIMIT=16.0
+#EXTINF:7.75,
+278327915.mp4
+#EXTINF:6.5,
+278327916.mp4
+#EXTINF:6.5,
+278327917.mp4
+#EXTINF:6.5,
+278327918.mp4
+#EXTINF:6.5,
+278327919.mp4
+#EXTINF:6.5,
+278327920.mp4`;
+    const prerollAssetListResponse = `{"ASSETS":[{ "DURATION": 15, "URI": "preroll-1.m3u8" },{ "DURATION": 15, "URI": "preroll-2.m3u8" }]}`;
+
+    it('starts preroll on first asset list index', function () {
+      attachMediaToHls();
+      setLoadedLevelDetails(playlist1);
+      const interstitials = interstitialsController.interstitialsManager;
+      if (!interstitials) {
+        expect(interstitials, 'interstitialsManager').to.be.an('object');
+        return;
+      }
+      expect(interstitials.events).is.an('array').which.has.lengthOf(3);
+      expectScheduleToInclude(
+        interstitials.schedule,
+        [
+          {
+            event: {
+              identifier: 'preroll',
+            },
+            start: 0,
+            end: 86.5,
+            playout: { start: 0, end: 0 },
+            integrated: { start: 0, end: 0 },
+          },
+          {
+            event: {
+              identifier: '1781298578033-101-270F',
+            },
+            start: 20,
+            end: 35,
+          },
+          {
+            start: 34.75,
+            end: 80.25,
+          },
+          {
+            event: {
+              identifier: '1781298637933-101-270F',
+            },
+            start: 80.25,
+            end: 95.25,
+          },
+          {
+            start: 95.25,
+            end: Infinity,
+          },
+        ],
+        'before-preroll',
+      );
+
+      expect(interstitials.bufferingIndex).to.equal(0, 'bufferingIndex');
+      expect(interstitials.playingIndex).to.equal(0, 'playingIndex');
+      // Load asset-list
+      const interstitial = interstitials.events[0];
+      interstitial.assetListResponse = JSON.parse(prerollAssetListResponse);
+      hls.trigger(Events.ASSET_LIST_LOADED, {
+        event: interstitial,
+        assetListResponse: interstitial.assetListResponse,
+        networkDetails: new Response('ok'),
+      });
+      // plays first index
+      expect(interstitials.interstitialPlayer?.playingIndex).to.equal(
+        0,
+        'interstitialPlayer.playingIndex',
+      );
+      expect(interstitials.interstitialPlayer?.currentTime).to.equal(
+        0,
+        'interstitialPlayer.currentTime',
+      );
+      expect(interstitials.interstitialPlayer?.duration).to.equal(
+        30,
+        'interstitialPlayer.duration',
+      );
+      expect(
+        interstitials.interstitialPlayer?.scheduleItem?.event,
+        `interstitialPlayer.scheduleItem`,
+      ).to.include({ identifier: 'preroll' });
+    });
+
+    it('resumes at segment boundary nearest to live-edge with X-SNAP', function () {
+      attachMediaToHls();
+      const details = setLoadedLevelDetails(playlist1);
+      const interstitials = interstitialsController.interstitialsManager;
+      if (!interstitials) {
+        expect(interstitials, 'interstitialsManager').to.be.an('object');
+        return;
+      }
+
+      // Load asset-list
+      const interstitial = interstitials.events[0];
+      interstitial.assetListResponse = JSON.parse(prerollAssetListResponse);
+      hls.trigger(Events.ASSET_LIST_LOADED, {
+        event: interstitial,
+        assetListResponse: interstitial.assetListResponse,
+        networkDetails: new Response('ok'),
+      });
+
+      if (!interstitials.interstitialPlayer) {
+        expect(interstitials.interstitialPlayer, `interstitialPlayer`).to.be.an(
+          'object',
+        );
+        return;
+      }
+      // plays preroll
+      expect(
+        interstitials.interstitialPlayer?.scheduleItem?.event,
+        `interstitialPlayer.scheduleItem`,
+      ).to.include({ identifier: 'preroll' });
+
+      const loadSpy = sandbox.spy(hls.config.loader.prototype, 'load');
+
+      // Advance playlists
+      const timeSinceLoadedStub = sinon.stub(details, 'age');
+      timeSinceLoadedStub.get(() => 12);
+
+      const details2 = setLoadedLevelDetails(playlist2);
+      const timeSinceLoadedStub2 = sinon.stub(details2, 'age');
+      timeSinceLoadedStub2.get(() => 4);
+
+      hls.trigger.resetHistory();
+      if (!interstitials.interstitialPlayer.assetPlayers) {
+        expect(interstitials.interstitialPlayer.assetPlayers).to.be.an('array');
+        return;
+      }
+
+      interstitials.interstitialPlayer.assetPlayers[1]?.hls?.trigger(
+        Events.BUFFERED_TO_END,
+        {} as any,
+      );
+      expect(loadSpy, 'next interstitial not requested').callCount(0);
+      const eventsAfterAssetListLoaded = getTriggerCalls();
+      expect(eventsAfterAssetListLoaded).to.deep.equal(
+        [Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY],
+        `Buffered to boundary without pre-loading adjacent interstitial (expected to resume in primary)`,
+      );
+
+      // skip preroll to advance schedule
+      interstitials.skip();
+
+      // Removing the CUE="ONCE" interstitial changes the `schedule` items, but does not remove it from `events`
+      expect(interstitials.events).is.an('array').which.has.lengthOf(3);
+      expectScheduleToInclude(
+        interstitials.schedule,
+        [
+          {
+            start: 0,
+            end: 20,
+          },
+          {
+            event: {
+              identifier: '1781298578033-101-270F',
+            },
+            start: 20,
+            end: 35,
+          },
+          {
+            start: 34.75,
+            end: 80.25,
+          },
+          {
+            event: {
+              identifier: '1781298637933-101-270F',
+            },
+            start: 80.25,
+            end: 95.25,
+          },
+          {
+            start: 95.25,
+            end: Infinity,
+          },
+        ],
+        'after-preroll',
+      );
+      // resumes at live-edge (snapped to segment boundary)
+      expect(hls.liveSyncPosition, 'liveSyncPosition').to.equal(103.5);
+      expect(interstitials.bufferingIndex).to.equal(4, 'bufferingIndex b');
+      expect(interstitials.playingIndex).to.equal(4, 'playingIndex b');
+      expect(interstitials.primary.currentTime).to.equal(103, 'timelinePos b');
+      const frag = findFragmentByPTS(
+        null,
+        details.fragments,
+        interstitials.primary.currentTime,
+      );
+      expect(frag).to.not.be.undefined;
+      expect(frag!.start, 'snapped to fragment boundary').to.eq(
+        interstitials.primary.currentTime,
+      );
+    });
+
+    it('requests upcoming midrolls with expected offset', function () {
+      attachMediaToHls();
+      const details = setLoadedLevelDetails(playlist1);
+      const interstitials = interstitialsController.interstitialsManager;
+      if (!interstitials) {
+        expect(interstitials, 'interstitialsManager').to.be.an('object');
+        return;
+      }
+
+      // Load asset-list
+      const interstitial = interstitials.events[0];
+      interstitial.assetListResponse = JSON.parse(prerollAssetListResponse);
+      hls.trigger(Events.ASSET_LIST_LOADED, {
+        event: interstitial,
+        assetListResponse: interstitial.assetListResponse,
+        networkDetails: new Response('ok'),
+      });
+
+      if (!interstitials.interstitialPlayer) {
+        expect(interstitials.interstitialPlayer, `interstitialPlayer`).to.be.an(
+          'object',
+        );
+        return;
+      }
+
+      const loadSpy = sandbox.spy(hls.config.loader.prototype, 'load');
+
+      // Advance playlists
+      const timeSinceLoadedStub = sinon.stub(details, 'age');
+      timeSinceLoadedStub.get(() => 12);
+
+      const details2 = setLoadedLevelDetails(
+        playlist2 +
+          `
+#EXT-X-DATERANGE:ID="new-midroll",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:11:09.000Z",PLANNED-DURATION=15.0,X-ASSET-LIST="new-midroll"`,
+      );
+
+      const timeSinceLoadedStub2 = sinon.stub(details2, 'age');
+      timeSinceLoadedStub2.get(() => 17);
+
+      hls.trigger.resetHistory();
+      if (!interstitials.interstitialPlayer.assetPlayers) {
+        expect(interstitials.interstitialPlayer.assetPlayers).to.be.an('array');
+        return;
+      }
+
+      interstitials.interstitialPlayer.assetPlayers[1]?.hls?.trigger(
+        Events.BUFFERED_TO_END,
+        {} as any,
+      );
+      expect(loadSpy).calledOnce;
+      const assetListUrl = loadSpy.getCalls()[0].args[0].url;
+      expect(
+        assetListUrl,
+        '_HLS_primary_id and _HLS_start_offset match',
+      ).to.equal(
+        `http://example.com/new-midroll?_HLS_primary_id=${hls.sessionId}&_HLS_start_offset=5.5`,
+      );
+
+      const eventsAfterAssetListLoaded = getTriggerCalls();
+      expect(eventsAfterAssetListLoaded).to.deep.equal(
+        [Events.INTERSTITIALS_BUFFERED_TO_BOUNDARY, Events.ASSET_LIST_LOADING],
+        `Buffered to boundary and preloaded interstitial expected at live edge`,
+      );
+
+      // skip preroll to advance schedule
+      interstitials.skip();
+
+      // Removing the CUE="ONCE" interstitial changes the `schedule` items, but does not remove it from `events`
+      expect(interstitials.events).is.an('array').which.has.lengthOf(4);
+      expectScheduleToInclude(
+        interstitials.schedule,
+        [
+          {
+            start: 0,
+            end: 20,
+          },
+          {
+            event: {
+              identifier: '1781298578033-101-270F',
+            },
+            start: 20,
+            end: 35,
+          },
+          {
+            start: 34.75,
+            end: 80.25,
+          },
+          {
+            event: {
+              identifier: '1781298637933-101-270F',
+            },
+            start: 80.25,
+            end: 95.25,
+          },
+          {
+            start: 95.25,
+            end: 111,
+          },
+          {
+            event: {
+              identifier: 'new-midroll',
+            },
+            start: 111,
+            end: 126,
+          },
+          {
+            start: 126,
+            end: Infinity,
+          },
+        ],
+        'after-preroll',
+      );
+      // resumes at live-edge (snapped to segment boundary)
+      expect(hls.liveSyncPosition, 'liveSyncPosition').to.equal(116.5);
+      expect(interstitials.bufferingIndex).to.equal(5, 'bufferingIndex b');
+      expect(interstitials.playingIndex).to.equal(5, 'playingIndex b');
+      expect(interstitials.primary.currentTime).to.equal(
+        116.5,
+        'timelinePos b',
+      );
     });
   });
 });


### PR DESCRIPTION
### This PR will...
Fix Low-Latency Live join with interstitial preroll (PRE,ONCE) and midroll transitions (w/ snap-in and w/o resume-offset)

Preroll behavior
- Do not lock in primary startPosition during interstitial (preroll) streaming (7f4d7fb)

MediaSource handling
- Fix signalling of end-of-stream in append-in-place asset players (related to #7659) (c1690cb)
- Ignore remove requests past MediaSource duration (293deb1)

Streaming improvements
- Preload primary at estimated join time at end of preroll (d696ea8)
- Do not (re)start primary segment loading in live until edge has reached resumption point (c1690cb)
  - Logs "Resume primary loading when live reaches <media element time>" when deferred
- Prevent primary (audio) low-latency live part loading and appending over buffered interstitials (c1690cb, 06cb1fb)

Fix incorrect seek behavior
- Fix "Alt audio track ahead of main track" skip ahead (d696ea8)
- Do not poll for stalls before playback reaches timeline offset (a5f2e22)
- Don't allow primary fallback to land outside seekable (live window) start (8a1170c)

Logging enhancements
- Improve "live playlist <N> MISSED" log lines (d696ea8)
- Include (_HLS_)start-offset and timeline-offset in "Load interstitial asset" log lines (d696ea8)





### Why is this Pull Request needed?
Live join following preroll was not working as expected in schedules with midrolls. This change fixes resumption and preload timing.

### Resolves issues:
Fixes #7906, #7911

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
