### PR TITLE
Fix fatal KEY_SYSTEM_ERROR handling

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1221,13 +1221,16 @@ export default class BaseStreamController
       const data = error.data;
       if (data.frag && data.details === ErrorDetails.INTERNAL_ABORTED) {
         this.handleFragLoadAborted(data.frag, data.part);
-      } else if (data.frag && data.type === ErrorTypes.KEY_SYSTEM_ERROR) {
+      } else if (
+        data.frag &&
+        data.type === ErrorTypes.KEY_SYSTEM_ERROR &&
+        !data.fatal
+      ) {
         data.frag.abortRequests();
         this.resetStartWhenNotLoaded();
         this.resetFragmentLoading(data.frag);
-      } else {
-        this.hls.trigger(Events.ERROR, data as ErrorData);
       }
+      this.hls.trigger(Events.ERROR, data as ErrorData);
     } else {
       this.hls.trigger(Events.ERROR, {
         type: ErrorTypes.OTHER_ERROR,


### PR DESCRIPTION
### This PR will...
Fix fatal KEY_SYSTEM_ERROR handling

### Why is this Pull Request needed?
KEY_SYSTEM_ERROR handling regressed in dev with #7867 #7874. By adding `frag` to all key errors and throwing them on frag loading, they were treated as non-fatal frag loading was retried. Now all key errors are emitted by the Hls instance and only non-fatal errors reset fragment loading state.

### Are there any points in the code the reviewer needs to double check?
Emitted errors are routed through the error-controller where error actions can be (re)assigned.

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
