### PR TITLE
Fix I-Frame trick play rendering of stretched and backward-loaded frames

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2016,9 +2016,9 @@ This is primarily used internally by HLS.js when creating interstitial asset pla
 
 (default: `2097152` (2 MB))
 
-The maximum total byte size of cached image I-Frame data retained by the `ImageIFrameStreamController`. When the cache exceeds this limit, the oldest entries are evicted and their `Fragment.data` is cleared to free memory.
+The maximum total byte size of cached I-Frame data retained by I-Frame player instances. When the cache exceeds this limit, the oldest entries are evicted and their `Fragment.data` is cleared to free memory.
 
-This option only applies to image I-Frame player instances created via `hls.createImageIFramePlayer()`. Video I-Frame data (from `hls.createIFramePlayer()`) is managed by the MSE video SourceBuffer and is not affected by this setting.
+Video I-Frame players (`hls.createIFramePlayer()`) cache loaded fragment data so that frames removed from the video SourceBuffer (buffered media beyond a rendered frame is removed so that it renders reliably) can be re-buffered without additional requests. Image I-Frame players (`hls.createImageIFramePlayer()`) cache the image data extracted from loaded fragments.
 
 ### `useMediaCapabilities`
 

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -3,6 +3,7 @@ import StreamController from './stream-controller';
 import { Events } from '../events';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper } from '../utils/buffer-helper';
+import { timeRangesToString } from '../utils/time-ranges';
 import type { Fragment, MediaFragment, Part } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
 import type { TimestampOffset } from '../utils/timescale-conversion';
@@ -12,7 +13,6 @@ export type LoadMediaAtOptions = { seekOnAppend: boolean };
 export class IFrameStreamController extends StreamController {
   private currentOp?: [time: number, options: LoadMediaAtOptions];
   private nextOp?: [time: number, options: LoadMediaAtOptions];
-  private gotNext: boolean = false;
   initDetails?: LevelDetails | null;
 
   setInitPts(initPTS: TimestampOffset[]) {
@@ -38,13 +38,9 @@ export class IFrameStreamController extends StreamController {
       this.tick();
       this.currentOp = [adjustedTime, options];
     } else {
-      const fragCurrent = this.fragCurrent;
-      if (
-        !fragCurrent ||
-        (time >= fragCurrent.start && time < fragCurrent.end)
-      ) {
-        this.nextOp = [adjustedTime, options];
-      }
+      // A load operation is active: queue this one (replacing any pending
+      // operation) so it is picked up when the active fragment completes.
+      this.nextOp = [adjustedTime, options];
     }
     const media = this.media;
     if (seekOnAppend && media) {
@@ -59,8 +55,15 @@ export class IFrameStreamController extends StreamController {
   private seekTo(time: number): boolean {
     const media = this.media;
     if (media) {
-      if (time > media.duration) {
-        time = media.duration - 0.01;
+      // Clamp to the playlist end so the last frame can be rendered. Do not
+      // clamp to `media.duration`: endOfStream() after each rendered frame
+      // truncates duration to the buffered end, and clamping to it would
+      // divert forward operations to a stale frame while the requested
+      // fragment is still loading.
+      const edge = this.getLevelDetails()?.edge;
+      const end = edge !== undefined ? edge : media.duration;
+      if (time >= end) {
+        time = end - 0.01;
       }
       const bufferInfo = BufferHelper.bufferInfo(media, time, 0);
       const hasEnough = bufferInfo.len > 0 && this.getBufferedAt(time);
@@ -87,8 +90,12 @@ export class IFrameStreamController extends StreamController {
     this.currentOp = this.nextOp = undefined;
     this.state = State.STOPPED;
     if (currentOp?.[1].seekOnAppend) {
-      this.seekTo(currentOp[0]);
-      if (!nextOp && !this.gotNext) {
+      if (!this.seekTo(currentOp[0])) {
+        this.warn(
+          `Could not seek to ${currentOp[0]} after fragment buffered (buffered: ${this.media ? timeRangesToString(BufferHelper.getBuffered(this.media)) : 'none'})`,
+        );
+      }
+      if (!nextOp) {
         // Mark end of stream to force rendering immediately
         this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       }
@@ -112,9 +119,8 @@ export class IFrameStreamController extends StreamController {
   // public getLevelDetails
   protected seekToStartPos() {}
   protected setStartPosition() {}
-  protected onMediaSeeking = () => {
-    this.gotNext = false;
-  };
+  // Seeking is always initiated by this controller; ignore media seek events.
+  protected onMediaSeeking = () => {};
 
   protected alignPlaylists(
     details: LevelDetails,

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -20,8 +20,7 @@ export class IFrameStreamController extends StreamController {
   private nextOp?: [time: number, options: LoadMediaAtOptions];
   protected cached: MediaFragment[] = [];
   protected cachedSize = 0;
-  // Cache loaded fragment payloads for replay. The image I-Frame controller
-  // disables this and caches decoded image data instead.
+  // Replay cache (image controller caches decoded image data instead)
   protected cacheFragmentData: boolean = true;
   initDetails?: LevelDetails | null;
 
@@ -48,8 +47,7 @@ export class IFrameStreamController extends StreamController {
       this.tick();
       this.currentOp = [adjustedTime, options];
     } else {
-      // A load operation is active: queue this one (replacing any pending
-      // operation) so it is picked up when the active fragment completes.
+      // Queue op (replacing any pending) to run once the active load completes
       this.nextOp = [adjustedTime, options];
     }
     // This operation supersedes any seek scheduled for end of stream
@@ -67,11 +65,7 @@ export class IFrameStreamController extends StreamController {
   private seekTo(time: number): boolean {
     const media = this.media;
     if (media) {
-      // Clamp to the playlist end so the last frame can be rendered. Do not
-      // clamp to `media.duration`: endOfStream() after each rendered frame
-      // truncates duration to the buffered end, and clamping to it would
-      // divert forward operations to a stale frame while the requested
-      // fragment is still loading.
+      // Clamp to playlist edge, not media.duration (truncated by endOfStream())
       const edge = this.getLevelDetails()?.edge;
       const end = edge !== undefined ? edge : media.duration;
       if (time >= end) {
@@ -94,9 +88,7 @@ export class IFrameStreamController extends StreamController {
     return this.fragmentTracker.getBufferedFrag(time, PlaylistLevelType.MAIN);
   }
 
-  // Retain fragment data up to `iframeCacheLimit` total bytes, evicting the
-  // oldest entries, so that removed frames can be re-buffered without
-  // additional requests
+  // Retain fragment data for re-buffering (up to iframeCacheLimit bytes, LRU)
   protected cacheSet(frag: MediaFragment, data: Uint8Array<ArrayBuffer>) {
     if (!this.hls) {
       return;
@@ -140,8 +132,7 @@ export class IFrameStreamController extends StreamController {
       !frag.data &&
       isMediaFragment(frag)
     ) {
-      // Cache a pristine copy of the payload for replay after the buffer is
-      // flushed (the remuxer rewrites I-Frame fragment data in place)
+      // Cache a pristine copy (the remuxer rewrites fragment data in place)
       this.cacheSet(frag, new Uint8Array(payload.slice(0)));
     }
     super._handleFragmentLoadProgress(data);
@@ -164,9 +155,7 @@ export class IFrameStreamController extends StreamController {
     super.loadFragment(frag, level, targetBufferTime);
   }
 
-  // Replay is possible when fragment data is cached and decryption does not
-  // depend on a key that has yet to be loaded (EME-managed key formats
-  // append encrypted samples as-is)
+  // Cached data can replay unless decryption needs a key that is not loaded
   private canReplayCached(frag: MediaFragment): boolean {
     if (!this.cacheFragmentData || !frag.data?.byteLength) {
       return false;
@@ -211,13 +200,8 @@ export class IFrameStreamController extends StreamController {
     this.state = State.STOPPED;
     if (currentOp?.[1].seekOnAppend) {
       if (!nextOp) {
-        // The decoder only renders a single appended keyframe once it can
-        // rule out more frames before the next composition deadline: the
-        // media element completes a seek into a buffered range when a frame
-        // follows the seek target, or end of stream marks the end of the
-        // range. Remove buffered media beyond the target fragment (loading
-        // an earlier fragment leaves a gap the decoder would otherwise wait
-        // on indefinitely) so that end of stream applies to it, then seek.
+        // Remove buffered media beyond the target and signal EOS before
+        // seeking: a lone keyframe followed by a gap does not render
         const media = this.media;
         const bufferedFrag = this.getBufferedAt(currentOp[0]);
         const flushFrom = (bufferedFrag || (frag as MediaFragment)).end;
@@ -230,8 +214,7 @@ export class IFrameStreamController extends StreamController {
             this.flushMainBuffer(flushFrom, Infinity);
           }
         }
-        // Should end of stream complete after the seek below, re-run the
-        // seek (see onBufferedToEnd).
+        // (onBufferedToEnd re-runs the seek if EOS completes after it)
         this.hls.once(Events.BUFFERED_TO_END, this.onBufferedToEnd);
         this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       }
@@ -249,8 +232,7 @@ export class IFrameStreamController extends StreamController {
   private onBufferedToEnd = () => {
     const media = this.media;
     if (media?.seeking) {
-      // Re-run the pending seek now that the MediaSource has ended so the
-      // decoder treats the gap after the target range as end of stream.
+      // Re-run the pending seek now that the MediaSource has ended
       // eslint-disable-next-line no-self-assign
       media.currentTime = media.currentTime;
     }

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -200,18 +200,20 @@ export class IFrameStreamController extends StreamController {
     this.state = State.STOPPED;
     if (currentOp?.[1].seekOnAppend) {
       if (!nextOp) {
-        // Remove buffered media beyond the target and signal EOS before
+        // Remove buffered ranges beyond the target's and signal EOS before
         // seeking: a lone keyframe followed by a gap does not render
         const media = this.media;
-        const bufferedFrag = this.getBufferedAt(currentOp[0]);
-        const flushFrom = (bufferedFrag || (frag as MediaFragment)).end;
         if (media) {
-          const buffered = BufferHelper.getBuffered(media);
-          const bufferedEnd = buffered.length
-            ? buffered.end(buffered.length - 1)
-            : 0;
-          if (bufferedEnd - flushFrom > 0.01) {
-            this.flushMainBuffer(flushFrom, Infinity);
+          const bufferInfo = BufferHelper.bufferInfo(media, currentOp[0], 0);
+          const nextRangeStart = bufferInfo.len ? bufferInfo.nextStart : 0;
+          if (nextRangeStart) {
+            // Evict now so queued operations do not seek into removed ranges
+            this.fragmentTracker.removeFragmentsInRange(
+              nextRangeStart,
+              Infinity,
+              PlaylistLevelType.MAIN,
+            );
+            this.flushMainBuffer(nextRangeStart, Infinity);
           }
         }
         // (onBufferedToEnd re-runs the seek if EOS completes after it)
@@ -219,8 +221,8 @@ export class IFrameStreamController extends StreamController {
         this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       }
       if (!this.seekTo(currentOp[0])) {
-        this.warn(
-          `Could not seek to ${currentOp[0]} after fragment buffered (buffered: ${this.media ? timeRangesToString(BufferHelper.getBuffered(this.media)) : 'none'})`,
+        this.log(
+          `Could not seek to ${currentOp[0]} after fragment buffered (superseded or flushed) buffer: ${this.media ? timeRangesToString(BufferHelper.getBuffered(this.media)) : 'none'}`,
         );
       }
     }

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -1,11 +1,16 @@
 import { State } from './base-stream-controller';
+import { FragmentState } from './fragment-tracker';
 import StreamController from './stream-controller';
 import { Events } from '../events';
+import { isMediaFragment } from '../loader/fragment';
+import { LoadStats } from '../loader/load-stats';
 import { PlaylistLevelType } from '../types/loader';
 import { BufferHelper } from '../utils/buffer-helper';
 import { timeRangesToString } from '../utils/time-ranges';
 import type { Fragment, MediaFragment, Part } from '../loader/fragment';
 import type { LevelDetails } from '../loader/level-details';
+import type { FragLoadedData } from '../types/events';
+import type { Level } from '../types/level';
 import type { TimestampOffset } from '../utils/timescale-conversion';
 
 export type LoadMediaAtOptions = { seekOnAppend: boolean };
@@ -13,6 +18,11 @@ export type LoadMediaAtOptions = { seekOnAppend: boolean };
 export class IFrameStreamController extends StreamController {
   private currentOp?: [time: number, options: LoadMediaAtOptions];
   private nextOp?: [time: number, options: LoadMediaAtOptions];
+  protected cached: MediaFragment[] = [];
+  protected cachedSize = 0;
+  // Cache loaded fragment payloads for replay. The image I-Frame controller
+  // disables this and caches decoded image data instead.
+  protected cacheFragmentData: boolean = true;
   initDetails?: LevelDetails | null;
 
   setInitPts(initPTS: TimestampOffset[]) {
@@ -84,7 +94,115 @@ export class IFrameStreamController extends StreamController {
     return this.fragmentTracker.getBufferedFrag(time, PlaylistLevelType.MAIN);
   }
 
+  // Retain fragment data up to `iframeCacheLimit` total bytes, evicting the
+  // oldest entries, so that removed frames can be re-buffered without
+  // additional requests
+  protected cacheSet(frag: MediaFragment, data: Uint8Array<ArrayBuffer>) {
+    if (!this.hls) {
+      return;
+    }
+    frag.data = data;
+    const cache = this.cached;
+    cache.push(frag);
+    this.cachedSize += data.buffer.byteLength;
+    const iframeCacheLimit = this.hls.config.iframeCacheLimit;
+    while (this.cachedSize > iframeCacheLimit && cache.length > 1) {
+      const evicted = cache.shift()!;
+      if (evicted.data) {
+        this.cachedSize -= evicted.data.byteLength;
+        evicted.data = undefined;
+      } else {
+        // Fragment was removed. Re-evaluate size.
+        this.cached = cache.filter((frag) => !!frag.data);
+        this.cachedSize = cache.reduce(
+          (acc, { data }) => (data ? data.buffer.byteLength : 0),
+          0,
+        );
+        break;
+      }
+    }
+  }
+
+  protected onHandlerDestroying() {
+    this.cached.length = 0;
+    this.cachedSize = 0;
+    super.onHandlerDestroying();
+  }
+
   // overrides
+  protected _handleFragmentLoadProgress(data: FragLoadedData) {
+    const frag = data.frag;
+    const { part, payload } = data;
+    if (
+      this.cacheFragmentData &&
+      !part &&
+      payload?.byteLength &&
+      !frag.data &&
+      isMediaFragment(frag)
+    ) {
+      // Cache a pristine copy of the payload for replay after the buffer is
+      // flushed (the remuxer rewrites I-Frame fragment data in place)
+      this.cacheSet(frag, new Uint8Array(payload.slice(0)));
+    }
+    super._handleFragmentLoadProgress(data);
+  }
+
+  protected loadFragment(
+    frag: MediaFragment,
+    level: Level,
+    targetBufferTime: number,
+  ) {
+    const fragState = this.fragmentTracker.getState(frag);
+    if (
+      (fragState === FragmentState.NOT_LOADED ||
+        fragState === FragmentState.PARTIAL) &&
+      this.canReplayCached(frag)
+    ) {
+      this.replayCachedFragment(frag);
+      return;
+    }
+    super.loadFragment(frag, level, targetBufferTime);
+  }
+
+  // Replay is possible when fragment data is cached and decryption does not
+  // depend on a key that has yet to be loaded (EME-managed key formats
+  // append encrypted samples as-is)
+  private canReplayCached(frag: MediaFragment): boolean {
+    if (!this.cacheFragmentData || !frag.data?.byteLength) {
+      return false;
+    }
+    const decryptdata = frag.decryptdata;
+    return decryptdata?.keyFormat !== 'identity' || !!decryptdata.key;
+  }
+
+  private replayCachedFragment(frag: MediaFragment) {
+    // The remuxer rewrites fragment data in place: transmux a copy
+    const payload = frag.data!.slice().buffer;
+    this.log(
+      `Buffering cached ${frag.type} sn: ${frag.sn} of level ${frag.level} (${payload.byteLength} bytes)`,
+    );
+    this.fragCurrent = frag;
+    this.startFragRequested = true;
+    const stats = (frag.stats = new LoadStats());
+    stats.loading.start =
+      stats.loading.first =
+      stats.loading.end =
+        self.performance.now();
+    stats.loaded = stats.total = payload.byteLength;
+    stats.chunkCount = 1;
+    this.state = State.FRAG_LOADING;
+    const data: FragLoadedData = {
+      frag,
+      part: null,
+      payload,
+      networkDetails: null,
+    };
+    this._handleFragmentLoadProgress(data);
+    // FRAG_LOADED registers the fragment with the fragment tracker
+    this.hls.trigger(Events.FRAG_LOADED, data);
+    this._handleFragmentLoadComplete(data);
+  }
+
   protected fragBufferedComplete(frag: Fragment, part: Part | null) {
     super.fragBufferedComplete(frag, part);
 

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -42,6 +42,8 @@ export class IFrameStreamController extends StreamController {
       // operation) so it is picked up when the active fragment completes.
       this.nextOp = [adjustedTime, options];
     }
+    // This operation supersedes any seek scheduled for end of stream
+    this.hls.off(Events.BUFFERED_TO_END, this.onBufferedToEnd);
     const media = this.media;
     if (seekOnAppend && media) {
       const seeking = this.seekTo(adjustedTime);
@@ -90,20 +92,51 @@ export class IFrameStreamController extends StreamController {
     this.currentOp = this.nextOp = undefined;
     this.state = State.STOPPED;
     if (currentOp?.[1].seekOnAppend) {
+      if (!nextOp) {
+        // The decoder only renders a single appended keyframe once it can
+        // rule out more frames before the next composition deadline: the
+        // media element completes a seek into a buffered range when a frame
+        // follows the seek target, or end of stream marks the end of the
+        // range. Remove buffered media beyond the target fragment (loading
+        // an earlier fragment leaves a gap the decoder would otherwise wait
+        // on indefinitely) so that end of stream applies to it, then seek.
+        const media = this.media;
+        const bufferedFrag = this.getBufferedAt(currentOp[0]);
+        const flushFrom = (bufferedFrag || (frag as MediaFragment)).end;
+        if (media) {
+          const buffered = BufferHelper.getBuffered(media);
+          const bufferedEnd = buffered.length
+            ? buffered.end(buffered.length - 1)
+            : 0;
+          if (bufferedEnd - flushFrom > 0.01) {
+            this.flushMainBuffer(flushFrom, Infinity);
+          }
+        }
+        // Should end of stream complete after the seek below, re-run the
+        // seek (see onBufferedToEnd).
+        this.hls.once(Events.BUFFERED_TO_END, this.onBufferedToEnd);
+        this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
+      }
       if (!this.seekTo(currentOp[0])) {
         this.warn(
           `Could not seek to ${currentOp[0]} after fragment buffered (buffered: ${this.media ? timeRangesToString(BufferHelper.getBuffered(this.media)) : 'none'})`,
         );
-      }
-      if (!nextOp) {
-        // Mark end of stream to force rendering immediately
-        this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       }
     }
     if (nextOp) {
       this.loadMediaAt.apply(this, nextOp);
     }
   }
+
+  private onBufferedToEnd = () => {
+    const media = this.media;
+    if (media?.seeking) {
+      // Re-run the pending seek now that the MediaSource has ended so the
+      // decoder treats the gap after the target range as end of stream.
+      // eslint-disable-next-line no-self-assign
+      media.currentTime = media.currentTime;
+    }
+  };
 
   get playhead(): number {
     return this.nextLoadPosition;

--- a/src/controller/image-iframe-stream-controller.ts
+++ b/src/controller/image-iframe-stream-controller.ts
@@ -15,8 +15,8 @@ import type { ChunkMetadata } from '../types/transmuxer';
 export class ImageIFrameStreamController extends IFrameStreamController {
   private _img?: HTMLImageElement;
   private queued?: [time: number];
-  private cached: MediaFragment[] = [];
-  private cachedSize = 0;
+  // Image data extracted from fragments is cached instead (bufferFragmentData)
+  protected cacheFragmentData: boolean = false;
 
   get image(): HTMLImageElement | undefined {
     return this._img;
@@ -62,35 +62,6 @@ export class ImageIFrameStreamController extends IFrameStreamController {
         (time >= fragCurrent.start && time < fragCurrent.end)
       ) {
         this.queued = [adjustedTime];
-      }
-    }
-  }
-
-  private cacheSet(
-    frag: MediaFragment,
-    imageBytesView: Uint8Array<ArrayBuffer>,
-  ) {
-    if (!this.hls) {
-      return;
-    }
-    frag.data = imageBytesView;
-    const cache = this.cached;
-    cache.push(frag);
-    this.cachedSize += imageBytesView.buffer.byteLength;
-    const iframeCacheLimit = this.hls.config.iframeCacheLimit;
-    while (this.cachedSize > iframeCacheLimit && cache.length > 1) {
-      const evicted = cache.shift()!;
-      if (evicted.data) {
-        this.cachedSize -= evicted.data.byteLength;
-        evicted.data = undefined;
-      } else {
-        // Fragment was removed. Re-evaluate size.
-        this.cached = cache.filter((frag) => !!frag.data);
-        this.cachedSize = cache.reduce(
-          (acc, { data }) => (data ? data.buffer.byteLength : 0),
-          0,
-        );
-        break;
       }
     }
   }
@@ -176,12 +147,6 @@ export class ImageIFrameStreamController extends IFrameStreamController {
   }
 
   // overrides
-  protected onHandlerDestroying() {
-    this.cached.length = 0;
-    this.cachedSize = 0;
-    super.onHandlerDestroying();
-  }
-
   protected _bufferInitSegment() {}
 
   protected bufferFragmentData(

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -284,9 +284,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
 
     let data1 = data;
     let data2: Uint8Array<ArrayBuffer> | undefined;
-    // Presentation end of rewritten I-Frame samples (video timescale units).
-    // Set whenever sample durations are stretched to the playlist duration so
-    // that the reported PTS range matches the appended media.
+    // Presentation end of stretched I-Frame samples (video timescale units)
     let videoPtsEnd: number | undefined;
     if (
       __USE_IFRAMES__ &&
@@ -328,8 +326,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
               totalSize,
             );
             if (mdatEnd) {
-              // Drop the bytes of any partially loaded sample after the
-              // rewritten mdat so the appended stream ends on a box boundary.
+              // End the appended stream on the rewritten mdat box boundary
               data1 = data.subarray(0, mdatEnd);
             }
           }
@@ -344,9 +341,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
               lastSampleDuration -= samples[i].duration;
             }
             if (lastSampleDuration <= 0) {
-              // Playlist duration is shorter than the preceding samples;
-              // keep the native duration rather than writing an unsigned
-              // wrap-around value.
+              // Keep the native duration rather than write a wrapped value
               lastSampleDuration = lastSample.duration;
             }
             writeUint32(data, lastSampleDurationOffset, lastSampleDuration);
@@ -403,9 +398,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
               lastSampleDuration -= remuxedSamples[i].duration;
             }
             if (lastSampleDuration <= 0) {
-              // Playlist duration is shorter than the preceding samples;
-              // keep the native duration rather than writing an unsigned
-              // wrap-around value.
+              // Keep the native duration rather than write a wrapped value
               lastSampleDuration = lastSample.duration;
             }
             lastSample.duration = lastSampleDuration;
@@ -507,11 +500,8 @@ class PassThroughRemuxer extends Logger implements Remuxer {
         ? baseOffsetSamples.ptsMin / baseOffsetSamples.timescale -
           initPTS.baseTime / initPTS.timescale
         : startDTS;
-    // Report the presentation end of rewritten I-Frame samples rather than
-    // the timing parsed from the input so that fragment start/end updates
-    // (updateFragPTSDTS) match the appended media. Otherwise a stretched
-    // single-sample fragment collapses frag.end to ~one frame, breaking
-    // buffered-fragment lookups and shifting playlist timing.
+    // Report the presentation end of stretched I-Frame samples so fragment
+    // start/end updates (updateFragPTSDTS) match the appended media
     const endPTS =
       videoPtsEnd !== undefined && videoSampleTimestamps
         ? videoPtsEnd / videoSampleTimestamps.timescale -

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -284,6 +284,10 @@ class PassThroughRemuxer extends Logger implements Remuxer {
 
     let data1 = data;
     let data2: Uint8Array<ArrayBuffer> | undefined;
+    // Presentation end of rewritten I-Frame samples (video timescale units).
+    // Set whenever sample durations are stretched to the playlist duration so
+    // that the reported PTS range matches the appended media.
+    let videoPtsEnd: number | undefined;
     if (
       __USE_IFRAMES__ &&
       videoSampleTimestamps &&
@@ -325,20 +329,33 @@ class PassThroughRemuxer extends Logger implements Remuxer {
             ? chunkMeta.duration
             : videoEndTime - videoStartTime;
           if (lastSampleDurationOffset !== undefined) {
+            const lastSample = samples[samples.length - 1];
             let lastSampleDuration = duration * initData.video.timescale;
             for (let i = 0; i < samples.length - 1; i++) {
               lastSampleDuration -= samples[i].duration;
             }
+            if (lastSampleDuration <= 0) {
+              // Playlist duration is shorter than the preceding samples;
+              // keep the native duration rather than writing an unsigned
+              // wrap-around value.
+              lastSampleDuration = lastSample.duration;
+            }
             writeUint32(data, lastSampleDurationOffset, lastSampleDuration);
+            lastSample.duration = lastSampleDuration;
           } else {
+            const defaultSampleDuration = Math.round(
+              (duration * initData.video.timescale) / samples.length,
+            );
             writeUint32(
               data,
               defaultSampleDurationOffset!,
-              Math.round(
-                (duration * initData.video.timescale) / samples.length,
-              ),
+              defaultSampleDuration,
             );
+            samples.forEach((sample) => {
+              sample.duration = defaultSampleDuration;
+            });
           }
+          videoPtsEnd = samplesPresentationEnd(start, samples);
         } else if (!initData.video.encrypted) {
           // Unencrypted: regenerate the moof from the in-range samples.
           // The in-place truncation path the encrypted branch uses doesn't
@@ -347,10 +364,9 @@ class PassThroughRemuxer extends Logger implements Remuxer {
             ? chunkMeta.duration
             : videoEndTime - videoStartTime;
           const sampleOffset = fragRun.sampleOffset;
-          const sampleDuration = videoSampleTimestamps.duration;
           let totalSize = 0;
           const remuxedSamples = samples.map((sample): TrackFragmentSample => {
-            const { cts, size, flags } = sample;
+            const { cts, duration: sampleDuration, size, flags } = sample;
             const { dependsOn, isNonSync } = Object.assign(
               { dependsOn: 2, isNonSync: 0 },
               flags,
@@ -377,7 +393,14 @@ class PassThroughRemuxer extends Logger implements Remuxer {
             for (let i = remuxedSamples.length - 1; i--; ) {
               lastSampleDuration -= remuxedSamples[i].duration;
             }
+            if (lastSampleDuration <= 0) {
+              // Playlist duration is shorter than the preceding samples;
+              // keep the native duration rather than writing an unsigned
+              // wrap-around value.
+              lastSampleDuration = lastSample.duration;
+            }
             lastSample.duration = lastSampleDuration;
+            videoPtsEnd = samplesPresentationEnd(start, remuxedSamples);
 
             data1 = MP4.moof(chunkMeta.sn, start, {
               type: 'video',
@@ -475,11 +498,19 @@ class PassThroughRemuxer extends Logger implements Remuxer {
         ? baseOffsetSamples.ptsMin / baseOffsetSamples.timescale -
           initPTS.baseTime / initPTS.timescale
         : startDTS;
+    // Report the presentation end of rewritten I-Frame samples rather than
+    // the timing parsed from the input so that fragment start/end updates
+    // (updateFragPTSDTS) match the appended media. Otherwise a stretched
+    // single-sample fragment collapses frag.end to ~one frame, breaking
+    // buffered-fragment lookups and shifting playlist timing.
     const endPTS =
-      hasVideo && baseOffsetSamples?.ptsMax
-        ? baseOffsetSamples.ptsMax / baseOffsetSamples.timescale -
+      videoPtsEnd !== undefined && videoSampleTimestamps
+        ? videoPtsEnd / videoSampleTimestamps.timescale -
           initPTS.baseTime / initPTS.timescale
-        : endDTS;
+        : hasVideo && baseOffsetSamples?.ptsMax
+          ? baseOffsetSamples.ptsMax / baseOffsetSamples.timescale -
+            initPTS.baseTime / initPTS.timescale
+          : endDTS;
 
     // For troubleshooting duplicates of https://github.com/video-dev/hls.js/issues/6777
     // if (videoSampleTimestamps) {
@@ -577,6 +608,20 @@ function toStartEndOrDefault(
     ? (trackTimes.start + (end ? trackTimes.duration : 0)) /
         trackTimes.timescale
     : defaultValue;
+}
+
+function samplesPresentationEnd(
+  baseDecodeTime: number,
+  samples: Array<{ cts?: number; duration: number }>,
+): number {
+  let dts = baseDecodeTime;
+  let end = baseDecodeTime;
+  for (let i = 0; i < samples.length; i++) {
+    const { cts, duration } = samples[i];
+    end = Math.max(end, dts + (cts || 0) + duration);
+    dts += duration;
+  }
+  return end;
 }
 
 function isInvalidInitPts(

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -322,7 +322,16 @@ class PassThroughRemuxer extends Logger implements Remuxer {
               (sum, sample) => sum + sample.size,
               0,
             );
-            truncateIFrameMoofToSamples(data, samples.length, totalSize);
+            const mdatEnd = truncateIFrameMoofToSamples(
+              data,
+              samples.length,
+              totalSize,
+            );
+            if (mdatEnd) {
+              // Drop the bytes of any partially loaded sample after the
+              // rewritten mdat so the appended stream ends on a box boundary.
+              data1 = data.subarray(0, mdatEnd);
+            }
           }
           // adjust duration
           duration = needsDurationAdjustment

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -149,8 +149,7 @@ export function truncateIFrameMoofToSamples(
       mdats[0].byteOffset - data.byteOffset - 8,
       8 + keepTotalSize,
     );
-    // Return the end of the rewritten mdat so callers can exclude trailing
-    // bytes of partially loaded samples from the appended byte stream.
+    // Callers use the mdat end to exclude trailing partial-sample bytes
     return mdats[0].byteOffset - data.byteOffset + keepTotalSize;
   }
 }
@@ -955,8 +954,7 @@ export function getSampleData(
           sampleOffset += size;
           // Capture only fitting samples so a partial-mdat truncation
           // can still rewrite the right uint32 to balance EXTINF. Field
-          // offsets must advance for every declared sample (including those
-          // beyond the loaded range) to keep trun parsing aligned.
+          // offsets above advance for every declared sample to stay aligned.
           if (sampleOffset <= eof) {
             if (thisSampleDurationOffset !== undefined) {
               fragRun.lastSampleDurationOffset = thisSampleDurationOffset;

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -931,36 +931,40 @@ export function getSampleData(
           } else {
             size = defaultSampleSize;
           }
+          let flags;
+          if (sampleFlagsPresent) {
+            const isNonSyncSample = trun[offset + 1] & 0x01;
+            flags = {
+              isNonSync: isNonSyncSample ? 1 : 0,
+              dependsOn: (trun[offset] & 0x03) === 1 ? 1 : 2,
+            };
+            offset += 4;
+          }
+          let cts = 0;
+          if (sampleCompositionTimeOffsetPresent) {
+            const version = trun[0];
+            cts =
+              version === 0
+                ? readUint32(trun, offset)
+                : readSint32(trun, offset);
+            offset += 4;
+          }
           sampleOffset += size;
+          // Capture only fitting samples so a partial-mdat truncation
+          // can still rewrite the right uint32 to balance EXTINF. Field
+          // offsets must advance for every declared sample (including those
+          // beyond the loaded range) to keep trun parsing aligned.
           if (sampleOffset <= eof) {
-            // Capture only fitting samples so a partial-mdat truncation
-            // can still rewrite the right uint32 to balance EXTINF.
             if (thisSampleDurationOffset !== undefined) {
               fragRun.lastSampleDurationOffset = thisSampleDurationOffset;
             }
-            let flags;
-            let cts = 0;
-            if (sampleFlagsPresent) {
-              const isNonSyncSample = trun[offset + 1] & 0x01;
-              flags = {
-                isNonSync: isNonSyncSample ? 1 : 0,
-                dependsOn: (trun[offset] & 0x03) === 1 ? 1 : 2,
-              };
-              if (!isNonSyncSample) {
-                if (trackTimes.keyFrameIndex === undefined) {
-                  trackTimes.keyFrameIndex = ix;
-                  trackTimes.keyFrameStart = sampleDTS;
-                }
-              }
-              offset += 4;
-            }
-            if (sampleCompositionTimeOffsetPresent) {
-              const version = trun[0];
-              cts =
-                version === 0
-                  ? readUint32(trun, offset)
-                  : readSint32(trun, offset);
-              offset += 4;
+            if (
+              flags &&
+              !flags.isNonSync &&
+              trackTimes.keyFrameIndex === undefined
+            ) {
+              trackTimes.keyFrameIndex = ix;
+              trackTimes.keyFrameStart = sampleDTS;
             }
             const pts = sampleDTS + cts;
             if (

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -110,7 +110,7 @@ export function truncateIFrameMoofToSamples(
   data: Uint8Array<ArrayBuffer>,
   keepSampleCount: number,
   keepTotalSize: number,
-): void {
+): number | undefined {
   const moofs = findBox(data, ['moof']);
   if (moofs.length !== 1) {
     return;
@@ -149,6 +149,9 @@ export function truncateIFrameMoofToSamples(
       mdats[0].byteOffset - data.byteOffset - 8,
       8 + keepTotalSize,
     );
+    // Return the end of the rewritten mdat so callers can exclude trailing
+    // bytes of partially loaded samples from the appended byte stream.
+    return mdats[0].byteOffset - data.byteOffset + keepTotalSize;
   }
 }
 

--- a/tests/unit/controller/iframe-controller.ts
+++ b/tests/unit/controller/iframe-controller.ts
@@ -259,6 +259,34 @@ describe('IFrameController', function () {
     ]);
   });
 
+  it('re-buffers cached fragment data instead of reloading it', function () {
+    const iframePlayer = loadedIFramePlayer(playlistWithIFrameVariants);
+    const streamController = (iframePlayer as any).streamController;
+    const frag = new Fragment(PlaylistLevelType.MAIN, '');
+    frag.sn = 30;
+    frag.level = 0;
+    frag.setStart(60);
+    frag.setDuration(2);
+    frag.data = new Uint8Array([1, 2, 3, 4]);
+    const calls: string[] = [];
+    sandbox
+      .stub(streamController, '_handleFragmentLoadProgress' as any)
+      .callsFake((data: any) =>
+        calls.push(`progress(${data.payload.byteLength})`),
+      );
+    sandbox
+      .stub(streamController, '_handleFragmentLoadComplete' as any)
+      .callsFake(() => calls.push('complete'));
+
+    streamController.loadFragment(frag, iframePlayer.levels[0], 60.5);
+
+    expect(calls).to.deep.equal(['progress(4)', 'complete']);
+    expect(streamController.fragCurrent).to.equal(frag);
+    expect(frag.stats.loaded).to.equal(4);
+    // The transmuxed payload is a copy; the cached bytes stay pristine
+    expect(frag.data).to.deep.equal(new Uint8Array([1, 2, 3, 4]));
+  });
+
   it('queues loadMediaAt operations issued while a fragment is loading', function () {
     const iframePlayer = loadedIFramePlayer(playlistWithIFrameVariants);
     const streamController = (iframePlayer as any).streamController;

--- a/tests/unit/controller/iframe-controller.ts
+++ b/tests/unit/controller/iframe-controller.ts
@@ -241,7 +241,9 @@ describe('IFrameController', function () {
     sandbox
       .stub(iframePlayer, 'trigger' as any)
       .callsFake((event: any, data: any) => {
-        if (event === Events.BUFFER_FLUSHING || event === Events.BUFFER_EOS) {
+        if (event === Events.BUFFER_FLUSHING) {
+          calls.push(`${event}@${data.startOffset}`);
+        } else if (event === Events.BUFFER_EOS) {
           calls.push(event);
         }
         return trigger(event, data);
@@ -249,14 +251,26 @@ describe('IFrameController', function () {
 
     streamController.fragBufferedComplete(frag, null);
 
-    // The buffered range after the target must be removed and end of stream
-    // signalled before seeking, so the decoder does not starve waiting for a
-    // frame after the seek target (it would never complete the seek).
+    // The disjoint buffered range after the target's must be removed (from
+    // its own start) and end of stream signalled before seeking, so the
+    // decoder does not starve waiting for a frame after the seek target.
     expect(calls).to.deep.equal([
-      Events.BUFFER_FLUSHING,
+      `${Events.BUFFER_FLUSHING}@420`,
       Events.BUFFER_EOS,
       'seek',
     ]);
+
+    // Media contiguous beyond the target (prefetch): nothing is flushed
+    streamController.media.buffered = {
+      length: 1,
+      start: () => 60,
+      end: () => 64,
+    };
+    streamController.currentOp = [61.2, { seekOnAppend: true }];
+    streamController.state = State.PARSED;
+    calls.length = 0;
+    streamController.fragBufferedComplete(frag, null);
+    expect(calls).to.deep.equal([Events.BUFFER_EOS, 'seek']);
   });
 
   it('re-buffers cached fragment data instead of reloading it', function () {

--- a/tests/unit/controller/iframe-controller.ts
+++ b/tests/unit/controller/iframe-controller.ts
@@ -1,6 +1,7 @@
 import { config as chaiConfig, expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { State } from '../../../src/controller/base-stream-controller';
 import { ImageIFrameStreamController } from '../../../src/controller/image-iframe-stream-controller';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
@@ -201,6 +202,21 @@ describe('IFrameController', function () {
     const iframeStreamController = (iframePlayer as any).streamController;
     expect(iframeStreamController.initPTS).to.not.equal(timestamps);
     expect(iframeStreamController.initPTS).to.deep.equal(timestamps);
+  });
+
+  it('queues loadMediaAt operations issued while a fragment is loading', function () {
+    const iframePlayer = loadedIFramePlayer(playlistWithIFrameVariants);
+    const streamController = (iframePlayer as any).streamController;
+    // Simulate an in-flight fragment load for a span that does not contain
+    // the newly requested time. The operation must be queued (not dropped)
+    // so it is issued when the active fragment completes.
+    streamController.state = State.FRAG_LOADING;
+    streamController.fragCurrent = { start: 0, end: 4 };
+    streamController.loadMediaAt(30, { seekOnAppend: true });
+    expect(streamController.nextOp).to.deep.equal([30, { seekOnAppend: true }]);
+    // A subsequent call replaces the pending operation
+    streamController.loadMediaAt(2, { seekOnAppend: true });
+    expect(streamController.nextOp).to.deep.equal([2, { seekOnAppend: true }]);
   });
 
   it('createImageIFramePlayer returns null when no image iframe variants exist', function () {

--- a/tests/unit/controller/iframe-controller.ts
+++ b/tests/unit/controller/iframe-controller.ts
@@ -204,6 +204,61 @@ describe('IFrameController', function () {
     expect(iframeStreamController.initPTS).to.deep.equal(timestamps);
   });
 
+  it('flushes buffer beyond the target and signals EOS before seeking on fragment buffered', function () {
+    const iframePlayer = loadedIFramePlayer(playlistWithIFrameVariants);
+    const streamController = (iframePlayer as any).streamController;
+    const frag = new Fragment(PlaylistLevelType.MAIN, '');
+    frag.sn = 30;
+    frag.level = 0;
+    frag.setStart(60);
+    frag.setDuration(2);
+    frag.elementaryStreams.video = {
+      startPTS: 60,
+      endPTS: 62,
+      startDTS: 60,
+      endDTS: 62,
+    };
+    // Media with a buffered range beyond the fragment (an earlier operation
+    // rendered a later frame)
+    streamController.media = {
+      seeking: false,
+      currentTime: 421.2,
+      buffered: {
+        length: 2,
+        start: (i: number) => [60, 420][i],
+        end: (i: number) => [62, 422][i],
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      pause: () => {},
+    };
+    streamController.currentOp = [61.2, { seekOnAppend: true }];
+    const calls: string[] = [];
+    sandbox
+      .stub(streamController, 'seekTo' as any)
+      .callsFake(() => calls.push('seek') > 0);
+    const trigger = iframePlayer.trigger.bind(iframePlayer);
+    sandbox
+      .stub(iframePlayer, 'trigger' as any)
+      .callsFake((event: any, data: any) => {
+        if (event === Events.BUFFER_FLUSHING || event === Events.BUFFER_EOS) {
+          calls.push(event);
+        }
+        return trigger(event, data);
+      });
+
+    streamController.fragBufferedComplete(frag, null);
+
+    // The buffered range after the target must be removed and end of stream
+    // signalled before seeking, so the decoder does not starve waiting for a
+    // frame after the seek target (it would never complete the seek).
+    expect(calls).to.deep.equal([
+      Events.BUFFER_FLUSHING,
+      Events.BUFFER_EOS,
+      'seek',
+    ]);
+  });
+
   it('queues loadMediaAt operations issued while a fragment is loading', function () {
     const iframePlayer = loadedIFramePlayer(playlistWithIFrameVariants);
     const streamController = (iframePlayer as any).streamController;

--- a/tests/unit/remux/passthrough-remuxer.ts
+++ b/tests/unit/remux/passthrough-remuxer.ts
@@ -189,6 +189,33 @@ describe('passthrough-remuxer', function () {
       1 / 90000,
     );
   });
+
+  it('truncates encrypted partial-mdat iframe fragments on the mdat box boundary', function () {
+    const extinfDuration = 4;
+    const samples = [sample(3003, 10, 0), sample(3003, 20, 0)];
+    const fragmentData = mp4Fragment(samples);
+    // Slice mid-way through the second sample's data, as a byte-range
+    // addressed I-Frame request would.
+    const mdatPayloadOffset = fragmentData.byteLength - 30;
+    const partialFragment = fragmentData.subarray(0, mdatPayloadOffset + 13);
+
+    const result = remuxIFrameFragment(partialFragment, extinfDuration, true);
+
+    expect(result.video, 'video track').to.exist;
+    expect(result.video!.encrypted).to.equal(true);
+    // Appended data ends at the rewritten mdat boundary, dropping the
+    // partially loaded sample's bytes.
+    expect(result.video!.data1.byteLength).to.equal(mdatPayloadOffset + 10);
+    expect(readUint32(result.video!.data1, mdatPayloadOffset - 8)).to.equal(18);
+    const trun = findBox(result.video!.data1, ['moof', 'traf', 'trun'])[0];
+    expect(readUint32(trun, 4), 'trun sample_count').to.equal(1);
+    expect(trunSampleDurations(result.video!.data1)).to.deep.equal([
+      extinfDuration * 90000,
+    ]);
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
+  });
 });
 
 function markVideoInitSegmentEncrypted(

--- a/tests/unit/remux/passthrough-remuxer.ts
+++ b/tests/unit/remux/passthrough-remuxer.ts
@@ -6,7 +6,7 @@ import PassThroughRemuxer from '../../../src/remux/passthrough-remuxer';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
 import { logger } from '../../../src/utils/logger';
-import { appendUint8Array } from '../../../src/utils/mp4-tools';
+import { appendUint8Array, findBox } from '../../../src/utils/mp4-tools';
 import type { HlsEventEmitter } from '../../../src/events';
 import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
 import type {
@@ -42,8 +42,12 @@ describe('passthrough-remuxer', function () {
   function remuxIFrameFragment(
     fragmentData: Uint8Array<ArrayBuffer>,
     extinfDuration: number,
+    encrypted = false,
   ) {
     const initSegment = MP4.initSegment([videoInitTrack()]);
+    if (encrypted) {
+      markVideoInitSegmentEncrypted(initSegment);
+    }
     remuxer.resetInitSegment(initSegment, undefined, 'avc1.42001e', null);
 
     return remuxer.remux(
@@ -81,6 +85,11 @@ describe('passthrough-remuxer', function () {
     expect(result.video!.endDTS - result.video!.startDTS).to.equal(
       extinfDuration,
     );
+    // The reported PTS range must cover the stretched sample so that
+    // fragment start/end updates match the appended media.
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
     expect(result.video!.nb).to.equal(1);
   });
 
@@ -114,8 +123,111 @@ describe('passthrough-remuxer', function () {
     expect(result.video!.endDTS - result.video!.startDTS).to.equal(
       extinfDuration,
     );
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
+    // Each sample keeps its own duration; only the last is stretched to
+    // balance EXTINF.
+    expect(trunSampleDurations(result.video!.data1)).to.deep.equal([
+      3003,
+      3003,
+      extinfDuration * 90000 - 6006,
+    ]);
+  });
+
+  it('reports the presentation end of stretched samples with composition offsets', function () {
+    const extinfDuration = 4;
+    const fragmentData = mp4Fragment([
+      sample(3003, 4, 9000),
+      sample(3003, 4, 0),
+    ]);
+
+    const result = remuxIFrameFragment(fragmentData, extinfDuration);
+
+    expect(result.video, 'video track').to.exist;
+    expect(result.video!.startPTS).to.equal(3003 / 90000);
+    expect(result.video!.endPTS).to.equal(extinfDuration);
+  });
+
+  it('keeps native sample durations when EXTINF is shorter than the preceding samples', function () {
+    // Stretching would make the last sample duration negative (writing an
+    // unsigned wrap-around value into the trun).
+    const extinfDuration = 1;
+    const fragmentData = mp4Fragment([
+      sample(45045, 4, 0),
+      sample(45045, 4, 0),
+      sample(45045, 4, 0),
+    ]);
+
+    const result = remuxIFrameFragment(fragmentData, extinfDuration);
+
+    expect(result.video, 'video track').to.exist;
+    expect(trunSampleDurations(result.video!.data1)).to.deep.equal([
+      45045, 45045, 45045,
+    ]);
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      (3 * 45045) / 90000,
+    );
+  });
+
+  it('rewrites the sample duration of encrypted iframe fragments in place', function () {
+    const extinfDuration = 4;
+    const fragmentData = mp4Fragment([sample(3003, 4, 9000)]);
+
+    const result = remuxIFrameFragment(fragmentData, extinfDuration, true);
+
+    expect(result.video, 'video track').to.exist;
+    // The original moof is retained so encryption boxes survive intact
+    expect(result.video!.data1).to.equal(fragmentData);
+    expect(result.video!.data2, 'data2').to.not.exist;
+    expect(result.video!.encrypted).to.equal(true);
+    expect(trunSampleDurations(fragmentData)).to.deep.equal([
+      extinfDuration * 90000,
+    ]);
+    expect(result.video!.endPTS - result.video!.startPTS).to.be.closeTo(
+      extinfDuration,
+      1 / 90000,
+    );
   });
 });
+
+function markVideoInitSegmentEncrypted(
+  initSegment: Uint8Array<ArrayBuffer>,
+): void {
+  const stsd = findBox(initSegment, [
+    'moov',
+    'trak',
+    'mdia',
+    'minf',
+    'stbl',
+    'stsd',
+  ])[0];
+  const sampleEntry = findBox(stsd.subarray(8), ['avc1'])[0];
+  const typeOffset = sampleEntry.byteOffset - initSegment.byteOffset - 4;
+  initSegment.set([0x65, 0x6e, 0x63, 0x76], typeOffset); // 'encv'
+}
+
+function readUint32(buffer: Uint8Array, offset: number): number {
+  return (
+    ((buffer[offset] << 24) |
+      (buffer[offset + 1] << 16) |
+      (buffer[offset + 2] << 8) |
+      buffer[offset + 3]) >>>
+    0
+  );
+}
+
+function trunSampleDurations(data: Uint8Array): number[] {
+  const trun = findBox(data, ['moof', 'traf', 'trun'])[0];
+  const sampleCount = readUint32(trun, 4);
+  const durations: number[] = [];
+  // full box header (4) + sample_count (4) + data_offset (4);
+  // entries are duration, size, flags, cts (16 bytes each)
+  for (let i = 0; i < sampleCount; i++) {
+    durations.push(readUint32(trun, 12 + i * 16));
+  }
+  return durations;
+}
 
 function videoInitTrack(): any {
   return {

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -5,7 +5,9 @@ import { ChunkMetadata } from '../../../src/types/transmuxer';
 import { logger } from '../../../src/utils/logger';
 import {
   appendUint8Array,
+  findBox,
   getSampleData,
+  truncateIFrameMoofToSamples,
   types,
 } from '../../../src/utils/mp4-tools';
 import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
@@ -74,6 +76,21 @@ describe('mp4-tools', function () {
     });
     expect(track.ptsMax).to.equal(500 + 1001);
   });
+
+  it('truncateIFrameMoofToSamples rewrites sample counts and returns the mdat end offset', function () {
+    const fragment = gopFragment();
+    const mdatPayloadOffset = fragment.byteLength - 60;
+
+    const mdatEnd = truncateIFrameMoofToSamples(fragment, 1, 10);
+
+    expect(mdatEnd).to.equal(mdatPayloadOffset + 10);
+    const trun = findBox(fragment, ['moof', 'traf', 'trun'])[0];
+    expect(readUint32(trun, 4), 'trun sample_count').to.equal(1);
+    expect(
+      readUint32(fragment, mdatPayloadOffset - 8),
+      'mdat box size',
+    ).to.equal(18);
+  });
 });
 
 // moof + mdat with three samples (per-sample duration, size, flags and cts)
@@ -109,6 +126,16 @@ function gopSample(
       paddingValue: 0,
     },
   };
+}
+
+function readUint32(buffer: Uint8Array, offset: number): number {
+  return (
+    ((buffer[offset] << 24) |
+      (buffer[offset + 1] << 16) |
+      (buffer[offset + 2] << 8) |
+      buffer[offset + 3]) >>>
+    0
+  );
 }
 
 function initData(): InitData {

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -8,6 +8,7 @@ import {
   getSampleData,
   types,
 } from '../../../src/utils/mp4-tools';
+import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
 import type { InitData } from '../../../src/utils/mp4-tools';
 
 describe('mp4-tools', function () {
@@ -45,7 +46,70 @@ describe('mp4-tools', function () {
     expect(sampleData[1].duration).to.equal(3003);
     expect(sampleData[1].trun[0].samples[0].size).to.equal(1234);
   });
+
+  it('parses trun entries beyond a truncated mdat without losing alignment', function () {
+    // A byte-range addressed I-Frame request loads a moof declaring the whole
+    // GOP with only the first sample's data present in the mdat slice.
+    const fragment = gopFragment();
+    const truncated = fragment.subarray(0, fragment.byteLength - 50);
+
+    const sampleData = getSampleData(
+      truncated,
+      initData(),
+      new ChunkMetadata(0, 0, 0),
+      logger,
+    );
+
+    const track = sampleData[1];
+    // All declared sample durations parse correctly (per-sample flags and
+    // composition offsets of out-of-range samples must be skipped)
+    expect(track.duration).to.equal(1001 + 2002 + 3003);
+    expect(track.sampleCount).to.equal(3);
+    // Only the sample whose data is within the loaded range is captured
+    expect(track.trun[0].samples).to.have.lengthOf(1);
+    expect(track.trun[0].samples[0]).to.deep.include({
+      duration: 1001,
+      size: 10,
+      cts: 500,
+    });
+    expect(track.ptsMax).to.equal(500 + 1001);
+  });
 });
+
+// moof + mdat with three samples (per-sample duration, size, flags and cts)
+// of sizes 10/20/30
+function gopFragment(): Uint8Array<ArrayBuffer> {
+  const samples: TrackFragmentSample[] = [
+    gopSample(1001, 10, 500),
+    gopSample(2002, 20, 0),
+    gopSample(3003, 30, 250),
+  ];
+  return appendUint8Array(
+    MP4.moof(0, 0, { type: 'video', id: 1, samples }),
+    MP4.mdat(new Uint8Array(60)),
+  );
+}
+
+function gopSample(
+  duration: number,
+  size: number,
+  cts: number,
+): TrackFragmentSample {
+  return {
+    cts,
+    duration,
+    size,
+    flags: {
+      degradPrio: 0,
+      dependsOn: 2,
+      hasRedundancy: 0,
+      isDependedOn: 0,
+      isLeading: 0,
+      isNonSync: 0,
+      paddingValue: 0,
+    },
+  };
+}
 
 function initData(): InitData {
   const data = [] as unknown as InitData;


### PR DESCRIPTION
### This PR will...

- Report the presentation end of rewritten I-Frame samples from the passthrough remuxer so that fragment start/end updates match the appended media. Stretching sample durations to EXTINF while reporting the input timing collapsed `frag.end` to ~one frame, which broke the buffered-fragment lookup used by `IFrameStreamController.seekTo()` (fragments buffered but never rendered) and re-timed neighboring fragments through `updateFragPTSDTS`, so later operations selected the wrong fragment. The TS remuxer already folds the stretched duration into `endPTS`; this brings the fMP4 path in line.
- Use each parsed sample's own duration when regenerating multi-sample I-Frame fragments (the track's total raw duration was applied to every sample, which could drive the last sample duration negative and write an unsigned wrap-around value into the trun).
- Keep trun parsing aligned past a truncated mdat: sample flags and composition time offset fields of samples beyond the loaded byte range were not skipped, so subsequent duration/size reads were garbage.
- End truncated encrypted I-Frame fragments on the rewritten mdat boundary so trailing bytes of a partially loaded sample are not parsed as a new box.
- Queue `loadMediaAt()` operations issued while a fragment is loading instead of dropping those outside the in-flight fragment's range, and clamp seeks to the playlist edge instead of `media.duration` (which `endOfStream()` truncates after every rendered frame).
- Remove buffered media beyond the target fragment and signal EOS before seeking, so a backward scrub to a fresh fragment renders. The decoder only presents a lone appended keyframe when a frame follows it or end of stream marks the end of its range; a backward load leaves a gap after the target range that end of stream cannot cover, and the media element remained seeking indefinitely.
- Cache loaded I-Frame fragment payloads (byte-limited LRU shared with the image I-Frame controller under the existing `iframeCacheLimit` config) and re-buffer them without additional requests when a removed position is revisited.

These changes landed in individual commits in this PR / branch to potentially help with the review.

### Why is this Pull Request needed?

`loadMediaAt()` did not consistently render the requested frame for streams whose I-Frame samples are stretched to the playlist duration (dedicated I-Frame segments and truncated byte ranges). Repro with hls.js@canary and Apple's own stream https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8 through `createIFramePlayer()`:

- `loadMediaAt(181.2)` buffers `[180.017, 182.017]` but `frag.end` collapses to `180.033`, no `seeked` event ever fires, and the video stays black.
- After one frame renders, a backward `loadMediaAt()` to an unbuffered position buffers its fragment but the media element remains `seeking` forever.

### Are there any points in the code the reviewer needs to double check?

- Removing buffered media beyond the target on each completed operation trades buffered frames for rendering reliability; the payload cache is intended to make that trade free (revisits re-buffer from memory). An alternative that loads the next contiguous fragment instead of flushing (restoring the pre-#7896 follow-up append) was tested and works for clear content, but Widevine backward scrubs never present with it - the CDM does not emit output for keyframe+1 without end of stream applying to the target's own range - so the flush approach was kept.
- EOS is now signaled before the seek, with a `BUFFERED_TO_END` handler re-running a still-pending seek. Seeking first left the media element seeking indefinitely in the backward case even when `endOfStream()` completed immediately after.
- `iframeCacheLimit` now applies to video I-Frame players as well as image players (API.md updated). The cache stores a pristine copy of the loaded payload because the remuxer rewrites fragment data in place; replay transmuxes a copy per use.
- Replayed fragments trigger `FRAG_LOADED` so the fragment tracker registers them (abr receives a zero TTFB sample from these; level selection is driven by `capLevelToPlayerSize` in I-Frame players). Replay is skipped for identity-key fragments whose key has not been loaded.
- Two adjacent observations, intentionally not changed here: `getSampleData` sets `keyFrameIndex` from the per-trun index rather than a global sample index (affects only multi-moof accounting), and the `iframesOnly` parameter of `updateFragPTSDTS` is no longer used inside the function since #7791.

### Resolves issues:

No open issue tracks this. Related work: #7757, #7791, #7884, #7892, #7896 (the EOS-on-append behavior this builds on was introduced in #7896).

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable) (6 unit tests: remuxer timing, trun parsing, truncation boundary, operation queueing, flush/EOS-before-seek ordering, cache replay)
- [x] API or design changes are documented in API.md (`iframeCacheLimit`)
