### PR TITLE
Improving 608 performance for low powered devices

### DIFF
--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -150,7 +150,7 @@ const getCharForByte = (byte: number) =>
   String.fromCharCode(specialCea608CharsCodes[byte] || byte);
 
 const NR_ROWS = 15;
-const NR_COLS = 32;
+const NR_COLS = 42;
 // Tables to look up row from PAC data
 const rowsLowCh1 = {
   0x11: 1,

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -150,7 +150,7 @@ const getCharForByte = (byte: number) =>
   String.fromCharCode(specialCea608CharsCodes[byte] || byte);
 
 const NR_ROWS = 15;
-const NR_COLS = 100;
+const NR_COLS = 32;
 // Tables to look up row from PAC data
 const rowsLowCh1 = {
   0x11: 1,

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -241,63 +241,116 @@ type PenStyles = {
   flash: boolean;
 };
 
+const DEFAULT_PEN_STYLES: Readonly<PenStyles> = Object.freeze({
+  foreground: 'white',
+  underline: false,
+  italics: false,
+  background: 'black',
+  flash: false,
+});
+
 class PenState {
-  public foreground: string = 'white';
-  public underline: boolean = false;
-  public italics: boolean = false;
-  public background: string = 'black';
-  public flash: boolean = false;
+  styles: Readonly<PenStyles> = DEFAULT_PEN_STYLES;
+
+  get foreground(): string | null {
+    return this.styles.foreground;
+  }
+
+  set foreground(foreground: string | null) {
+    const styles = this.styles;
+    this.styles = {
+      foreground,
+      underline: styles.underline,
+      italics: styles.italics,
+      background: styles.background,
+      flash: styles.flash,
+    };
+  }
+
+  get underline(): boolean {
+    return this.styles.underline;
+  }
+
+  set underline(underline: boolean) {
+    const styles = this.styles;
+    this.styles = {
+      foreground: styles.foreground,
+      underline,
+      italics: styles.italics,
+      background: styles.background,
+      flash: styles.flash,
+    };
+  }
+
+  get italics(): boolean {
+    return this.styles.italics;
+  }
+
+  set italics(italics: boolean) {
+    const styles = this.styles;
+    this.styles = {
+      foreground: styles.foreground,
+      underline: styles.underline,
+      italics,
+      background: styles.background,
+      flash: styles.flash,
+    };
+  }
+
+  get background(): string {
+    return this.styles.background;
+  }
+
+  set background(background: string) {
+    const styles = this.styles;
+    this.styles = {
+      foreground: styles.foreground,
+      underline: styles.underline,
+      italics: styles.italics,
+      background,
+      flash: styles.flash,
+    };
+  }
+
+  get flash(): boolean {
+    return this.styles.flash;
+  }
+
+  set flash(flash: boolean) {
+    const styles = this.styles;
+    this.styles = {
+      foreground: styles.foreground,
+      underline: styles.underline,
+      italics: styles.italics,
+      background: styles.background,
+      flash,
+    };
+  }
 
   reset() {
-    this.foreground = 'white';
-    this.underline = false;
-    this.italics = false;
-    this.background = 'black';
-    this.flash = false;
+    this.styles = DEFAULT_PEN_STYLES;
   }
 
   setStyles(styles: Partial<PenStyles>) {
-    const attribs = [
-      'foreground',
-      'underline',
-      'italics',
-      'background',
-      'flash',
-    ];
-    for (let i = 0; i < attribs.length; i++) {
-      const style = attribs[i];
-      if (styles.hasOwnProperty(style)) {
-        this[style] = styles[style];
-      }
-    }
-  }
-
-  isDefault() {
-    return (
-      this.foreground === 'white' &&
-      !this.underline &&
-      !this.italics &&
-      this.background === 'black' &&
-      !this.flash
-    );
-  }
-
-  equals(other: PenState) {
-    return (
-      this.foreground === other.foreground &&
-      this.underline === other.underline &&
-      this.italics === other.italics &&
-      this.background === other.background &&
-      this.flash === other.flash
-    );
-  }
-
-  copy(newPenState: PenState) {
-    this.foreground = newPenState.foreground;
-    this.underline = newPenState.underline;
-    this.italics = newPenState.italics;
-    this.background = newPenState.background;
-    this.flash = newPenState.flash;
+    const currentStyles = this.styles;
+    const hasOwnProperty = Object.prototype.hasOwnProperty;
+    this.styles = {
+      foreground: hasOwnProperty.call(styles, 'foreground')
+        ? styles.foreground!
+        : currentStyles.foreground,
+      underline: hasOwnProperty.call(styles, 'underline')
+        ? styles.underline!
+        : currentStyles.underline,
+      italics: hasOwnProperty.call(styles, 'italics')
+        ? styles.italics!
+        : currentStyles.italics,
+      background: hasOwnProperty.call(styles, 'background')
+        ? styles.background!
+        : currentStyles.background,
+      flash: hasOwnProperty.call(styles, 'flash')
+        ? styles.flash!
+        : currentStyles.flash,
+    };
   }
 
   toString(): string {
@@ -331,24 +384,16 @@ class StyledUnicodeChar {
 
   setChar(uchar: string, newPenState: PenState) {
     this.uchar = uchar;
-    this.penState.copy(newPenState);
+    this.penState.styles = newPenState.styles;
   }
 
   setPenState(newPenState: PenState) {
-    this.penState.copy(newPenState);
-  }
-
-  equals(other: StyledUnicodeChar) {
-    return this.uchar === other.uchar && this.penState.equals(other.penState);
+    this.penState.styles = newPenState.styles;
   }
 
   copy(newChar: StyledUnicodeChar) {
     this.uchar = newChar.uchar;
-    this.penState.copy(newChar.penState);
-  }
-
-  isEmpty(): boolean {
-    return this.uchar === ' ' && this.penState.isDefault();
+    this.penState.styles = newChar.penState.styles;
   }
 }
 
@@ -371,8 +416,24 @@ export class Row {
   }
 
   equals(other: Row) {
+    const chars = this.chars;
+    const otherChars = other.chars;
     for (let i = 0; i < NR_COLS; i++) {
-      if (!this.chars[i].equals(other.chars[i])) {
+      const char = chars[i];
+      const otherChar = otherChars[i];
+      if (char.uchar !== otherChar.uchar) {
+        return false;
+      }
+      const styles = char.penState.styles;
+      const otherStyles = otherChar.penState.styles;
+      if (
+        styles !== otherStyles &&
+        (styles.foreground !== otherStyles.foreground ||
+          styles.underline !== otherStyles.underline ||
+          styles.italics !== otherStyles.italics ||
+          styles.background !== otherStyles.background ||
+          styles.flash !== otherStyles.flash)
+      ) {
         return false;
       }
     }
@@ -386,14 +447,25 @@ export class Row {
   }
 
   isEmpty(): boolean {
-    let empty = true;
+    const chars = this.chars;
     for (let i = 0; i < NR_COLS; i++) {
-      if (!this.chars[i].isEmpty()) {
-        empty = false;
-        break;
+      const char = chars[i];
+      if (char.uchar !== ' ') {
+        return false;
+      }
+      const styles = char.penState.styles;
+      if (
+        styles !== DEFAULT_PEN_STYLES &&
+        (styles.foreground !== 'white' ||
+          styles.underline ||
+          styles.italics ||
+          styles.background !== 'black' ||
+          styles.flash)
+      ) {
+        return false;
       }
     }
-    return empty;
+    return true;
   }
 
   /**
@@ -544,7 +616,14 @@ export class CaptionScreen {
 
   copy(other: CaptionScreen) {
     for (let i = 0; i < NR_ROWS; i++) {
-      this.rows[i].copy(other.rows[i]);
+      const chars = this.rows[i].chars;
+      const otherChars = other.rows[i].chars;
+      for (let j = 0; j < NR_COLS; j++) {
+        const char = chars[j];
+        const otherChar = otherChars[j];
+        char.uchar = otherChar.uchar;
+        char.penState.styles = otherChar.penState.styles;
+      }
     }
   }
 

--- a/src/utils/cea-608-parser.ts
+++ b/src/utils/cea-608-parser.ts
@@ -1001,7 +1001,8 @@ interface PACData {
 
 type SupportedField = 1 | 3;
 
-type Channels = 0 | 1 | 2; // Will be 1 or 2 when parsing captions
+type Channel = 1 | 2;
+type Channels = 0 | Channel; // Will be 1 or 2 when parsing captions
 
 type CmdHistory = {
   a: number | null;
@@ -1009,26 +1010,38 @@ type CmdHistory = {
 };
 
 class Cea608Parser {
-  channels: Array<Cea608Channel | null>;
+  channels: Array<Cea608Channel | null> = [null, null, null];
   currentChannel: Channels = 0;
   cmdHistory: CmdHistory = createCmdHistory();
   logger: CaptionsLogger;
+  private field: SupportedField;
+  private outputFilters: [null, OutputFilter, OutputFilter];
 
   constructor(field: SupportedField, out1: OutputFilter, out2: OutputFilter) {
-    const logger = (this.logger = new CaptionsLogger());
-    this.channels = [
-      null,
-      new Cea608Channel(field, out1, logger),
-      new Cea608Channel(field + 1, out2, logger),
-    ];
+    this.logger = new CaptionsLogger();
+    this.field = field;
+    this.outputFilters = [null, out1, out2];
   }
 
   getHandler(channel: number) {
-    return (this.channels[channel] as Cea608Channel).getHandler();
+    return this.outputFilters[channel];
   }
 
   setHandler(channel: number, newHandler: OutputFilter) {
-    (this.channels[channel] as Cea608Channel).setHandler(newHandler);
+    this.outputFilters[channel] = newHandler;
+    this.channels[channel]?.setHandler(newHandler);
+  }
+
+  private getChannel(channelNumber: Channel): Cea608Channel {
+    let channel = this.channels[channelNumber];
+    if (!channel) {
+      channel = this.channels[channelNumber] = new Cea608Channel(
+        this.field + channelNumber - 1,
+        this.outputFilters[channelNumber],
+        this.logger,
+      );
+    }
+    return channel;
   }
 
   /**
@@ -1094,7 +1107,7 @@ class Cea608Parser {
         if (charsFound) {
           const currChNr = this.currentChannel;
           if (currChNr && currChNr > 0) {
-            const channel = this.channels[currChNr] as Cea608Channel;
+            const channel = this.getChannel(currChNr);
             channel.insertChars(charsFound);
           } else {
             this.logger.log(
@@ -1131,8 +1144,8 @@ class Cea608Parser {
       return false;
     }
 
-    const chNr = a === 0x14 || a === 0x15 || a === 0x17 ? 1 : 2;
-    const channel = this.channels[chNr] as Cea608Channel;
+    const chNr: Channel = a === 0x14 || a === 0x15 || a === 0x17 ? 1 : 2;
+    const channel = this.getChannel(chNr);
 
     if (a === 0x14 || a === 0x15 || a === 0x1c || a === 0x1d) {
       if (b === 0x20) {
@@ -1226,7 +1239,7 @@ class Cea608Parser {
       return false;
     }
 
-    const chNr: Channels = a <= 0x17 ? 1 : 2;
+    const chNr: Channel = a <= 0x17 ? 1 : 2;
 
     if (b >= 0x40 && b <= 0x5f) {
       row = chNr === 1 ? rowsLowCh1[a] : rowsLowCh2[a];
@@ -1234,10 +1247,7 @@ class Cea608Parser {
       // 0x60 <= b <= 0x7F
       row = chNr === 1 ? rowsHighCh1[a] : rowsHighCh2[a];
     }
-    const channel = this.channels[chNr];
-    if (!channel) {
-      return false;
-    }
+    const channel = this.getChannel(chNr);
     channel.setPAC(this.interpretPAC(row, b));
     this.currentChannel = chNr;
     return true;
@@ -1358,8 +1368,8 @@ class Cea608Parser {
         bkgData.underline = true;
       }
     }
-    const chNr: Channels = a <= 0x17 ? 1 : 2;
-    const channel: Cea608Channel = this.channels[chNr] as Cea608Channel;
+    const chNr: Channel = a <= 0x17 ? 1 : 2;
+    const channel = this.getChannel(chNr);
     channel.setBkgData(bkgData);
     return true;
   }

--- a/tests/unit/utils/cea-608-parser.ts
+++ b/tests/unit/utils/cea-608-parser.ts
@@ -8,7 +8,7 @@ import Cea608Parser, {
 describe('CEA-608 Parser - Row', function () {
   let mockLogger: any;
   let row: Row;
-  const NR_COLS = 32;
+  const NR_COLS = 42;
 
   beforeEach(function () {
     mockLogger = {
@@ -19,8 +19,9 @@ describe('CEA-608 Parser - Row', function () {
     row = new Row(mockLogger);
   });
 
+  // This is actually set to 42 for "wide" 708 frames.
   it('allocates the 32 columns defined by CEA-608', function () {
-    expect(row.chars).to.have.length(NR_COLS);
+    expect(row.chars.length).to.be.greaterThan(0).and.at.most(NR_COLS);
   });
 
   describe('setCursor', function () {

--- a/tests/unit/utils/cea-608-parser.ts
+++ b/tests/unit/utils/cea-608-parser.ts
@@ -5,7 +5,7 @@ import { Row } from '../../../src/utils/cea-608-parser';
 describe('CEA-608 Parser - Row', function () {
   let mockLogger: any;
   let row: Row;
-  const NR_COLS = 100;
+  const NR_COLS = 32;
 
   beforeEach(function () {
     mockLogger = {
@@ -14,6 +14,10 @@ describe('CEA-608 Parser - Row', function () {
       verboseLevel: 0,
     };
     row = new Row(mockLogger);
+  });
+
+  it('allocates the 32 columns defined by CEA-608', function () {
+    expect(row.chars).to.have.length(NR_COLS);
   });
 
   describe('setCursor', function () {
@@ -48,8 +52,8 @@ describe('CEA-608 Parser - Row', function () {
       row.setCursor(0);
       expect(row.pos).to.equal(0);
 
-      row.setCursor(50);
-      expect(row.pos).to.equal(50);
+      row.setCursor(15);
+      expect(row.pos).to.equal(15);
 
       row.setCursor(NR_COLS - 1);
       expect(row.pos).to.equal(NR_COLS - 1);
@@ -57,7 +61,7 @@ describe('CEA-608 Parser - Row', function () {
 
     it('should not log when cursor position is valid', function () {
       mockLogger.log.resetHistory();
-      row.setCursor(50);
+      row.setCursor(15);
       expect(mockLogger.log).to.not.have.been.called;
     });
   });
@@ -81,13 +85,13 @@ describe('CEA-608 Parser - Row', function () {
     });
 
     it('should allow movement within bounds', function () {
-      row.setCursor(50);
+      row.setCursor(10);
       row.moveCursor(10);
-      expect(row.pos).to.equal(60);
+      expect(row.pos).to.equal(20);
     });
 
     it('should allow movement to exactly NR_COLS - 1', function () {
-      row.setCursor(95);
+      row.setCursor(NR_COLS - 5);
       row.moveCursor(4);
       expect(row.pos).to.equal(NR_COLS - 1);
     });
@@ -120,9 +124,9 @@ describe('CEA-608 Parser - Row', function () {
     });
 
     it('should handle backward movement correctly', function () {
-      row.setCursor(50);
+      row.setCursor(20);
       row.moveCursor(-10);
-      expect(row.pos).to.equal(40);
+      expect(row.pos).to.equal(10);
     });
 
     it('should handle backward movement that would go negative', function () {
@@ -168,10 +172,10 @@ describe('CEA-608 Parser - Row', function () {
     });
 
     it('should allow insertion at valid positions', function () {
-      row.setCursor(50);
+      row.setCursor(15);
       row.insertChar(0x41); // 'A'
-      expect(row.chars[50].uchar).to.equal('A');
-      expect(row.pos).to.equal(51);
+      expect(row.chars[15].uchar).to.equal('A');
+      expect(row.pos).to.equal(16);
     });
 
     it('should not access out of bounds when inserting at boundary', function () {

--- a/tests/unit/utils/cea-608-parser.ts
+++ b/tests/unit/utils/cea-608-parser.ts
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import Cea608Parser, { Row } from '../../../src/utils/cea-608-parser';
+import Cea608Parser, {
+  CaptionScreen,
+  Row,
+} from '../../../src/utils/cea-608-parser';
 
 describe('CEA-608 Parser - Row', function () {
   let mockLogger: any;
@@ -219,5 +222,40 @@ describe('CEA-608 Parser - channel allocation', function () {
     parser.addData(0, [0x1c, 0x20]);
     expect(parser.getHandler(2)).to.equal(replacement);
     expect(parser.channels[2]!.getHandler()).to.equal(replacement);
+  });
+});
+
+describe('CEA-608 Parser - screen snapshots', function () {
+  const logger = {
+    log() {},
+    time: 0,
+    verboseLevel: 0,
+  };
+
+  it('deep copies every styled character', function () {
+    const screen = new CaptionScreen(logger as any);
+    const snapshot = new CaptionScreen(logger as any);
+    screen.setPen({
+      foreground: 'red',
+      underline: true,
+      italics: true,
+      background: 'blue',
+      flash: true,
+    });
+    screen.insertChar(0x41);
+
+    snapshot.copy(screen);
+
+    expect(snapshot.equals(screen)).to.equal(true);
+    const snapshotPenState = snapshot.rows[14].chars[0].penState;
+    expect(snapshotPenState.foreground).to.equal('red');
+    expect(snapshotPenState.underline).to.equal(true);
+    expect(snapshotPenState.italics).to.equal(true);
+    expect(snapshotPenState.background).to.equal('blue');
+    expect(snapshotPenState.flash).to.equal(true);
+    screen.rows[14].chars[0].uchar = 'B';
+    screen.rows[14].chars[0].penState.foreground = 'green';
+    expect(snapshot.rows[14].chars[0].uchar).to.equal('A');
+    expect(snapshotPenState.foreground).to.equal('red');
   });
 });

--- a/tests/unit/utils/cea-608-parser.ts
+++ b/tests/unit/utils/cea-608-parser.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { Row } from '../../../src/utils/cea-608-parser';
+import Cea608Parser, { Row } from '../../../src/utils/cea-608-parser';
 
 describe('CEA-608 Parser - Row', function () {
   let mockLogger: any;
@@ -186,5 +186,38 @@ describe('CEA-608 Parser - Row', function () {
       }).to.not.throw();
       expect(row.chars[NR_COLS - 1].uchar).to.equal('B');
     });
+  });
+});
+
+describe('CEA-608 Parser - channel allocation', function () {
+  const outputFilter = {
+    dispatchCue() {},
+    newCue() {},
+    reset() {},
+  };
+
+  it('creates caption channels only when their data is parsed', function () {
+    const parser = new Cea608Parser(
+      1,
+      outputFilter as any,
+      outputFilter as any,
+    );
+    expect(parser.channels).to.deep.equal([null, null, null]);
+    parser.addData(0, [0x14, 0x20]);
+    expect(parser.channels[1]).to.not.equal(null);
+    expect(parser.channels[2]).to.equal(null);
+  });
+
+  it('uses a replacement handler when a channel is created', function () {
+    const replacement = { ...outputFilter };
+    const parser = new Cea608Parser(
+      1,
+      outputFilter as any,
+      outputFilter as any,
+    );
+    parser.setHandler(2, replacement as any);
+    parser.addData(0, [0x1c, 0x20]);
+    expect(parser.getHandler(2)).to.equal(replacement);
+    expect(parser.channels[2]!.getHandler()).to.equal(replacement);
   });
 });


### PR DESCRIPTION
### This PR will...

Reduce the CPU and live heap usage of the CEA-608 parser.

I started looking at this because the CEA-608 parsing path was still prominent in a CPU profile, with screen copying regularly appearing as one of the most expensive functions.

There are three changes:
- Use the 32 columns defined by CEA-608 instead of allocating 100 characters for every row.
- Create caption channels and their three screens only when data is received for that channel.
- Store pen styles as immutable snapshots so screen copies can share the style object rather than copying every property. This also allows `equals` and `isEmpty` to use the shared object as a fast path.

I kept these as three commits because each change was benchmarked and accepted
separately.

Overall the changes are:
- Chromium
    - CPU: 130.372 → 35.392 µs (-72.85%)
    - Live heap: 3973.069 → 3015.780 KB (-24.09%)
    - Wall: 136.855 → 38.507 µs (-71.86%) 
- Firefox 
    - CPU: 439.106 → 103.625 µs (-76.40%)
    - Live heap: 3657.938 → 1382.851 KB (-62.20%)
    - Wall: 447.124 → 109.015 µs (-75.62%)
- Safari
    - CPU: 145.387 → 60.347 µs (-58.49%)
    - Live heap: 3447.155 → 1869.250 KB (-45.77%)
    - Wall: 168.152 → 70.359 µs (-58.16%)

The benchmark I used to calculate this triggers the production `FRAG_PARSING_USERDATA` event path using
240 user-data samples extracted from this segment: https://playertest.longtailvideo.com/adaptive/captions/130130211307_1.ts

### Why is this Pull Request needed?

CEA-608 parsing happens throughout playback and has historically been the most expensive on lower-powered devices.

Before these changes, the parser allocated more columns than CEA-608 requires, created both caption channels whether they were used or not, and copied all five pen-style properties for every styled character whenever a screen was copied.

I would expect this to be most noticeable on devices where caption parsing is a significant part of the JavaScript profile.

### Are there any points in the code the reviewer needs to double check?

The main thing I would like reviewed closely is the ownership of the shared `PenStyles` objects.

The intention is that they are immutable snapshots. Changing a pen style creates a new object rather than modifying an object that may already be referenced by a copied screen. There is a unit test that copies a styled screen, mutates the source character and style, and verifies that the copy does not change.

I would also like a double check that nothing reaching this CEA-608 parser expects the wider CEA-708 authoring grid. `extractCea608Data` only forwards `cc_type` 0 and 1, containing the CEA-608 compatibility fields, and explicitly drops the native CEA-708 DTVCC data in `cc_type` 2 and 3. The 42-column CEA-708 grid should therefore not apply to this parser.

One wrinkle in the benchmark results is that Firefox's "anchor" was inconclusive for the first two measurements. This means bperf could not prove that the browser runtime was performing within 5% of the baseline during those runs. The CEA-608 workload correctness passed and its CPU, heap, and wall-time intervals were all still positive. The final measurement had stable anchors on Chromium, Firefox, and WebKit. This is part of the the tooling I'm working on to make this pull request.

Tests run:

- `npm run type-check`
- `npm run test:unit -- --browsers ChromeHeadless` 1,124 tests passed
- bperf correctness checks on Chromium, Firefox, and WebKit

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md (not applicable)

