### PR TITLE
fix(abr): guard abandon-rules check after destroy

### DIFF
--- a/src/controller/abr-controller.ts
+++ b/src/controller/abr-controller.ts
@@ -239,6 +239,9 @@ class AbrController extends Logger implements AbrComponentAPI {
     */
   private _abandonRulesCheck = (levelLoaded?: Level) => {
     const { fragCurrent: frag, partCurrent: part, hls } = this;
+    if (!hls) {
+      return;
+    }
     const { autoLevelEnabled, media } = hls;
     if (!frag || !media) {
       return;

--- a/tests/unit/controller/abr-controller.ts
+++ b/tests/unit/controller/abr-controller.ts
@@ -47,6 +47,16 @@ describe('AbrController', function () {
     hls.destroy();
   });
 
+  describe('destroy', function () {
+    it('does not throw when a queued abandon-rules callback runs after destroy', function () {
+      const abandonRulesCheck = (abrController as any)._abandonRulesCheck;
+
+      hls.destroy();
+
+      expect(() => abandonRulesCheck()).not.to.throw();
+    });
+  });
+
   describe('resetEstimator', function () {
     it('estimate can be reset with new value', function () {
       const { abrEwmaDefaultEstimate } = hls.config;

--- a/tests/unit/controller/abr-controller.ts
+++ b/tests/unit/controller/abr-controller.ts
@@ -48,7 +48,7 @@ describe('AbrController', function () {
   });
 
   describe('destroy', function () {
-    it('does not throw when a queued abandon-rules callback runs after destroy', function () {
+    it('does not throw when an abandon-rules callback runs after destroy', function () {
       const abandonRulesCheck = (abrController as any)._abandonRulesCheck;
 
       hls.destroy();


### PR DESCRIPTION
## Summary

- return early when an ABR abandon-rules check reaches a controller whose HLS reference has been released
- add a regression test that invokes the retained callback after `hls.destroy()`

## Observed behavior

The following exception was observed in Chrome 149 Stable on macOS while rapidly switching live HLS sources:

```
Uncaught TypeError: Cannot read properties of null (reading 'autoLevelEnabled')
    at AbrController._abandonRulesCheck (abr-controller.ts:244)
```

Original application-side workaround:
https://github.com/AmPlace/waveflow/commit/e4fdbde64bec72ec360e297bd3901be8cd793c52

The exact browser scheduling or re-entrant path that causes the post-destroy invocation has not been isolated.

## Confirmed failure path

`AbrController.destroy()` releases references by setting `this.hls` to `null`. `_abandonRulesCheck` currently dereferences `hls.autoLevelEnabled` without checking whether the controller has already been destroyed.

The callback now returns when the controller no longer has an HLS instance. Active ABR behavior is unchanged. The regression test covers safe behavior after destroy; it does not claim to reproduce the macOS browser timing.

Fixes #7937

## Checks

- `npm run type-check`
- `npx eslint src/controller/abr-controller.ts tests/unit/controller/abr-controller.ts`
- `npx prettier --check src/controller/abr-controller.ts tests/unit/controller/abr-controller.ts`
- Rollup builds, TypeScript declaration build, and API Extractor
- `npx es-check`
- built-bundle smoke check invoking a retained `_abandonRulesCheck` callback after `hls.destroy()`