### PR TITLE
perf(tsdemuxer): find markers with indexOf

### DIFF
--- a/src/demux/video/base-video-parser.ts
+++ b/src/demux/video/base-video-parser.ts
@@ -9,6 +9,10 @@ import type { ChunkMetadata } from '../../types/transmuxer';
 import type { ParsedVideoSample } from '../tsdemuxer';
 import type { PES } from '../tsdemuxer';
 
+const ANNEX_B_START_CODE_MARKER = 0x01;
+const MIN_START_CODE_ZERO_RUN = 2;
+const NAL_UNIT_TYPE_PENDING = -1;
+
 abstract class BaseVideoParser {
   protected VideoSample: ParsedVideoSample | null = null;
 
@@ -79,120 +83,118 @@ abstract class BaseVideoParser {
   protected parseNALu(
     track: DemuxedVideoTrack,
     array: Uint8Array,
-    endOfSegment: boolean,
-  ): Array<{
-    data: Uint8Array;
-    type: number;
-    state?: number;
-  }> {
+    _endOfSegment: boolean,
+  ): VideoSampleUnit[] {
     const len = array.byteLength;
-    let state = track.naluState || 0;
-    const lastState = state;
+    if (len === 0) {
+      return [];
+    }
+
+    const previousState = track.naluState || 0;
+    const previousZeroRun =
+      previousState === NAL_UNIT_TYPE_PENDING ? 0 : previousState;
+
     const units: VideoSampleUnit[] = [];
-    let i = 0;
-    let value: number;
-    let overflow: number;
-    let unitType: number;
-    let lastUnitStart = -1;
-    let lastUnitType: number = 0;
-    // logger.log('PES:' + Hex.hexDump(array));
+    let nextState = 0;
+    let searchFrom = 0;
+    let unitStart = -1;
+    let unitType = 0;
 
-    if (state === -1) {
-      // special use case where we found 3 or 4-byte start codes exactly at the end of previous PES packet
-      lastUnitStart = 0;
-      // NALu type is value read from offset 0
-      lastUnitType = this.getNALuType(array, 0);
-      state = 0;
-      i = 1;
+    if (previousState === NAL_UNIT_TYPE_PENDING) {
+      // A delimiter ended at the preceding chunk boundary.
+      unitStart = 0;
+      unitType = this.getNALuType(array, 0);
+      searchFrom = 1;
     }
 
-    while (i < len) {
-      value = array[i++];
-      // optimization. state 0 and 1 are the predominant case. let's handle them outside of the switch/case
-      if (!state) {
-        state = value ? 0 : 1;
-        continue;
-      }
-      if (state === 1) {
-        state = value ? 0 : 2;
-        continue;
-      }
-      // here we have state either equal to 2 or 3
-      if (!value) {
-        state = 3;
-      } else if (value === 1) {
-        overflow = i - state - 1;
-        if (lastUnitStart >= 0) {
-          const unit: VideoSampleUnit = {
-            data: array.subarray(lastUnitStart, overflow),
-            type: lastUnitType,
-          };
-          // logger.log('pushing NALU, type/size:' + unit.type + '/' + unit.data.byteLength);
-          units.push(unit);
-        } else {
-          // lastUnitStart is undefined => this is the first start code found in this PES packet
-          // first check if start code delimiter is overlapping between 2 PES packets,
-          // ie it started in last packet (lastState not zero)
-          // and ended at the beginning of this PES packet (i <= 4 - lastState)
-          const lastUnit = this.getLastNalUnit(track.samples);
-          if (lastUnit) {
-            if (lastState && i <= 4 - lastState) {
-              // start delimiter overlapping between PES packets
-              // strip start delimiter bytes from the end of last NAL unit
-              // check if lastUnit had a state different from zero
-              if (lastUnit.state) {
-                // strip last bytes
-                lastUnit.data = lastUnit.data.subarray(
-                  0,
-                  lastUnit.data.byteLength - lastState,
-                );
-              }
-            }
-            // If NAL units are not starting right at the beginning of the PES packet, push preceding data into previous NAL unit.
+    while (searchFrom < len) {
+      // Native marker search avoids a JavaScript branch for every payload byte.
+      const markerIndex = array.indexOf(ANNEX_B_START_CODE_MARKER, searchFrom);
 
-            if (overflow > 0) {
-              // logger.log('first NALU found with overflow:' + overflow);
-              lastUnit.data = appendUint8Array(
-                lastUnit.data,
-                array.subarray(0, overflow),
-              );
-              lastUnit.state = 0;
-            }
-          }
-        }
-        // check if we can read unit type
-        if (i < len) {
-          unitType = this.getNALuType(array, i);
-          // logger.log('find NALU @ offset:' + i + ',type:' + unitType);
-          lastUnitStart = i;
-          lastUnitType = unitType;
-          state = 0;
-        } else {
-          // not enough byte to read unit type. let's read it on next PES parsing
-          state = -1;
-        }
+      if (markerIndex === -1) {
+        break;
+      }
+
+      searchFrom = markerIndex + 1;
+
+      let nalEnd = markerIndex;
+      while (nalEnd > 0 && array[nalEnd - 1] === 0) {
+        nalEnd--;
+      }
+
+      // The delimiter's zero run may begin in the preceding chunk.
+      const zeroRun =
+        markerIndex - nalEnd + (nalEnd === 0 ? previousZeroRun : 0);
+
+      if (zeroRun < MIN_START_CODE_ZERO_RUN) {
+        continue;
+      }
+
+      if (unitStart >= 0) {
+        units.push({
+          data: array.subarray(unitStart, nalEnd),
+          type: unitType,
+        });
       } else {
-        state = 0;
+        const previousUnit = this.getLastNalUnit(track.samples);
+
+        if (previousUnit) {
+          if (nalEnd > 0) {
+            // Bytes before the first delimiter continue the preceding NAL.
+            previousUnit.data = appendUint8Array(
+              previousUnit.data,
+              array.subarray(0, nalEnd),
+            );
+          } else if (previousZeroRun > 0) {
+            previousUnit.data = previousUnit.data.subarray(
+              0,
+              previousUnit.data.byteLength - previousZeroRun,
+            );
+          }
+
+          previousUnit.state = 0;
+        }
+      }
+
+      if (searchFrom < len) {
+        unitStart = searchFrom;
+        unitType = this.getNALuType(array, searchFrom);
+      } else {
+        nextState = NAL_UNIT_TYPE_PENDING;
+        unitStart = -1;
+        break;
       }
     }
-    if (lastUnitStart >= 0 && state >= 0) {
-      const unit: VideoSampleUnit = {
-        data: array.subarray(lastUnitStart, len),
-        type: lastUnitType,
-        state: state,
-      };
-      units.push(unit);
-      // logger.log('pushing NALU, type/size/state:' + unit.type + '/' + unit.data.byteLength + '/' + state);
+
+    if (nextState !== NAL_UNIT_TYPE_PENDING) {
+      let trailingZeroStart = len;
+
+      while (trailingZeroStart > 0 && array[trailingZeroStart - 1] === 0) {
+        trailingZeroStart--;
+      }
+
+      nextState =
+        len -
+        trailingZeroStart +
+        (trailingZeroStart === 0 ? previousZeroRun : 0);
     }
-    // no NALu found
-    if (units.length === 0) {
-      // append pes.data to previous NAL unit
-      const lastUnit = this.getLastNalUnit(track.samples);
-      if (lastUnit) {
-        lastUnit.data = appendUint8Array(lastUnit.data, array);
+
+    if (unitStart >= 0) {
+      units.push({
+        data: array.subarray(unitStart),
+        type: unitType,
+        state: nextState,
+      });
+    } else if (units.length === 0 && nextState !== NAL_UNIT_TYPE_PENDING) {
+      const previousUnit = this.getLastNalUnit(track.samples);
+
+      if (previousUnit) {
+        previousUnit.data = appendUint8Array(previousUnit.data, array);
+        previousUnit.state = nextState;
       }
     }
-    track.naluState = state;
+
+    track.naluState = nextState;
     return units;
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -33,6 +33,7 @@ import './unit/crypt/aes-decryptor';
 import './unit/crypt/decrypter';
 import './unit/demuxer/adts';
 import './unit/demuxer/base-audio-demuxer';
+import './unit/demuxer/base-video-parser';
 import './unit/loader/date-range';
 import './unit/loader/fragment-loader';
 import './unit/loader/fragment';

--- a/tests/unit/demuxer/base-video-parser.ts
+++ b/tests/unit/demuxer/base-video-parser.ts
@@ -1,0 +1,243 @@
+import { expect } from 'chai';
+import BaseVideoParser from '../../../src/demux/video/base-video-parser';
+import type { PES } from '../../../src/demux/tsdemuxer';
+import type {
+  DemuxedUserdataTrack,
+  DemuxedVideoTrack,
+  VideoSampleUnit,
+} from '../../../src/types/demuxer';
+import type { ChunkMetadata } from '../../../src/types/transmuxer';
+
+class TestVideoParser extends BaseVideoParser {
+  public parse(track: DemuxedVideoTrack, data: number[]) {
+    return this.parseNALu(track, new Uint8Array(data), false);
+  }
+
+  public parsePES(
+    _track: DemuxedVideoTrack,
+    _textTrack: DemuxedUserdataTrack,
+    _pes: PES,
+    _last: boolean,
+    _chunkMeta?: ChunkMetadata,
+  ) {}
+
+  protected getNALuType(data: Uint8Array, offset: number): number {
+    return data[offset] & 0x1f;
+  }
+}
+
+describe('BaseVideoParser', function () {
+  let parser: TestVideoParser;
+  let track: DemuxedVideoTrack;
+
+  beforeEach(function () {
+    parser = new TestVideoParser();
+    track = videoTrack();
+  });
+
+  it('parses three and four-byte NAL unit start codes', function () {
+    const units = parser.parse(
+      track,
+      [0, 0, 1, 0x65, 0xaa, 0, 0, 0, 1, 0x06, 0xbb],
+    );
+
+    expectUnits(units, [
+      { data: [0x65, 0xaa], type: 5 },
+      { data: [0x06, 0xbb], type: 6, state: 0 },
+    ]);
+    expect(track.naluState).to.equal(0);
+  });
+
+  it('discards padding zeros preceding a start code', function () {
+    const units = parser.parse(
+      track,
+      [0, 0, 1, 0x65, 0xaa, 0, 0, 0, 0, 1, 0x06],
+    );
+
+    expectUnits(units, [
+      { data: [0x65, 0xaa], type: 5 },
+      { data: [0x06], type: 6, state: 0 },
+    ]);
+  });
+
+  it('requires the Annex-B marker byte to equal 0x01', function () {
+    const units = parser.parse(
+      track,
+      [0, 0, 1, 0x65, 0xaa, 0, 0, 0x02, 0xbb, 0, 0, 0x81, 0xcc, 0, 0, 1, 0x06],
+    );
+
+    expectUnits(units, [
+      {
+        data: [0x65, 0xaa, 0, 0, 0x02, 0xbb, 0, 0, 0x81, 0xcc],
+        type: 5,
+      },
+      { data: [0x06], type: 6, state: 0 },
+    ]);
+  });
+  it('recognizes a start code split across PES packets', function () {
+    const previousUnit = addLastUnit(track, [0x65, 0xaa, 0, 0], 2);
+
+    const units = parser.parse(track, [1, 0x06, 0xbb]);
+
+    expect(Array.from(previousUnit.data)).to.deep.equal([0x65, 0xaa]);
+    expectUnits(units, [{ data: [0x06, 0xbb], type: 6, state: 0 }]);
+    expect(track.naluState).to.equal(0);
+  });
+
+  it('reads the NAL unit type from the next packet', function () {
+    const firstUnits = parser.parse(track, [0, 0, 1, 0x65, 0xaa, 0, 0, 1]);
+
+    expectUnits(firstUnits, [{ data: [0x65, 0xaa], type: 5 }]);
+    expect(track.naluState).to.equal(-1);
+
+    const secondUnits = parser.parse(track, [0x06, 0xbb]);
+
+    expectUnits(secondUnits, [{ data: [0x06, 0xbb], type: 6, state: 0 }]);
+    expect(track.naluState).to.equal(0);
+  });
+
+  it('appends data without a start code to the previous NAL unit', function () {
+    const previousUnit = addLastUnit(track, [0x65, 0xaa], 0);
+
+    const units = parser.parse(track, [0xbb, 0]);
+
+    expect(units).to.have.lengthOf(0);
+    expect(Array.from(previousUnit.data)).to.deep.equal([0x65, 0xaa, 0xbb, 0]);
+    expect(previousUnit.state).to.equal(1);
+    expect(track.naluState).to.equal(1);
+  });
+
+  it('skips payload without zero bytes', function () {
+    const previousUnit = addLastUnit(track, [0x65, 0xaa], 0);
+
+    const units = parser.parse(track, [0xbb, 0xcc]);
+
+    expect(units).to.have.lengthOf(0);
+    expect(Array.from(previousUnit.data)).to.deep.equal([
+      0x65, 0xaa, 0xbb, 0xcc,
+    ]);
+    expect(track.naluState).to.equal(0);
+  });
+
+  it('produces the same NAL units at every PES split boundary', function () {
+    const data = [
+      0, 0, 1, 0x65, 0x12, 0x34, 0x56, 0, 0, 0, 1, 0x06, 0x78, 0x9a, 0, 0, 0, 0,
+      1, 0x61, 0xbc, 0xde,
+    ];
+    const expected = {
+      state: 0,
+      units: [
+        { data: [0x65, 0x12, 0x34, 0x56], type: 5 },
+        { data: [0x06, 0x78, 0x9a], type: 6 },
+        { data: [0x61, 0xbc, 0xde], type: 1 },
+      ],
+    };
+
+    expect(parseChunks([data])).to.deep.equal(expected);
+
+    for (let split = 1; split < data.length; split++) {
+      expect(
+        parseChunks([data.slice(0, split), data.slice(split)]),
+        `split at byte ${split}`,
+      ).to.deep.equal(expected);
+    }
+  });
+
+  it('recognizes a start code split across three PES packets', function () {
+    expect(
+      parseChunks([[0, 0, 1, 0x65, 0xaa, 0], [0], [1], [0x06, 0xbb]]),
+    ).to.deep.equal({
+      state: 0,
+      units: [
+        { data: [0x65, 0xaa], type: 5 },
+        { data: [0x06, 0xbb], type: 6 },
+      ],
+    });
+  });
+});
+
+function videoTrack(): DemuxedVideoTrack {
+  return {
+    type: 'video',
+    id: 1,
+    pid: 0x100,
+    inputTimeScale: 90000,
+    sequenceNumber: 0,
+    samples: [],
+    dropped: 0,
+    segmentCodec: 'avc',
+    pixelRatio: [1, 1],
+    width: 0,
+    height: 0,
+  };
+}
+
+function addLastUnit(
+  track: DemuxedVideoTrack,
+  data: number[],
+  state: number,
+): VideoSampleUnit {
+  const unit = {
+    data: new Uint8Array(data),
+    type: 5,
+    state,
+  };
+  track.samples.push({
+    dts: 0,
+    pts: 0,
+    key: true,
+    frame: true,
+    units: [unit],
+    length: data.length,
+  });
+  track.naluState = state;
+  return unit;
+}
+
+function expectUnits(
+  actual: VideoSampleUnit[],
+  expected: Array<{ data: number[]; type: number; state?: number }>,
+) {
+  const serialized = actual.map((unit) => {
+    const result: { data: number[]; type: number; state?: number } = {
+      data: Array.from(unit.data),
+      type: unit.type,
+    };
+    if (unit.state !== undefined) {
+      result.state = unit.state;
+    }
+    return result;
+  });
+  expect(serialized).to.deep.equal(expected);
+}
+
+function parseChunks(chunks: number[][]) {
+  const parser = new TestVideoParser();
+  const track = videoTrack();
+
+  for (let i = 0; i < chunks.length; i++) {
+    const units = parser.parse(track, chunks[i]);
+    if (units.length) {
+      track.samples.push({
+        dts: 0,
+        pts: 0,
+        key: true,
+        frame: true,
+        units,
+        length: units.reduce((length, unit) => length + unit.data.length, 0),
+      });
+    }
+  }
+
+  const units = track.samples.reduce<VideoSampleUnit[]>(
+    (result, sample) => result.concat(sample.units),
+    [],
+  );
+  return {
+    state: track.naluState,
+    units: units.map((unit) => ({
+      data: Array.from(unit.data),
+      type: unit.type,
+    })),
+  };
+}


### PR DESCRIPTION
### This PR will...

Reduce the CPU time spent parsing NAL units during MPEG-TS demuxing.

`BaseVideoParser.parseNALu` previously examined every byte with a JavaScript
state machine. This change uses `Uint8Array#indexOf` to jump directly to
possible `0x01` marker bytes, then validates the preceding zero run.

It also makes the cross-PES state explicit so that start codes and their NAL
unit type can remain split across packet boundaries. This path is shared by
the AVC and HEVC parsers used by `TSDemuxer`.

Overall the changes are:

- Chromium
    - CPU: 17.842 → 10.448 ms (-41.44%)
    - Live heap: 20549.992 → 20572.290 KB (+0.11%, equivalent)
    - Wall: 18.727 → 11.069 ms (-40.89%)
- Firefox
    - CPU: 23.454 → 13.070 ms (-44.27%)
    - Live heap: 27711.604 → 27712.030 KB (+0.00%, equivalent)
    - Wall: 23.314 → 12.979 ms (-44.33%)
- WebKit
    - CPU: 14.659 → 8.565 ms (-41.57%)
    - Live heap: 11209.903 → 11216.443 KB (+0.06%, equivalent)
    - Wall: 16.663 → 9.901 ms (-40.58%)

The benchmark demuxs a 9MB MPEG-TS fixture containing eight
concatenated segments spanning ~78 seconds. It exercises the production
`TSDemuxer.demux` path that produces the `UserdataSample` objects eventually
emitted with `FRAG_PARSING_USERDATA`.

The benchmark I used verifed the exact sample count, byte count, first and last
PTS, and a hash of the 2,352 generated samples.

### Why is this Pull Request needed?

NAL payload bytes make up most of each video PES packet, but only a small
fraction can be Annex-B start-code markers. Processing every payload byte
through JavaScript branches adds unnecessary work throughout MPEG-TS
playback.

Moving the sparse marker search into the browser's native `indexOf`
implementation substantially reduces CPU and wall time without changing the
generated NAL units or user-data samples. This matches the browser support 
for Hls.js of Chrome 45+

I would expect this to be most noticeable on lower-powered devices and streams
with higher video bitrates.

### Are there any points in the code the reviewer needs to double check?

The main thing I would like reviewed closely is the state carried across PES
boundaries.

The parser accepts three- and four-byte Annex-B start codes, treats additional
zeros before a marker as padding, and supports a delimiter or NAL unit type
split across consecutive PES packets. The unit tests compare the output at
every possible split point and include a start code divided across three
packets.

Tests run:

- `npm run type-check`
- `npm run test:unit` — 1,151 tests passed
- Focused ESLint and Prettier checks
- bperf correctness checks on Chromium, Firefox, and WebKit

### Resolves issues:

N/A

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md (not applicable)