### PR TITLE
Consolidated the I-Frame remux code into one function

### DIFF
--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -1,4 +1,3 @@
-import MP4 from './mp4-generator';
 import {
   flushTextTrackMetadataCueSamples,
   flushTextTrackUserdataCueSamples,
@@ -8,15 +7,12 @@ import { getCodecCompatibleName } from '../utils/codecs';
 import { type ILogger, Logger } from '../utils/logger';
 import {
   patchEncyptionData,
-  truncateIFrameMoofToSamples,
-  videoOnlyIFrameMoof,
+  remuxVideoOnlyIFrameMoof,
   videoOnlyInitSegment,
-  writeUint32,
 } from '../utils/mp4-tools';
 import { getSampleData, parseInitSegment } from '../utils/mp4-tools';
-import type { HlsEventEmitter } from '../events';
-import type { TrackFragmentSample } from './mp4-generator';
 import type { HlsConfig } from '../config';
+import type { HlsEventEmitter } from '../events';
 import type { DecryptData } from '../loader/level-key';
 import type {
   DemuxedAudioTrack,
@@ -34,7 +30,12 @@ import type {
 import type { TrackSet } from '../types/track';
 import type { ChunkMetadata } from '../types/transmuxer';
 import type { TypeSupported } from '../utils/codecs';
-import type { InitData, InitDataTrack, TrackTimes } from '../utils/mp4-tools';
+import type {
+  IFrameDurationRewrite,
+  InitData,
+  InitDataTrack,
+  TrackTimes,
+} from '../utils/mp4-tools';
 import type { TimestampOffset } from '../utils/timescale-conversion';
 
 class PassThroughRemuxer extends Logger implements Remuxer {
@@ -203,7 +204,7 @@ class PassThroughRemuxer extends Logger implements Remuxer {
 
     // The binary segment data is added to the videoTrack in the mp4demuxer. We don't check to see if the data is only
     // audio or video (or both); adding it to video was an arbitrary choice.
-    let data = videoTrack.samples;
+    const data = videoTrack.samples;
     if (!data.length) {
       return result;
     }
@@ -223,31 +224,24 @@ class PassThroughRemuxer extends Logger implements Remuxer {
       this.warn('Failed to generate initSegment.');
       return result;
     }
-    let excisedVideoOnly = false;
-    if (__USE_IFRAMES__ && chunkMeta.iframe) {
-      if (initData.audio && initData.video) {
-        // Video-only I-Frame appends must not starve a muxed audio track buffer
-        const muxedInit = this.initTracks?.audiovideo?.initSegment;
-        const videoInit = muxedInit ? videoOnlyInitSegment(muxedInit) : null;
-        if (videoInit) {
-          this.log(
-            'Converted muxed init segment to video-only for I-Frame playback',
-          );
-          this.generateInitSegment(videoInit, this.decryptdata);
-          if (this.initData?.length) {
-            initData = this.initData;
-            this.emitInitSegment = true;
-            this.videoOnlyRemux = true;
-          }
-        }
-      }
-      if (this.videoOnlyRemux && initData.video?.encrypted) {
-        // Encrypted moofs cannot be regenerated without losing senc/saiz/saio —
-        // splice the non-video trafs out of each muxed fragment in place instead
-        const videoOnlyData = videoOnlyIFrameMoof(data, initData.video.id);
-        if (videoOnlyData) {
-          data = videoOnlyData;
-          excisedVideoOnly = true;
+    if (
+      __USE_IFRAMES__ &&
+      chunkMeta.iframe &&
+      initData.audio &&
+      initData.video
+    ) {
+      // Video-only I-Frame appends must not starve a muxed audio track buffer
+      const muxedInit = this.initTracks?.audiovideo?.initSegment;
+      const videoInit = muxedInit ? videoOnlyInitSegment(muxedInit) : null;
+      if (videoInit) {
+        this.log(
+          'Converted muxed init segment to video-only for I-Frame playback',
+        );
+        this.generateInitSegment(videoInit, this.decryptdata);
+        if (this.initData?.length) {
+          initData = this.initData;
+          this.emitInitSegment = true;
+          this.videoOnlyRemux = true;
         }
       }
     }
@@ -355,159 +349,46 @@ class PassThroughRemuxer extends Logger implements Remuxer {
           partialMdat ||
           this.videoOnlyRemux ||
           !singleRun;
-        const canRewriteInPlace =
-          lastSampleDurationOffset !== undefined ||
-          defaultSampleDurationOffset !== undefined;
         if (!needsRemux) {
           // MP4 timing already spans EXTINF and every declared sample's
           // data is in the slice — pass through unchanged.
           duration = videoEndTime - videoStartTime;
-        } else if (
-          initData.video.encrypted &&
-          canRewriteInPlace &&
-          (!this.videoOnlyRemux || excisedVideoOnly)
-        ) {
-          // Encrypted I-Frame: mutate the moof in place so senc /
-          // saiz / saio (and any other moof/traf children) survive intact.
-          if (this.videoOnlyRemux) {
-            // Mark the excised fragment as remuxed for the drop-guard below
-            data1 = data.subarray(0);
-          }
-          if (partialMdat) {
-            // End of the last in-range sample's bytes
-            const keepEndOffset =
-              lastRun.sampleOffset +
-              lastRun.samples.reduce((sum, sample) => sum + sample.size, 0);
-            const mdatEnd = truncateIFrameMoofToSamples(
-              data,
-              samples.length,
-              keepEndOffset,
-            );
-            if (mdatEnd) {
-              // End the appended stream on the rewritten mdat box boundary
-              data1 = data.subarray(0, mdatEnd);
-            }
-          }
-          // adjust duration
-          duration = needsDurationAdjustment
-            ? chunkMeta.duration
-            : videoEndTime - videoStartTime;
-          if (lastSampleDurationOffset !== undefined) {
-            const lastSample = samples[samples.length - 1];
-            let lastSampleDuration = duration * initData.video.timescale;
-            for (let i = 0; i < samples.length - 1; i++) {
-              lastSampleDuration -= samples[i].duration;
-            }
-            if (lastSampleDuration <= 0) {
-              // Keep the native duration rather than write a wrapped value
-              lastSampleDuration = lastSample.duration;
-            }
-            writeUint32(data, lastSampleDurationOffset, lastSampleDuration);
-            lastSample.duration = lastSampleDuration;
-          } else {
-            const defaultSampleDuration = Math.round(
-              (duration * initData.video.timescale) / samples.length,
-            );
-            writeUint32(
-              data,
-              defaultSampleDurationOffset!,
-              defaultSampleDuration,
-            );
-            samples.forEach((sample) => {
-              sample.duration = defaultSampleDuration;
-            });
-          }
-          videoPtsEnd = samplesPresentationEnd(start, samples);
-        } else if (!initData.video.encrypted) {
-          // Unencrypted: regenerate the moof from the in-range samples.
-          // The in-place truncation path the encrypted branch uses doesn't
-          // preserve enough structure for some unencrypted codecs
-          duration = needsDurationAdjustment
-            ? chunkMeta.duration
-            : videoEndTime - videoStartTime;
-          const sampleOffset = fragRun.sampleOffset;
-          let totalSize = 0;
-          const remuxedSamples = samples.map((sample): TrackFragmentSample => {
-            const { cts, duration: sampleDuration, size, flags } = sample;
-            const { dependsOn, isNonSync } = Object.assign(
-              { dependsOn: 2, isNonSync: 0 },
-              flags,
-            );
-            totalSize += size;
-            return {
-              cts: cts || 0,
-              duration: sampleDuration,
-              size,
-              flags: {
-                isLeading: 0,
-                isDependedOn: 0,
-                hasRedundancy: 0,
-                degradPrio: 0,
-                dependsOn,
-                isNonSync,
-                paddingValue: 0,
-              },
-            };
-          });
-          if (remuxedSamples.length) {
-            const lastSample = remuxedSamples[remuxedSamples.length - 1];
-            let lastSampleDuration = duration * initData.video.timescale;
-            for (let i = remuxedSamples.length - 1; i--; ) {
-              lastSampleDuration -= remuxedSamples[i].duration;
-            }
-            if (lastSampleDuration <= 0) {
-              // Keep the native duration rather than write a wrapped value
-              lastSampleDuration = lastSample.duration;
-            }
-            lastSample.duration = lastSampleDuration;
-            videoPtsEnd = samplesPresentationEnd(start, remuxedSamples);
-
-            data1 = MP4.moof(chunkMeta.sn, start, {
-              type: 'video',
-              id: videoTrack.id,
-              samples: remuxedSamples,
-            });
-            if (singleRun) {
-              data2 = data.subarray(sampleOffset - 8, sampleOffset + totalSize);
-              writeUint32(data2, 0, totalSize + 8);
-            } else {
-              // Gather each run's in-range sample bytes into one mdat
-              const mdat = new Uint8Array(8 + totalSize);
-              writeUint32(mdat, 0, mdat.byteLength);
-              mdat.set([0x6d, 0x64, 0x61, 0x74], 4); // 'mdat'
-              let write = 8;
-              for (let i = 0; i < trun.length; i++) {
-                const run = trun[i];
-                const runBytes = run.samples.reduce(
-                  (sum, sample) => sum + sample.size,
-                  0,
-                );
-                if (runBytes) {
-                  mdat.set(
-                    data.subarray(
-                      run.sampleOffset,
-                      run.sampleOffset + runBytes,
-                    ),
-                    write,
-                  );
-                  write += runBytes;
-                }
-              }
-              data2 = mdat;
-            }
-          } else {
-            this.warn(
-              `Could not remux IFrame track fragment (sampleOffset ${sampleOffset}: totalSize: ${totalSize} bytes: ${data})`,
-            );
-            duration = videoEndTime - videoStartTime;
-          }
         } else {
-          // Encrypted without a rewritable trun or tfhd sample duration
-          // (moov trex defaults), or a muxed moof that could not be excised
-          this.warn(
-            `IFrame remux skipped for encrypted segment (sn ${chunkMeta.sn}); using native sample duration`,
+          const keepEndOffset = partialMdat
+            ? lastRun.sampleOffset +
+              lastRun.samples.reduce((sum, sample) => sum + sample.size, 0)
+            : undefined;
+          // A partial mdat or dropped runs leave fewer samples than declared, so
+          // stretch the kept samples to the playlist time whenever a duration
+          // field can be rewritten (undefined keeps native durations)
+          const target = needsDurationAdjustment
+            ? chunkMeta.duration
+            : videoEndTime - videoStartTime;
+          const durationRewrite = computeIFrameDurationRewrite(
+            samples,
+            target * initData.video.timescale,
+            lastSampleDurationOffset,
+            defaultSampleDurationOffset,
           );
-          duration = videoEndTime - videoStartTime;
+          const remuxed = remuxVideoOnlyIFrameMoof(
+            data,
+            initData.video.id,
+            samples.length,
+            keepEndOffset,
+            durationRewrite,
+          );
+          if (remuxed) {
+            data1 = remuxed;
+            videoPtsEnd = samplesPresentationEnd(start, samples);
+          } else {
+            // Could not rewrite (e.g. muxed without moof-relative sample
+            // offsets) — fall back to the native sample duration
+            this.warn(
+              `IFrame remux skipped (sn ${chunkMeta.sn}); using native sample duration`,
+            );
+          }
+          duration =
+            remuxed && durationRewrite ? target : videoEndTime - videoStartTime;
         }
       } else {
         this.warn(
@@ -713,6 +594,44 @@ function samplesPresentationEnd(
     dts += duration;
   }
   return end;
+}
+
+// Stretch the kept I-Frame samples to `totalDuration`, mutating them so the
+// reported presentation end matches. Returns undefined when no duration field
+// can be written (durations come from moov trex defaults).
+function computeIFrameDurationRewrite(
+  samples: Array<{ duration: number }>,
+  totalDuration: number,
+  lastSampleDurationOffset: number | undefined,
+  defaultSampleDurationOffset: number | undefined,
+): IFrameDurationRewrite | undefined {
+  if (lastSampleDurationOffset !== undefined) {
+    const lastSample = samples[samples.length - 1];
+    let lastSampleDuration = totalDuration;
+    for (let i = 0; i < samples.length - 1; i++) {
+      lastSampleDuration -= samples[i].duration;
+    }
+    if (lastSampleDuration <= 0) {
+      // Keep the native duration rather than write a wrapped value
+      lastSampleDuration = lastSample.duration;
+    }
+    lastSample.duration = lastSampleDuration;
+    return {
+      durationOffset: lastSampleDurationOffset,
+      value: lastSampleDuration,
+    };
+  }
+  if (defaultSampleDurationOffset === undefined) {
+    return undefined;
+  }
+  const defaultSampleDuration = Math.round(totalDuration / samples.length);
+  for (let i = 0; i < samples.length; i++) {
+    samples[i].duration = defaultSampleDuration;
+  }
+  return {
+    durationOffset: defaultSampleDurationOffset,
+    value: defaultSampleDuration,
+  };
 }
 
 function isInvalidInitPts(

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -123,82 +123,43 @@ function shrinkBox(data: Uint8Array, box: Uint8Array, newPayloadSize: number) {
   writeUint32(data, start + newSize + 4, types.free);
 }
 
-export function truncateIFrameMoofToSamples(
+// View-relative [start, end) byte range of a box, including its 8-byte header
+function boxRange(box: Uint8Array, base: number): [number, number] {
+  return [box.byteOffset - base - 8, box.byteOffset - base + box.byteLength];
+}
+
+// Splice the given byte ranges out of `data`, returning the shrunk copy, the
+// total bytes removed, and a droppedBefore(offset) helper for repositioning
+// surviving offsets. Ranges are view-relative and sorted in place.
+function spliceOutBoxes(
   data: Uint8Array<ArrayBuffer>,
-  keepSampleCount: number,
-  keepEndOffset: number,
-): number | undefined {
-  const moofs = findBox(data, ['moof']);
-  if (moofs.length !== 1) {
-    return;
+  dropRanges: [number, number][],
+): {
+  result: Uint8Array<ArrayBuffer>;
+  dropped: number;
+  droppedBefore: (offset: number) => number;
+} {
+  dropRanges.sort((a, b) => a[0] - b[0]);
+  const dropped = dropRanges.reduce(
+    (sum, [start, end]) => sum + end - start,
+    0,
+  );
+  const result = new Uint8Array(data.byteLength - dropped);
+  let read = 0;
+  let write = 0;
+  for (let i = 0; i < dropRanges.length; i++) {
+    const [start, end] = dropRanges[i];
+    result.set(data.subarray(read, start), write);
+    write += start - read;
+    read = end;
   }
-  const moof = moofs[0];
-  const trafs = findBox(moof, ['traf']);
-  for (let i = 0; i < trafs.length; i++) {
-    const traf = trafs[i];
-    // Distribute the kept sample count across the track fragment runs;
-    // runs left with no samples become 'free' boxes (parsers reject
-    // zero-sample truns)
-    let remaining = keepSampleCount;
-    const truns = findBox(traf, ['trun']);
-    for (let j = 0; j < truns.length; j++) {
-      const trun = truns[j];
-      const count = Math.min(remaining, readUint32(trun, 4));
-      if (count) {
-        writeUint32(data, trun.byteOffset - data.byteOffset + 4, count);
-        const flags = readUint32(trun, 0) & 0xffffff;
-        const perSample =
-          (flags & 0x100 ? 4 : 0) +
-          (flags & 0x200 ? 4 : 0) +
-          (flags & 0x400 ? 4 : 0) +
-          (flags & 0x800 ? 4 : 0);
-        shrinkBox(
-          data,
-          trun,
-          8 +
-            (flags & 0x01 ? 4 : 0) +
-            (flags & 0x04 ? 4 : 0) +
-            count * perSample,
-        );
-      } else {
-        writeUint32(data, trun.byteOffset - data.byteOffset - 4, types.free);
-      }
-      remaining -= count;
-    }
-    const senc = findBox(traf, ['senc'])[0];
-    if (senc) {
-      // The size of a senc box cannot be validated without the tenc IV size,
-      // so rewriting the sample count alone is accepted
-      writeUint32(data, senc.byteOffset - data.byteOffset + 4, keepSampleCount);
-    }
-    const saiz = findBox(traf, ['saiz'])[0];
-    if (saiz) {
-      const saizFlags = (saiz[1] << 16) | (saiz[2] << 8) | saiz[3];
-      let off = 4;
-      if (saizFlags & 0x01) {
-        off += 8;
-      }
-      const defaultSampleInfoSize = saiz[off];
-      off += 1;
-      writeUint32(
-        data,
-        saiz.byteOffset - data.byteOffset + off,
-        keepSampleCount,
-      );
-      shrinkBox(
-        data,
-        saiz,
-        off + 4 + (defaultSampleInfoSize === 0 ? keepSampleCount : 0),
-      );
-    }
-  }
-  const mdats = findBox(data, ['mdat']);
-  if (mdats.length === 1) {
-    const mdatStart = mdats[0].byteOffset - data.byteOffset - 8;
-    writeUint32(data, mdatStart, keepEndOffset - mdatStart);
-    // Callers use the mdat end to exclude trailing partial-sample bytes
-    return keepEndOffset;
-  }
+  result.set(data.subarray(read), write);
+  const droppedBefore = (offset: number) =>
+    dropRanges.reduce(
+      (sum, [start, end]) => (end <= offset ? sum + end - start : sum),
+      0,
+    );
+  return { result, dropped, droppedBefore };
 }
 
 // Video-only copy of an init segment, or null when there is no video track or nothing to remove
@@ -210,10 +171,6 @@ export function videoOnlyInitSegment(
     return null;
   }
   const base = initSegment.byteOffset;
-  const boxRange = (box: Uint8Array): [number, number] => [
-    box.byteOffset - base - 8,
-    box.byteOffset - base + box.byteLength,
-  ];
   const dropRanges: [number, number][] = [];
   const dropTrackIds: number[] = [];
   let hasVideo = false;
@@ -232,7 +189,7 @@ export function videoOnlyInitSegment(
     }
     const version = tkhd[0];
     dropTrackIds.push(readUint32(tkhd, version === 0 ? 12 : 20));
-    dropRanges.push(boxRange(trak));
+    dropRanges.push(boxRange(trak, base));
   }
   if (!hasVideo || !dropRanges.length) {
     return null;
@@ -244,32 +201,16 @@ export function videoOnlyInitSegment(
     for (let i = 0; i < trexs.length; i++) {
       const trex = trexs[i];
       if (dropTrackIds.indexOf(readUint32(trex, 4)) !== -1) {
-        dropRanges.push(boxRange(trex));
+        dropRanges.push(boxRange(trex, base));
         mvexDropped += trex.byteLength + 8;
       }
     }
   }
   // Splice out the dropped ranges, then patch sizes at their result offsets
-  dropRanges.sort((a, b) => a[0] - b[0]);
-  const dropped = dropRanges.reduce(
-    (sum, [start, end]) => sum + end - start,
-    0,
+  const { result, dropped, droppedBefore } = spliceOutBoxes(
+    initSegment,
+    dropRanges,
   );
-  const droppedBefore = (offset: number) =>
-    dropRanges.reduce(
-      (sum, [start, end]) => (end <= offset ? sum + end - start : sum),
-      0,
-    );
-  const result = new Uint8Array(initSegment.byteLength - dropped);
-  let read = 0;
-  let write = 0;
-  for (let i = 0; i < dropRanges.length; i++) {
-    const [start, end] = dropRanges[i];
-    result.set(initSegment.subarray(read, start), write);
-    write += start - read;
-    read = end;
-  }
-  result.set(initSegment.subarray(read), write);
   const moovStart = moovs[0].byteOffset - base - 8;
   writeUint32(result, moovStart, moovs[0].byteLength + 8 - dropped);
   if (mvex && mvexDropped) {
@@ -283,23 +224,37 @@ export function videoOnlyInitSegment(
   return result;
 }
 
-// Splice non-video track fragments out of a muxed I-Frame moof so encrypted
-// fragments keep their senc/saiz/saio boxes intact (regenerating the moof
-// would drop them). Returns null when the sample data offsets are not
-// moof-relative (default-base-is-moof, required of CMAF content).
-export function videoOnlyIFrameMoof(
+// Duration rewrite for remuxVideoOnlyIFrameMoof: `value` (video timescale) is
+// written at `durationOffset` — the last sample's duration or the tfhd default
+export type IFrameDurationRewrite = {
+  durationOffset: number;
+  value: number;
+};
+
+// Remux a moof+mdat I-Frame fragment to video-only in place: drop non-video trafs
+// (muxed A/V), truncate to the in-range samples (partial mdat), and stretch the
+// last sample duration, preserving senc/saiz/saio. Returns null when it cannot be
+// rewritten (no video traf, no samples, or non-moof-relative muxed content).
+export function remuxVideoOnlyIFrameMoof(
   data: Uint8Array<ArrayBuffer>,
   videoTrackId: number,
+  keepSampleCount: number,
+  keepEndOffset: number | undefined,
+  durationRewrite: IFrameDurationRewrite | undefined,
 ): Uint8Array<ArrayBuffer> | null {
+  if (keepSampleCount < 1) {
+    return null;
+  }
   const moofs = findBox(data, ['moof']);
   if (moofs.length !== 1) {
     return null;
   }
   const moof = moofs[0];
   const base = data.byteOffset;
+  const videoTrafs: Uint8Array[] = [];
   const dropRanges: [number, number][] = [];
-  let videoTraf: Uint8Array | null = null;
   const trafs = findBox(moof, ['traf']);
+  let videoBaseIsMoof = true;
   for (let i = 0; i < trafs.length; i++) {
     const traf = trafs[i];
     const tfhd = findBox(traf, ['tfhd'])[0];
@@ -307,76 +262,141 @@ export function videoOnlyIFrameMoof(
       return null;
     }
     if (readUint32(tfhd, 4) === videoTrackId) {
+      videoTrafs.push(traf);
       if (!(readUint32(tfhd, 0) & 0x20000)) {
-        return null;
+        videoBaseIsMoof = false;
       }
-      videoTraf = traf;
     } else {
-      dropRanges.push([
-        traf.byteOffset - base - 8,
-        traf.byteOffset - base + traf.byteLength,
-      ]);
+      dropRanges.push(boxRange(traf, base));
     }
   }
-  if (!videoTraf || !dropRanges.length) {
+  if (!videoTrafs.length) {
     return null;
   }
-  const dropped = dropRanges.reduce(
-    (sum, [start, end]) => sum + end - start,
-    0,
-  );
-  // The mdat moves up by everything dropped, the video traf and the senc
-  // payload its saio points to by what was dropped before the traf
-  const trafShift = dropRanges.reduce(
-    (sum, [start, end]) =>
-      end <= videoTraf!.byteOffset - base ? sum + end - start : sum,
-    0,
-  );
-  const result = new Uint8Array(data.byteLength - dropped);
-  let read = 0;
-  let write = 0;
-  for (let i = 0; i < dropRanges.length; i++) {
-    const [start, end] = dropRanges[i];
-    result.set(data.subarray(read, start), write);
-    write += start - read;
-    read = end;
+  // Patching moof-relative offsets after a splice requires default-base-is-moof
+  if (dropRanges.length && !videoBaseIsMoof) {
+    return null;
   }
-  result.set(data.subarray(read), write);
-  writeUint32(
-    result,
-    moof.byteOffset - base - 8,
-    moof.byteLength + 8 - dropped,
-  );
-  const truns = findBox(videoTraf, ['trun']);
-  for (let i = 0; i < truns.length; i++) {
-    const trun = truns[i];
-    if (readUint32(trun, 0) & 0x01) {
-      writeUint32(
-        result,
-        trun.byteOffset - base - trafShift + 8,
-        readUint32(trun, 8) - dropped,
-      );
-    }
-  }
-  if (trafShift) {
-    const saios = findBox(videoTraf, ['saio']);
-    for (let i = 0; i < saios.length; i++) {
-      const saio = saios[i];
-      const stride = saio[0] === 0 ? 4 : 8;
-      let offset = readUint32(saio, 0) & 0x01 ? 12 : 4;
-      let entries = readUint32(saio, offset);
-      for (offset += 4; entries--; offset += stride) {
-        // Patch the low word of each aux info offset
-        const at = offset + stride - 4;
-        writeUint32(
-          result,
-          saio.byteOffset - base - trafShift + at,
-          readUint32(saio, at) - trafShift,
+
+  if (keepEndOffset !== undefined) {
+    // Distribute the kept count across the runs; emptied runs become 'free'
+    // boxes (parsers reject zero-sample truns)
+    let remaining = keepSampleCount;
+    for (let t = 0; t < videoTrafs.length; t++) {
+      const traf = videoTrafs[t];
+      let trafKept = 0;
+      const truns = findBox(traf, ['trun']);
+      for (let j = 0; j < truns.length; j++) {
+        const trun = truns[j];
+        const count = Math.min(remaining, readUint32(trun, 4));
+        if (count) {
+          writeUint32(data, trun.byteOffset - base + 4, count);
+          const flags = readUint32(trun, 0) & 0xffffff;
+          const perSample =
+            (flags & 0x100 ? 4 : 0) +
+            (flags & 0x200 ? 4 : 0) +
+            (flags & 0x400 ? 4 : 0) +
+            (flags & 0x800 ? 4 : 0);
+          shrinkBox(
+            data,
+            trun,
+            8 +
+              (flags & 0x01 ? 4 : 0) +
+              (flags & 0x04 ? 4 : 0) +
+              count * perSample,
+          );
+        } else {
+          writeUint32(data, trun.byteOffset - base - 4, types.free);
+        }
+        remaining -= count;
+        trafKept += count;
+      }
+      const senc = findBox(traf, ['senc'])[0];
+      if (senc) {
+        // The size of a senc box cannot be validated without the tenc IV size,
+        // so rewriting the sample count alone is accepted
+        writeUint32(data, senc.byteOffset - base + 4, trafKept);
+      }
+      const saiz = findBox(traf, ['saiz'])[0];
+      if (saiz) {
+        const saizFlags = (saiz[1] << 16) | (saiz[2] << 8) | saiz[3];
+        let off = 4;
+        if (saizFlags & 0x01) {
+          off += 8;
+        }
+        const defaultSampleInfoSize = saiz[off];
+        off += 1;
+        writeUint32(data, saiz.byteOffset - base + off, trafKept);
+        shrinkBox(
+          data,
+          saiz,
+          off + 4 + (defaultSampleInfoSize === 0 ? trafKept : 0),
         );
       }
     }
+    const mdats = findBox(data, ['mdat']);
+    if (mdats.length === 1) {
+      const mdatStart = mdats[0].byteOffset - base - 8;
+      writeUint32(data, mdatStart, keepEndOffset - mdatStart);
+    }
   }
-  return result;
+
+  let result: Uint8Array<ArrayBuffer> = data;
+  let dropped = 0;
+  let droppedBefore: (offset: number) => number = () => 0;
+  if (dropRanges.length) {
+    // Splice out the dropped ranges, then patch sizes/offsets at their result offsets
+    ({ result, dropped, droppedBefore } = spliceOutBoxes(data, dropRanges));
+    writeUint32(
+      result,
+      moof.byteOffset - base - 8,
+      moof.byteLength + 8 - dropped,
+    );
+    for (let t = 0; t < videoTrafs.length; t++) {
+      const traf = videoTrafs[t];
+      // The mdat moves up by everything dropped; the traf and the senc payload
+      // its saio points to by what was dropped before the traf
+      const trafShift = droppedBefore(traf.byteOffset - base);
+      const truns = findBox(traf, ['trun']);
+      for (let j = 0; j < truns.length; j++) {
+        const trun = truns[j];
+        if (readUint32(trun, 0) & 0x01) {
+          writeUint32(
+            result,
+            trun.byteOffset - base - trafShift + 8,
+            readUint32(trun, 8) - dropped,
+          );
+        }
+      }
+      if (trafShift) {
+        const saios = findBox(traf, ['saio']);
+        for (let s = 0; s < saios.length; s++) {
+          const saio = saios[s];
+          const stride = saio[0] === 0 ? 4 : 8;
+          let offset = readUint32(saio, 0) & 0x01 ? 12 : 4;
+          let entries = readUint32(saio, offset);
+          for (offset += 4; entries--; offset += stride) {
+            // Patch the low word of each aux info offset
+            const at = offset + stride - 4;
+            writeUint32(
+              result,
+              saio.byteOffset - base - trafShift + at,
+              readUint32(saio, at) - trafShift,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (durationRewrite) {
+    const { durationOffset, value } = durationRewrite;
+    writeUint32(result, durationOffset - droppedBefore(durationOffset), value);
+  }
+
+  return keepEndOffset !== undefined
+    ? result.subarray(0, keepEndOffset - dropped)
+    : result;
 }
 
 export function hasBoxData(data: Uint8Array, type: BoxType): boolean {

--- a/tests/unit/remux/passthrough-remuxer.ts
+++ b/tests/unit/remux/passthrough-remuxer.ts
@@ -111,9 +111,13 @@ describe('passthrough-remuxer', function () {
     const result = remuxIFrameFragment(fragmentData, extinfDuration);
 
     expect(result.video, 'video track').to.exist;
-    // regenerated: a fresh moof in data1 and a separate mdat in data2
-    expect(result.video!.data1, 'data1').to.not.equal(fragmentData);
-    expect(result.video!.data2, 'data2').to.exist;
+    // Rewritten in place: the moof+mdat stays in data1, no separate mdat
+    expect(result.video!.data1, 'data1').to.equal(fragmentData);
+    expect(result.video!.data2, 'data2').to.not.exist;
+    // The single sample is stretched to the EXTINF duration
+    expect(trunSampleDurations(result.video!.data1)).to.deep.equal([
+      extinfDuration * 90000,
+    ]);
     expect(result.video!.endDTS - result.video!.startDTS).to.equal(
       extinfDuration,
     );
@@ -137,7 +141,7 @@ describe('passthrough-remuxer', function () {
     expect(result.video!.data1).to.equal(fragmentData);
   });
 
-  it('regenerates moof+mdat for a multi-sample iframe fragment, keeping every sample', function () {
+  it('remuxes a multi-sample iframe fragment in place, keeping every sample', function () {
     const extinfDuration = 4;
     const fragmentData = mp4Fragment([
       sample(3003, 4, 0),
@@ -148,8 +152,8 @@ describe('passthrough-remuxer', function () {
     const result = remuxIFrameFragment(fragmentData, extinfDuration);
 
     expect(result.video, 'video track').to.exist;
-    expect(result.video!.data1, 'data1').to.not.equal(fragmentData);
-    expect(result.video!.data2, 'data2').to.exist;
+    expect(result.video!.data1, 'data1').to.equal(fragmentData);
+    expect(result.video!.data2, 'data2').to.not.exist;
     // all three parsed samples are reported, not collapsed to one
     expect(result.video!.nb).to.equal(3);
     expect(result.video!.endDTS - result.video!.startDTS).to.equal(
@@ -266,12 +270,17 @@ describe('passthrough-remuxer', function () {
     expect(parsedInit.video, 'filtered init video').to.exist;
     expect(parsedInit.audio, 'filtered init audio').to.not.exist;
 
-    // Video-only output: regenerated moof and an mdat with only video bytes
+    // Video-only output: the audio traf is spliced out (audio sample bytes are
+    // left in the mdat as unreferenced data)
     expect(result.video, 'video track').to.exist;
     expect(result.video!.type).to.equal('video');
     expect(result.video!.hasAudio).to.equal(false);
-    expect(result.video!.data1, 'data1 regenerated').to.not.equal(fragmentData);
-    expect(result.video!.data2!.byteLength, 'video-only mdat').to.equal(24 + 8);
+    expect(result.video!.data1, 'data1').to.not.equal(fragmentData);
+    expect(result.video!.data2, 'data2').to.not.exist;
+    const trafs = findBox(result.video!.data1, ['moof', 'traf']);
+    expect(trafs, 'trafs').to.have.lengthOf(1);
+    const tfhd = findBox(trafs[0], ['tfhd'])[0];
+    expect(readUint32(tfhd, 4), 'video track id').to.equal(1);
     expect(result.video!.endPTS - result.video!.startPTS).to.equal(
       extinfDuration,
     );
@@ -294,7 +303,12 @@ describe('passthrough-remuxer', function () {
 
     expect(result.video, 'video track').to.exist;
     expect(result.video!.type).to.equal('video');
-    expect(result.video!.data2!.byteLength, 'video-only mdat').to.equal(24 + 8);
+    expect(result.video!.data2, 'data2').to.not.exist;
+    const trafs = findBox(result.video!.data1, ['moof', 'traf']);
+    expect(trafs, 'trafs').to.have.lengthOf(1);
+    expect(readUint32(findBox(trafs[0], ['tfhd'])[0], 4), 'video id').to.equal(
+      1,
+    );
     expect(result.video!.endPTS - result.video!.startPTS).to.equal(
       extinfDuration,
     );
@@ -314,7 +328,13 @@ describe('passthrough-remuxer', function () {
     const result = remuxIFrame(fragmentData, extinfDuration);
 
     expect(result.video, 'video track').to.exist;
-    expect(result.video!.data2!.byteLength, 'gathered mdat').to.equal(24 + 8);
+    expect(result.video!.data2, 'data2').to.not.exist;
+    // The audio traf is spliced out; both video trafs are retained
+    const trafs = findBox(result.video!.data1, ['moof', 'traf']);
+    expect(trafs, 'video trafs').to.have.lengthOf(2);
+    trafs.forEach((traf) => {
+      expect(readUint32(findBox(traf, ['tfhd'])[0], 4), 'video id').to.equal(1);
+    });
     expect(result.video!.endPTS - result.video!.startPTS).to.equal(
       extinfDuration,
     );
@@ -358,6 +378,31 @@ describe('passthrough-remuxer', function () {
     expect(readUint32(result.video!.data1, mdatPayloadOffset - 8)).to.equal(18);
     const trun = findBox(result.video!.data1, ['moof', 'traf', 'trun'])[0];
     expect(readUint32(trun, 4), 'trun sample_count').to.equal(1);
+    expect(trunSampleDurations(result.video!.data1)).to.deep.equal([
+      extinfDuration * 90000,
+    ]);
+    expect(result.video!.endPTS - result.video!.startPTS).to.equal(
+      extinfDuration,
+    );
+  });
+
+  it('stretches a partial-mdat iframe whose declared duration already matches EXTINF', function () {
+    // The moof declares two samples that together already span EXTINF, so
+    // needsDurationAdjustment is false — but only the first sample's data is
+    // present in the byte-range slice (as with a muxed I-Frame byte range).
+    const extinfDuration = 4;
+    const fragmentData = mp4Fragment([
+      sample(extinfDuration * 90000 - 3003, 10, 0),
+      sample(3003, 20, 0),
+    ]);
+    const mdatPayloadOffset = fragmentData.byteLength - 30;
+    const partialFragment = fragmentData.subarray(0, mdatPayloadOffset + 13);
+
+    const result = remuxIFrameFragment(partialFragment, extinfDuration);
+
+    expect(result.video, 'video track').to.exist;
+    // The single kept keyframe is stretched to the full declared duration even
+    // though the moof timing did not disagree with EXTINF
     expect(trunSampleDurations(result.video!.data1)).to.deep.equal([
       extinfDuration * 90000,
     ]);
@@ -492,6 +537,10 @@ function muxedMp4Fragment(
     truns[1].byteOffset - moof.byteOffset + 8,
     moof.byteLength + 8 + (audioFirst ? 0 : videoBytes),
   );
+  // CMAF muxed content addresses samples from the moof; the video traf must
+  // set default-base-is-moof so the remuxer can splice out the audio traf
+  const videoTfhd = findBox(moof, ['moof', 'traf', 'tfhd'])[0];
+  videoTfhd[1] = 0x02;
 
   return appendUint8Array(
     moof,

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -8,9 +8,8 @@ import {
   findBox,
   getSampleData,
   parseInitSegment,
-  truncateIFrameMoofToSamples,
+  remuxVideoOnlyIFrameMoof,
   types,
-  videoOnlyIFrameMoof,
   videoOnlyInitSegment,
 } from '../../../src/utils/mp4-tools';
 import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
@@ -80,17 +79,21 @@ describe('mp4-tools', function () {
     expect(track.ptsMax).to.equal(500 + 1001);
   });
 
-  it('truncateIFrameMoofToSamples rewrites sample counts and returns the mdat end offset', function () {
+  it('remuxVideoOnlyIFrameMoof truncates a partial mdat to the kept samples', function () {
     const fragment = gopFragment();
     const mdatPayloadOffset = fragment.byteLength - 60;
 
-    const mdatEnd = truncateIFrameMoofToSamples(
+    const result = remuxVideoOnlyIFrameMoof(
       fragment,
       1,
+      1,
       mdatPayloadOffset + 10,
+      undefined,
     );
 
-    expect(mdatEnd).to.equal(mdatPayloadOffset + 10);
+    expect(result, 'result').to.not.equal(null);
+    // The kept stream ends on the rewritten mdat box boundary
+    expect(result!.byteLength, 'kept length').to.equal(mdatPayloadOffset + 10);
     const trun = findBox(fragment, ['moof', 'traf', 'trun'])[0];
     expect(readUint32(trun, 4), 'trun sample_count').to.equal(1);
     expect(
@@ -99,17 +102,19 @@ describe('mp4-tools', function () {
     ).to.equal(18);
   });
 
-  it('truncateIFrameMoofToSamples distributes the kept count across runs', function () {
+  it('remuxVideoOnlyIFrameMoof distributes the kept count across runs', function () {
     const fragment = multiRunIFrameMoof();
     const mdatPayloadOffset = fragment.byteLength - 60;
 
-    const mdatEnd = truncateIFrameMoofToSamples(
+    const result = remuxVideoOnlyIFrameMoof(
       fragment,
+      1,
       3,
       mdatPayloadOffset + 25,
+      undefined,
     );
 
-    expect(mdatEnd).to.equal(mdatPayloadOffset + 25);
+    expect(result!.byteLength, 'kept length').to.equal(mdatPayloadOffset + 25);
     const truns = findBox(fragment, ['moof', 'traf', 'trun']);
     expect(readUint32(truns[0], 4), 'first run count').to.equal(2);
     expect(readUint32(truns[1], 4), 'second run count').to.equal(1);
@@ -126,11 +131,11 @@ describe('mp4-tools', function () {
     ).to.equal(33);
   });
 
-  it('truncateIFrameMoofToSamples frees runs left without samples', function () {
+  it('remuxVideoOnlyIFrameMoof frees runs left without samples', function () {
     const fragment = multiRunIFrameMoof();
     const mdatPayloadOffset = fragment.byteLength - 60;
 
-    truncateIFrameMoofToSamples(fragment, 1, mdatPayloadOffset + 10);
+    remuxVideoOnlyIFrameMoof(fragment, 1, 1, mdatPayloadOffset + 10, undefined);
 
     // Parsers reject zero-sample truns, so the emptied run becomes 'free'
     const truns = findBox(fragment, ['moof', 'traf', 'trun']);
@@ -161,13 +166,19 @@ describe('mp4-tools', function () {
     expect(videoOnlyInitSegment(filtered!)).to.equal(null);
   });
 
-  it('videoOnlyIFrameMoof removes non-video track fragments and patches offsets', function () {
+  it('remuxVideoOnlyIFrameMoof removes non-video track fragments and patches offsets', function () {
     const fragment = muxedIFrameMoof(1, 2);
     const audioTrafSize = trafSize(fragment, 2);
     const sencOffset = indexOfFourcc(fragment, 'senc');
     const moofSize = readUint32(fragment, 0);
 
-    const result = videoOnlyIFrameMoof(fragment, 1);
+    const result = remuxVideoOnlyIFrameMoof(
+      fragment,
+      1,
+      2,
+      undefined,
+      undefined,
+    );
 
     expect(result, 'result').to.not.equal(null);
     expect(result!.byteLength).to.equal(fragment.byteLength - audioTrafSize);
@@ -186,11 +197,17 @@ describe('mp4-tools', function () {
     expect(indexOfFourcc(result!, 'mdat')).to.be.greaterThan(0);
   });
 
-  it('videoOnlyIFrameMoof shifts video traf offsets when it follows a dropped traf', function () {
+  it('remuxVideoOnlyIFrameMoof shifts video traf offsets when it follows a dropped traf', function () {
     const fragment = muxedIFrameMoof(2, 1);
     const audioTrafSize = trafSize(fragment, 2);
 
-    const result = videoOnlyIFrameMoof(fragment, 1);
+    const result = remuxVideoOnlyIFrameMoof(
+      fragment,
+      1,
+      2,
+      undefined,
+      undefined,
+    );
 
     expect(result, 'result').to.not.equal(null);
     expect(findBox(result!, ['moof', 'traf'])).to.have.lengthOf(1);
@@ -203,8 +220,59 @@ describe('mp4-tools', function () {
     expect(readUint32(saio, 8), 'saio offset').to.equal(0x99 - audioTrafSize);
   });
 
-  it('videoOnlyIFrameMoof returns null without moof-relative data offsets', function () {
-    expect(videoOnlyIFrameMoof(muxedIFrameMoof(1, 2, false), 1)).to.equal(null);
+  it('remuxVideoOnlyIFrameMoof drops non-video trafs and truncates in one pass', function () {
+    const fragment = muxedIFrameMoof(1, 2);
+    const audioTrafSize = trafSize(fragment, 2);
+    const mdatPayloadOffset = fragment.byteLength - 60;
+
+    // Keep 1 of the video traf's 2 samples while excising the audio traf
+    const result = remuxVideoOnlyIFrameMoof(
+      fragment,
+      1,
+      1,
+      mdatPayloadOffset + 10,
+      undefined,
+    );
+
+    expect(result, 'result').to.not.equal(null);
+    // Length reflects both the excised audio traf and the truncated mdat tail
+    expect(result!.byteLength).to.equal(mdatPayloadOffset + 10 - audioTrafSize);
+    expect(findBox(result!, ['moof', 'traf']), 'trafs').to.have.lengthOf(1);
+    const trun = findBox(result!, ['moof', 'traf', 'trun'])[0];
+    expect(readUint32(trun, 4), 'trun sample_count').to.equal(1);
+    const senc = findBox(result!, ['moof', 'traf', 'senc'])[0];
+    expect(readUint32(senc, 4), 'senc sample_count').to.equal(1);
+  });
+
+  it('remuxVideoOnlyIFrameMoof stretches the last sample duration', function () {
+    const fragment = gopFragment();
+    const trun = findBox(fragment, ['moof', 'traf', 'trun'])[0];
+    // Per-sample layout is data-offset + duration/size/flags/cts (4 words each);
+    // the third sample's duration sits after 2 samples of 16 bytes
+    const durationOffset =
+      trun.byteOffset - fragment.byteOffset + 4 + 4 + 4 + 2 * 16;
+
+    const result = remuxVideoOnlyIFrameMoof(fragment, 1, 3, undefined, {
+      durationOffset,
+      value: 5005,
+    });
+
+    expect(result, 'result').to.not.equal(null);
+    expect(readUint32(fragment, durationOffset), 'last duration').to.equal(
+      5005,
+    );
+  });
+
+  it('remuxVideoOnlyIFrameMoof returns null without moof-relative data offsets', function () {
+    expect(
+      remuxVideoOnlyIFrameMoof(
+        muxedIFrameMoof(1, 2, false),
+        1,
+        2,
+        undefined,
+        undefined,
+      ),
+    ).to.equal(null);
   });
 });
 


### PR DESCRIPTION
### This PR will...
Consolidated the I-Frame remux code into one function.

### Why is this Pull Request needed?
Follow up to #7940, this change makes iframe remuxing of mp4 complete/partial/muxed-av iframe media segments into one helper function, with consistent duration calculation across all paths. Most of this was in place (thanks @rudemateo). The goal here was to remove code duplication and unify the path for iFrame remuxing.