### PR TITLE
Force rendering of requested I-Frames and prevent loading of following segments

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1895,7 +1895,12 @@ export default class BaseStreamController
     }
 
     // Clear fragPrevious if removed from buffer / tracker so that is picked again
-    fragPrevious = this.filterBuffered(fragPrevious);
+    if (
+      fragPrevious &&
+      this.fragmentTracker.getState(fragPrevious) === FragmentState.NOT_LOADED
+    ) {
+      fragPrevious = null;
+    }
 
     let frag: MediaFragment | null;
     if (bufferEnd < end) {
@@ -1924,9 +1929,12 @@ export default class BaseStreamController
       const curSNIdx = frag.sn - levelDetails.startSN;
       // Move fragPrevious forward to support forcing the next fragment to load
       // when the buffer catches up to a previously buffered range.
-      const bufferedFrag = this.filterBuffered(frag);
-      if (bufferedFrag) {
-        fragPrevious = bufferedFrag;
+      const fragState = this.fragmentTracker.getState(frag);
+      if (
+        fragState === FragmentState.OK ||
+        (fragState === FragmentState.PARTIAL && frag.gap)
+      ) {
+        fragPrevious = frag;
       }
       if (
         mediaFragmentsAreEqual(frag, fragPrevious) &&
@@ -1946,19 +1954,6 @@ export default class BaseStreamController
       }
     }
     return frag;
-  }
-
-  private filterBuffered(frag: MediaFragment | null): MediaFragment | null {
-    if (frag) {
-      const fragState = this.fragmentTracker.getState(frag);
-      if (
-        fragState === FragmentState.OK ||
-        (fragState === FragmentState.PARTIAL && frag.gap)
-      ) {
-        return frag;
-      }
-    }
-    return null;
   }
 
   protected alignPlaylists(

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1894,6 +1894,9 @@ export default class BaseStreamController
       endSN = fragmentHint.sn;
     }
 
+    // Clear fragPrevious if removed from buffer / tracker so that is picked again
+    fragPrevious = this.filterBuffered(fragPrevious);
+
     let frag: MediaFragment | null;
     if (bufferEnd < end) {
       const backwardSeek = bufferEnd < this.lastCurrentTime;
@@ -1921,12 +1924,9 @@ export default class BaseStreamController
       const curSNIdx = frag.sn - levelDetails.startSN;
       // Move fragPrevious forward to support forcing the next fragment to load
       // when the buffer catches up to a previously buffered range.
-      const fragState = this.fragmentTracker.getState(frag);
-      if (
-        fragState === FragmentState.OK ||
-        (fragState === FragmentState.PARTIAL && frag.gap)
-      ) {
-        fragPrevious = frag;
+      const bufferedFrag = this.filterBuffered(frag);
+      if (bufferedFrag) {
+        fragPrevious = bufferedFrag;
       }
       if (
         mediaFragmentsAreEqual(frag, fragPrevious) &&
@@ -1946,6 +1946,19 @@ export default class BaseStreamController
       }
     }
     return frag;
+  }
+
+  private filterBuffered(frag: MediaFragment | null): MediaFragment | null {
+    if (frag) {
+      const fragState = this.fragmentTracker.getState(frag);
+      if (
+        fragState === FragmentState.OK ||
+        (fragState === FragmentState.PARTIAL && frag.gap)
+      ) {
+        return frag;
+      }
+    }
+    return null;
   }
 
   protected alignPlaylists(

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1953,6 +1953,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const removeStart = Math.max(0, startOffset);
     if (removeStart >= msDuration) {
       this.currentOp(type)?.onComplete();
+      this.shiftAndExecuteNext(type);
       return;
     }
     const removeEnd = Math.min(endOffset, mediaDuration, msDuration);

--- a/src/controller/iframe-controller.ts
+++ b/src/controller/iframe-controller.ts
@@ -255,6 +255,7 @@ export class IFrameController extends Logger {
 
       // Only load and unload as needed
       backBufferLength: Infinity,
+      maxMaxBufferLength: 1,
       // Adapt to attached HTMLVideoElement dimension
       capLevelToPlayerSize: true,
 

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -58,6 +58,7 @@ export class IFrameStreamController extends StreamController {
       if (seeking) {
         this.currentOp = [adjustedTime, options];
         this.nextOp = undefined;
+        this.flushPipeline(adjustedTime, true);
       }
     }
   }
@@ -75,9 +76,6 @@ export class IFrameStreamController extends StreamController {
       const hasEnough = bufferInfo.len > 0 && this.getBufferedAt(time);
       if (hasEnough) {
         media.currentTime = time;
-        if (this.state === State.IDLE) {
-          this.tick();
-        }
         return true;
       }
     }
@@ -199,27 +197,7 @@ export class IFrameStreamController extends StreamController {
     this.currentOp = this.nextOp = undefined;
     this.state = State.STOPPED;
     if (currentOp?.[1].seekOnAppend) {
-      if (!nextOp) {
-        // Remove buffered ranges beyond the target's and signal EOS before
-        // seeking: a lone keyframe followed by a gap does not render
-        const media = this.media;
-        if (media) {
-          const bufferInfo = BufferHelper.bufferInfo(media, currentOp[0], 0);
-          const nextRangeStart = bufferInfo.len ? bufferInfo.nextStart : 0;
-          if (nextRangeStart) {
-            // Evict now so queued operations do not seek into removed ranges
-            this.fragmentTracker.removeFragmentsInRange(
-              nextRangeStart,
-              Infinity,
-              PlaylistLevelType.MAIN,
-            );
-            this.flushMainBuffer(nextRangeStart, Infinity);
-          }
-        }
-        // (onBufferedToEnd re-runs the seek if EOS completes after it)
-        this.hls.once(Events.BUFFERED_TO_END, this.onBufferedToEnd);
-      }
-      this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
+      this.flushPipeline(currentOp[0], !nextOp);
       if (!this.seekTo(currentOp[0])) {
         this.log(
           `Could not seek to ${currentOp[0]} after fragment buffered (superseded or flushed) buffer: ${this.media ? timeRangesToString(BufferHelper.getBuffered(this.media)) : 'none'}`,
@@ -229,6 +207,30 @@ export class IFrameStreamController extends StreamController {
     if (nextOp) {
       this.loadMediaAt.apply(this, nextOp);
     }
+  }
+
+  private flushPipeline(time: number, removeDisjointRanges: boolean) {
+    if (removeDisjointRanges) {
+      // Remove buffered ranges beyond the target's and signal EOS before
+      // seeking: a lone keyframe followed by a gap does not render
+      const media = this.media;
+      if (media) {
+        const bufferInfo = BufferHelper.bufferInfo(media, time, 0);
+        const nextRangeStart = bufferInfo.len ? bufferInfo.nextStart : 0;
+        if (nextRangeStart) {
+          // Evict now so queued operations do not seek into removed ranges
+          this.fragmentTracker.removeFragmentsInRange(
+            nextRangeStart,
+            Infinity,
+            PlaylistLevelType.MAIN,
+          );
+          this.flushMainBuffer(nextRangeStart, Infinity);
+        }
+      }
+      // (onBufferedToEnd re-runs the seek if EOS completes after it)
+      this.hls.once(Events.BUFFERED_TO_END, this.onBufferedToEnd);
+    }
+    this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
   }
 
   private onBufferedToEnd = () => {

--- a/src/controller/iframe-stream-controller.ts
+++ b/src/controller/iframe-stream-controller.ts
@@ -218,8 +218,8 @@ export class IFrameStreamController extends StreamController {
         }
         // (onBufferedToEnd re-runs the seek if EOS completes after it)
         this.hls.once(Events.BUFFERED_TO_END, this.onBufferedToEnd);
-        this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       }
+      this.hls.trigger(Events.BUFFER_EOS, { type: 'video' });
       if (!this.seekTo(currentOp[0])) {
         this.log(
           `Could not seek to ${currentOp[0]} after fragment buffered (superseded or flushed) buffer: ${this.media ? timeRangesToString(BufferHelper.getBuffered(this.media)) : 'none'}`,

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -556,11 +556,11 @@ export default class StreamController
       PlaylistLevelType.MAIN,
       0,
     );
-    if (bufferInfo === null || bufferInfo.len === 0) {
-      this.warn(
-        `Main forward buffer length at ${currentTime} on "seeked" event ${
-          bufferInfo ? bufferInfo.len : 'empty'
-        })`,
+    if (!bufferInfo || bufferInfo.len === 0) {
+      this.log(
+        `Main buffer empty at ${currentTime} on "seeked" event: ${
+          bufferInfo ? bufferInfo.len : bufferInfo
+        }`,
       );
       return;
     }

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -840,6 +840,86 @@ describe('BufferController with attached media', function () {
         'Cannot remove invalid range (9001 >= 9000) from the audio SourceBuffer',
       );
     });
+
+    it('advances the queue without removing when start is at/after mediaSource.duration', function () {
+      // endOfStream() clamps mediaSource.duration below the requested flush start
+      (bufferController as any).mediaSource.duration = 9;
+
+      hls.trigger(Events.BUFFER_FLUSHING, {
+        startOffset: 11,
+        endOffset: Infinity,
+        type: 'video',
+      });
+
+      const buffer = getSourceBufferTrack(bufferController, 'video')?.buffer;
+      expect(buffer).to.not.be.undefined;
+      if (!buffer) {
+        return;
+      }
+      // No SourceBuffer.remove(): no 'updateend' will fire for this operation
+      expect(
+        buffer.remove,
+        'remove should not be called when start is at/after duration',
+      ).to.not.have.been.called;
+      // Regression guard: the queue must still advance (previously locked here)
+      expect(
+        shiftAndExecuteNextSpy,
+        'the queue must advance even though remove was skipped',
+      ).to.have.been.calledOnce;
+      // onComplete still signals a (no-op) flush
+      expect(triggerSpy).to.have.been.calledWith(Events.BUFFER_FLUSHED, {
+        type: 'video',
+        start: 11,
+        end: Infinity,
+      });
+    });
+
+    it('does not block a following queued operation when start is at/after mediaSource.duration', function () {
+      (bufferController as any).mediaSource.duration = 9;
+      const videoQueue = (operationQueue as any).queues
+        .video as BufferOperation[];
+
+      // Occupy the head so subsequently-queued ops accumulate behind it
+      // (direct push does not auto-execute)
+      videoQueue.push({
+        label: 'head',
+        execute: () => {},
+        onStart: () => {},
+        onComplete: () => {},
+        onError: () => {},
+      });
+
+      // Queues the no-op remove behind the head (queue length > 1, no auto-exec)
+      hls.trigger(Events.BUFFER_FLUSHING, {
+        startOffset: 11,
+        endOffset: Infinity,
+        type: 'video',
+      });
+
+      // Queue a following operation behind the remove
+      const nextExecute = sandbox.spy();
+      videoQueue.push({
+        label: 'next',
+        execute: nextExecute,
+        onStart: () => {},
+        onComplete: () => {},
+        onError: () => {},
+      });
+
+      expect(videoQueue.map((op) => op.label)).to.deep.equal([
+        'head',
+        'remove',
+        'next',
+      ]);
+
+      // Complete the head op: cascades to the no-op remove, then to next
+      (operationQueue as any).shiftAndExecuteNext('video');
+
+      expect(
+        nextExecute,
+        'the operation queued behind the no-op remove must execute',
+      ).to.have.been.calledOnce;
+    });
   });
 
   describe('trimBuffers', function () {


### PR DESCRIPTION
### This PR will...
Limit I-Frame stream controller forward buffer to one seconds and always flush renderer using EOS.

### Why is this Pull Request needed?
Prevents stream-controller tick logic from loading subsequent segments more than one second past `loadMediaAt` input time, and forces renderer to flush after each append.

### Are there any points in the code the reviewer needs to double check?
Follow-up to #7930 

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
