### PR TITLE
Fix subtitle buffering up to or past media buffer

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -444,13 +444,15 @@ export class SubtitleStreamController
         config.maxBufferHole,
       );
       const { end: targetBufferTime, len: bufferLen } = bufferedInfo;
-      const maxBufLen =
-        this.hls.maxBufferLength + trackDetails.levelTargetDuration;
+      const maxBufLen = Math.max(
+        this.hls.maxBufferLength + trackDetails.levelTargetDuration,
+        this.hls.mainForwardBufferInfo?.len || 0,
+      );
 
       if (bufferLen > maxBufLen || (bufferLen && !this.buffering)) {
         return;
       }
-      let frag = this.getNextFragment(currentTime, trackDetails);
+      let frag = this.getNextFragment(targetBufferTime, trackDetails);
       if (!frag) {
         return;
       }


### PR DESCRIPTION
### This PR will...
Fix subtitle buffering up to or past media buffer

### Why is this Pull Request needed?
Fixes regression introduced in dev with #7522 that only loaded current and next subtitle segment

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
