### PR TITLE
Prevent loop loading for SourceBuffer mismatch append errors

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1021,9 +1021,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
         const mediaError = this.media?.error;
         if (
           error.name === TRACK_REMOVED_ERROR_NAME &&
-          this.sourceBufferCount === 0
+          this.sourceBufferCount === 0 &&
+          (!this.media || this.pendingTrackCount === 0)
         ) {
-          // Do nothing if sourceBuffers were removed (media is detached and append was not aborted)
+          // Do nothing if sourceBuffers were removed (media is detached or tracks resolved, and append was not aborted)
           event.errorAction = createDoNothingErrorAction(true);
         } else {
           if (isQuotaError) {

--- a/tests/unit/controller/buffer-controller.ts
+++ b/tests/unit/controller/buffer-controller.ts
@@ -391,6 +391,31 @@ describe('BufferController', function () {
         originalAudioTrack.codec,
       );
     });
+
+    it('ignores unmuxed tracks once a muxed "audiovideo" SourceBuffer is created', function () {
+      const buffer = {} as unknown as ExtendedSourceBuffer;
+      bufferController.tracks = {
+        audiovideo: {
+          id: 'main',
+          container: 'video/mp4',
+          buffer,
+          listeners: [],
+        },
+      };
+      bufferController.sourceBuffers = [
+        ['audiovideo', buffer],
+        [null, null],
+      ];
+      hls.trigger(Events.BUFFER_CODECS, {
+        audio: {
+          id: 'audio',
+          container: 'audio/mp4',
+          codec: 'mp4a.40.2',
+        },
+      });
+      expect(bufferController.tracks).to.not.have.property('audio');
+      expect(bufferController.tracks).to.have.property('audiovideo');
+    });
   });
 
   describe('bufferedToEnd', function () {


### PR DESCRIPTION
### This PR will...
Prevent loop loading for SourceBuffer mismatch append errors

### Why is this Pull Request needed?
Prevents recursive errors with unsupported content with a mix of unmuxed mp4 main and alt-audio.

### Resolves issues:
Related to #7142
