### PR TITLE
fix: skip AAC PES without ADTS headers instead of triggering fragPars…

### DIFF
--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -708,21 +708,20 @@ class TSDemuxer implements Demuxer {
     }
     // if ADTS header does not start straight from the beginning of the PES payload, raise an error
     if (offset !== startOffset) {
-      let reason: string;
       const recoverable = offset < len - 1;
       if (recoverable) {
-        reason = `AAC PES did not start with ADTS header,offset:${offset}`;
+        emitParsingError(
+          this.observer,
+          new Error(`AAC PES did not start with ADTS header,offset:${offset}`),
+          chunkMeta,
+          true,
+          this.logger,
+        );
       } else {
-        reason = 'No ADTS header found in AAC PES';
-      }
-      emitParsingError(
-        this.observer,
-        new Error(reason),
-        chunkMeta,
-        recoverable,
-        this.logger,
-      );
-      if (!recoverable) {
+        // No ADTS header in AAC PES — stream may have no audio input. Skip silently to avoid fragParsingError.
+        this.logger.warn(
+          `No ADTS header found in AAC PES (${len} bytes), audio may be absent`,
+        );
         return;
       }
     }


### PR DESCRIPTION
…ingError

When encoder has no audio input, AAC PES packets in the TS stream contain no valid ADTS frames. Previously this triggered a fragParsingError with recoverable=false, causing 6 retry attempts and eventual playback failure. Now it logs a warning and skips the audio, allowing video-only playback to continue.

### This PR will...

  Fix a false-positive `fragParsingError` when TS segments contain AAC PES
  packets without valid ADTS frames. Instead of treating this as an unrecoverable
  parsing error, log a warning and skip the audio data, allowing video-only
  playback to continue normally.

### Why is this Pull Request needed?
  
  When a live encoder has no audio input, it may still declare an AAC audio PID
  in the TS PMT. The resulting PES packets contain no valid ADTS headers.
  Previously, `parseAACPES()` called `emitParsingError()` with `recoverable=false`,
  triggering a `fragParsingError` that caused hls.js to retry the fragment 6 times
  and then stop playback entirely. This prevented video-only live streams from
  playing at all.

### Resolves issues:

### Checklist

  - [x] changes have been done against master branch, and PR does not conflict
  - [ ] new unit / functional tests have been added (whenever applicable)
  - [ ] API or design changes are documented in API.md
