### PR TITLE
Handle init segment load context change gracefully

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -18,6 +18,7 @@ import {
   type Part,
 } from '../loader/fragment';
 import FragmentLoader, { getAESAdjustments } from '../loader/fragment-loader';
+import { LoadError } from '../loader/fragment-loader';
 import TaskLoop from '../task-loop';
 import { PlaylistLevelType } from '../types/loader';
 import { ChunkMetadata } from '../types/transmuxer';
@@ -50,10 +51,7 @@ import type { FragmentTracker } from './fragment-tracker';
 import type { HlsAssetPlayer } from './interstitial-player';
 import type TransmuxerInterface from '../demux/transmuxer-interface';
 import type Hls from '../hls';
-import type {
-  FragmentLoadProgressCallback,
-  LoadError,
-} from '../loader/fragment-loader';
+import type { FragmentLoadProgressCallback } from '../loader/fragment-loader';
 import type KeyLoader from '../loader/key-loader';
 import type { LevelDetails } from '../loader/level-details';
 import type { SourceBufferName } from '../types/buffer';
@@ -716,13 +714,19 @@ export default class BaseStreamController
     return this.initFragmentLoader
       .load(initFrag)
       .then((data) => {
-        const frag = data?.frag;
+        const frag = data.frag;
         if (
-          !frag ||
-          !fragmentsAreEqual(frag, this.fragCurrent?.initSegment) ||
-          !this.levels
+          !this.levels ||
+          !fragmentsAreEqual(frag, this.fragCurrent?.initSegment)
         ) {
-          throw new Error('init load aborted');
+          throw new LoadError({
+            type: ErrorTypes.NETWORK_ERROR,
+            details: ErrorDetails.INTERNAL_ABORTED,
+            error: new Error('init load aborted'),
+            fatal: false,
+            frag,
+            networkDetails: null,
+          });
         }
         return data;
       })

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -891,11 +891,18 @@ export default class InterstitialsController
       const assetPlayer = player as HlsAssetPlayer;
       const timelineStart = assetPlayer.assetItem.timelineStart;
       if (timelineStart) {
+        const assetHls = assetPlayer.hls!;
         const timePastStart = Math.max(
           this.timelinePos - timelineStart,
           Number.EPSILON,
         );
-        assetPlayer.hls!.config.startPosition = timePastStart;
+        if (assetHls.startPosition !== timePastStart) {
+          this.log(`Set ${assetPlayer} startPosition: ${timePastStart}`);
+          assetHls.config.startPosition = timePastStart;
+          if (assetHls.loadingEnabled) {
+            assetHls.startLoad(timePastStart);
+          }
+        }
       }
     }
     player.attachMedia(dataToAttach);

--- a/tests/unit/controller/base-stream-controller.ts
+++ b/tests/unit/controller/base-stream-controller.ts
@@ -995,6 +995,50 @@ describe('BaseStreamController', function () {
           resetFragmentLoadingStub.restore();
         });
     });
+
+    it('loadInitSegmentIfNeeded handles init segment context switch before abort load errors', function () {
+      const { mediaFrag, initSegment } = createMediaFragWithInitSegment(false);
+      baseStreamController.state = State.FRAG_LOADING;
+      (baseStreamController as any).levels = [{}];
+
+      // The in-flight init request resolves successfully
+      sinon
+        .stub((baseStreamController as any).initFragmentLoader, 'load')
+        .resolves({ frag: initSegment } as any);
+
+      // context changed before loadInitSegmentIfNeeded is resolved
+      baseStreamController.fragCurrent = null;
+
+      const errorSpy = sinon.spy();
+      hls.on(Hls.Events.ERROR, errorSpy);
+
+      // expect error to be routed through handleFragLoadError
+      const initDataPromise = (
+        baseStreamController as any
+      ).loadInitSegmentIfNeeded(mediaFrag);
+      expect(
+        initDataPromise,
+        'loadInitSegmentIfNeeded should return a promise',
+      ).to.be.a('promise');
+
+      return initDataPromise
+        .catch((error) =>
+          (baseStreamController as any).handleFragLoadError(error),
+        )
+        .then(() => {
+          const fatalInternalException = errorSpy
+            .getCalls()
+            .some(
+              (call) =>
+                call.args[1]?.details === ErrorDetails.INTERNAL_EXCEPTION &&
+                call.args[1]?.fatal === true,
+            );
+          expect(
+            fatalInternalException,
+            'init-segment load abort must not be reported as a fatal INTERNAL_EXCEPTION',
+          ).to.equal(false);
+        });
+    });
   });
 
   describe('backtrackFragment and couldBacktrack properties', function () {


### PR DESCRIPTION
### This PR will...
- Fix the fatal error escalation described in #7931
- Force live-join midroll asset loading from start position on attach when already started at a different position

### Why is this Pull Request needed?
A. Handles a case where switch down caused by delayed loading of an init segment could result in a fatal error breaking playback.
B . Handles case where preloading start of a midroll before attach, prevents seek-to-start when a later startPosition is set just prior to attach.

### Resolves issues:
Fixes for error paths A and B of #7931

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
