### PR TITLE
Fix live resumption estimate from preroll

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1539,6 +1539,10 @@ export default class BaseStreamController
         );
         return null;
       }
+      if (!this.startFragRequested && canLoadParts && !this.loadingParts) {
+        this.log(`LL-Part loading ON for initial live fragment`);
+        this.loadingParts = true;
+      }
       // The real fragment start times for a live stream are only known after the PTS range for that level is known.
       // In order to discover the range, we load the best matching fragment for that level and demux it.
       // Do not load using live logic if the starting frag is requested - we want to use getFragmentAtPosition() so that
@@ -1549,10 +1553,6 @@ export default class BaseStreamController
           this.startPosition === -1) ||
         pos < playlistStart
       ) {
-        if (canLoadParts && !this.loadingParts) {
-          this.log(`LL-Part loading ON for initial live fragment`);
-          this.loadingParts = true;
-        }
         frag = this.getInitialLiveFragment(levelDetails);
         const configValue = this.config.startPosition;
         const mainStart = this.hls.startPosition;
@@ -2765,18 +2765,16 @@ export function fragOverlapsQueuedInterstitial(
   if (__USE_INTERSTITIALS__ && playerQueue) {
     for (let i = playerQueue.length; i--; ) {
       const interstitial = playerQueue[i].interstitial;
+      const start = interstitial.startTime;
+      const end = Math.min(
+        start + interstitial.duration,
+        interstitial.resumeTime,
+      );
       if (interstitial.appendInPlace) {
-        if (
-          frag.start >= interstitial.startTime &&
-          frag.end <= interstitial.resumeTime
-        ) {
+        if (frag.start >= start && frag.end <= end) {
           return true;
         }
-        if (
-          playhead > frag.start &&
-          frag.end > interstitial.startTime &&
-          frag.start < interstitial.resumeTime
-        ) {
+        if (playhead > frag.start && frag.end > start && frag.start < end) {
           return true;
         }
       }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1127,6 +1127,7 @@ export default class InterstitialsController
 
   private livePrerollResumption(
     interstitial: InterstitialEvent,
+    buffering?: boolean,
   ): number | undefined {
     if (
       interstitial.cue.pre &&
@@ -1134,7 +1135,15 @@ export default class InterstitialsController
       !Number.isFinite(interstitial.resumeOffset) &&
       this.hls
     ) {
-      return this.hls.liveSyncPosition || this.hls.startPosition;
+      const liveStartPosition = this.getLiveStartPos();
+      if (buffering) {
+        const bufferingPlayer = this.getBufferingPlayer();
+        const timeRemaining = bufferingPlayer?.interstitial.cue.pre
+          ? bufferingPlayer.remaining
+          : 0;
+        return liveStartPosition + timeRemaining;
+      }
+      return liveStartPosition;
     }
   }
 
@@ -1143,11 +1152,10 @@ export default class InterstitialsController
     buffering?: boolean,
   ): number {
     if (this.schedule) {
-      const liveResumptionTime = buffering
-        ? item.event.cue.pre
-          ? item.end + item.event.duration
-          : undefined
-        : this.livePrerollResumption(item.event);
+      const liveResumptionTime = this.livePrerollResumption(
+        item.event,
+        buffering,
+      );
       if (liveResumptionTime !== undefined) {
         this.log(`find next item index @${liveResumptionTime}`);
         return this.schedule.findItemIndexAtTime(liveResumptionTime);
@@ -1570,36 +1578,32 @@ export default class InterstitialsController
   ): number {
     const itemStart = scheduledItem.start;
     if (this.primaryLive) {
-      const details = this.primaryDetails;
-      const resumingFromItem = this.endedItem || this.playingItem;
-      const startPosition = this.hls.startPosition;
+      // primary start
       if (index === 0) {
-        return startPosition;
-      } else if (
-        details &&
-        (resumingFromItem?.event?.cue.pre ||
-          itemStart < details.fragmentStart ||
-          itemStart > details.edge)
-      ) {
-        const liveStartPosition = this.getLiveStartPos();
-        const liveSync = this.hls.liveSyncPosition;
-        const logPrefix = `primary resumption${preloading ? ' (preloading)' : ''}: `;
-        if (preloading) {
-          const bufferingPlayer = this.getBufferingPlayer();
-          const timeRemaining = bufferingPlayer?.interstitial.cue.pre
-            ? bufferingPlayer.remaining
-            : 0;
+        return this.hls.startPosition;
+      }
+      // preroll resumption
+      const resumingFromItem = this.endedItem || this.playingItem;
+      const livePrerollResumption = resumingFromItem?.event
+        ? this.livePrerollResumption(resumingFromItem.event, preloading)
+        : undefined;
+      if (livePrerollResumption !== undefined) {
+        return livePrerollResumption;
+      }
+      // start at live edge when item start is outside live playlist window
+      const details = this.primaryDetails;
+      if (details) {
+        const { fragmentStart, edge } = details;
+        if (itemStart < fragmentStart || (itemStart > edge && !preloading)) {
+          const liveSync = this.hls.liveSyncPosition;
           this.log(
-            `${logPrefix}${liveStartPosition + timeRemaining}(startPos: ${startPosition} liveSync: ${liveSync} + timeRemaining: ${timeRemaining})`,
+            `primary resumption out of bounds (${itemStart} [${fragmentStart}-${edge}]) snapping to liveSync ${liveSync}`,
           );
-          return liveStartPosition + timeRemaining;
+          return liveSync || fragmentStart;
         }
-        this.log(
-          `${logPrefix}${liveStartPosition}(startPos: ${startPosition} liveSync: ${liveSync})`,
-        );
-        return liveStartPosition;
       }
     }
+    // resume at schedule item start
     this.log(`primary resumption itemStart: ${itemStart}`);
     return itemStart;
   }
@@ -1609,8 +1613,8 @@ export default class InterstitialsController
     const liveSync = this.hls.liveSyncPosition || 0;
     const behindLive = (this.primaryDetails?.targetduration || 10) * 3;
     if (
-      liveSync &&
-      (startPosition === -1 || liveSync - startPosition > behindLive)
+      startPosition === -1 ||
+      (liveSync && liveSync - startPosition < behindLive)
     ) {
       return liveSync || 0;
     }
@@ -2814,6 +2818,10 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     player.loadSource();
     this.setBufferingItem(item);
     this.bufferingAsset = assetItem;
+    if (player.bufferedInPlaceToEnd(this.primaryMedia, player.currentTime)) {
+      this.advanceAssetBuffering(item, assetItem);
+      return;
+    }
     const bufferingPlayer = this.getBufferingPlayer();
     if (bufferingPlayer === player) {
       return;

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1572,35 +1572,49 @@ export default class InterstitialsController
     if (this.primaryLive) {
       const details = this.primaryDetails;
       const resumingFromItem = this.endedItem || this.playingItem;
+      const startPosition = this.hls.startPosition;
       if (index === 0) {
-        return this.hls.startPosition;
+        return startPosition;
       } else if (
         details &&
         (resumingFromItem?.event?.cue.pre ||
           itemStart < details.fragmentStart ||
           itemStart > details.edge)
       ) {
+        const liveStartPosition = this.getLiveStartPos();
         const liveSync = this.hls.liveSyncPosition;
-        if (liveSync !== null) {
-          if (preloading) {
-            const timeRemaining = this.getBufferingPlayer()?.remaining || 0;
-            this.log(
-              `primary resumption liveSync: ${liveSync} + timeRemaining ${timeRemaining}`,
-            );
-            return Math.min(
-              liveSync + timeRemaining,
-              details.edge,
-              scheduledItem.end,
-            );
-          }
-          this.log(`primary resumption liveSync: ${liveSync}`);
-          return liveSync;
+        const logPrefix = `primary resumption${preloading ? ' (preloading)' : ''}: `;
+        if (preloading) {
+          const bufferingPlayer = this.getBufferingPlayer();
+          const timeRemaining = bufferingPlayer?.interstitial.cue.pre
+            ? bufferingPlayer.remaining
+            : 0;
+          this.log(
+            `${logPrefix}${liveStartPosition + timeRemaining}(startPos: ${startPosition} liveSync: ${liveSync} + timeRemaining: ${timeRemaining})`,
+          );
+          return liveStartPosition + timeRemaining;
         }
-        return -1;
+        this.log(
+          `${logPrefix}${liveStartPosition}(startPos: ${startPosition} liveSync: ${liveSync})`,
+        );
+        return liveStartPosition;
       }
     }
     this.log(`primary resumption itemStart: ${itemStart}`);
     return itemStart;
+  }
+
+  private getLiveStartPos(): number {
+    const startPosition = this.hls.startPosition;
+    const liveSync = this.hls.liveSyncPosition || 0;
+    const behindLive = (this.primaryDetails?.targetduration || 10) * 3;
+    if (
+      liveSync &&
+      (startPosition === -1 || liveSync - startPosition > behindLive)
+    ) {
+      return liveSync || 0;
+    }
+    return startPosition;
   }
 
   private isAssetBuffered(asset: InterstitialAssetItem): boolean {
@@ -2331,6 +2345,7 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
     if (neverLoaded) {
       const timelineStart = interstitial.timelineStart;
       const playingItem = this.playingItem;
+      const bufferingPlayer = this.getBufferingPlayer();
       if (interstitial.appendInPlace) {
         if (
           !this.isInterstitial(playingItem) &&
@@ -2342,15 +2357,12 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
       let hlsStartOffset;
       let liveStartPosition = 0;
       if (
-        (!playingItem ||
-          (this.isInterstitial(playingItem) && playingItem.event.cue.pre)) &&
+        (!bufferingPlayer || bufferingPlayer.interstitial.cue.pre) &&
         this.primaryLive
       ) {
-        liveStartPosition = playingItem
-          ? playingItem.end + playingItem.event.duration
-          : this.hls.startPosition;
-        if (liveStartPosition === -1) {
-          liveStartPosition = this.hls.liveSyncPosition || 0;
+        liveStartPosition = this.getLiveStartPos();
+        if (bufferingPlayer) {
+          liveStartPosition += bufferingPlayer.remaining;
         }
       }
       if (

--- a/src/controller/interstitials-schedule.ts
+++ b/src/controller/interstitials-schedule.ts
@@ -493,6 +493,14 @@ export class InterstitialsSchedule extends Logger {
         const resumeTime = livePrerollResumption || interstitial.resumeTime;
         if (postroll || resumeTime > primaryDuration) {
           primaryPosition = primaryDuration;
+        } else if (
+          !preroll &&
+          end &&
+          interstitial.appendInPlaceStarted &&
+          resumeTime - end > ABUTTING_THRESHOLD_SECONDS
+        ) {
+          // snap last primary segment to end of midroll when resumeTime produces a gap
+          primaryPosition = end;
         } else {
           primaryPosition = resumeTime;
         }

--- a/tests/unit/controller/interstitials-controller.ts
+++ b/tests/unit/controller/interstitials-controller.ts
@@ -2882,6 +2882,15 @@ fileSequence-60.s
         return;
       }
 
+      const bufferingPlayer = (
+        interstitialsController as any
+      ).getBufferingPlayer();
+      expect(
+        (interstitialsController as any).getLiveStartPos(),
+        'live start position',
+      ).to.equal(116.5);
+      expect(bufferingPlayer.remaining, 'preroll remaining').to.equal(15);
+
       interstitials.interstitialPlayer.assetPlayers[1]?.hls?.trigger(
         Events.BUFFERED_TO_END,
         {} as any,
@@ -2892,7 +2901,7 @@ fileSequence-60.s
         assetListUrl,
         '_HLS_primary_id and _HLS_start_offset match',
       ).to.equal(
-        `http://example.com/new-midroll?_HLS_primary_id=${hls.sessionId}&_HLS_start_offset=5.5`,
+        `http://example.com/new-midroll?_HLS_primary_id=${hls.sessionId}&_HLS_start_offset=7.5`,
       );
 
       const eventsAfterAssetListLoaded = getTriggerCalls();
@@ -2954,6 +2963,58 @@ fileSequence-60.s
       expect(interstitials.bufferingIndex).to.equal(4, 'bufferingIndex b');
       expect(interstitials.playingIndex).to.equal(4, 'playingIndex b');
       expect(interstitials.primary.currentTime).to.equal(116, 'timelinePos b');
+    });
+
+    it('resumes primary preload at live-sync plus buffering preroll remaining time', function () {
+      attachMediaToHls();
+      const details = setLoadedLevelDetails(playlist1);
+      const interstitials = interstitialsController.interstitialsManager;
+      if (!interstitials) {
+        expect(interstitials, 'interstitialsManager').to.be.an('object');
+        return;
+      }
+
+      const interstitial = interstitials.events[0];
+      interstitial.assetListResponse = JSON.parse(prerollAssetListResponse);
+      hls.trigger(Events.ASSET_LIST_LOADED, {
+        event: interstitial,
+        assetListResponse: interstitial.assetListResponse,
+        networkDetails: new Response('ok'),
+      });
+
+      if (!interstitials.interstitialPlayer?.assetPlayers) {
+        expect(interstitials.interstitialPlayer?.assetPlayers).to.be.an(
+          'array',
+        );
+        return;
+      }
+
+      const timeSinceLoadedStub = sinon.stub(details, 'age');
+      timeSinceLoadedStub.get(() => 12);
+      const details2 = setLoadedLevelDetails(playlist2);
+      const timeSinceLoadedStub2 = sinon.stub(details2, 'age');
+      timeSinceLoadedStub2.get(() => 17);
+
+      const bufferingPlayer = (
+        interstitialsController as any
+      ).getBufferingPlayer();
+      expect(
+        (interstitialsController as any).getLiveStartPos(),
+        'live start position',
+      ).to.equal(116.5);
+      expect(bufferingPlayer.remaining, 'preroll remaining').to.equal(15);
+      const primaryLoadSpy = sandbox.spy(
+        interstitialsController as any,
+        'startLoadingPrimaryAt',
+      );
+
+      interstitials.interstitialPlayer.assetPlayers[1]?.hls?.trigger(
+        Events.BUFFERED_TO_END,
+        {} as any,
+      );
+
+      expect(primaryLoadSpy, 'primary load requested').called;
+      expect(primaryLoadSpy.getCalls()[0].args[0]).to.equal(131.5);
     });
   });
 });


### PR DESCRIPTION
### This PR will...
Use asset player remaining time to estimate start position of primary and asset(-list) content once preroll has buffered to end.

### Why is this Pull Request needed?
Fixes missing or inaccurate asset-list `_HLS_start_offset` parameter value, as well as preloading the wrong primary fragments and parts when joining live from preroll playout.

### Resolves issues:
Resolves #7942

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
