### PR TITLE
Fix Live Interstitial midroll buffering and playback

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -2419,7 +2419,7 @@ export class HlsAssetPlayer {
     // (undocumented)
     get bufferedEnd(): number;
     // (undocumented)
-    bufferedInPlaceToEnd(media?: HTMLMediaElement | null): boolean;
+    bufferedInPlaceToEnd(media?: HTMLMediaElement | null, fromTime?: number): boolean;
     // (undocumented)
     get currentTime(): number;
     // (undocumented)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -222,20 +222,28 @@ class AudioStreamController
     const lastCurrentTime = this.lastCurrentTime;
     this.stopLoad();
     this.setInterval(TICK_INTERVAL);
-    if (lastCurrentTime > 0 && startPosition === -1) {
+    if (
+      lastCurrentTime > 0 &&
+      startPosition === -1 &&
+      !skipSeekToStartPosition
+    ) {
       this.log(
         `Override startPosition with lastCurrentTime @${lastCurrentTime.toFixed(
           3,
         )}`,
       );
       startPosition = lastCurrentTime;
-      this.state = State.IDLE;
-    } else {
-      this.state = State.WAITING_TRACK;
     }
+    this.state = State.IDLE;
     this.nextLoadPosition = this.lastCurrentTime =
       startPosition + this.timelineOffset;
     this.startPosition = skipSeekToStartPosition ? -1 : startPosition;
+    if (
+      !skipSeekToStartPosition &&
+      !this.fragmentTracker.hasFragments(this.playlistType)
+    ) {
+      this.startFragRequested = false;
+    }
     this.tick();
   }
 

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -225,7 +225,8 @@ class AudioStreamController
     if (
       lastCurrentTime > 0 &&
       startPosition === -1 &&
-      !skipSeekToStartPosition
+      !skipSeekToStartPosition &&
+      this.initPTS.length
     ) {
       this.log(
         `Override startPosition with lastCurrentTime @${lastCurrentTime.toFixed(

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -3,6 +3,7 @@ import {
   findFragmentByPDT,
   findFragmentByPTS,
   findNearestWithCC,
+  getNextFrag,
 } from './fragment-finders';
 import { FragmentState } from './fragment-tracker';
 import Decrypter from '../crypt/decrypter';
@@ -1600,7 +1601,10 @@ export default class BaseStreamController
     }
     let programFrag = this.filterReplacedPrimary(frag, levelDetails);
     if (!programFrag && frag) {
-      programFrag = fragments[1 + frag.sn - levelDetails.startSN] || null;
+      programFrag = getNextFrag(levelDetails, frag.sn, this.loadingParts);
+      if (programFrag) {
+        this.nextLoadPosition = programFrag.start;
+      }
     }
     return programFrag;
   }
@@ -1710,7 +1714,8 @@ export default class BaseStreamController
             // fragment is past schedule item end
             // allow some overflow when not appending in place to prevent stalls
             if (
-              bufferingItem.nextEvent.appendInPlace ||
+              (bufferingItem.nextEvent.appendInPlace &&
+                !bufferingItem.nextEvent.hasPlayed) ||
               frag.start - bufferingItem.end > 1
             ) {
               return null;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1693,9 +1693,9 @@ export default class BaseStreamController
         if (bufferingInterstitial) {
           // Do not stream fragments while buffering Interstitial Events (except for overlap at the start)
           if (
-            bufferingInterstitial.appendInPlace ||
-            Math.abs(frag.start - bufferingItem.start) > 1 ||
-            bufferingItem.start === 0
+            !bufferingInterstitial.appendInPlace &&
+            (Math.abs(frag.start - bufferingItem.start) > 1 ||
+              bufferingItem.start === 0)
           ) {
             return null;
           }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -837,12 +837,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         const videoAppendEnd = partOrFrag.end;
         const diff = this.lastVideoAppendEnd - videoAppendEnd;
         this.lastVideoAppendEnd = videoAppendEnd;
-        if (this.isAudioBlocked()) {
-          if (diff < 0 || diff > partOrFrag.duration) {
-            this.unblockAudio();
-          } else {
-            this.executeNext('audio');
-          }
+        if (diff < 0 || diff > partOrFrag.duration) {
+          this.unblockAudio();
+        } else if (this.isAudioBlocked()) {
+          this.executeNext('audio');
         }
       }
     }

--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -239,3 +239,13 @@ export function findNearestWithCC(
   }
   return null;
 }
+
+export function getNextFrag(
+  details: LevelDetails,
+  sn: number,
+  fragmentHintForParts?: boolean,
+): MediaFragment | null {
+  return fragmentHintForParts && sn === details.endSN && details.fragmentHint
+    ? details.fragmentHint
+    : details.fragments[1 + sn - details.startSN] || null;
+}

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -3,6 +3,7 @@ import {
   interstitialsEnabled,
   State,
 } from './base-stream-controller';
+import { getNextFrag } from './fragment-finders';
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
 import TaskLoop from '../task-loop';
@@ -763,7 +764,7 @@ function withInterstitialBoundary(
     hls.interstitialsManager
   ) {
     const frag = 'type' in appended ? appended : appended.fragment;
-    const nextFrag = levelDetails.fragments[1 + frag.sn - levelDetails.startSN];
+    const nextFrag = getNextFrag(levelDetails, frag.sn, true);
     if (
       nextFrag?.level === frag.level &&
       fragOverlapsQueuedInterstitial(

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -345,6 +345,15 @@ export default class GapController extends TaskLoop {
       if (!this.media || (!this.hls as any)) {
         return;
       }
+      if (media.currentTime !== currentTime) {
+        const currentTimeBeforeStallEvent = currentTime;
+        currentTime = media.currentTime;
+        this.moved = true;
+        this.log(
+          `currentTime changed ${currentTimeBeforeStallEvent} > ${currentTime}`,
+        );
+        return;
+      }
     }
 
     const bufferedWithHoles = BufferHelper.bufferInfo(

--- a/src/controller/interstitial-player.ts
+++ b/src/controller/interstitial-player.ts
@@ -92,7 +92,7 @@ export class HlsAssetPlayer {
     }
   }
 
-  bufferedInPlaceToEnd(media?: HTMLMediaElement | null) {
+  bufferedInPlaceToEnd(media?: HTMLMediaElement | null, fromTime?: number) {
     if (!this.appendInPlace) {
       return false;
     }
@@ -103,8 +103,8 @@ export class HlsAssetPlayer {
       return false;
     }
     const duration = Math.min(this._bufferedEosTime || Infinity, this.duration);
-    const start = this.timelineOffset;
-    const bufferInfo = BufferHelper.bufferInfo(media, start, 0);
+    const start = this.timelineOffset + (fromTime || 0);
+    const bufferInfo = BufferHelper.bufferInfo(media, start, 0.02);
     const bufferedEnd = this.getAssetTime(bufferInfo.end);
     return bufferedEnd >= duration - 0.02;
   }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -42,6 +42,7 @@ import type {
   InterstitialPlayer,
 } from './interstitial-player';
 import type Hls from '../hls';
+import type { InterstitialId } from '../loader/interstitial-event';
 import type { LevelDetails } from '../loader/level-details';
 import type { SourceBufferName } from '../types/buffer';
 import type { NetworkComponentAPI } from '../types/component-api';
@@ -884,6 +885,19 @@ export default class InterstitialsController
           (player as HlsAssetPlayer).appendInPlace === false,
       };
     }
+    if (!transferring && appendInPlace) {
+      // Set a non-zero startPosition for assets that do not start at 0.
+      // Ensures seek to start on attach.
+      const assetPlayer = player as HlsAssetPlayer;
+      const timelineStart = assetPlayer.assetItem.timelineStart;
+      if (timelineStart) {
+        const timePastStart = Math.max(
+          this.timelinePos - timelineStart,
+          Number.EPSILON,
+        );
+        assetPlayer.hls!.config.startPosition = timePastStart;
+      }
+    }
     player.attachMedia(dataToAttach);
   }
 
@@ -1128,6 +1142,7 @@ export default class InterstitialsController
           : undefined
         : this.livePrerollResumption(item.event);
       if (liveResumptionTime !== undefined) {
+        this.log(`find next item index @${liveResumptionTime}`);
         return this.schedule.findItemIndexAtTime(liveResumptionTime);
       }
     }
@@ -1255,7 +1270,7 @@ export default class InterstitialsController
       }
       if (!this.eventItemsMatch(currentItem, scheduledItem)) {
         this.endedItem = currentItem;
-        this.playingItem = null;
+        this.playingItem = this.waitingItem = null;
         this.log(
           `INTERSTITIAL_ENDED ${interstitial} ${segmentToString(currentItem)}`,
         );
@@ -1498,9 +1513,10 @@ export default class InterstitialsController
   ) {
     this.playingItem = scheduledItem;
     this.playingAsset = this.endedAsset = null;
-    this.waitingItem = this.endedItem = null;
+    this.waitingItem = null;
 
     this.bufferedToItem(scheduledItem);
+    this.endedItem = null;
 
     this.log(`resuming ${segmentToString(scheduledItem)}`);
 
@@ -1548,11 +1564,12 @@ export default class InterstitialsController
     const itemStart = scheduledItem.start;
     if (this.primaryLive) {
       const details = this.primaryDetails;
+      const resumingFromItem = this.endedItem || this.playingItem;
       if (index === 0) {
         return this.hls.startPosition;
       } else if (
         details &&
-        (this.playingItem?.event?.cue.pre ||
+        (resumingFromItem?.event?.cue.pre ||
           itemStart < details.fragmentStart ||
           itemStart > details.edge)
       ) {
@@ -1560,17 +1577,22 @@ export default class InterstitialsController
         if (liveSync !== null) {
           if (preloading) {
             const timeRemaining = this.getBufferingPlayer()?.remaining || 0;
+            this.log(
+              `primary resumption liveSync: ${liveSync} + timeRemaining ${timeRemaining}`,
+            );
             return Math.min(
               liveSync + timeRemaining,
               details.edge,
               scheduledItem.end,
             );
           }
+          this.log(`primary resumption liveSync: ${liveSync}`);
           return liveSync;
         }
         return -1;
       }
     }
+    this.log(`primary resumption itemStart: ${itemStart}`);
     return itemStart;
   }
 
@@ -1625,23 +1647,30 @@ export default class InterstitialsController
     skipSeekToStartPosition?: boolean,
   ) {
     const hls = this.hls;
+    const { loadingEnabled, bufferingEnabled, startPosition } = hls;
+
+    const instructToSeek = !skipSeekToStartPosition && hls.hasEnoughToStart;
+
+    this.log(
+      `Start loading primary @${bufferPos} bufferedPos: ${this.bufferedPos} instructToSeek: ${instructToSeek} startPosition: ${startPosition} loadingEnabled: ${loadingEnabled} bufferingEnabled: ${bufferingEnabled}`,
+    );
     if (
-      !skipSeekToStartPosition ||
-      !hls.loadingEnabled ||
-      !hls.media ||
-      Math.abs(
-        (hls.mainForwardBufferInfo?.start || hls.media.currentTime) - bufferPos,
-      ) > 0.5
+      instructToSeek ||
+      !loadingEnabled ||
+      Math.abs(startPosition - bufferPos) > 0.1
     ) {
       const details = this.primaryDetails;
       if (details?.live && bufferPos >= details.edge) {
-        this.log(`Resume primary loading when live reaches ${bufferPos}`);
+        const bufferingItem = this.bufferingItem;
+        this.log(
+          `Resume primary loading when live reaches ${bufferPos} buffering item: ${bufferingItem ? segmentToString(bufferingItem) : null}`,
+        );
         hls.pauseBuffering();
         this.bufferPastEdge = true;
         return;
       }
       hls.startLoad(bufferPos, skipSeekToStartPosition);
-    } else if (!hls.bufferingEnabled) {
+    } else if (!bufferingEnabled) {
       hls.resumeBuffering();
     }
   }
@@ -1697,10 +1726,15 @@ export default class InterstitialsController
       const bufferedPos = this.bufferedPos;
       if (details?.live && bufferedPos < details.edge) {
         this.bufferPastEdge = false;
-        this.log(`Live edge ${details.edge} reached buffer: ${bufferedPos} `);
-        const primaryWaiting = this.bufferingItem?.end === Infinity;
+        const bufferingItem = this.bufferingItem;
+        this.log(
+          `Live edge ${details.edge} reached buffer: ${bufferedPos} buffering item: ${bufferingItem ? segmentToString(bufferingItem) : null}`,
+        );
+        const primaryWaiting = bufferingItem?.end === Infinity;
         if (primaryWaiting) {
-          this.startLoadingPrimaryAt(this.timelinePos);
+          this.startLoadingPrimaryAt(
+            Math.max(bufferedPos, bufferingItem.start),
+          );
         } else {
           const bufferingPlayer = this.getBufferingPlayer();
           if (bufferingPlayer) {
@@ -1809,14 +1843,8 @@ export default class InterstitialsController
       for (let i = 0; i < interstitialEvents.length; i++) {
         const interstitial = interstitialEvents[i];
         if (interstitial.cue.post) {
-          const scheduleIndex = this.schedule.findEventIndex(
-            interstitial.identifier,
-          );
-          const item = this.schedule.items?.[scheduleIndex];
-          if (
-            this.isInterstitial(item) &&
-            this.eventItemsMatch(item, this.bufferingItem)
-          ) {
+          const item = this.getEventItem(interstitial.identifier);
+          if (item && this.eventItemsMatch(item, this.bufferingItem)) {
             this.bufferedToItem(item, 0);
           }
           break;
@@ -1876,12 +1904,11 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       if (this.itemsMatch(playingItem, updatedPlayingItem)) {
         this.playingItem = updatedPlayingItem;
       } else {
-        this.waitingItem = this.endedItem = null;
+        this.waitingItem = null;
       }
     }
     // Clear waitingItem if it has been removed from the schedule
     this.waitingItem = this.updateItem(this.waitingItem);
-    this.endedItem = this.updateItem(this.endedItem);
     // Do not replace Interstitial bufferingItem without a match - used for transfering media element or source
     const bufferingItem = this.bufferingItem;
     if (bufferingItem) {
@@ -2017,6 +2044,21 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     b: InterstitialScheduleItem | null | undefined,
   ): boolean {
     return !!b && (a === b || a.event.identifier === b.event?.identifier);
+  }
+
+  private findEventIndex(identifier: InterstitialId): number {
+    return this.schedule ? this.schedule.findEventIndex(identifier) : -1;
+  }
+
+  private getEventItem(
+    identifier: InterstitialId,
+  ): InterstitialScheduleEventItem | undefined {
+    if (this.schedule) {
+      const item = this.schedule.items?.[this.findEventIndex(identifier)];
+      if (this.isInterstitial(item) && item.event.identifier === identifier) {
+        return item;
+      }
+    }
   }
 
   private findItemIndex(
@@ -2225,25 +2267,30 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     } else if (bufferingLast !== null) {
       // If primary player is detached, it is also stopped, restart loading at primary position
       this.bufferingAsset = null;
+      const primaryResumption = this.getPrimaryResumption(
+        item,
+        this.findItemIndex(item),
+        true,
+      );
+      const bufferedPos = (this.bufferedPos = Math.max(
+        primaryResumption,
+        Math.min(this.bufferedPos, item.end),
+        this.timelinePos,
+        item.start,
+      ));
       const detachedData = this.detachedData;
       if (detachedData) {
         if (detachedData.mediaSource) {
           const skipSeekToStartPosition = true;
-          this.attachPrimary(item.start, item, skipSeekToStartPosition);
+          this.attachPrimary(bufferedPos, item, skipSeekToStartPosition);
         } else {
-          this.preloadPrimary(item);
+          this.startLoadingPrimaryAt(bufferedPos);
         }
       } else {
         // If not detached seek to resumption point
-        this.preloadPrimary(item);
+        this.startLoadingPrimaryAt(bufferedPos);
       }
     }
-  }
-
-  private preloadPrimary(item: InterstitialSchedulePrimaryItem) {
-    const index = this.findItemIndex(item);
-    const timelinePos = this.getPrimaryResumption(item, index, true);
-    this.startLoadingPrimaryAt(timelinePos);
   }
 
   private bufferedToEvent(
@@ -2509,8 +2556,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           details: ErrorDetails.INTERSTITIAL_ASSET_ITEM_ERROR,
           error,
         };
-        const scheduleIndex =
-          this.schedule?.findEventIndex(interstitial.identifier) || -1;
+        const scheduleIndex = this.findEventIndex(interstitial.identifier);
         this.handleAssetItemError(
           errorData,
           interstitial,
@@ -2570,12 +2616,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         return;
       }
       // Preload at end of asset
-      const scheduleIndex = this.schedule.findEventIndex(
-        interstitial.identifier,
-      );
-      const item = this.schedule.items?.[scheduleIndex];
-      if (this.isInterstitial(item)) {
-        this.advanceAssetBuffering(item, assetItem);
+      const item = this.getEventItem(interstitial.identifier);
+      if (item) {
+        this.advanceAssetBuffering(item, inQueuPlayer.assetItem);
       }
     };
     player.on(Events.BUFFERED_TO_END, bufferedToEnd);
@@ -2586,9 +2629,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           return;
         }
         this.shouldPlay = true;
-        const scheduleIndex = this.schedule.findEventIndex(
-          interstitial.identifier,
-        );
+        const scheduleIndex = this.findEventIndex(interstitial.identifier);
         this.advanceAfterAssetEnded(interstitial, scheduleIndex, assetIndex);
       };
     };
@@ -2613,7 +2654,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       this.handleAssetItemError(
         data,
         interstitial,
-        this.schedule.findEventIndex(interstitial.identifier),
+        this.findEventIndex(interstitial.identifier),
         assetListIndex,
         `Asset player error ${data.error} ${interstitial}`,
       );
@@ -2633,7 +2674,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       this.handleAssetItemError(
         errorData,
         interstitial,
-        this.schedule.findEventIndex(interstitial.identifier),
+        this.findEventIndex(interstitial.identifier),
         assetListIndex,
         error.message,
       );
@@ -2747,8 +2788,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       return;
     }
     const { interstitial, assetItem } = player;
-    const scheduleIndex = this.schedule.findEventIndex(interstitial.identifier);
-    const item = this.schedule.items?.[scheduleIndex];
+    const item = this.getEventItem(interstitial.identifier);
     if (!item) {
       return;
     }
@@ -2794,7 +2834,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         this.handleAssetItemError(
           errorData,
           interstitial,
-          scheduleIndex,
+          this.findEventIndex(interstitial.identifier),
           assetListIndex,
           error.message,
         );
@@ -2928,11 +2968,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     // Fallback to Primary by on current or future events by updating schedule to skip errored interstitials/assets
     const flushStart = interstitial.timelineStart;
     const playingItem = this.effectivePlayingItem;
+    const currentItem = this.playingItem;
     const seekableStart = this.seekableStart;
     const startPosition = this.hls.startPosition;
     let timelinePos = this.timelinePos;
     // Update schedule now that interstitial/assets are flagged with `error` for fallback
-    if (playingItem) {
+    if (this.isInterstitial(playingItem)) {
       this.log(
         `Fallback to primary from event "${interstitial.identifier}" start: ${
           flushStart
@@ -2959,6 +3000,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       return;
     }
     if (!this.schedule) {
+      return;
+    }
+    if (!this.isInterstitial(currentItem)) {
       return;
     }
     const scheduleIndex = this.schedule.findItemIndexAtTime(timelinePos);
@@ -3007,8 +3051,8 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     // If buffer reached Interstitial, start buffering first asset
     if (waitingForItem) {
       // Advance schedule when waiting for asset list data to play
-      const scheduleIndex = this.schedule.findEventIndex(interstitialId);
-      const item = this.schedule.items?.[scheduleIndex];
+      const scheduleIndex = this.findEventIndex(interstitialId);
+      const item = this.getEventItem(interstitialId);
       if (item) {
         if (!this.playingItem && this.timelinePos > item.end) {
           // Abandon if new duration is reduced enough to land playback in primary start

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -136,6 +136,7 @@ export default class InterstitialsController
   private playingAsset: InterstitialAssetItem | null = null;
   private endedAsset: InterstitialAssetItem | null = null;
   private bufferingAsset: InterstitialAssetItem | null = null;
+  private bufferPastEdge: boolean = false;
   private shouldPlay: boolean = false;
 
   constructor(hls: Hls, HlsPlayerClass: typeof Hls) {
@@ -811,16 +812,17 @@ export default class InterstitialsController
         this.detachedData = attachMediaSourceData;
       }
       logFromSource = `Primary`;
-    } else if (detachedMediaSource) {
+    } else {
       const bufferingPlayer = this.getBufferingPlayer();
       if (bufferingPlayer) {
         attachMediaSourceData = bufferingPlayer.transferMedia();
+        this.detachedData = attachMediaSourceData;
         logFromSource = `${bufferingPlayer}`;
-      } else {
+      } else if (detachedMediaSource) {
         logFromSource = `detached MediaSource`;
+      } else {
+        logFromSource = `detached media`;
       }
-    } else {
-      logFromSource = `detached media`;
     }
     if (!attachMediaSourceData) {
       if (detachedMediaSource) {
@@ -1152,7 +1154,8 @@ export default class InterstitialsController
       // check if we've reached the end of the program
       const scheduleItems = this.schedule.items;
       if (scheduleItems) {
-        const nextIndex = index + 1;
+        const item = scheduleItems[index];
+        const nextIndex = item.event ? this.getNextItemIndex(item) : index + 1;
         const scheduleLength = scheduleItems.length;
         if (nextIndex >= scheduleLength) {
           this.setSchedulePosition(-1);
@@ -1162,9 +1165,6 @@ export default class InterstitialsController
         if (this.timelinePos < resumptionTime) {
           this.log(timelineMessage('advanceAfterAssetEnded', resumptionTime));
           this.timelinePos = resumptionTime;
-          if (interstitial.appendInPlace) {
-            this.advanceInPlace(resumptionTime);
-          }
           this.checkBuffer(this.bufferedPos < resumptionTime);
         }
         this.setSchedulePosition(nextIndex);
@@ -1498,8 +1498,8 @@ export default class InterstitialsController
 
     this.log(`resuming ${segmentToString(scheduledItem)}`);
 
+    let timelinePos = this.timelinePos;
     if (!this.detachedData?.mediaSource) {
-      let timelinePos = this.timelinePos;
       if (
         timelinePos < scheduledItem.start ||
         timelinePos >= scheduledItem.end ||
@@ -1510,6 +1510,8 @@ export default class InterstitialsController
         this.timelinePos = timelinePos;
       }
       this.attachPrimary(timelinePos, scheduledItem);
+    } else if (this.primaryLive) {
+      this.startLoadingPrimaryAt(timelinePos);
     }
 
     if (!fromItem) {
@@ -1613,24 +1615,26 @@ export default class InterstitialsController
   }
 
   private startLoadingPrimaryAt(
-    timelinePos: number,
+    bufferPos: number,
     skipSeekToStartPosition?: boolean,
   ) {
     const hls = this.hls;
     if (
+      !skipSeekToStartPosition ||
       !hls.loadingEnabled ||
       !hls.media ||
       Math.abs(
-        (hls.mainForwardBufferInfo?.start || hls.media.currentTime) -
-          timelinePos,
+        (hls.mainForwardBufferInfo?.start || hls.media.currentTime) - bufferPos,
       ) > 0.5
     ) {
       const details = this.primaryDetails;
-      if (details?.live && timelinePos > details.edge) {
-        this.log(`Resume primary loading when live reaches ${timelinePos}`);
+      if (details?.live && bufferPos > details.edge) {
+        this.log(`Resume primary loading when live reaches ${bufferPos}`);
+        hls.pauseBuffering();
+        this.bufferPastEdge = true;
         return;
       }
-      hls.startLoad(timelinePos, skipSeekToStartPosition);
+      hls.startLoad(bufferPos, skipSeekToStartPosition);
     } else if (!hls.bufferingEnabled) {
       hls.resumeBuffering();
     }
@@ -1676,8 +1680,33 @@ export default class InterstitialsController
       startPosition === -1 ? 0 : startPosition,
     );
 
-    if (!this.effectivePlayingItem && this.schedule.items) {
+    const items = this.schedule.items;
+    if (!items) {
+      return;
+    }
+    if (!this.effectivePlayingItem) {
       this.checkStart();
+    } else if (this.bufferPastEdge) {
+      const details = this.primaryDetails;
+      const bufferedPos = this.bufferedPos;
+      if (details?.live && bufferedPos < details.edge) {
+        this.bufferPastEdge = false;
+        this.log(`Live edge ${details.edge} reached buffer: ${bufferedPos} `);
+        const primaryWaiting = this.bufferingItem?.end === Infinity;
+        if (primaryWaiting) {
+          this.startLoadingPrimaryAt(this.timelinePos);
+        } else {
+          const bufferingPlayer = this.getBufferingPlayer();
+          if (bufferingPlayer) {
+            const assetWaiting = bufferingPlayer.bufferedInPlaceToEnd(
+              this.primaryMedia,
+            );
+            if (assetWaiting && bufferingPlayer.hls) {
+              bufferingPlayer.hls.trigger(Events.BUFFERED_TO_END, undefined);
+            }
+          }
+        }
+      }
     }
   }
 
@@ -2407,7 +2436,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     let startPosition = 0;
     if (this.primaryLive || interstitial.appendInPlace) {
       const timePastStart = this.timelinePos - assetItem.timelineStart;
-      if (timePastStart > 1) {
+      if (timePastStart >= 0) {
         const duration = assetItem.duration;
         if (duration && timePastStart < duration) {
           startPosition = timePastStart;
@@ -2811,7 +2840,13 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
   private advanceInPlace(time: number) {
     const media = this.primaryMedia;
     if (media && media.currentTime < time) {
-      media.currentTime = time;
+      const msg = `advance currentTime to ${time}, duration: ${media.duration}`;
+      if (media.duration > time) {
+        this.log(msg);
+        media.currentTime = time;
+      } else {
+        this.log(`Cannot ${msg}`);
+      }
     }
   }
 

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1167,6 +1167,9 @@ export default class InterstitialsController
         if (this.timelinePos < resumptionTime) {
           this.log(timelineMessage('advanceAfterAssetEnded', resumptionTime));
           this.timelinePos = resumptionTime;
+          if (interstitial.appendInPlace) {
+            this.advanceInPlace(resumptionTime + 0.01);
+          }
           this.checkBuffer(this.bufferedPos < resumptionTime);
         }
         this.setSchedulePosition(nextIndex);
@@ -1703,6 +1706,7 @@ export default class InterstitialsController
           if (bufferingPlayer) {
             const assetWaiting = bufferingPlayer.bufferedInPlaceToEnd(
               this.primaryMedia,
+              bufferingPlayer.currentTime,
             );
             if (assetWaiting && bufferingPlayer.hls) {
               bufferingPlayer.hls.trigger(Events.BUFFERED_TO_END, undefined);
@@ -2824,7 +2828,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
         if (
           assetCurrentTime &&
           (distanceFromEnd / media.playbackRate < 0.5 ||
-            player.bufferedInPlaceToEnd(media)) &&
+            player.bufferedInPlaceToEnd(media, player.currentTime)) &&
           player.hls
         ) {
           const scheduleIndex = schedule.findEventIndex(
@@ -3065,8 +3069,9 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           this.handleInPlaceStall(stallingItem.event);
           return;
         }
+        const media = this.primaryMedia;
         this.log(
-          `Primary player stall @${this.timelinePos} bufferedPos: ${this.bufferedPos}`,
+          `Primary player stall @${this.timelinePos} currentTime: ${media?.currentTime} bufferedPos: ${this.bufferedPos}`,
         );
         this.onTimeupdate();
         this.checkBuffer(true);

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1123,7 +1123,9 @@ export default class InterstitialsController
   ): number {
     if (this.schedule) {
       const liveResumptionTime = buffering
-        ? item.end + item.event.duration
+        ? item.event.cue.pre
+          ? item.end + item.event.duration
+          : undefined
         : this.livePrerollResumption(item.event);
       if (liveResumptionTime !== undefined) {
         return this.schedule.findItemIndexAtTime(liveResumptionTime);
@@ -1388,6 +1390,7 @@ export default class InterstitialsController
         this.log(
           `INTERSTITIAL_STARTED ${segmentToString(scheduledItem)} ${interstitial.appendInPlace ? 'append in place' : ''}`,
         );
+        interstitial.hasPlayed = false;
         this.hls.trigger(Events.INTERSTITIAL_STARTED, {
           event: interstitial,
           schedule: scheduleItems.slice(0),
@@ -1628,7 +1631,7 @@ export default class InterstitialsController
       ) > 0.5
     ) {
       const details = this.primaryDetails;
-      if (details?.live && bufferPos > details.edge) {
+      if (details?.live && bufferPos >= details.edge) {
         this.log(`Resume primary loading when live reaches ${bufferPos}`);
         hls.pauseBuffering();
         this.bufferPastEdge = true;

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1167,8 +1167,8 @@ export default class InterstitialsController
         if (this.timelinePos < resumptionTime) {
           this.log(timelineMessage('advanceAfterAssetEnded', resumptionTime));
           this.timelinePos = resumptionTime;
-          if (interstitial.appendInPlace) {
-            this.advanceInPlace(resumptionTime + 0.01);
+          if (interstitial.appendInPlace && !scheduleItems[nextIndex].event) {
+            this.hls.startLoad(resumptionTime + 0.01);
           }
           this.checkBuffer(this.bufferedPos < resumptionTime);
         }

--- a/src/controller/interstitials-schedule.ts
+++ b/src/controller/interstitials-schedule.ts
@@ -167,9 +167,12 @@ export class InterstitialsSchedule extends Logger {
         if (timelineType && timelineType !== 'primary') {
           timeRange = timeRange[timelineType];
         }
+        const start = timeRange.start;
+        const event = items[i].event;
+        const end = event?.cue.pre ? event.duration : timeRange.end;
         if (
-          timelinePos === timeRange.start ||
-          (timelinePos > timeRange.start && timelinePos < timeRange.end)
+          timelinePos === start ||
+          (timelinePos > start && timelinePos < end)
         ) {
           return i;
         }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -169,7 +169,8 @@ export default class StreamController
       if (
         lastCurrentTime > 0 &&
         startPosition === -1 &&
-        !skipSeekToStartPosition
+        !skipSeekToStartPosition &&
+        this.initPTS.length
       ) {
         this.log(
           `Override startPosition with lastCurrentTime @${lastCurrentTime}`,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -180,6 +180,12 @@ export default class StreamController
       this.nextLoadPosition = this.lastCurrentTime =
         startPosition + this.timelineOffset;
       this.startPosition = skipSeekToStartPosition ? -1 : startPosition;
+      if (
+        !skipSeekToStartPosition &&
+        !this.fragmentTracker.hasFragments(this.playlistType)
+      ) {
+        this._hasEnoughToStart = this.startFragRequested = false;
+      }
       this.tick();
     } else {
       this._forceStartLoad = true;

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -2,6 +2,7 @@ import { uuid } from '@svta/cml-utils';
 import { EventEmitter } from 'eventemitter3';
 import { buildAbsoluteURL } from 'url-toolkit';
 import { enableStreamingMode, hlsDefaultConfig, mergeConfig } from './config';
+import { State } from './controller/base-stream-controller';
 import { FragmentTracker } from './controller/fragment-tracker';
 import LevelController from './controller/level-controller';
 import { ErrorDetails, ErrorTypes } from './errors';
@@ -22,7 +23,7 @@ import type AbrController from './controller/abr-controller';
 import type AudioStreamController from './controller/audio-stream-controller';
 import type AudioTrackController from './controller/audio-track-controller';
 import type BasePlaylistController from './controller/base-playlist-controller';
-import type { InFlightData, State } from './controller/base-stream-controller';
+import type { InFlightData } from './controller/base-stream-controller';
 import type BaseStreamController from './controller/base-stream-controller';
 import type BufferController from './controller/buffer-controller';
 import type CapLevelController from './controller/cap-level-controller';
@@ -627,7 +628,7 @@ export default class Hls implements HlsEventEmitter {
    * Returns whether loading, toggled with `startLoad()` and `stopLoad()`, is active or not`.
    */
   get loadingEnabled(): boolean {
-    return this.started;
+    return this.started && this.streamController.state !== State.STOPPED;
   }
 
   /**

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -1331,8 +1331,11 @@ fileSequence3.mp4
         ],
         `Actual events after asset-list`,
       );
+      expect(interstitials.events).is.an('array').which.has.lengthOf(1);
+      expect(interstitials.schedule).is.an('array').which.has.lengthOf(2);
       expect(interstitials.bufferingIndex).to.equal(1, 'bufferingIndex b');
       expect(interstitials.playingIndex).to.equal(1, 'playingIndex b');
+      expect(interstitials.playingItem).to.not.have.property('event');
       expect(interstitials.primary.currentTime).to.equal(
         0,
         'playback should resume primary at 0 because no interstitial played',
@@ -2867,7 +2870,7 @@ fileSequence-60.s
       const details2 = setLoadedLevelDetails(
         playlist2 +
           `
-#EXT-X-DATERANGE:ID="new-midroll",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:11:09.000Z",PLANNED-DURATION=15.0,X-ASSET-LIST="new-midroll"`,
+#EXT-X-DATERANGE:ID="new-midroll",CLASS="com.apple.hls.interstitial",START-DATE="2026-06-12T21:11:22.000Z",PLANNED-DURATION=15.0,X-ASSET-LIST="new-midroll"`,
       );
 
       const timeSinceLoadedStub2 = sinon.stub(details2, 'age');
@@ -2930,17 +2933,17 @@ fileSequence-60.s
           },
           {
             start: 95.25,
-            end: 111,
+            end: 124,
           },
           {
             event: {
               identifier: 'new-midroll',
             },
-            start: 111,
-            end: 126,
+            start: 124,
+            end: 139,
           },
           {
-            start: 126,
+            start: 139,
             end: Infinity,
           },
         ],
@@ -2948,12 +2951,9 @@ fileSequence-60.s
       );
       // resumes at live-edge (snapped to segment boundary)
       expect(hls.liveSyncPosition, 'liveSyncPosition').to.equal(116.5);
-      expect(interstitials.bufferingIndex).to.equal(5, 'bufferingIndex b');
-      expect(interstitials.playingIndex).to.equal(5, 'playingIndex b');
-      expect(interstitials.primary.currentTime).to.equal(
-        116.5,
-        'timelinePos b',
-      );
+      expect(interstitials.bufferingIndex).to.equal(4, 'bufferingIndex b');
+      expect(interstitials.playingIndex).to.equal(4, 'playingIndex b');
+      expect(interstitials.primary.currentTime).to.equal(116, 'timelinePos b');
     });
   });
 });

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -592,8 +592,13 @@ describe('StreamController', function () {
         expect(streamController['lastCurrentTime']).to.equal(5);
       });
 
-      it('should set startPosition to lastCurrentTime if unset and lastCurrentTime > 0', function () {
+      it('should set startPosition to lastCurrentTime if unset and lastCurrentTime > 0 after parsing segments', function () {
         streamController['lastCurrentTime'] = 5;
+        streamController['initPTS'].push({
+          baseTime: 0,
+          timescale: 1,
+          trackId: 0,
+        });
         streamController.startLoad(-1);
         assertStreamControllerStarted(streamController);
         expect(streamController['nextLoadPosition']).to.equal(5);


### PR DESCRIPTION
### This PR will...
Fix midroll buffering and playback progression from preroll at live edge.

- Rely completely on `fragOverlapsQueuedInterstitial` primary segment filtering for append-in-place asset-players
- Improve transferring of MediaSource between asset players and primary
- Fix `advanceAfterAssetEnded` next index following preroll
- Ensure primary loading is restarted on resume
- Pause buffering when buffer reaches end of midroll before live edge (`bufferPastEdge: true`)
- Resume buffering and restore scheduled buffering item when live edge reaches scheduled primary item (`bufferPastEdge` flips back to `false`)
- Always set `startPosition` on asset players (ensures seek to midroll @ ~0 following preroll)
- Limit use of `advanceInPlace` in to seek forward at end of append-in-place asset playback and log prior to seeking
- Fixing seeking out of preroll using `hls.interstitialsManager.primary.currentTime` into position earlier than scheduled resumption
- Reset stream-controller start state when `hls.startLoad` is called multiple times in different contexts (preload, seek to start) with no buffered segments
- Asset player and primary player stall handling improvements 
- Ensure seek to start on midroll join
- Prevent lastCurrentTime > startPosition lock-in before segments are parsed
- Improve live primary resumption estimate at end of interstitial playback

### Why is this Pull Request needed?
Interstitial buffering and schedule progression would get stuck when buffering and playing through mid-roll asset-lists ahead of the live edge. This in addition to issues with transferring media between preroll and midroll asset players and back again to primary caused #7912.

### Are there any points in the code the reviewer needs to double check?
This PR is a follow up to changes made in #7908.

### Resolves issues:
Fixes #7912

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
