### PR TITLE
Defer playlist reload while network is offline  

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -7,7 +7,11 @@ import {
   HlsUrlParameters,
   type Level,
 } from '../types/level';
-import { getRetryDelay, isTimeoutError } from '../utils/error-helper';
+import {
+  getRetryDelay,
+  isTimeoutError,
+  offlineHttpStatus,
+} from '../utils/error-helper';
 import { computeReloadInterval, mergeDetails } from '../utils/level-helper';
 import { Logger } from '../utils/logger';
 import type Hls from '../hls';
@@ -426,20 +430,37 @@ export default class BasePlaylistController
         );
         this.loadPlaylist();
       } else {
-        const delay = getRetryDelay(retryConfig, retryCount);
+        const offlineStatus = offlineHttpStatus(errorEvent.response?.code);
         // Schedule level/track reload
         this.clearTimer();
-        this.timer = self.setTimeout(() => this.loadPlaylist(), delay);
-        this.warn(
-          `Retrying playlist loading ${retryCount + 1}/${
-            retryConfig.maxNumRetry
-          } after "${errorDetails}" in ${delay}ms`,
-        );
+        if (offlineStatus) {
+          this.log(`Waiting for connection (offline)`);
+          errorEvent.reason = 'offline';
+          this.timer = self.setTimeout(() => this.checkOfflineStatus(), 1000);
+        } else {
+          const delay = getRetryDelay(retryConfig, retryCount);
+          this.warn(
+            `Retrying playlist loading ${retryCount + 1}/${
+              retryConfig.maxNumRetry
+            } after "${errorDetails}" in ${delay}ms`,
+          );
+          this.timer = self.setTimeout(() => this.loadPlaylist(), delay);
+        }
       }
       // `levelRetry = true` used to inform other controllers that a retry is happening
       errorEvent.levelRetry = true;
       errorAction.resolved = true;
     }
     return retry;
+  }
+
+  private checkOfflineStatus() {
+    this.clearTimer();
+    if (offlineHttpStatus(0)) {
+      this.timer = self.setTimeout(() => this.checkOfflineStatus(), 1000);
+    } else {
+      this.log(`Connection restored (online)`);
+      this.loadPlaylist();
+    }
   }
 }


### PR DESCRIPTION
### This PR will...
Defer offline media playlist load error retry until online status is restored.

### Why is this Pull Request needed?
This makes Live and VOD offline behavior more consistent, since fragment loading retries are already deferred in the same way. Live was more likely to produce a fatal playlist load error than VOD because playlist retries were not deferred, and live playlists are reloaded at regular intervals.

### Are there any points in the code the reviewer needs to double check?
Aligned with #7476

Applications are expected to escalate offline errors or stalls or timeouts while offline to fatal.

### Resolves issues:
Resolves #7898

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
