### PR TITLE
Fix unterminated emsg infinite loop and scheme parsing

### DIFF
--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -95,17 +95,18 @@ function readUint64(buffer: Uint8Array, offset: number) {
   return result;
 }
 
-// Returns a null-terminated string including its terminator, or the remaining
-// bytes when the buffer ends before the terminator.
-function readCString(buffer: Uint8Array, offset: number): string {
+// Returns a null-terminated string including its terminator, or null when the
+// buffer ends before the terminator. Callers advance by the returned length;
+// an unterminated string consumes the rest of the buffer.
+function readCString(buffer: Uint8Array, offset: number): string | null {
   let result = '';
   for (let i = offset; i < buffer.length; i++) {
     result += String.fromCharCode(buffer[i]);
     if (buffer[i] === 0) {
-      break;
+      return result;
     }
   }
-  return result;
+  return null;
 }
 
 function readSint32(buffer: Uint8Array, offset: number): number {
@@ -2013,20 +2014,27 @@ export function parseEmsg(data: Uint8Array): IEmsgParsingData {
   let offset: number = 4;
 
   if (version === 0) {
-    schemeIdUri = readCString(data, offset);
-    offset += schemeIdUri.length;
+    const scheme = readCString(data, offset);
+    const schemeValue =
+      scheme !== null ? readCString(data, offset + scheme.length) : null;
 
-    value = readCString(data, offset);
-    offset += value.length;
+    if (scheme !== null && schemeValue !== null) {
+      schemeIdUri = scheme;
+      value = schemeValue;
+      offset += scheme.length + schemeValue.length;
 
-    timeScale = readUint32(data, offset);
-    offset += 4;
-    presentationTimeDelta = readUint32(data, offset);
-    offset += 4;
-    eventDuration = readUint32(data, offset);
-    offset += 4;
-    id = readUint32(data, offset);
-    offset += 4;
+      timeScale = readUint32(data, offset);
+      offset += 4;
+      presentationTimeDelta = readUint32(data, offset);
+      offset += 4;
+      eventDuration = readUint32(data, offset);
+      offset += 4;
+      id = readUint32(data, offset);
+      offset += 4;
+    } else {
+      // The box ends inside a string, so every field of the box follows it
+      offset = data.length;
+    }
   } else if (version === 1) {
     timeScale = readUint32(data, offset);
     offset += 4;
@@ -2047,11 +2055,21 @@ export function parseEmsg(data: Uint8Array): IEmsgParsingData {
     id = readUint32(data, offset);
     offset += 4;
 
-    schemeIdUri = readCString(data, offset);
-    offset += schemeIdUri.length;
+    const scheme = readCString(data, offset);
+    const schemeValue =
+      scheme !== null ? readCString(data, offset + scheme.length) : null;
 
-    value = readCString(data, offset);
-    offset += value.length;
+    if (scheme !== null) {
+      schemeIdUri = scheme;
+      offset += scheme.length;
+    }
+    if (schemeValue !== null) {
+      value = schemeValue;
+      offset += schemeValue.length;
+    } else {
+      // The box ends inside a string, so it carries no payload
+      offset = data.length;
+    }
   }
   const payload = data.subarray(offset, data.byteLength);
 

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -2032,6 +2032,9 @@ export function parseEmsg(data: Uint8Array): IEmsgParsingData {
       id = readUint32(data, offset);
       offset += 4;
     } else {
+      logger.warn(
+        `Unterminated ${scheme === null ? 'scheme_id_uri' : 'value'} in parsing emsg box: version 0 box ends inside a string, dropping all of its fields`,
+      );
       // The box ends inside a string, so every field of the box follows it
       offset = data.length;
     }
@@ -2067,6 +2070,9 @@ export function parseEmsg(data: Uint8Array): IEmsgParsingData {
       value = schemeValue;
       offset += schemeValue.length;
     } else {
+      logger.warn(
+        `Unterminated ${scheme === null ? 'scheme_id_uri' : 'value'} in parsing emsg box: version 1 box ends inside a string, dropping its ${scheme === null ? 'strings and payload' : 'value and payload'}`,
+      );
       // The box ends inside a string, so it carries no payload
       offset = data.length;
     }

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -95,6 +95,19 @@ function readUint64(buffer: Uint8Array, offset: number) {
   return result;
 }
 
+// Returns a null-terminated string including its terminator, or the remaining
+// bytes when the buffer ends before the terminator.
+function readCString(buffer: Uint8Array, offset: number): string {
+  let result = '';
+  for (let i = offset; i < buffer.length; i++) {
+    result += String.fromCharCode(buffer[i]);
+    if (buffer[i] === 0) {
+      break;
+    }
+  }
+  return result;
+}
+
 function readSint32(buffer: Uint8Array, offset: number): number {
   return (
     (buffer[offset] << 24) |
@@ -1993,35 +2006,28 @@ export function parseEmsg(data: Uint8Array): IEmsgParsingData {
   let value: string = '';
   let timeScale: number = 0;
   let presentationTimeDelta: number = 0;
-  let presentationTime: number = 0;
+  let presentationTime: number | undefined;
   let eventDuration: number = 0;
   let id: number = 0;
-  let offset: number = 0;
+  // Skip the FullBox version and flags
+  let offset: number = 4;
 
   if (version === 0) {
-    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
-      schemeIdUri += bin2str(data.subarray(offset, offset + 1));
-      offset += 1;
-    }
+    schemeIdUri = readCString(data, offset);
+    offset += schemeIdUri.length;
 
-    schemeIdUri += bin2str(data.subarray(offset, offset + 1));
-    offset += 1;
+    value = readCString(data, offset);
+    offset += value.length;
 
-    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
-      value += bin2str(data.subarray(offset, offset + 1));
-      offset += 1;
-    }
-
-    value += bin2str(data.subarray(offset, offset + 1));
-    offset += 1;
-
-    timeScale = readUint32(data, 12);
-    presentationTimeDelta = readUint32(data, 16);
-    eventDuration = readUint32(data, 20);
-    id = readUint32(data, 24);
-    offset = 28;
-  } else if (version === 1) {
+    timeScale = readUint32(data, offset);
     offset += 4;
+    presentationTimeDelta = readUint32(data, offset);
+    offset += 4;
+    eventDuration = readUint32(data, offset);
+    offset += 4;
+    id = readUint32(data, offset);
+    offset += 4;
+  } else if (version === 1) {
     timeScale = readUint32(data, offset);
     offset += 4;
     const leftPresentationTime = readUint32(data, offset);
@@ -2041,21 +2047,11 @@ export function parseEmsg(data: Uint8Array): IEmsgParsingData {
     id = readUint32(data, offset);
     offset += 4;
 
-    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
-      schemeIdUri += bin2str(data.subarray(offset, offset + 1));
-      offset += 1;
-    }
+    schemeIdUri = readCString(data, offset);
+    offset += schemeIdUri.length;
 
-    schemeIdUri += bin2str(data.subarray(offset, offset + 1));
-    offset += 1;
-
-    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
-      value += bin2str(data.subarray(offset, offset + 1));
-      offset += 1;
-    }
-
-    value += bin2str(data.subarray(offset, offset + 1));
-    offset += 1;
+    value = readCString(data, offset);
+    offset += value.length;
   }
   const payload = data.subarray(offset, data.byteLength);
 

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -8,6 +8,7 @@ import {
   discardEPB,
   findBox,
   getSampleData,
+  parseEmsg,
   parseInitSegment,
   parseSEIMessageFromNALu,
   remuxVideoOnlyIFrameMoof,
@@ -315,6 +316,103 @@ describe('mp4-tools', function () {
       ),
     ).to.equal(null);
   });
+
+  it('parseEmsg reads a version 1 box', function () {
+    const emsg = parseEmsg(
+      appendBytes(
+        emsgHeader(1),
+        uint32(90000),
+        uint64(900000),
+        uint32(180000),
+        uint32(7),
+        cString('https://aomedia.org/emsg/ID3'),
+        cString(''),
+        new Uint8Array([0x49, 0x44, 0x33]),
+      ),
+    );
+    expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
+    expect(emsg.value).to.equal('\0');
+    expect(emsg.timeScale).to.equal(90000);
+    expect(emsg.presentationTime).to.equal(900000);
+    expect(emsg.eventDuration).to.equal(180000);
+    expect(emsg.id).to.equal(7);
+    expect(emsg.payload).to.deep.equal(new Uint8Array([0x49, 0x44, 0x33]));
+  });
+
+  it('parseEmsg reads a version 0 box after the version and flags', function () {
+    const emsg = parseEmsg(
+      appendBytes(
+        emsgHeader(0),
+        cString('https://aomedia.org/emsg/ID3'),
+        cString('1'),
+        uint32(90000),
+        uint32(4500),
+        uint32(180000),
+        uint32(7),
+        new Uint8Array([0x49, 0x44, 0x33]),
+      ),
+    );
+    expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
+    expect(emsg.value).to.equal('1\0');
+    expect(emsg.timeScale).to.equal(90000);
+    // Version 0 carries a delta rather than an absolute presentation time
+    expect(emsg.presentationTime).to.equal(undefined);
+    expect(emsg.presentationTimeDelta).to.equal(4500);
+    expect(emsg.eventDuration).to.equal(180000);
+    expect(emsg.id).to.equal(7);
+    expect(emsg.payload).to.deep.equal(new Uint8Array([0x49, 0x44, 0x33]));
+  });
+
+  it('parseEmsg returns on a box truncated before its scheme id uri', function () {
+    const emsg = parseEmsg(
+      appendBytes(
+        emsgHeader(1),
+        uint32(90000),
+        uint64(900000),
+        uint32(180000),
+        uint32(7),
+      ),
+    );
+    expect(emsg.schemeIdUri).to.equal('');
+    expect(emsg.value).to.equal('');
+    expect(emsg.timeScale).to.equal(90000);
+    expect(emsg.payload).to.have.lengthOf(0);
+  });
+
+  it('parseEmsg returns on an unterminated scheme id uri', function () {
+    const emsg = parseEmsg(
+      appendBytes(
+        emsgHeader(1),
+        uint32(90000),
+        uint64(900000),
+        uint32(180000),
+        uint32(7),
+        new Uint8Array([0x75, 0x72, 0x6e, 0x3a, 0x61]),
+      ),
+    );
+    expect(emsg.schemeIdUri).to.equal('urn:a');
+    expect(emsg.value).to.equal('');
+  });
+
+  it('parseEmsg returns on an emsg box that findBox truncated to the bytes received', function () {
+    const body = appendBytes(
+      emsgHeader(1),
+      uint32(90000),
+      uint64(900000),
+      uint32(180000),
+      uint32(7),
+      cString('urn:a'),
+    );
+    const box = appendBytes(
+      uint32(8 + body.length),
+      new Uint8Array([0x65, 0x6d, 0x73, 0x67]),
+      body,
+    );
+    // Segment delivery stopped before the scheme id uri arrived, so findBox
+    // clamps the box to the bytes that are actually present.
+    const [truncated] = findBox(box.subarray(0, box.length - 6), ['emsg']);
+    expect(parseEmsg(truncated).schemeIdUri).to.equal('');
+  });
 });
 
 // Track fragment with per-sample sizes and senc/saio (one aux info offset)
@@ -564,6 +662,19 @@ function uint32(value: number): Uint8Array {
     (value >>> 8) & 0xff,
     value & 0xff,
   ]);
+}
+
+// emsg box body header: the FullBox version followed by three flag bytes
+function emsgHeader(version: number): Uint8Array {
+  return new Uint8Array([version, 0, 0, 0]);
+}
+
+function cString(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length + 1);
+  for (let i = 0; i < value.length; i++) {
+    bytes[i] = value.charCodeAt(i);
+  }
+  return bytes;
 }
 
 function uint64(value: number): Uint8Array {

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -390,7 +390,7 @@ describe('mp4-tools', function () {
         new Uint8Array([0x75, 0x72, 0x6e, 0x3a, 0x61]),
       ),
     );
-    expect(emsg.schemeIdUri).to.equal('urn:a');
+    expect(emsg.schemeIdUri).to.equal('');
     expect(emsg.value).to.equal('');
   });
 
@@ -407,8 +407,9 @@ describe('mp4-tools', function () {
         new Uint8Array([0x31]),
       ),
     );
+    // The fields the box did carry are kept, the unterminated value is not
     expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
-    expect(emsg.value).to.equal('1');
+    expect(emsg.value).to.equal('');
     expect(emsg.timeScale).to.equal(90000);
     expect(emsg.presentationTime).to.equal(900000);
     expect(emsg.eventDuration).to.equal(180000);
@@ -426,8 +427,9 @@ describe('mp4-tools', function () {
         new Uint8Array([0x31]),
       ),
     );
-    expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
-    expect(emsg.value).to.equal('1');
+    // Nothing in a version 0 box precedes its strings, so nothing is usable
+    expect(emsg.schemeIdUri).to.equal('');
+    expect(emsg.value).to.equal('');
     expect(emsg.timeScale).to.equal(0);
     expect(emsg.presentationTimeDelta).to.equal(0);
     expect(emsg.eventDuration).to.equal(0);

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { ElementaryStreamTypes } from '../../../src/loader/fragment';
 import MP4 from '../../../src/remux/mp4-generator';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
@@ -17,7 +18,7 @@ import {
 } from '../../../src/utils/mp4-tools';
 import type { TrackFragmentSample } from '../../../src/remux/mp4-generator';
 import type { UserdataSample } from '../../../src/types/demuxer';
-import type { InitData } from '../../../src/utils/mp4-tools';
+import type { IEmsgParsingData, InitData } from '../../../src/utils/mp4-tools';
 
 describe('mp4-tools', function () {
   it('preserves SEI user-data event fields and raw bytes', function () {
@@ -395,18 +396,24 @@ describe('mp4-tools', function () {
   });
 
   it('parseEmsg returns on a version 1 box whose value is unterminated', function () {
-    const emsg = parseEmsg(
-      appendBytes(
-        emsgHeader(1),
-        uint32(90000),
-        uint64(900000),
-        uint32(180000),
-        uint32(7),
-        cString('https://aomedia.org/emsg/ID3'),
-        // The value runs to the last byte of the box without a terminator
-        new Uint8Array([0x31]),
-      ),
-    );
+    const warn = sinon.stub(logger, 'warn');
+    let emsg: IEmsgParsingData;
+    try {
+      emsg = parseEmsg(
+        appendBytes(
+          emsgHeader(1),
+          uint32(90000),
+          uint64(900000),
+          uint32(180000),
+          uint32(7),
+          cString('https://aomedia.org/emsg/ID3'),
+          // The value runs to the last byte of the box without a terminator
+          new Uint8Array([0x31]),
+        ),
+      );
+    } finally {
+      warn.restore();
+    }
     // The fields the box did carry are kept, the unterminated value is not
     expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
     expect(emsg.value).to.equal('');
@@ -415,18 +422,27 @@ describe('mp4-tools', function () {
     expect(emsg.eventDuration).to.equal(180000);
     expect(emsg.id).to.equal(7);
     expect(emsg.payload).to.have.lengthOf(0);
+    // The stream is broken, so say so rather than dropping the value silently
+    expect(warn.callCount, 'logger.warn call count').to.equal(1);
+    expect(warn.firstCall.args[0]).to.contain('Unterminated value');
   });
 
   it('parseEmsg returns on a version 0 box whose value is unterminated', function () {
-    const emsg = parseEmsg(
-      appendBytes(
-        emsgHeader(0),
-        cString('https://aomedia.org/emsg/ID3'),
-        // The value runs to the last byte of the box without a terminator, so
-        // none of the fields that follow it are present either
-        new Uint8Array([0x31]),
-      ),
-    );
+    const warn = sinon.stub(logger, 'warn');
+    let emsg: IEmsgParsingData;
+    try {
+      emsg = parseEmsg(
+        appendBytes(
+          emsgHeader(0),
+          cString('https://aomedia.org/emsg/ID3'),
+          // The value runs to the last byte of the box without a terminator, so
+          // none of the fields that follow it are present either
+          new Uint8Array([0x31]),
+        ),
+      );
+    } finally {
+      warn.restore();
+    }
     // Nothing in a version 0 box precedes its strings, so nothing is usable
     expect(emsg.schemeIdUri).to.equal('');
     expect(emsg.value).to.equal('');
@@ -435,6 +451,8 @@ describe('mp4-tools', function () {
     expect(emsg.eventDuration).to.equal(0);
     expect(emsg.id).to.equal(0);
     expect(emsg.payload).to.have.lengthOf(0);
+    expect(warn.callCount, 'logger.warn call count').to.equal(1);
+    expect(warn.firstCall.args[0]).to.contain('Unterminated value');
   });
 
   it('parseEmsg returns on an emsg box that findBox truncated to the bytes received', function () {

--- a/tests/unit/utils/mp4-tools.ts
+++ b/tests/unit/utils/mp4-tools.ts
@@ -394,6 +394,47 @@ describe('mp4-tools', function () {
     expect(emsg.value).to.equal('');
   });
 
+  it('parseEmsg returns on a version 1 box whose value is unterminated', function () {
+    const emsg = parseEmsg(
+      appendBytes(
+        emsgHeader(1),
+        uint32(90000),
+        uint64(900000),
+        uint32(180000),
+        uint32(7),
+        cString('https://aomedia.org/emsg/ID3'),
+        // The value runs to the last byte of the box without a terminator
+        new Uint8Array([0x31]),
+      ),
+    );
+    expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
+    expect(emsg.value).to.equal('1');
+    expect(emsg.timeScale).to.equal(90000);
+    expect(emsg.presentationTime).to.equal(900000);
+    expect(emsg.eventDuration).to.equal(180000);
+    expect(emsg.id).to.equal(7);
+    expect(emsg.payload).to.have.lengthOf(0);
+  });
+
+  it('parseEmsg returns on a version 0 box whose value is unterminated', function () {
+    const emsg = parseEmsg(
+      appendBytes(
+        emsgHeader(0),
+        cString('https://aomedia.org/emsg/ID3'),
+        // The value runs to the last byte of the box without a terminator, so
+        // none of the fields that follow it are present either
+        new Uint8Array([0x31]),
+      ),
+    );
+    expect(emsg.schemeIdUri).to.equal('https://aomedia.org/emsg/ID3\0');
+    expect(emsg.value).to.equal('1');
+    expect(emsg.timeScale).to.equal(0);
+    expect(emsg.presentationTimeDelta).to.equal(0);
+    expect(emsg.eventDuration).to.equal(0);
+    expect(emsg.id).to.equal(0);
+    expect(emsg.payload).to.have.lengthOf(0);
+  });
+
   it('parseEmsg returns on an emsg box that findBox truncated to the bytes received', function () {
     const body = appendBytes(
       emsgHeader(1),


### PR DESCRIPTION
### This PR will...

Stop `parseEmsg()` from looping forever when an `emsg` box ends before the null terminator of its `scheme_id_uri` or `value`, and read the version 0 layout from the correct offset.

### Why is this Pull Request needed?

#### 1. A truncated or non-conformant `emsg` box hangs the demuxer permanently

Both string fields are walked a byte at a time:

```js
while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
  schemeIdUri += bin2str(data.subarray(offset, offset + 1));
  offset += 1;
}
```

Once `offset` reaches the end of the box, `data.subarray(offset, offset + 1)` is an empty `Uint8Array`, so `bin2str()` returns `''` — which never equals `'\0'`. The loop has no other exit and spins forever incrementing `offset`.

`findBox()` clamps a box to the bytes that are actually present (`const boxEnd = Math.min(endbox, end)`), so a segment whose delivery stops mid-box produces exactly this input; so does a packager that writes an unterminated string.

`parseEmsg()` runs from `MP4Demuxer.extractID3Track()` on every `emsg` box in an fMP4 segment, with no config gate. `enableWorker` defaults to `true`, so the transmuxer worker wedges at 100% CPU — playback stops, no `ERROR` event is emitted, and there is no state to recover from.

Three inputs that never return on `master`:

| input | `master` | this PR |
| --- | --- | --- |
| v1 box truncated after the fixed fields | hangs | `schemeIdUri: ''` |
| v1 box whose `scheme_id_uri` has no terminator | hangs | `schemeIdUri: 'urn:a'` |
| v1 `emsg` clamped by `findBox()` to the bytes received | hangs | `schemeIdUri: ''` |

Worth noting for comparison: `mux.js`'s equivalent loop indexes with `data[index]`, so past the end it reads `undefined`, `String.fromCharCode(undefined)` is `'\0'`, and the loop terminates. Reading a byte via `subarray()` instead is what removes that exit.

#### 2. Version 0 has never parsed

The version 1 branch steps over the FullBox version and flags with `offset += 4`; the version 0 branch does not, so it starts reading `scheme_id_uri` at the version byte. That byte is `0`, so the string terminates immediately and `schemeIdUri` is always `"\0"`. It then reads `timescale`, `presentation_time_delta`, `event_duration` and `id` from hardcoded offsets 12/16/20/24, which land inside the URI text for any real box.

A well-formed v0 box carrying `https://aomedia.org/emsg/ID3`, `VALUE=1`, timescale 90000, delta 4500, duration 180000, id 7:

```
master:  schemeIdUri="\0"  value="\0"  timeScale=1634692453
         presentationTimeDelta=1684627758  eventDuration=1869768495  id=1701671783
this PR: schemeIdUri="https://aomedia.org/emsg/ID3\0"  value="1\0"  timeScale=90000
         presentationTimeDelta=4500  eventDuration=180000  id=7
```

Because `"\0"` matches neither `emsgSchemePattern` nor `config.emsgKLVSchemaUri`, every version 0 `emsg` box is dropped downstream today, so correcting it cannot regress a stream that currently works.

### Are there any points in the code the reviewer needs to double check?

- `readCString()` returns the terminator as part of the string so callers advance by `.length`. That preserves the previous output: `schemeIdUri` and `value` still carry their trailing `\0`.
- `presentationTime` is now left `undefined` for version 0 rather than defaulting to `0`. `getEmsgStartTime()` branches on `Number.isFinite(presentationTime)`, so a `0` default would time every version 0 event at 0 instead of `timeOffset + presentationTimeDelta / timeScale`. The field is already optional on `IEmsgParsingData`.
- **Version 1 output is unchanged.** I ran 20,000 randomised well-formed version 1 boxes (varying scheme, value, timescale, presentation time, duration, id and payload) through the old and new implementations: 20,000/20,000 returned identical results. The same 20,000 boxes rebuilt as version 0 all now match the spec layout, and agree field-for-field with `mux.js` on every box it accepts.
- The three regression tests hang rather than fail against the unpatched `parseEmsg` — that is the bug they cover.
- Happy to split the version 0 offset correction into a separate PR if you would rather keep this one to the loop fix.

### Resolves issues:

None open — found while reading the fMP4 in-band metadata path.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md — no API or config change
