### PR TITLE
Fix permanent stall loading fragment-hint parts of encrypted low-latency streams (v1.6.x)

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -820,6 +820,39 @@ export default class BaseStreamController
     frag: PartsLoadedData | FragLoadedData,
   ) {}
 
+  private loadKeyFor(
+    frag: Fragment,
+    details: LevelDetails,
+  ): Promise<KeyLoadedData | void> | null {
+    let keyLoadingPromise: Promise<KeyLoadedData | void> | null = null;
+    if (frag.encrypted && !frag.decryptdata?.key) {
+      this.log(
+        `Loading key for ${frag.sn} of [${details.startSN}-${details.endSN}], ${this.playlistLabel()} ${frag.level}`,
+      );
+      this.state = State.KEY_LOADING;
+      keyLoadingPromise = this.keyLoader.load(frag).then((keyLoadedData) => {
+        if (!this.fragContextChanged(keyLoadedData.frag)) {
+          this.hls.trigger(Events.KEY_LOADED, keyLoadedData);
+          if (this.state === State.KEY_LOADING) {
+            this.state = State.IDLE;
+          }
+          return keyLoadedData;
+        }
+      });
+      this.hls.trigger(Events.KEY_LOADING, { frag });
+    } else if (!frag.encrypted) {
+      keyLoadingPromise = this.keyLoader.loadClear(
+        frag,
+        details.encryptedFragments,
+        this.startFragRequested,
+      );
+      if (keyLoadingPromise) {
+        this.log(`[eme] blocking frag load until media-keys acquired`);
+      }
+    }
+    return keyLoadingPromise;
+  }
+
   protected _doFragLoad(
     frag: Fragment,
     level: Level,
@@ -832,38 +865,6 @@ export default class BaseStreamController
       throw new Error(
         `frag load aborted, missing level${details ? '' : ' detail'}s`,
       );
-    }
-
-    let keyLoadingPromise: Promise<KeyLoadedData | void> | null = null;
-    if (frag.encrypted && !frag.decryptdata?.key) {
-      this.log(
-        `Loading key for ${frag.sn} of [${details.startSN}-${details.endSN}], ${this.playlistLabel()} ${frag.level}`,
-      );
-      this.state = State.KEY_LOADING;
-      this.fragCurrent = frag;
-      keyLoadingPromise = this.keyLoader.load(frag).then((keyLoadedData) => {
-        if (!this.fragContextChanged(keyLoadedData.frag)) {
-          this.hls.trigger(Events.KEY_LOADED, keyLoadedData);
-          if (this.state === State.KEY_LOADING) {
-            this.state = State.IDLE;
-          }
-          return keyLoadedData;
-        }
-      });
-      this.hls.trigger(Events.KEY_LOADING, { frag });
-      if ((this.fragCurrent as Fragment | null) === null) {
-        this.log(`context changed in KEY_LOADING`);
-        return Promise.resolve(null);
-      }
-    } else if (!frag.encrypted) {
-      keyLoadingPromise = this.keyLoader.loadClear(
-        frag,
-        details.encryptedFragments,
-        this.startFragRequested,
-      );
-      if (keyLoadingPromise) {
-        this.log(`[eme] blocking frag load until media-keys acquired`);
-      }
     }
 
     const fragPrevious = this.fragPrevious;
@@ -892,6 +893,10 @@ export default class BaseStreamController
         if (partIndex > -1) {
           const part = partList[partIndex];
           frag = this.fragCurrent = part.fragment;
+          const keyLoadingPromise = this.loadKeyFor(frag, details);
+          if (this.fragContextChanged(frag)) {
+            return Promise.resolve(null);
+          }
           this.log(
             `Loading ${frag.type} sn: ${frag.sn} part: ${part.index} (${partIndex}/${partList.length - 1}) of ${this.fragInfo(frag, false, part)}) cc: ${
               frag.cc
@@ -962,6 +967,14 @@ export default class BaseStreamController
       return Promise.resolve(null);
     }
 
+    const keyLoadingPromise = this.loadKeyFor(frag, details);
+    if (this.fragContextChanged(frag)) {
+      this.log(
+        `Context changed in KEY_LOADING sn: ${frag.sn} ${frag.relurl} > ${this.fragCurrent?.relurl}`,
+      );
+      keyLoadingPromise?.catch(() => null);
+      return Promise.resolve(null);
+    }
     this.log(
       `Loading ${frag.type} sn: ${frag.sn} of ${this.fragInfo(frag, false)}) cc: ${frag.cc} ${
         '[' + details.startSN + '-' + details.endSN + ']'


### PR DESCRIPTION
## This PR will...

Fix a permanent video stall on the v1.6.x line when an encrypted LL-HLS load advances onto the fragment hint while its key-loading promise is in flight. Fixes #7975 for `patch/v1.6.x`.

## Why is this Pull Request needed?

`_doFragLoad` armed `keyLoadingPromise` with the fragment passed in, before the LL-HLS parts branch could advance the load onto the fragment hint (`frag = this.fragCurrent = part.fragment`). Both resolution-time context checks then compared the stale pre-swap fragment against the new `fragCurrent`, read the mismatch as an abort, and resolved silently — leaving the stream-controller in `FRAG_LOADING` with no loader in flight, no reachable `fragLoadPolicy` timeout, and no other escape in `doTick`. Video fragment loading stopped permanently while the media playlist kept polling and alt audio kept playing (full debug logs in #7975).

Per review feedback, this now follows the approach of #7874 rather than patching the context checks: key loading moves into a `loadKeyFor()` helper called only once fragment selection is finalized — after the part/hint selection in the parts branch, and after the loading-parts fallback in the whole-fragment path — with a `fragContextChanged(frag)` bail after each call site, mirroring master.

## Are there any points in the code the reviewer needs to double check?

- Validated against a live Widevine (cbcs) LL-HLS stream with a build of this branch: a resize storm (`capLevelToPlayerSize` flapping) that froze the unpatched 1.6.18 within 1–3 toggles now survives 20 toggles with no stall — including the `KEY_LOADING`-parked sibling shape, which the earlier check-only patch did not cover. Only transient non-fatal `bufferStalledError` + nudge during the storm.
- The whole-fragment tail now bails (`Context changed in KEY_LOADING` log, as on master) when `frag` was hint-swapped without a part selection; the next tick reloads cleanly with `loadingParts` off.
- `tsc`, `eslint`, `prettier`, and `npm run test:unit` (767 tests) pass on this branch.

## Resolves issues:

#7975 (v1.6.x line)

## Checklist

- [x] changes have been done against master branch, and PR does not conflict — *targeted at `patch/v1.6.x` deliberately; master already has this ordering via #7874*
- [x] new unit / functional tests have been added (whenever applicable) — *no new test; existing unit suite passes. Happy to add one if you can point at a preferred harness for the LL parts pipeline.*
- [x] API or design changes are documented in API.md — *not applicable*
