### PR TITLE
Migrate CI to Sauce Connect 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,12 +390,14 @@ jobs:
           name: build
 
       - name: start SauceConnect tunnel
-        uses: saucelabs/sauce-connect-action@0ca0e6ce3a5513d6bec2a54044a536c3da3a53fb # v2
+        uses: saucelabs/sauce-connect-action@cb88b508c6f9ff4d84490093733315dbd55de022 # v3
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          tunnelIdentifier: ${{ github.run_id }}-${{ matrix.config }}
-          retryTimeout: 300
+          region: us-west-1
+          tunnelName: ${{ github.run_id }}-${{ matrix.config }}
+          retryTimeout: 5
+          proxyLocalhost: direct # sc4 was false
 
       - name: install
         run: |

--- a/tests/functional/auto/setup.js
+++ b/tests/functional/auto/setup.js
@@ -704,16 +704,16 @@ describe(`Testing hls.js playback in ${browserConfig.name} ${browserConfig.versi
       if (process.env.SAUCE_TUNNEL_ID) {
         capabilities['sauce:options'] = {
           build: 'HLSJS-' + process.env.SAUCE_TUNNEL_ID,
-          ['tunnel-identifier']: process.env.SAUCE_TUNNEL_ID,
+          tunnelName: process.env.SAUCE_TUNNEL_ID,
         };
       } else {
         capabilities['sauce:options'] = {
-          ['tunnel-identifier']: `local-${Date.now()}`,
+          tunnelName: `local-${Date.now()}`,
         };
       }
       if (!process.env.SAUCE_TUNNEL_ID) {
         sauceConnectProcess = await sauceConnect(
-          capabilities['tunnel-identifier']
+          capabilities['sauce:options'].tunnelName
         );
       }
       capabilities['sauce:options'].public = 'public restricted';


### PR DESCRIPTION
## Summary

- upgrade the Sauce Connect action from v2 to v3
- configure the v5-compatible `region` and `tunnelName` inputs
- update functional-test capabilities and local tunnel setup to use `sauce:options.tunnelName`

## Why

Sauce Labs ended server support for Sauce Connect 4 traffic on July 31, 2026. The existing v2 action starts Sauce Connect 4, which is now remotely shut down before the CI tunnel can start.

## Impact

This restores Sauce-backed browser test tunnels without changing unrelated GitHub Actions versions.

The unrelated GitHub Action versions are that technically this runs under Node 24 due to Node 20 being deprecated. So a bunch of versions should be upgraded, but.. don't fix what isn't broken 👍 

## Validation

- `npx --no-install prettier --check .github/workflows/build.yml tests/functional/auto/setup.js`
- `npx --no-install eslint tests/functional/auto/setup.js`
- `git diff HEAD^ --check`
