### PR TITLE
Support muxed audio+video fMP4 and multi-trun I-Frame fragments

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -9,6 +9,8 @@ import { type ILogger, Logger } from '../utils/logger';
 import {
   patchEncyptionData,
   truncateIFrameMoofToSamples,
+  videoOnlyIFrameMoof,
+  videoOnlyInitSegment,
   writeUint32,
 } from '../utils/mp4-tools';
 import { getSampleData, parseInitSegment } from '../utils/mp4-tools';
@@ -45,6 +47,8 @@ class PassThroughRemuxer extends Logger implements Remuxer {
   private initTracks?: TrackSet;
   private lastEndTime: number | null = null;
   private isVideoContiguous: boolean = false;
+  private videoOnlyRemux: boolean = false;
+  private decryptdata: DecryptData | null = null;
 
   constructor(
     observer: HlsEventEmitter,
@@ -91,6 +95,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
   ) {
     this.audioCodec = audioCodec;
     this.videoCodec = videoCodec;
+    this.decryptdata = decryptdata;
     this.generateInitSegment(initSegment, decryptdata);
     this.emitInitSegment = true;
   }
@@ -99,6 +104,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
     initSegment: Uint8Array<ArrayBuffer> | undefined,
     decryptdata?: DecryptData | null,
   ) {
+    this.videoOnlyRemux = false;
     let { audioCodec, videoCodec } = this;
     if (!initSegment?.byteLength) {
       this.initTracks = undefined;
@@ -197,7 +203,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
 
     // The binary segment data is added to the videoTrack in the mp4demuxer. We don't check to see if the data is only
     // audio or video (or both); adding it to video was an arbitrary choice.
-    const data = videoTrack.samples;
+    let data = videoTrack.samples;
     if (!data.length) {
       return result;
     }
@@ -216,6 +222,34 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       // We can't remux if the initSegment could not be generated
       this.warn('Failed to generate initSegment.');
       return result;
+    }
+    let excisedVideoOnly = false;
+    if (__USE_IFRAMES__ && chunkMeta.iframe) {
+      if (initData.audio && initData.video) {
+        // Video-only I-Frame appends must not starve a muxed audio track buffer
+        const muxedInit = this.initTracks?.audiovideo?.initSegment;
+        const videoInit = muxedInit ? videoOnlyInitSegment(muxedInit) : null;
+        if (videoInit) {
+          this.log(
+            'Converted muxed init segment to video-only for I-Frame playback',
+          );
+          this.generateInitSegment(videoInit, this.decryptdata);
+          if (this.initData?.length) {
+            initData = this.initData;
+            this.emitInitSegment = true;
+            this.videoOnlyRemux = true;
+          }
+        }
+      }
+      if (this.videoOnlyRemux && initData.video?.encrypted) {
+        // Encrypted moofs cannot be regenerated without losing senc/saiz/saio —
+        // splice the non-video trafs out of each muxed fragment in place instead
+        const videoOnlyData = videoOnlyIFrameMoof(data, initData.video.id);
+        if (videoOnlyData) {
+          data = videoOnlyData;
+          excisedVideoOnly = true;
+        }
+      }
     }
     if (this.emitInitSegment) {
       initSegment.tracks = this.initTracks;
@@ -294,17 +328,33 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       chunkMeta.iframe
     ) {
       const { trun, start } = videoSampleTimestamps;
-      if (trun.length === 1 && trun[0].samples.length) {
+      const singleRun = trun.length === 1;
+      const samples = !trun.length
+        ? []
+        : singleRun
+          ? trun[0].samples
+          : trun[0].samples.concat(...trun.slice(1).map((run) => run.samples));
+      if (samples.length) {
         const fragRun = trun[0];
-        const samples = fragRun.samples;
-        const { lastSampleDurationOffset, defaultSampleDurationOffset } =
-          fragRun;
+        let lastRun = fragRun;
+        for (let i = trun.length; i--; ) {
+          if (trun[i].samples.length) {
+            lastRun = trun[i];
+            break;
+          }
+        }
+        const lastSampleDurationOffset = lastRun.lastSampleDurationOffset;
+        const { defaultSampleDurationOffset } = fragRun;
         // Stretch samples to playlist time when the moof's
         // sample timing is off by more than 1/20s.
         const needsDurationAdjustment =
           Math.abs(chunkMeta.duration - (videoEndTime - videoStartTime)) > 0.05;
         const partialMdat = samples.length < videoSampleTimestamps.sampleCount;
-        const needsRemux = needsDurationAdjustment || partialMdat;
+        const needsRemux =
+          needsDurationAdjustment ||
+          partialMdat ||
+          this.videoOnlyRemux ||
+          !singleRun;
         const canRewriteInPlace =
           lastSampleDurationOffset !== undefined ||
           defaultSampleDurationOffset !== undefined;
@@ -312,18 +362,26 @@ class PassThroughRemuxer extends Logger implements Remuxer {
           // MP4 timing already spans EXTINF and every declared sample's
           // data is in the slice — pass through unchanged.
           duration = videoEndTime - videoStartTime;
-        } else if (initData.video.encrypted && canRewriteInPlace) {
+        } else if (
+          initData.video.encrypted &&
+          canRewriteInPlace &&
+          (!this.videoOnlyRemux || excisedVideoOnly)
+        ) {
           // Encrypted I-Frame: mutate the moof in place so senc /
           // saiz / saio (and any other moof/traf children) survive intact.
+          if (this.videoOnlyRemux) {
+            // Mark the excised fragment as remuxed for the drop-guard below
+            data1 = data.subarray(0);
+          }
           if (partialMdat) {
-            const totalSize = samples.reduce(
-              (sum, sample) => sum + sample.size,
-              0,
-            );
+            // End of the last in-range sample's bytes
+            const keepEndOffset =
+              lastRun.sampleOffset +
+              lastRun.samples.reduce((sum, sample) => sum + sample.size, 0);
             const mdatEnd = truncateIFrameMoofToSamples(
               data,
               samples.length,
-              totalSize,
+              keepEndOffset,
             );
             if (mdatEnd) {
               // End the appended stream on the rewritten mdat box boundary
@@ -409,8 +467,34 @@ class PassThroughRemuxer extends Logger implements Remuxer {
               id: videoTrack.id,
               samples: remuxedSamples,
             });
-            data2 = data.subarray(sampleOffset - 8, sampleOffset + totalSize);
-            writeUint32(data2, 0, totalSize + 8);
+            if (singleRun) {
+              data2 = data.subarray(sampleOffset - 8, sampleOffset + totalSize);
+              writeUint32(data2, 0, totalSize + 8);
+            } else {
+              // Gather each run's in-range sample bytes into one mdat
+              const mdat = new Uint8Array(8 + totalSize);
+              writeUint32(mdat, 0, mdat.byteLength);
+              mdat.set([0x6d, 0x64, 0x61, 0x74], 4); // 'mdat'
+              let write = 8;
+              for (let i = 0; i < trun.length; i++) {
+                const run = trun[i];
+                const runBytes = run.samples.reduce(
+                  (sum, sample) => sum + sample.size,
+                  0,
+                );
+                if (runBytes) {
+                  mdat.set(
+                    data.subarray(
+                      run.sampleOffset,
+                      run.sampleOffset + runBytes,
+                    ),
+                    write,
+                  );
+                  write += runBytes;
+                }
+              }
+              data2 = mdat;
+            }
           } else {
             this.warn(
               `Could not remux IFrame track fragment (sampleOffset ${sampleOffset}: totalSize: ${totalSize} bytes: ${data})`,
@@ -418,16 +502,16 @@ class PassThroughRemuxer extends Logger implements Remuxer {
             duration = videoEndTime - videoStartTime;
           }
         } else {
-          // Encrypted, but neither trun nor tfhd carries a duration we
-          // can rewrite (encoder relies on moov trex defaults).
+          // Encrypted without a rewritable trun or tfhd sample duration
+          // (moov trex defaults), or a muxed moof that could not be excised
           this.warn(
-            `IFrame remux skipped for encrypted segment without trun or tfhd sample_duration (sn ${chunkMeta.sn}); using native sample duration`,
+            `IFrame remux skipped for encrypted segment (sn ${chunkMeta.sn}); using native sample duration`,
           );
           duration = videoEndTime - videoStartTime;
         }
       } else {
         this.warn(
-          `Could not remux IFrame track fragment (trun count ${trun.length})`,
+          `Could not remux IFrame track fragment (no samples in range, trun count ${trun.length})`,
         );
         duration = videoEndTime - videoStartTime;
       }
@@ -435,6 +519,14 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       duration = syncOnAudio
         ? audioEndTime - audioStartTime
         : videoEndTime - videoStartTime;
+    }
+
+    if (__USE_IFRAMES__ && this.videoOnlyRemux && data1 === data) {
+      // Muxed data that was not remuxed cannot enter the video-only buffer
+      this.warn(
+        `Dropping muxed I-Frame fragment that could not be remuxed to video-only (sn: ${chunkMeta.sn})`,
+      );
+      return result;
     }
 
     const timescale = baseOffsetSamples.timescale;

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -22,6 +22,7 @@ export const types = {
   dinf: 0x64696e66,
   dref: 0x64726566,
   esds: 0x65736473,
+  free: 0x66726565,
   ftyp: 0x66747970,
   hdlr: 0x68646c72,
   mdat: 0x6d646174,
@@ -106,10 +107,26 @@ export function writeUint32(buffer: Uint8Array, offset: number, value: number) {
   buffer[offset + 3] = value & 0xff;
 }
 
+// Shrink a box to newPayloadSize + header, turning the remainder into a
+// nested 'free' box (Safari rejects trun/saiz boxes larger than their
+// declared sample count requires)
+function shrinkBox(data: Uint8Array, box: Uint8Array, newPayloadSize: number) {
+  const start = box.byteOffset - data.byteOffset - 8;
+  const newSize = 8 + newPayloadSize;
+  const tail = box.byteLength + 8 - newSize;
+  if (tail < 8) {
+    // No change needed, or the remainder is too small to hold a box header
+    return;
+  }
+  writeUint32(data, start, newSize);
+  writeUint32(data, start + newSize, tail);
+  writeUint32(data, start + newSize + 4, types.free);
+}
+
 export function truncateIFrameMoofToSamples(
   data: Uint8Array<ArrayBuffer>,
   keepSampleCount: number,
-  keepTotalSize: number,
+  keepEndOffset: number,
 ): number | undefined {
   const moofs = findBox(data, ['moof']);
   if (moofs.length !== 1) {
@@ -119,12 +136,39 @@ export function truncateIFrameMoofToSamples(
   const trafs = findBox(moof, ['traf']);
   for (let i = 0; i < trafs.length; i++) {
     const traf = trafs[i];
-    const trun = findBox(traf, ['trun'])[0];
-    if (trun) {
-      writeUint32(data, trun.byteOffset - data.byteOffset + 4, keepSampleCount);
+    // Distribute the kept sample count across the track fragment runs;
+    // runs left with no samples become 'free' boxes (parsers reject
+    // zero-sample truns)
+    let remaining = keepSampleCount;
+    const truns = findBox(traf, ['trun']);
+    for (let j = 0; j < truns.length; j++) {
+      const trun = truns[j];
+      const count = Math.min(remaining, readUint32(trun, 4));
+      if (count) {
+        writeUint32(data, trun.byteOffset - data.byteOffset + 4, count);
+        const flags = readUint32(trun, 0) & 0xffffff;
+        const perSample =
+          (flags & 0x100 ? 4 : 0) +
+          (flags & 0x200 ? 4 : 0) +
+          (flags & 0x400 ? 4 : 0) +
+          (flags & 0x800 ? 4 : 0);
+        shrinkBox(
+          data,
+          trun,
+          8 +
+            (flags & 0x01 ? 4 : 0) +
+            (flags & 0x04 ? 4 : 0) +
+            count * perSample,
+        );
+      } else {
+        writeUint32(data, trun.byteOffset - data.byteOffset - 4, types.free);
+      }
+      remaining -= count;
     }
     const senc = findBox(traf, ['senc'])[0];
     if (senc) {
+      // The size of a senc box cannot be validated without the tenc IV size,
+      // so rewriting the sample count alone is accepted
       writeUint32(data, senc.byteOffset - data.byteOffset + 4, keepSampleCount);
     }
     const saiz = findBox(traf, ['saiz'])[0];
@@ -134,24 +178,205 @@ export function truncateIFrameMoofToSamples(
       if (saizFlags & 0x01) {
         off += 8;
       }
+      const defaultSampleInfoSize = saiz[off];
       off += 1;
       writeUint32(
         data,
         saiz.byteOffset - data.byteOffset + off,
         keepSampleCount,
       );
+      shrinkBox(
+        data,
+        saiz,
+        off + 4 + (defaultSampleInfoSize === 0 ? keepSampleCount : 0),
+      );
     }
   }
   const mdats = findBox(data, ['mdat']);
   if (mdats.length === 1) {
-    writeUint32(
-      data,
-      mdats[0].byteOffset - data.byteOffset - 8,
-      8 + keepTotalSize,
-    );
+    const mdatStart = mdats[0].byteOffset - data.byteOffset - 8;
+    writeUint32(data, mdatStart, keepEndOffset - mdatStart);
     // Callers use the mdat end to exclude trailing partial-sample bytes
-    return mdats[0].byteOffset - data.byteOffset + keepTotalSize;
+    return keepEndOffset;
   }
+}
+
+// Video-only copy of an init segment, or null when there is no video track or nothing to remove
+export function videoOnlyInitSegment(
+  initSegment: Uint8Array<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> | null {
+  const moovs = findBox(initSegment, ['moov']);
+  if (moovs.length !== 1 || findBox(initSegment, ['moof']).length) {
+    return null;
+  }
+  const base = initSegment.byteOffset;
+  const boxRange = (box: Uint8Array): [number, number] => [
+    box.byteOffset - base - 8,
+    box.byteOffset - base + box.byteLength,
+  ];
+  const dropRanges: [number, number][] = [];
+  const dropTrackIds: number[] = [];
+  let hasVideo = false;
+  const traks = findBox(moovs[0], ['trak']);
+  for (let i = 0; i < traks.length; i++) {
+    const trak = traks[i];
+    const hdlr = findBox(trak, ['mdia', 'hdlr'])[0];
+    const handler = hdlr ? bin2str(hdlr.subarray(8, 12)) : '';
+    if (handler === 'vide') {
+      hasVideo = true;
+      continue;
+    }
+    const tkhd = findBox(trak, ['tkhd'])[0];
+    if (!tkhd) {
+      return null;
+    }
+    const version = tkhd[0];
+    dropTrackIds.push(readUint32(tkhd, version === 0 ? 12 : 20));
+    dropRanges.push(boxRange(trak));
+  }
+  if (!hasVideo || !dropRanges.length) {
+    return null;
+  }
+  const mvex = findBox(moovs[0], ['mvex'])[0];
+  let mvexDropped = 0;
+  if (mvex) {
+    const trexs = findBox(mvex, ['trex']);
+    for (let i = 0; i < trexs.length; i++) {
+      const trex = trexs[i];
+      if (dropTrackIds.indexOf(readUint32(trex, 4)) !== -1) {
+        dropRanges.push(boxRange(trex));
+        mvexDropped += trex.byteLength + 8;
+      }
+    }
+  }
+  // Splice out the dropped ranges, then patch sizes at their result offsets
+  dropRanges.sort((a, b) => a[0] - b[0]);
+  const dropped = dropRanges.reduce(
+    (sum, [start, end]) => sum + end - start,
+    0,
+  );
+  const droppedBefore = (offset: number) =>
+    dropRanges.reduce(
+      (sum, [start, end]) => (end <= offset ? sum + end - start : sum),
+      0,
+    );
+  const result = new Uint8Array(initSegment.byteLength - dropped);
+  let read = 0;
+  let write = 0;
+  for (let i = 0; i < dropRanges.length; i++) {
+    const [start, end] = dropRanges[i];
+    result.set(initSegment.subarray(read, start), write);
+    write += start - read;
+    read = end;
+  }
+  result.set(initSegment.subarray(read), write);
+  const moovStart = moovs[0].byteOffset - base - 8;
+  writeUint32(result, moovStart, moovs[0].byteLength + 8 - dropped);
+  if (mvex && mvexDropped) {
+    const mvexStart = mvex.byteOffset - base - 8;
+    writeUint32(
+      result,
+      mvexStart - droppedBefore(mvexStart),
+      mvex.byteLength + 8 - mvexDropped,
+    );
+  }
+  return result;
+}
+
+// Splice non-video track fragments out of a muxed I-Frame moof so encrypted
+// fragments keep their senc/saiz/saio boxes intact (regenerating the moof
+// would drop them). Returns null when the sample data offsets are not
+// moof-relative (default-base-is-moof, required of CMAF content).
+export function videoOnlyIFrameMoof(
+  data: Uint8Array<ArrayBuffer>,
+  videoTrackId: number,
+): Uint8Array<ArrayBuffer> | null {
+  const moofs = findBox(data, ['moof']);
+  if (moofs.length !== 1) {
+    return null;
+  }
+  const moof = moofs[0];
+  const base = data.byteOffset;
+  const dropRanges: [number, number][] = [];
+  let videoTraf: Uint8Array | null = null;
+  const trafs = findBox(moof, ['traf']);
+  for (let i = 0; i < trafs.length; i++) {
+    const traf = trafs[i];
+    const tfhd = findBox(traf, ['tfhd'])[0];
+    if (!tfhd) {
+      return null;
+    }
+    if (readUint32(tfhd, 4) === videoTrackId) {
+      if (!(readUint32(tfhd, 0) & 0x20000)) {
+        return null;
+      }
+      videoTraf = traf;
+    } else {
+      dropRanges.push([
+        traf.byteOffset - base - 8,
+        traf.byteOffset - base + traf.byteLength,
+      ]);
+    }
+  }
+  if (!videoTraf || !dropRanges.length) {
+    return null;
+  }
+  const dropped = dropRanges.reduce(
+    (sum, [start, end]) => sum + end - start,
+    0,
+  );
+  // The mdat moves up by everything dropped, the video traf and the senc
+  // payload its saio points to by what was dropped before the traf
+  const trafShift = dropRanges.reduce(
+    (sum, [start, end]) =>
+      end <= videoTraf!.byteOffset - base ? sum + end - start : sum,
+    0,
+  );
+  const result = new Uint8Array(data.byteLength - dropped);
+  let read = 0;
+  let write = 0;
+  for (let i = 0; i < dropRanges.length; i++) {
+    const [start, end] = dropRanges[i];
+    result.set(data.subarray(read, start), write);
+    write += start - read;
+    read = end;
+  }
+  result.set(data.subarray(read), write);
+  writeUint32(
+    result,
+    moof.byteOffset - base - 8,
+    moof.byteLength + 8 - dropped,
+  );
+  const truns = findBox(videoTraf, ['trun']);
+  for (let i = 0; i < truns.length; i++) {
+    const trun = truns[i];
+    if (readUint32(trun, 0) & 0x01) {
+      writeUint32(
+        result,
+        trun.byteOffset - base - trafShift + 8,
+        readUint32(trun, 8) - dropped,
+      );
+    }
+  }
+  if (trafShift) {
+    const saios = findBox(videoTraf, ['saio']);
+    for (let i = 0; i < saios.length; i++) {
+      const saio = saios[i];
+      const stride = saio[0] === 0 ? 4 : 8;
+      let offset = readUint32(saio, 0) & 0x01 ? 12 : 4;
+      let entries = readUint32(saio, offset);
+      for (offset += 4; entries--; offset += stride) {
+        // Patch the low word of each aux info offset
+        const at = offset + stride - 4;
+        writeUint32(
+          result,
+          saio.byteOffset - base - trafShift + at,
+          readUint32(saio, at) - trafShift,
+        );
+      }
+    }
+  }
+  return result;
 }
 
 export function hasBoxData(data: Uint8Array, type: BoxType): boolean {
@@ -659,7 +884,9 @@ export function patchEncyptionData(
     return;
   }
   const keyId = decryptdata.keyId;
-  if (keyId && decryptdata.isCommonEncryption) {
+  // FairPlay skd keys carry the key URI bytes as their keyId — only a 16 byte
+  // key id can be written into the tenc default_KID field
+  if (keyId?.byteLength === 16 && decryptdata.isCommonEncryption) {
     applyToTencBoxes(initSegment, (tenc, isAudio) => {
       // Look for default key id (keyID offset is always 8 within the tenc box):
       const tencKeyId = tenc.subarray(8, 24);

--- a/tests/unit/remux/passthrough-remuxer.ts
+++ b/tests/unit/remux/passthrough-remuxer.ts
@@ -6,7 +6,13 @@ import PassThroughRemuxer from '../../../src/remux/passthrough-remuxer';
 import { PlaylistLevelType } from '../../../src/types/loader';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
 import { logger } from '../../../src/utils/logger';
-import { appendUint8Array, findBox } from '../../../src/utils/mp4-tools';
+import {
+  appendUint8Array,
+  findBox,
+  parseInitSegment,
+  types,
+  writeUint32,
+} from '../../../src/utils/mp4-tools';
 import type { HlsEventEmitter } from '../../../src/events';
 import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
 import type {
@@ -50,6 +56,32 @@ describe('passthrough-remuxer', function () {
     }
     remuxer.resetInitSegment(initSegment, undefined, 'avc1.42001e', null);
 
+    return remuxer.remux(
+      audioTrack(),
+      passthroughTrack(fragmentData),
+      metadataTrack(),
+      userdataTrack(),
+      0,
+      true,
+      true,
+      PlaylistLevelType.MAIN,
+      new ChunkMetadata(
+        0,
+        0,
+        0,
+        fragmentData.byteLength,
+        -1,
+        false,
+        extinfDuration,
+        true,
+      ),
+    );
+  }
+
+  function remuxIFrame(
+    fragmentData: Uint8Array<ArrayBuffer>,
+    extinfDuration: number,
+  ) {
     return remuxer.remux(
       audioTrack(),
       passthroughTrack(fragmentData),
@@ -190,6 +222,123 @@ describe('passthrough-remuxer', function () {
     );
   });
 
+  it('converts muxed input to video-only for iframe fragments', function () {
+    const extinfDuration = 4;
+    const initSegment = MP4.initSegment([
+      videoInitTrack(),
+      audioInitTrack(),
+    ] as any);
+    remuxer.resetInitSegment(initSegment, 'mp4a.40.2', 'avc1.42001e', null);
+    // Video sample duration matches EXTINF: the muxed moof must still be
+    // regenerated so the audio track fragment is not appended
+    const fragmentData = muxedMp4Fragment(
+      [sample(extinfDuration * 90000, 24, 0)],
+      [50, 60],
+    );
+
+    const result = remuxer.remux(
+      audioTrack(),
+      passthroughTrack(fragmentData),
+      metadataTrack(),
+      userdataTrack(),
+      0,
+      true,
+      true,
+      PlaylistLevelType.MAIN,
+      new ChunkMetadata(
+        0,
+        0,
+        0,
+        fragmentData.byteLength,
+        -1,
+        false,
+        extinfDuration,
+        true,
+      ),
+    );
+
+    // The emitted init segment is converted to video-only
+    const videoInitTrackInfo = result.initSegment?.tracks?.video;
+    expect(videoInitTrackInfo, 'video init track').to.exist;
+    expect(result.initSegment?.tracks?.audiovideo, 'audiovideo init track').to
+      .not.exist;
+    const parsedInit = parseInitSegment(videoInitTrackInfo!.initSegment!);
+    expect(parsedInit.video, 'filtered init video').to.exist;
+    expect(parsedInit.audio, 'filtered init audio').to.not.exist;
+
+    // Video-only output: regenerated moof and an mdat with only video bytes
+    expect(result.video, 'video track').to.exist;
+    expect(result.video!.type).to.equal('video');
+    expect(result.video!.hasAudio).to.equal(false);
+    expect(result.video!.data1, 'data1 regenerated').to.not.equal(fragmentData);
+    expect(result.video!.data2!.byteLength, 'video-only mdat').to.equal(24 + 8);
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
+  });
+
+  it('remuxes muxed iframe fragments with the audio run first in the mdat', function () {
+    const extinfDuration = 4;
+    const initSegment = MP4.initSegment([
+      videoInitTrack(),
+      audioInitTrack(),
+    ] as any);
+    remuxer.resetInitSegment(initSegment, 'mp4a.40.2', 'avc1.42001e', null);
+    const fragmentData = muxedMp4Fragment(
+      [sample(3003, 24, 0)],
+      [50, 60],
+      true,
+    );
+
+    const result = remuxIFrame(fragmentData, extinfDuration);
+
+    expect(result.video, 'video track').to.exist;
+    expect(result.video!.type).to.equal('video');
+    expect(result.video!.data2!.byteLength, 'video-only mdat').to.equal(24 + 8);
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
+  });
+
+  it('remuxes iframe fragments with multiple video track fragment runs', function () {
+    const extinfDuration = 4;
+    const initSegment = MP4.initSegment([
+      videoInitTrack(),
+      audioInitTrack(),
+    ] as any);
+    remuxer.resetInitSegment(initSegment, 'mp4a.40.2', 'avc1.42001e', null);
+    const fragmentData = withSecondVideoTraf(
+      muxedMp4Fragment([sample(3003, 24, 0)], [50]),
+    );
+
+    const result = remuxIFrame(fragmentData, extinfDuration);
+
+    expect(result.video, 'video track').to.exist;
+    expect(result.video!.data2!.byteLength, 'gathered mdat').to.equal(24 + 8);
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
+  });
+
+  it('drops muxed iframe fragments with no video sample in range', function () {
+    const extinfDuration = 4;
+    const initSegment = MP4.initSegment([
+      videoInitTrack(),
+      audioInitTrack(),
+    ] as any);
+    remuxer.resetInitSegment(initSegment, 'mp4a.40.2', 'avc1.42001e', null);
+    // Audio-first layout sliced before the video sample: nothing can be
+    // appended to the video-only SourceBuffer
+    const fragmentData = muxedMp4Fragment([sample(3003, 24, 0)], [50], true);
+    const moofSize = findBox(fragmentData, ['moof'])[0].byteLength + 8;
+    const partialFragment = fragmentData.subarray(0, moofSize + 8 + 30);
+
+    const result = remuxIFrame(partialFragment, extinfDuration);
+
+    expect(result.initSegment?.tracks?.video, 'video init track').to.exist;
+    expect(result.video, 'video track').to.equal(undefined);
+  });
+
   it('truncates encrypted partial-mdat iframe fragments on the mdat box boundary', function () {
     const extinfDuration = 4;
     const samples = [sample(3003, 10, 0), sample(3003, 20, 0)];
@@ -277,6 +426,101 @@ function videoInitTrack(): any {
     width: 16,
     height: 16,
   };
+}
+
+function audioInitTrack(): any {
+  return {
+    codec: 'mp4a.40.2',
+    segmentCodec: 'aac',
+    channelCount: 2,
+    samplerate: 48000,
+    config: [0x11, 0x90],
+    duration: 4,
+    id: 2,
+    timescale: 48000,
+    type: 'audio',
+  };
+}
+
+// moof with a video traf (track 1) and an audio traf (track 2) sharing one
+// mdat: video run first, audio run after (ffmpeg muxed fMP4 layout)
+function muxedMp4Fragment(
+  videoSamples: TrackFragmentSample[],
+  audioSampleSizes: number[],
+  audioFirst = false,
+): Uint8Array<ArrayBuffer> {
+  const videoBytes = videoSamples.reduce((total, s) => total + s.size, 0);
+  const audioBytes = audioSampleSizes.reduce((total, s) => total + s, 0);
+  const videoMoof = MP4.moof(0, 0, {
+    type: 'video',
+    id: 1,
+    samples: videoSamples,
+  });
+
+  const tfhd = new Uint8Array(8);
+  tfhd.set([0x00, 0x02, 0x00, 0x00]); // version 0, default-base-is-moof
+  writeUint32(tfhd, 4, 2); // track_ID
+  const tfdt = new Uint8Array(8);
+  const audioTrun = new Uint8Array(12 + audioSampleSizes.length * 8);
+  audioTrun.set([0x00, 0x00, 0x03, 0x01]); // data-offset + duration + size
+  writeUint32(audioTrun, 4, audioSampleSizes.length);
+  audioSampleSizes.forEach((size, i) => {
+    writeUint32(audioTrun, 12 + i * 8, 1024);
+    writeUint32(audioTrun, 12 + i * 8 + 4, size);
+  });
+  const audioTraf = MP4.box(
+    types.traf,
+    MP4.box(types.tfhd, tfhd),
+    MP4.box(types.tfdt, tfdt),
+    MP4.box(types.trun, audioTrun),
+  );
+
+  // Splice the audio traf into the moof, then patch the moof size and both
+  // trun data offsets for the combined mdat layout
+  const moof = new Uint8Array(videoMoof.byteLength + audioTraf.byteLength);
+  moof.set(videoMoof, 0);
+  moof.set(audioTraf, videoMoof.byteLength);
+  writeUint32(moof, 0, moof.byteLength);
+  const truns = findBox(moof, ['moof', 'traf', 'trun']);
+  writeUint32(
+    moof,
+    truns[0].byteOffset - moof.byteOffset + 8,
+    moof.byteLength + 8 + (audioFirst ? audioBytes : 0),
+  );
+  writeUint32(
+    moof,
+    truns[1].byteOffset - moof.byteOffset + 8,
+    moof.byteLength + 8 + (audioFirst ? 0 : videoBytes),
+  );
+
+  return appendUint8Array(
+    moof,
+    MP4.mdat(new Uint8Array(videoBytes + audioBytes)),
+  ) as Uint8Array<ArrayBuffer>;
+}
+
+// Appends a second (empty) video track fragment to the moof so the video
+// track has more than one trun
+function withSecondVideoTraf(
+  fragment: Uint8Array<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> {
+  const tfhd = new Uint8Array(8);
+  tfhd.set([0x00, 0x02, 0x00, 0x00]);
+  writeUint32(tfhd, 4, 1); // video track_ID
+  const trun = new Uint8Array(12);
+  trun[2] = 0x01; // data-offset present
+  const traf = MP4.box(
+    types.traf,
+    MP4.box(types.tfhd, tfhd),
+    MP4.box(types.trun, trun),
+  );
+  const moofSize = findBox(fragment, ['moof'])[0].byteLength + 8;
+  const result = new Uint8Array(fragment.byteLength + traf.byteLength);
+  result.set(fragment.subarray(0, moofSize), 0);
+  result.set(traf, moofSize);
+  result.set(fragment.subarray(moofSize), moofSize + traf.byteLength);
+  writeUint32(result, 0, moofSize + traf.byteLength);
+  return result;
 }
 
 function mp4Fragment(samples: TrackFragmentSample[]): Uint8Array<ArrayBuffer> {

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -7,8 +7,11 @@ import {
   appendUint8Array,
   findBox,
   getSampleData,
+  parseInitSegment,
   truncateIFrameMoofToSamples,
   types,
+  videoOnlyIFrameMoof,
+  videoOnlyInitSegment,
 } from '../../../src/utils/mp4-tools';
 import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
 import type { InitData } from '../../../src/utils/mp4-tools';
@@ -81,7 +84,11 @@ describe('mp4-tools', function () {
     const fragment = gopFragment();
     const mdatPayloadOffset = fragment.byteLength - 60;
 
-    const mdatEnd = truncateIFrameMoofToSamples(fragment, 1, 10);
+    const mdatEnd = truncateIFrameMoofToSamples(
+      fragment,
+      1,
+      mdatPayloadOffset + 10,
+    );
 
     expect(mdatEnd).to.equal(mdatPayloadOffset + 10);
     const trun = findBox(fragment, ['moof', 'traf', 'trun'])[0];
@@ -91,7 +98,261 @@ describe('mp4-tools', function () {
       'mdat box size',
     ).to.equal(18);
   });
+
+  it('truncateIFrameMoofToSamples distributes the kept count across runs', function () {
+    const fragment = multiRunIFrameMoof();
+    const mdatPayloadOffset = fragment.byteLength - 60;
+
+    const mdatEnd = truncateIFrameMoofToSamples(
+      fragment,
+      3,
+      mdatPayloadOffset + 25,
+    );
+
+    expect(mdatEnd).to.equal(mdatPayloadOffset + 25);
+    const truns = findBox(fragment, ['moof', 'traf', 'trun']);
+    expect(readUint32(truns[0], 4), 'first run count').to.equal(2);
+    expect(readUint32(truns[1], 4), 'second run count').to.equal(1);
+    // Boxes shrink to their kept count (Safari rejects oversized truns);
+    // the tail bytes become a nested 'free' box
+    expect(truns[0].byteLength, 'first run size').to.equal(20);
+    expect(truns[1].byteLength, 'second run shrunk').to.equal(16);
+    expect(indexOfFourcc(fragment, 'free')).to.be.greaterThan(0);
+    const senc = findBox(fragment, ['moof', 'traf', 'senc'])[0];
+    expect(readUint32(senc, 4), 'senc sample_count').to.equal(3);
+    expect(
+      readUint32(fragment, mdatPayloadOffset - 8),
+      'mdat box size',
+    ).to.equal(33);
+  });
+
+  it('truncateIFrameMoofToSamples frees runs left without samples', function () {
+    const fragment = multiRunIFrameMoof();
+    const mdatPayloadOffset = fragment.byteLength - 60;
+
+    truncateIFrameMoofToSamples(fragment, 1, mdatPayloadOffset + 10);
+
+    // Parsers reject zero-sample truns, so the emptied run becomes 'free'
+    const truns = findBox(fragment, ['moof', 'traf', 'trun']);
+    expect(truns, 'remaining truns').to.have.lengthOf(1);
+    expect(readUint32(truns[0], 4), 'first run count').to.equal(1);
+    expect(indexOfFourcc(fragment, 'free')).to.be.greaterThan(0);
+  });
+
+  it('videoOnlyInitSegment removes non-video tracks and patches box sizes', function () {
+    const muxed = MP4.initSegment([
+      videoInitTrack(1),
+      audioInitTrack(2),
+    ] as any);
+    const muxedParsed = parseInitSegment(muxed);
+    expect(muxedParsed.audio, 'muxed audio').to.exist;
+    expect(muxedParsed.video, 'muxed video').to.exist;
+
+    const filtered = videoOnlyInitSegment(muxed);
+    expect(filtered, 'filtered').to.not.equal(null);
+    expect(filtered!.byteLength).to.be.lessThan(muxed.byteLength);
+    const parsed = parseInitSegment(filtered!);
+    expect(parsed.video, 'video track').to.exist;
+    expect(parsed.audio, 'audio track').to.equal(undefined);
+    expect(findBox(filtered!, ['moov', 'trak'])).to.have.lengthOf(1);
+    expect(findBox(filtered!, ['moov', 'mvex', 'trex'])).to.have.lengthOf(1);
+
+    // Nothing to remove from a video-only init
+    expect(videoOnlyInitSegment(filtered!)).to.equal(null);
+  });
+
+  it('videoOnlyIFrameMoof removes non-video track fragments and patches offsets', function () {
+    const fragment = muxedIFrameMoof(1, 2);
+    const audioTrafSize = trafSize(fragment, 2);
+    const sencOffset = indexOfFourcc(fragment, 'senc');
+    const moofSize = readUint32(fragment, 0);
+
+    const result = videoOnlyIFrameMoof(fragment, 1);
+
+    expect(result, 'result').to.not.equal(null);
+    expect(result!.byteLength).to.equal(fragment.byteLength - audioTrafSize);
+    expect(findBox(result!, ['moof', 'traf'])).to.have.lengthOf(1);
+    expect(readUint32(result!, 0), 'moof size').to.equal(
+      moofSize - audioTrafSize,
+    );
+    const trun = findBox(result!, ['moof', 'traf', 'trun'])[0];
+    expect(readUint32(trun, 8), 'trun data_offset').to.equal(
+      1000 - audioTrafSize,
+    );
+    // The video traf did not move, so its interior is untouched
+    expect(indexOfFourcc(result!, 'senc')).to.equal(sencOffset);
+    const saio = findBox(result!, ['moof', 'traf', 'saio'])[0];
+    expect(readUint32(saio, 8), 'saio offset').to.equal(0x99);
+    expect(indexOfFourcc(result!, 'mdat')).to.be.greaterThan(0);
+  });
+
+  it('videoOnlyIFrameMoof shifts video traf offsets when it follows a dropped traf', function () {
+    const fragment = muxedIFrameMoof(2, 1);
+    const audioTrafSize = trafSize(fragment, 2);
+
+    const result = videoOnlyIFrameMoof(fragment, 1);
+
+    expect(result, 'result').to.not.equal(null);
+    expect(findBox(result!, ['moof', 'traf'])).to.have.lengthOf(1);
+    const trun = findBox(result!, ['moof', 'traf', 'trun'])[0];
+    expect(readUint32(trun, 8), 'trun data_offset').to.equal(
+      1030 - audioTrafSize,
+    );
+    // saio points at the senc payload, which moved up with the traf
+    const saio = findBox(result!, ['moof', 'traf', 'saio'])[0];
+    expect(readUint32(saio, 8), 'saio offset').to.equal(0x99 - audioTrafSize);
+  });
+
+  it('videoOnlyIFrameMoof returns null without moof-relative data offsets', function () {
+    expect(videoOnlyIFrameMoof(muxedIFrameMoof(1, 2, false), 1)).to.equal(null);
+  });
 });
+
+// Track fragment with per-sample sizes and senc/saio (one aux info offset)
+function cryptoTraf(
+  trackId: number,
+  tfhdFlags: number,
+  dataOffset: number,
+): Uint8Array {
+  return MP4.box(
+    types.traf,
+    MP4.box(
+      types.tfhd,
+      appendBytes(fullBoxHeader(tfhdFlags), uint32(trackId), uint32(1001)),
+    ),
+    MP4.box(
+      types.trun,
+      appendBytes(
+        fullBoxHeader(0x201),
+        uint32(2),
+        uint32(dataOffset),
+        uint32(10),
+        uint32(20),
+      ),
+    ),
+    MP4.box(
+      0x73656e63, // 'senc'
+      appendBytes(fullBoxHeader(0), uint32(2), uint32(0x11223344)),
+    ),
+    MP4.box(
+      0x7361696f, // 'saio'
+      appendBytes(fullBoxHeader(0), uint32(1), uint32(0x99)),
+    ),
+  );
+}
+
+// moof with two encrypted track fragments followed by an mdat
+function muxedIFrameMoof(
+  firstTrackId: number,
+  secondTrackId: number,
+  baseIsMoof: boolean = true,
+): Uint8Array<ArrayBuffer> {
+  const tfhdFlags = (baseIsMoof ? 0x020000 : 0) | 0x000008;
+  const moof = MP4.box(
+    types.moof,
+    MP4.box(types.mfhd, appendBytes(fullBoxHeader(0), uint32(1))),
+    cryptoTraf(firstTrackId, tfhdFlags, 1000),
+    cryptoTraf(secondTrackId, tfhdFlags, 1030),
+  );
+  return appendUint8Array(moof, MP4.mdat(new Uint8Array(60)));
+}
+
+// moof with one track fragment holding two runs (2 + 3 samples) and a senc
+function multiRunIFrameMoof(): Uint8Array<ArrayBuffer> {
+  const traf = MP4.box(
+    types.traf,
+    MP4.box(
+      types.tfhd,
+      appendBytes(fullBoxHeader(0x020008), uint32(1), uint32(1001)),
+    ),
+    MP4.box(
+      types.trun,
+      appendBytes(
+        fullBoxHeader(0x201),
+        uint32(2),
+        uint32(1000),
+        uint32(10),
+        uint32(15),
+      ),
+    ),
+    MP4.box(
+      types.trun,
+      appendBytes(
+        fullBoxHeader(0x201),
+        uint32(3),
+        uint32(1050),
+        uint32(5),
+        uint32(5),
+        uint32(5),
+      ),
+    ),
+    MP4.box(
+      0x73656e63, // 'senc'
+      appendBytes(fullBoxHeader(0), uint32(5), uint32(0x11223344)),
+    ),
+  );
+  const moof = MP4.box(
+    types.moof,
+    MP4.box(types.mfhd, appendBytes(fullBoxHeader(0), uint32(1))),
+    traf,
+  );
+  return appendUint8Array(moof, MP4.mdat(new Uint8Array(60)));
+}
+
+function trafSize(fragment: Uint8Array, trackId: number): number {
+  const trafs = findBox(fragment, ['moof', 'traf']);
+  for (let i = 0; i < trafs.length; i++) {
+    const tfhd = findBox(trafs[i], ['tfhd'])[0];
+    if (readUint32(tfhd, 4) === trackId) {
+      return trafs[i].byteLength + 8;
+    }
+  }
+  return 0;
+}
+
+function indexOfFourcc(data: Uint8Array, fourcc: string): number {
+  for (let i = 0; i < data.byteLength - 3; i++) {
+    if (
+      data[i] === fourcc.charCodeAt(0) &&
+      data[i + 1] === fourcc.charCodeAt(1) &&
+      data[i + 2] === fourcc.charCodeAt(2) &&
+      data[i + 3] === fourcc.charCodeAt(3)
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function videoInitTrack(id: number): any {
+  return {
+    codec: 'avc1.42001e',
+    segmentCodec: 'avc',
+    duration: 4,
+    id,
+    pixelRatio: [1, 1],
+    pps: [new Uint8Array([0x68, 0xce, 0x06, 0xe2])],
+    sps: [new Uint8Array([0x67, 0x42, 0x00, 0x1e, 0xab, 0x40])],
+    timescale: 90000,
+    type: 'video',
+    width: 16,
+    height: 16,
+  };
+}
+
+function audioInitTrack(id: number): any {
+  return {
+    codec: 'mp4a.40.2',
+    segmentCodec: 'aac',
+    channelCount: 2,
+    samplerate: 48000,
+    config: [0x11, 0x90],
+    duration: 4,
+    id,
+    timescale: 48000,
+    type: 'audio',
+  };
+}
 
 // moof + mdat with three samples (per-sample duration, size, flags and cts)
 // of sizes 10/20/30


### PR DESCRIPTION
### This PR will...

- Convert muxed audio+video fMP4 init segments to video-only when transmuxing I-Frame fragments, so a video SourceBuffer is created instead of an `audiovideo` buffer that video-only appends can never satisfy. `videoOnlyInitSegment()` splices the non-video traks and their trex out of the init in a single allocation, and re-parsing the filtered init drops the audio track from all downstream handling. Muxed fragment data is always remuxed to video-only; fragments that cannot be are dropped with a warning rather than appended.
- Collect I-Frame samples across multiple track fragment runs. This fix is independent of muxing: fragments with more than one trun skipped I-Frame handling entirely and were appended as loaded — for byte-range I-Frames (always a truncated mdat) that appends a moof declaring samples whose bytes are absent. Apple's mediafilesegmenter emits multiple runs per traf in both muxed and video-only output.
- Support encrypted muxed fragments. The moof cannot be regenerated without losing `senc`/`saiz`/`saio`, so `videoOnlyIFrameMoof()` splices the non-video trafs out in place, patching the moof size and the trun data and saio offsets. The in-place truncation now distributes the kept sample count across runs and shrinks `trun`/`saiz` boxes to fit, rewriting remainders and emptied runs as `free` boxes — This is need because Safari rejects those boxes when larger than their sample count requires. note: after this PR, the only refused layout is sample data offsets that are not moof-relative (default-base-is-moof, required of CMAF content and already assumed throughout the byte-range I-Frame pipeline).
- Fix `patchEncyptionData` throwing a RangeError on zero-KID inits when the playlist key is FairPlay-only: skd keys carry the key URI bytes as their keyId, which cannot be written into the 16-byte tenc default_KID field. Apple's mediafilesegmenter writes zero KIDs, so any of its SAMPLE-AES output reaches this.

### Why is this Pull Request needed?

This PR tries to address the following two "Known issues" from #7757:
- Muxed mp4 is not supported. An "audiovideo" sourcebuffer is created for muxed mp4 init segments. Editing mp4 init segments is currently missing, as is remuxing and dropping audio in muxed fmp4 media segments.
- Some mp4 I-Frame segment content has multiple track fragment runs which are not supported

Verified on five muxed test streams built for this PR (PBS test pattern with burned-in timecode for frame identity):

- https://pbs.github.io/test-streams/pbs/test-pattern-muxed-fmp4/pbs-bars_muxed-avc.m3u8 (ffmpeg, AVC 720p/432p)
- https://pbs.github.io/test-streams/pbs/test-pattern-muxed-fmp4/pbs-bars_muxed-hevc.m3u8 (ffmpeg, HEVC 720p)
- https://pbs.github.io/test-streams/pbs/test-pattern-muxed-fmp4/pbs-bars_muxed-hevc-apple.m3u8 (Apple mediafilesegmenter with its own I-Frame index; interleaved multi-trun trafs)
- https://pbs.github.io/test-streams/pbs/test-pattern-muxed-fmp4/pbs-bars_muxed-avc-cbcs.m3u8 (CBCS-encrypted with Bento4 mp4encrypt, single-file byterange; licenses through Axinom's public Widevine server with the key in that repo's README)
- https://pbs.github.io/test-streams/pbs/test-pattern-muxed-fmp4/pbs-bars_muxed-avc-apple-cbcs.m3u8 (mediafilesegmenter-packaged interleaved multi-trun, CBCS-encrypted; the encrypted multi-run path)

### Are there any points in the code the reviewer needs to double check?

- The init conversion happens per I-Frame chunk in `remux()` (the init is not identifiable as I-Frame content until `chunkMeta.iframe` is seen) and is cached through `generateInitSegment`. The traf excision runs per fragment, keyed on `videoOnlyRemux`, since later fragments arrive with the init already converted.
- Safari's parser rejects `trun`/`saiz` boxes sized larger than their rewritten sample count requires; `senc` sizes cannot be validated without the tenc IV size and the count rewrite alone is accepted there.
- `videoOnlyIFrameMoof` returning null (no moof-relative offsets) makes an existing pipeline-wide assumption explicit — such content never worked in the byte-range I-Frame path. The fragment then falls through to the drop-guard rather than appending muxed bytes.
- Multiple video runs force `needsRemux` even when timing spans EXTINF — a multi-run moof cannot pass through unchanged, since audio run bytes sit between the video runs in the mdat (clear content regenerates the moof; encrypted content is rewritten in place).
- `resetInitSegment`'s `decryptdata` is retained so the regenerated video-only init is patched like the original.

### Resolves issues:

No open issue tracks this

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (multiple unit tests across mp4-tools and the passthrough remuxer)
- [] API or design changes are documented in API.md
