### PR TITLE
Preserve existing query string when adding HLS delivery directives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,8 @@ const selfVsWindowGlobalMsg =
   'Use `self` instead of `window` to access the global context everywhere (including workers).';
 const arrayIncludesCompatibilityMsg =
   'Usage of Array includes method is restricted for compatibility. Use Array indexOf instead. (For String includes, suppress this with an eslint-disable comment.)';
+const searchParamsSetMsg =
+  'URLSearchParams.set re-encodes the whole query string, percent-encoding characters like `~`, `=` and `/` in parameters the playlist author wrote (breaking signed CDN tokens). Use `setQueryParam` from utils/url-tools instead. See https://github.com/video-dev/hls.js/pull/7969';
 
 const baseRestrictedSyntax = [
   {
@@ -17,6 +19,11 @@ const baseRestrictedSyntax = [
   {
     selector: 'MethodDefinition[value.async=true]',
     message: asyncKeywordConstraintMsg,
+  },
+  {
+    selector:
+      'MemberExpression[property.name="set"][object.property.name="searchParams"], MemberExpression[property.name="set"][object.name="searchParams"]',
+    message: searchParamsSetMsg,
   },
 ];
 

--- a/src/controller/content-steering-controller.ts
+++ b/src/controller/content-steering-controller.ts
@@ -16,6 +16,7 @@ import { AttrList } from '../utils/attr-list';
 import { reassignFragmentLevelIndexes } from '../utils/level-helper';
 import { Logger } from '../utils/logger';
 import { stringify } from '../utils/safe-json-stringify';
+import { setQueryParam } from '../utils/url-tools';
 import type { RetryConfig } from '../config';
 import type Hls from '../hls';
 import type { NetworkComponentAPI } from '../types/component-api';
@@ -434,8 +435,8 @@ export default class ContentSteeringController
     if (url.protocol !== 'data:') {
       const throughput =
         (this.hls.bandwidthEstimate || config.abrEwmaDefaultEstimate) | 0;
-      url.searchParams.set('_HLS_pathway', this.pathwayId);
-      url.searchParams.set('_HLS_throughput', '' + throughput);
+      setQueryParam(url, '_HLS_pathway', this.pathwayId);
+      setQueryParam(url, '_HLS_throughput', '' + throughput);
     }
     const context: LoaderContext = {
       type: LoaderContextType.STEERING_MANIFEST,
@@ -614,7 +615,7 @@ function performUriReplacement(
       .sort()
       .forEach((key) => {
         if (key) {
-          url.searchParams.set(key, params[key]);
+          setQueryParam(url, key, params[key]);
         }
       });
   }

--- a/src/loader/interstitial-asset-list.ts
+++ b/src/loader/interstitial-asset-list.ts
@@ -6,6 +6,7 @@ import {
 import { ErrorDetails, ErrorTypes } from '../errors';
 import { Events } from '../events';
 import { LoaderContextType } from '../types/loader';
+import { setQueryParam } from '../utils/url-tools';
 import type { InterstitialEvent } from './interstitial-event';
 import type Hls from '../hls';
 import type { ErrorData } from '../types/events';
@@ -54,7 +55,7 @@ export class AssetListLoader {
       return;
     }
     if (hlsStartOffset && url.protocol !== 'data:') {
-      url.searchParams.set('_HLS_start_offset', '' + hlsStartOffset);
+      setQueryParam(url, '_HLS_start_offset', '' + hlsStartOffset);
     }
     const config = this.hls.config;
     const Loader = config.loader;

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -1,4 +1,5 @@
 import { hash } from '../utils/hash';
+import { setQueryParam } from '../utils/url-tools';
 import type { DateRange, DateRangeCue } from './date-range';
 import type { MediaFragmentRef } from './fragment';
 import type { Loader, LoaderContext } from '../types/loader';
@@ -311,7 +312,7 @@ export function getInterstitialUrl(
 ): URL | never {
   const url = new self.URL(uri, baseUrl);
   if (url.protocol !== 'data:') {
-    url.searchParams.set('_HLS_primary_id', sessionId);
+    setQueryParam(url, '_HLS_primary_id', sessionId);
   }
   return url;
 }

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -95,15 +95,30 @@ export class HlsUrlParameters {
 
   addDirectives(uri: string): string | never {
     const url: URL = new self.URL(uri);
+    const directives: string[] = [];
     if (this.msn !== undefined) {
-      url.searchParams.set('_HLS_msn', this.msn.toString());
+      directives.push(`_HLS_msn=${this.msn}`);
     }
     if (this.part !== undefined) {
-      url.searchParams.set('_HLS_part', this.part.toString());
+      directives.push(`_HLS_part=${this.part}`);
     }
     if (this.skip) {
-      url.searchParams.set('_HLS_skip', this.skip);
+      directives.push(`_HLS_skip=${this.skip}`);
     }
+    if (!directives.length) {
+      return url.href;
+    }
+    // Append the directives as text rather than going through
+    // `url.searchParams`. Mutating searchParams and then reading `url.href`
+    // re-serializes the *entire* query using application/x-www-form-urlencoded
+    // rules, which percent-encodes `~`, `=` and `/` — characters that CDN
+    // tokens carry verbatim and sign byte-for-byte, yielding 403s. See #3786.
+    const replacedKeys = directives.map((d) => d.slice(0, d.indexOf('=') + 1));
+    const params = url.search
+      .substring(1)
+      .split('&')
+      .filter((p) => p && !replacedKeys.some((key) => p.startsWith(key)));
+    url.search = params.concat(directives).join('&');
     return url.href;
   }
 }

--- a/src/types/level.ts
+++ b/src/types/level.ts
@@ -1,3 +1,4 @@
+import { setQueryParam } from '../utils/url-tools';
 import type { MediaPlaylist } from './media-playlist';
 import type { LevelDetails } from '../loader/level-details';
 import type { AttrList } from '../utils/attr-list';
@@ -95,30 +96,15 @@ export class HlsUrlParameters {
 
   addDirectives(uri: string): string | never {
     const url: URL = new self.URL(uri);
-    const directives: string[] = [];
     if (this.msn !== undefined) {
-      directives.push(`_HLS_msn=${this.msn}`);
+      setQueryParam(url, '_HLS_msn', this.msn.toString());
     }
     if (this.part !== undefined) {
-      directives.push(`_HLS_part=${this.part}`);
+      setQueryParam(url, '_HLS_part', this.part.toString());
     }
     if (this.skip) {
-      directives.push(`_HLS_skip=${this.skip}`);
+      setQueryParam(url, '_HLS_skip', this.skip);
     }
-    if (!directives.length) {
-      return url.href;
-    }
-    // Append the directives as text rather than going through
-    // `url.searchParams`. Mutating searchParams and then reading `url.href`
-    // re-serializes the *entire* query using application/x-www-form-urlencoded
-    // rules, which percent-encodes `~`, `=` and `/` — characters that CDN
-    // tokens carry verbatim and sign byte-for-byte, yielding 403s. See #3786.
-    const replacedKeys = directives.map((d) => d.slice(0, d.indexOf('=') + 1));
-    const params = url.search
-      .substring(1)
-      .split('&')
-      .filter((p) => p && !replacedKeys.some((key) => p.startsWith(key)));
-    url.search = params.concat(directives).join('&');
     return url.href;
   }
 }

--- a/src/utils/url-tools.ts
+++ b/src/utils/url-tools.ts
@@ -1,0 +1,36 @@
+/**
+ * Set a query parameter on a URL without re-encoding the rest of its query
+ * string.
+ *
+ * `URLSearchParams.set` re-serializes the entire query using
+ * application/x-www-form-urlencoded rules, percent-encoding characters like
+ * `~`, `=` and `/` in parameters the playlist author wrote. Signed CDN tokens
+ * carry those characters verbatim and are validated byte-for-byte, so
+ * re-encoding them breaks token validation (see #7963). This helper
+ * component-encodes only the inserted key/value pair and leaves existing
+ * parameters untouched. Like `URLSearchParams.set`, an existing parameter
+ * with the same key is replaced in place and duplicates are removed.
+ */
+export function setQueryParam(url: URL, key: string, value: string) {
+  const encodedKey = encodeURIComponent(key);
+  const param = `${encodedKey}=${encodeURIComponent(value)}`;
+  let replaced = false;
+  const params: string[] = [];
+  url.search
+    .substring(1)
+    .split('&')
+    .forEach((p) => {
+      if (p === encodedKey || p.startsWith(encodedKey + '=')) {
+        if (!replaced) {
+          params.push(param);
+          replaced = true;
+        }
+      } else if (p) {
+        params.push(p);
+      }
+    });
+  if (!replaced) {
+    params.push(param);
+  }
+  url.search = params.join('&');
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -43,6 +43,7 @@ import './unit/loader/m3u8-parser';
 import './unit/loader/playlist-loader';
 import './unit/remux/mp4-remuxer';
 import './unit/remux/passthrough-remuxer';
+import './unit/types/level';
 import './unit/utils/attr-list';
 import './unit/utils/binary-search';
 import './unit/utils/buffer-helper';

--- a/tests/index.js
+++ b/tests/index.js
@@ -58,6 +58,7 @@ import './unit/utils/mp4-tools';
 import './unit/utils/output-filter';
 import './unit/utils/safe-json-stringify';
 import './unit/utils/texttrack-utils';
+import './unit/utils/url-tools';
 import './unit/utils/vttparser';
 import './unit/utils/utf8';
 import './unit/demuxer/transmuxer';

--- a/tests/unit/types/level.ts
+++ b/tests/unit/types/level.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { HlsSkip, HlsUrlParameters } from '../../../src/types/level';
+
+describe('HlsUrlParameters', function () {
+  describe('addDirectives', function () {
+    it('appends directives to a URI without a query string', function () {
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.Yes);
+      expect(params.addDirectives('https://example.com/media.m3u8')).to.equal(
+        'https://example.com/media.m3u8?_HLS_skip=YES',
+      );
+    });
+
+    it('appends blocking reload directives', function () {
+      const params = new HlsUrlParameters(100, 2);
+      expect(params.addDirectives('https://example.com/media.m3u8')).to.equal(
+        'https://example.com/media.m3u8?_HLS_msn=100&_HLS_part=2',
+      );
+    });
+
+    it('appends directives after an existing query string', function () {
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.v2);
+      expect(
+        params.addDirectives('https://example.com/media.m3u8?foo=1&bar=2'),
+      ).to.equal('https://example.com/media.m3u8?foo=1&bar=2&_HLS_skip=v2');
+    });
+
+    it('leaves reserved characters in existing query parameters untouched', function () {
+      // Signed CDN URLs carry `~`, `=` and `/` verbatim inside a query
+      // parameter and validate the result byte-for-byte, so re-encoding them
+      // as %7E, %3D and %2F invalidates the signature.
+      const token = 'st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123';
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.Yes);
+      expect(
+        params.addDirectives(`https://example.com/media.m3u8?token=${token}`),
+      ).to.equal(`https://example.com/media.m3u8?token=${token}&_HLS_skip=YES`);
+    });
+
+    it('preserves multiple existing query parameters and their order', function () {
+      const token = 'exp=1600003600~acl=%2f*%2f12345*~hmac=abc123';
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.Yes);
+      expect(
+        params.addDirectives(
+          `https://example.com/media.m3u8?hdntl=${token}&unique_id=9f8e7d`,
+        ),
+      ).to.equal(
+        `https://example.com/media.m3u8?hdntl=${token}&unique_id=9f8e7d&_HLS_skip=YES`,
+      );
+    });
+
+    it('replaces a directive already present rather than duplicating it', function () {
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.v2);
+      expect(
+        params.addDirectives(
+          'https://example.com/media.m3u8?foo=1&_HLS_skip=YES',
+        ),
+      ).to.equal('https://example.com/media.m3u8?foo=1&_HLS_skip=v2');
+    });
+
+    it('returns the URI unchanged when no directives are set', function () {
+      const token = 'st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123';
+      const params = new HlsUrlParameters();
+      expect(
+        params.addDirectives(`https://example.com/media.m3u8?token=${token}`),
+      ).to.equal(`https://example.com/media.m3u8?token=${token}`);
+    });
+
+    it('treats HlsSkip.No as no skip directive', function () {
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.No);
+      expect(
+        params.addDirectives('https://example.com/media.m3u8?foo=1'),
+      ).to.equal('https://example.com/media.m3u8?foo=1');
+    });
+
+    it('does not drop a zero-valued msn or part', function () {
+      const params = new HlsUrlParameters(0, 0);
+      expect(params.addDirectives('https://example.com/media.m3u8')).to.equal(
+        'https://example.com/media.m3u8?_HLS_msn=0&_HLS_part=0',
+      );
+    });
+
+    it('throws on an invalid URI', function () {
+      const params = new HlsUrlParameters(undefined, undefined, HlsSkip.Yes);
+      expect(() => params.addDirectives('not a url')).to.throw();
+    });
+  });
+});

--- a/tests/unit/utils/url-tools.ts
+++ b/tests/unit/utils/url-tools.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import { setQueryParam } from '../../../src/utils/url-tools';
+
+describe('url-tools', function () {
+  describe('setQueryParam', function () {
+    it('appends a parameter to a URL without a query string', function () {
+      const url = new URL('https://example.com/media.m3u8');
+      setQueryParam(url, '_HLS_skip', 'YES');
+      expect(url.href).to.equal('https://example.com/media.m3u8?_HLS_skip=YES');
+    });
+
+    it('appends a parameter after an existing query string', function () {
+      const url = new URL('https://example.com/media.m3u8?foo=1&bar=2');
+      setQueryParam(url, '_HLS_msn', '100');
+      expect(url.href).to.equal(
+        'https://example.com/media.m3u8?foo=1&bar=2&_HLS_msn=100',
+      );
+    });
+
+    it('leaves reserved characters in existing parameters untouched', function () {
+      // Signed CDN URLs carry `~`, `=` and `/` verbatim inside a query
+      // parameter and validate the result byte-for-byte, so re-encoding them
+      // as %7E, %3D and %2F invalidates the signature.
+      const token = 'st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123';
+      const url = new URL(`https://example.com/media.m3u8?token=${token}`);
+      setQueryParam(url, '_HLS_part', '2');
+      expect(url.href).to.equal(
+        `https://example.com/media.m3u8?token=${token}&_HLS_part=2`,
+      );
+    });
+
+    it('replaces an existing parameter in place rather than duplicating it', function () {
+      const url = new URL(
+        'https://example.com/media.m3u8?foo=1&_HLS_skip=YES&bar=2',
+      );
+      setQueryParam(url, '_HLS_skip', 'v2');
+      expect(url.href).to.equal(
+        'https://example.com/media.m3u8?foo=1&_HLS_skip=v2&bar=2',
+      );
+    });
+
+    it('replaces an existing parameter that has no value', function () {
+      const url = new URL('https://example.com/media.m3u8?foo&bar=2');
+      setQueryParam(url, 'foo', '1');
+      expect(url.href).to.equal('https://example.com/media.m3u8?foo=1&bar=2');
+    });
+
+    it('removes duplicates of the key, keeping the first position', function () {
+      const url = new URL('https://example.com/media.m3u8?a=1&b=2&a=3');
+      setQueryParam(url, 'a', '9');
+      expect(url.href).to.equal('https://example.com/media.m3u8?a=9&b=2');
+    });
+
+    it('does not replace a parameter whose key only shares a prefix', function () {
+      const url = new URL('https://example.com/media.m3u8?_HLS_msn2=5');
+      setQueryParam(url, '_HLS_msn', '100');
+      expect(url.href).to.equal(
+        'https://example.com/media.m3u8?_HLS_msn2=5&_HLS_msn=100',
+      );
+    });
+
+    it('component-encodes the inserted key and value', function () {
+      const url = new URL('https://example.com/media.m3u8?foo=1');
+      setQueryParam(url, 'redirect uri', 'https://example.com/?a=1&b=2');
+      expect(url.href).to.equal(
+        'https://example.com/media.m3u8?foo=1&redirect%20uri=https%3A%2F%2Fexample.com%2F%3Fa%3D1%26b%3D2',
+      );
+    });
+  });
+});


### PR DESCRIPTION
### This PR will...

Stop `HlsUrlParameters.addDirectives` from re-encoding query parameters it did not add, so signed playlist URLs survive Playlist Delta Update and blocking reload requests.

### Why is this Pull Request needed?

`addDirectives` sets `_HLS_msn` / `_HLS_part` / `_HLS_skip` through `url.searchParams`. Reading `url.href` afterwards re-serializes the whole query using application/x-www-form-urlencoded rules, so characters that are perfectly legal in a query (`~`, `=`, `/`) come back percent-encoded in parameters hls.js never touched.

Given a playlist URL carrying a signed token:

```
https://example.com/media.m3u8?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123
```

a delta update request currently becomes:

```
https://example.com/media.m3u8?token=st%3D1600000000%7Eexp%3D1600003600%7Eacl%3D%2Flive%2F*%7Ehmac%3Dabc123&_HLS_skip=YES
```

CDNs that sign URLs compare the token byte-for-byte, so the request is rejected with 403 and live playback stalls on the first reload. Akamai tokens are the common case; CloudFront is affected too, since its URL-safe base64 maps `/` to `~`, putting `~` in every `Policy` and `Signature` value. Native HLS implementations do not rewrite the URL, so affected streams play fine outside hls.js.

With this change the request keeps the token intact:

```
https://example.com/media.m3u8?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123&_HLS_skip=YES
```

#3786 reported this in 2021. #3787 fixed the parameter *reordering* half by removing `searchParams.sort()`, but `url.searchParams.set()` still forces a full re-serialization when `href` is read, so the re-encoding half remained.

### Are there any points in the code the reviewer needs to double check?

- Directives are appended as text, with any directive already present filtered out first, so repeated reloads replace rather than duplicate, matching `searchParams.set()`. The one behavioural difference is position: a replaced directive moves to the end of the query instead of keeping its original slot. Since `searchParams.sort()` was removed in #3787, query order is not normalized either way.
- The fix relies on `url.search = ...` not percent-encoding `~`, `=`, `/` or `*`, as those are outside the URL query percent-encode set. Worth a second pair of eyes.
- `HlsSkip.No` is the empty string and stays falsy, and `msn` / `part` of `0` are still emitted. Both are covered by tests.

### Resolves issues:

Completes the fix for #3786, partially addressed by #3787.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md — not applicable, no API or design change
