### PR TITLE
Fix Interstitial snap-out at live edge and BUFFER_APPEND_NO_PROGRESS false positives

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1608,7 +1608,7 @@ export default class BaseStreamController
     }
     let programFrag = this.filterReplacedPrimary(frag, levelDetails);
     if (!programFrag && frag) {
-      programFrag = getNextFrag(levelDetails, frag.sn, this.loadingParts);
+      programFrag = getNextFrag(levelDetails, frag.sn);
       if (programFrag) {
         this.nextLoadPosition = programFrag.start;
       }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1406,7 +1406,11 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const key = appendProgressKey(frag);
     const progress = this.fragmentAppendProgress[key];
     delete this.fragmentAppendProgress[key];
-    const cycle = progress?.stats === frag.stats ? progress : undefined;
+    if (!progress) {
+      // Tracking miss
+      return;
+    }
+    const cycle = progress.stats === frag.stats ? progress : undefined;
     if (cycle?.errored) {
       // Counted by the append-error path
       return;
@@ -2441,5 +2445,6 @@ function isFragmentFullyBuffered(
   coverage: number,
   fragment: Fragment,
 ): boolean {
-  return fragment.duration - coverage <= MIN_BUFFERED_PROGRESS;
+  // .05 BUFFER_APPEND_NO_PROGRESS coverage tolerance accounts for large composition times
+  return fragment.duration - coverage <= 0.05;
 }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -1406,11 +1406,12 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     const key = appendProgressKey(frag);
     const progress = this.fragmentAppendProgress[key];
     delete this.fragmentAppendProgress[key];
-    if (!progress) {
-      // Tracking miss
+    const fragBuffering = frag.stats.buffering;
+    if (fragBuffering.start && !fragBuffering.first) {
+      // Queued appends never completed (displaced by end-of-stream or transfer)
       return;
     }
-    const cycle = progress.stats === frag.stats ? progress : undefined;
+    const cycle = progress?.stats === frag.stats ? progress : undefined;
     if (cycle?.errored) {
       // Counted by the append-error path
       return;

--- a/src/controller/fragment-finders.ts
+++ b/src/controller/fragment-finders.ts
@@ -243,9 +243,9 @@ export function findNearestWithCC(
 export function getNextFrag(
   details: LevelDetails,
   sn: number,
-  fragmentHintForParts?: boolean,
 ): MediaFragment | null {
-  return fragmentHintForParts && sn === details.endSN && details.fragmentHint
-    ? details.fragmentHint
-    : details.fragments[1 + sn - details.startSN] || null;
+  if (sn === details.endSN && details.fragmentHint) {
+    return details.fragmentHint;
+  }
+  return details.fragments[1 + sn - details.startSN] || null;
 }

--- a/src/controller/gap-controller.ts
+++ b/src/controller/gap-controller.ts
@@ -773,7 +773,7 @@ function withInterstitialBoundary(
     hls.interstitialsManager
   ) {
     const frag = 'type' in appended ? appended : appended.fragment;
-    const nextFrag = getNextFrag(levelDetails, frag.sn, true);
+    const nextFrag = getNextFrag(levelDetails, frag.sn);
     if (
       nextFrag?.level === frag.level &&
       fragOverlapsQueuedInterstitial(

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -1673,22 +1673,21 @@ export default class InterstitialsController
   ) {
     const hls = this.hls;
     const { loadingEnabled, bufferingEnabled, startPosition } = hls;
-
-    const instructToSeek = !skipSeekToStartPosition && hls.hasEnoughToStart;
+    const hasEnoughToStart = hls.hasEnoughToStart;
 
     this.log(
-      `Start loading primary @${bufferPos} bufferedPos: ${this.bufferedPos} instructToSeek: ${instructToSeek} startPosition: ${startPosition} loadingEnabled: ${loadingEnabled} bufferingEnabled: ${bufferingEnabled}`,
+      `Start loading primary @${bufferPos} bufferedPos: ${this.bufferedPos} startPosition: ${startPosition} skip seek: ${skipSeekToStartPosition} has enough ${hasEnoughToStart} loadingEnabled: ${loadingEnabled} bufferingEnabled: ${bufferingEnabled}`,
     );
     if (
-      instructToSeek ||
+      (!skipSeekToStartPosition && hasEnoughToStart) ||
       !loadingEnabled ||
       Math.abs(startPosition - bufferPos) > 0.1
     ) {
       const details = this.primaryDetails;
-      if (details?.live && bufferPos >= details.edge) {
+      if (details?.live && bufferPos + 0.5 >= details.edge) {
         const bufferingItem = this.bufferingItem;
         this.log(
-          `Resume primary loading when live reaches ${bufferPos} buffering item: ${bufferingItem ? segmentToString(bufferingItem) : null}`,
+          `Resume primary loading when live passes ${bufferPos} buffering item: ${bufferingItem ? segmentToString(bufferingItem) : null}`,
         );
         hls.pauseBuffering();
         this.bufferPastEdge = true;
@@ -1749,16 +1748,20 @@ export default class InterstitialsController
     } else if (this.bufferPastEdge) {
       const details = this.primaryDetails;
       const bufferedPos = this.bufferedPos;
-      if (details?.live && bufferedPos < details.edge) {
+      if (details?.live && bufferedPos + 0.5 < details.edge) {
         this.bufferPastEdge = false;
         const bufferingItem = this.bufferingItem;
         this.log(
-          `Live edge ${details.edge} reached buffer: ${bufferedPos} buffering item: ${bufferingItem ? segmentToString(bufferingItem) : null}`,
+          `Live edge ${details.edge} passed buffer: ${bufferedPos} buffering item: ${bufferingItem ? segmentToString(bufferingItem) : null}`,
         );
         const primaryWaiting = bufferingItem?.end === Infinity;
         if (primaryWaiting) {
-          this.startLoadingPrimaryAt(
+          const playingItem = this.playingItem;
+          const skipSeekToStartPosition =
+            this.isInterstitial(playingItem) && playingItem.event.appendInPlace;
+          this.hls.startLoad(
             Math.max(bufferedPos, bufferingItem.start),
+            skipSeekToStartPosition,
           );
         } else {
           const bufferingPlayer = this.getBufferingPlayer();
@@ -2312,8 +2315,11 @@ Schedule: ${scheduleItems.map((seg) => segmentToString(seg))} pos: ${this.timeli
           this.startLoadingPrimaryAt(bufferedPos);
         }
       } else {
-        // If not detached seek to resumption point
-        this.startLoadingPrimaryAt(bufferedPos);
+        // If not detached check playing item for seek to resumption point
+        const playingItem = this.playingItem;
+        const skipSeekToStartPosition =
+          this.isInterstitial(playingItem) && playingItem.event.appendInPlace;
+        this.startLoadingPrimaryAt(bufferedPos, skipSeekToStartPosition);
       }
     }
   }

--- a/src/controller/interstitials-controller.ts
+++ b/src/controller/interstitials-controller.ts
@@ -870,17 +870,17 @@ export default class InterstitialsController
       return;
     }
     const dataToAttach =
-      transferring && attachMediaSourceData ? attachMediaSourceData : { media };
+      transferring && attachMediaSourceData
+        ? { ...attachMediaSourceData }
+        : { media };
     const schedule = this.schedule;
-    if (schedule) {
+    if (schedule && isAssetPlayer) {
       const isAssetAtEndOfSchedule =
-        isAssetPlayer &&
         (player as HlsAssetPlayer).assetId === schedule.assetIdAtEnd;
       // Prevent asset players from marking EoS on transferred MediaSource
       dataToAttach.overrides = {
         duration: schedule.duration,
         endOfStream:
-          !isAssetPlayer ||
           isAssetAtEndOfSchedule ||
           (player as HlsAssetPlayer).appendInPlace === false,
       };

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -1,18 +1,18 @@
+import { interstitialsEnabled } from './base-stream-controller';
 import { ErrorDetails } from '../errors';
 import { Events } from '../events';
-import type { HlsConfig } from '../config';
 import type Hls from '../hls';
 import type { LevelDetails } from '../loader/level-details';
 import type { ComponentAPI } from '../types/component-api';
 import type {
   ErrorData,
+  InterstitialAssetStartedData,
   LevelUpdatedData,
   MediaAttachingData,
 } from '../types/events';
 
 export default class LatencyController implements ComponentAPI {
   private hls: Hls | null;
-  private readonly config: HlsConfig;
   private media: HTMLMediaElement | null = null;
   private currentTime: number = 0;
   private stallCount: number = 0;
@@ -21,7 +21,6 @@ export default class LatencyController implements ComponentAPI {
 
   constructor(hls: Hls) {
     this.hls = hls;
-    this.config = hls.config;
     this.registerListeners();
   }
 
@@ -34,7 +33,10 @@ export default class LatencyController implements ComponentAPI {
   }
 
   get maxLatency(): number {
-    const { config } = this;
+    const config = this.hls?.config;
+    if (!config) {
+      return 0;
+    }
     if (config.liveMaxLatencyDuration !== undefined) {
       return config.liveMaxLatencyDuration;
     }
@@ -46,12 +48,12 @@ export default class LatencyController implements ComponentAPI {
 
   get targetLatency(): number | null {
     const levelDetails = this.levelDetails;
-    if (levelDetails === null || this.hls === null) {
+    if (levelDetails === null || !this.hls) {
       return null;
     }
+    const config = this.hls.config;
     const { holdBack, partHoldBack, targetduration } = levelDetails;
-    const { liveSyncDuration, liveSyncDurationCount, lowLatencyMode } =
-      this.config;
+    const { liveSyncDuration, liveSyncDurationCount, lowLatencyMode } = config;
     const userConfig = this.hls.userConfig;
     let targetLatency = lowLatencyMode ? partHoldBack || holdBack : holdBack;
     if (
@@ -69,22 +71,25 @@ export default class LatencyController implements ComponentAPI {
     return (
       targetLatency +
       Math.min(
-        this.stallCount * this.config.liveSyncOnStallIncrease,
+        this.stallCount * config.liveSyncOnStallIncrease,
         maxLiveSyncOnStallIncrease,
       )
     );
   }
 
   set targetLatency(latency: number) {
+    if (!this.hls) {
+      return;
+    }
     this.stallCount = 0;
-    this.config.liveSyncDuration = latency;
+    this.hls.config.liveSyncDuration = latency;
     this._targetLatencyUpdated = true;
   }
 
   get liveSyncPosition(): number | null {
     const liveEdge = this.estimateLiveEdge();
     const targetLatency = this.targetLatency;
-    if (liveEdge === null || targetLatency === null) {
+    if (liveEdge === null || targetLatency === null || !this.hls) {
       return null;
     }
     const levelDetails = this.levelDetails;
@@ -96,7 +101,7 @@ export default class LatencyController implements ComponentAPI {
     const min = edge - levelDetails.totalduration;
     const max =
       edge -
-      ((this.config.lowLatencyMode && levelDetails.partTarget) ||
+      ((this.hls.config.lowLatencyMode && levelDetails.partTarget) ||
         levelDetails.targetduration);
     return Math.min(Math.max(min, syncPosition), max);
   }
@@ -111,11 +116,11 @@ export default class LatencyController implements ComponentAPI {
 
   get edgeStalled(): number {
     const levelDetails = this.levelDetails;
-    if (levelDetails === null) {
+    if (levelDetails === null || !this.hls) {
       return 0;
     }
     const maxLevelUpdateAge =
-      ((this.config.lowLatencyMode && levelDetails.partTarget) ||
+      ((this.hls.config.lowLatencyMode && levelDetails.partTarget) ||
         levelDetails.targetduration) * 3;
     return Math.max(levelDetails.age - maxLevelUpdateAge, 0);
   }
@@ -138,6 +143,8 @@ export default class LatencyController implements ComponentAPI {
     this.unregisterListeners();
     this.onMediaDetaching();
     this.hls = null;
+    // @ts-ignore
+    this.config = null;
   }
 
   private registerListeners() {
@@ -150,6 +157,7 @@ export default class LatencyController implements ComponentAPI {
     hls.on(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.on(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
     hls.on(Events.ERROR, this.onError, this);
+    hls.on(Events.INTERSTITIAL_ASSET_STARTED, this.onAssetStarted, this);
   }
 
   private unregisterListeners() {
@@ -162,6 +170,7 @@ export default class LatencyController implements ComponentAPI {
     hls.off(Events.MANIFEST_LOADING, this.onManifestLoading, this);
     hls.off(Events.LEVEL_UPDATED, this.onLevelUpdated, this);
     hls.off(Events.ERROR, this.onError, this);
+    hls.off(Events.INTERSTITIAL_ASSET_STARTED, this.onAssetStarted, this);
   }
 
   private onMediaAttached(
@@ -196,6 +205,28 @@ export default class LatencyController implements ComponentAPI {
     }
   }
 
+  private onAssetStarted(
+    event: Events.INTERSTITIAL_ASSET_STARTED,
+    data: InterstitialAssetStartedData,
+  ) {
+    const hls = this.hls;
+    const media =
+      this.media ||
+      (data.event.appendInPlace &&
+        hls?.interstitialsManager?.playerQueue.reduce(
+          (found, player) => found || player.media,
+          null,
+        ));
+    if (
+      hls &&
+      media &&
+      media.playbackRate > 1 &&
+      media.playbackRate <= hls.config.maxLiveSyncPlaybackRate
+    ) {
+      this.changeMediaPlaybackRate(media, 1);
+    }
+  }
+
   private onError(event: Events.ERROR, data: ErrorData) {
     if (data.details !== ErrorDetails.BUFFER_STALLED_ERROR) {
       return;
@@ -211,11 +242,12 @@ export default class LatencyController implements ComponentAPI {
   private onTimeupdate = () => {
     const { media } = this;
     const levelDetails = this.levelDetails;
-    if (!media || !levelDetails) {
+    if (!media || !levelDetails || !this.hls) {
       return;
     }
     this.currentTime = media.currentTime;
 
+    const config = this.hls.config;
     const latency = this.computeLatency();
     if (latency === null) {
       return;
@@ -223,7 +255,7 @@ export default class LatencyController implements ComponentAPI {
     this._latency = latency;
 
     // Adapt playbackRate to meet target latency in low-latency mode
-    const { lowLatencyMode, maxLiveSyncPlaybackRate } = this.config;
+    const { lowLatencyMode, maxLiveSyncPlaybackRate } = config;
     if (
       !lowLatencyMode ||
       maxLiveSyncPlaybackRate === 1 ||
@@ -245,10 +277,15 @@ export default class LatencyController implements ComponentAPI {
     );
     const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
 
+    const playingInterstitial =
+      interstitialsEnabled(config) &&
+      !!this.hls.interstitialsManager?.playingItem?.event;
+
     if (
       inLiveRange &&
       distanceFromTarget > 0.05 &&
-      this.forwardBufferLength > 1
+      this.forwardBufferLength > 1 &&
+      !playingInterstitial
     ) {
       const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
       const rate =

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -143,8 +143,6 @@ export default class LatencyController implements ComponentAPI {
     this.unregisterListeners();
     this.onMediaDetaching();
     this.hls = null;
-    // @ts-ignore
-    this.config = null;
   }
 
   private registerListeners() {

--- a/src/loader/interstitial-event.ts
+++ b/src/loader/interstitial-event.ts
@@ -152,6 +152,10 @@ export class InterstitialEvent {
     if (this.snapOptions.out) {
       const frag = this.dateRange.tagAnchor;
       if (frag) {
+        if (!fragmentRefCoversTime(frag, startTime)) {
+          // Do not snap to segment boundary when segment does not cover datetime
+          return startTime;
+        }
         return getSnapToFragmentTime(startTime, frag);
       }
     }
@@ -187,6 +191,10 @@ export class InterstitialEvent {
     if (this.snapOptions.in) {
       const frag = this.resumeAnchor;
       if (frag) {
+        if (!fragmentRefCoversTime(frag, resumeTime)) {
+          // Do not snap to segment boundary when segment does not cover datetime
+          return resumeTime;
+        }
         return getSnapToFragmentTime(resumeTime, frag);
       }
     }
@@ -303,6 +311,13 @@ export function getSnapToFragmentTime(time: number, frag: MediaFragmentRef) {
     )
     ? frag.start
     : frag.start + frag.duration;
+}
+
+function fragmentRefCoversTime(frag: MediaFragmentRef, time: number): boolean {
+  return (
+    time > frag.start - ALIGNED_END_THRESHOLD_SECONDS &&
+    time < frag.start + frag.duration + ALIGNED_END_THRESHOLD_SECONDS
+  );
 }
 
 export function getInterstitialUrl(

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -872,15 +872,15 @@ export function mapDateRanges(
       if (programDateTimes[j]?.sn < details.startSN) {
         break;
       }
-      const fragIndex = findFragmentWithStartDate(
+      const fragment = findFragmentWithStartDate(
         details,
         startDateTime,
         programDateTimes,
         j,
         playlistEnd,
       );
-      if (fragIndex !== -1) {
-        dateRange.tagAnchor = details.fragments[fragIndex].ref;
+      if (fragment) {
+        dateRange.tagAnchor = fragment.ref;
         break;
       }
     }
@@ -893,7 +893,7 @@ function findFragmentWithStartDate(
   programDateTimes: MediaFragment[],
   index: number,
   endTime: number,
-): number {
+): MediaFragment | null {
   const pdtFragment = programDateTimes[index] as MediaFragment | undefined;
   if (pdtFragment) {
     // find matching range between PDT tags
@@ -903,30 +903,32 @@ function findFragmentWithStartDate(
         (programDateTimes[index + 1]?.start || endTime) - pdtFragment.start;
       if (startDateTime <= pdtStart + durationBetweenPdt * 1000) {
         // map to fragment with date-time range
-        const startIndex = programDateTimes[index].sn - details.startSN;
-        if (startIndex < 0) {
-          return -1;
-        }
+        const startIndex = pdtFragment.sn - details.startSN;
         const fragments = details.fragments;
-        if (fragments.length > programDateTimes.length) {
-          const endSegment =
-            programDateTimes[index + 1] || fragments[fragments.length - 1];
-          const endIndex = endSegment.sn - details.startSN;
-          for (let i = endIndex; i > startIndex; i--) {
-            const fragStartDateTime = fragments[i].programDateTime as number;
-            if (
-              startDateTime >= fragStartDateTime &&
-              startDateTime < fragStartDateTime + fragments[i].duration * 1000
-            ) {
-              return i;
+        if (startIndex >= 0 && startIndex < fragments.length) {
+          if (fragments.length > programDateTimes.length) {
+            const endSegment =
+              programDateTimes[index + 1] || fragments[fragments.length - 1];
+            const endIndex = Math.min(
+              endSegment.sn - details.startSN,
+              fragments.length - 1,
+            );
+            for (let i = endIndex; i > startIndex; i--) {
+              const fragStartDateTime = fragments[i].programDateTime as number;
+              if (
+                startDateTime >= fragStartDateTime &&
+                startDateTime < fragStartDateTime + fragments[i].duration * 1000
+              ) {
+                return fragments[i];
+              }
             }
           }
+          return fragments[startIndex];
         }
-        return startIndex;
       }
     }
   }
-  return -1;
+  return null;
 }
 
 function parseKey(

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -1144,6 +1144,8 @@ describe('BufferController with attached media', function () {
             }
           }, reject);
         });
+        (bufferController as any).getFragmentAppendProgress(frag).progressed =
+          false;
         hls.trigger(Events.FRAG_PARSED, {
           frag,
           part: null,
@@ -1182,6 +1184,8 @@ describe('BufferController with attached media', function () {
             reject(e);
           }
         });
+        (bufferController as any).getFragmentAppendProgress(frag).progressed =
+          false;
         hls.trigger(Events.FRAG_PARSED, {
           frag,
           part: null,

--- a/tests/unit/controller/latency-controller.ts
+++ b/tests/unit/controller/latency-controller.ts
@@ -6,6 +6,7 @@ import LatencyController from '../../../src/controller/latency-controller';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
 import { LevelDetails } from '../../../src/loader/level-details';
+import type { HlsConfig } from '../../../src/config';
 import type { LevelUpdatedData } from '../../../src/types/events';
 
 use(sinonChai);
@@ -18,7 +19,7 @@ interface TestLevelDetails extends LevelDetails {
 
 describe('LatencyController', function () {
   let latencyController: LatencyController;
-  let hls: Hls;
+  let hls: Hls & { config: HlsConfig };
   let media: {
     currentTime: number;
     playbackRate: number;
@@ -105,12 +106,12 @@ describe('LatencyController', function () {
 
   describe('maxLatency', function () {
     it('returns liveMaxLatencyDurationCount * targetduration', function () {
-      latencyController['config'].liveMaxLatencyDurationCount = 3;
+      hls.config.liveMaxLatencyDurationCount = 3;
       expect(latencyController.maxLatency).to.equal(15);
     });
 
     it('returns liveMaxLatencyDuration when set', function () {
-      latencyController['config'].liveMaxLatencyDuration = 30;
+      hls.config.liveMaxLatencyDuration = 30;
       expect(latencyController.maxLatency).to.equal(30);
     });
   });
@@ -127,12 +128,12 @@ describe('LatencyController', function () {
     });
 
     it('returns liveSyncDuration if set', function () {
-      latencyController['config'].liveSyncDuration = 12;
+      hls.config.liveSyncDuration = 12;
       expect(latencyController.targetLatency).to.equal(12);
     });
 
     it('returns targetduration * liveSyncDurationCount if set', function () {
-      latencyController['config'].liveSyncDurationCount = 2;
+      hls.config.liveSyncDurationCount = 2;
       expect(latencyController.targetLatency).to.equal(10);
     });
 
@@ -144,28 +145,28 @@ describe('LatencyController', function () {
     it('returns partHoldBack in lowLatencyMode when set in playlist', function () {
       levelDetails.holdBack = 8;
       levelDetails.partHoldBack = 3;
-      latencyController['config'].lowLatencyMode = false;
+      hls.config.lowLatencyMode = false;
       expect(latencyController.targetLatency).to.equal(8);
-      latencyController['config'].lowLatencyMode = true;
+      hls.config.lowLatencyMode = true;
       expect(latencyController.targetLatency).to.equal(3);
     });
 
     it('liveSyncDuration overrides holdBack when set by user', function () {
       hls.userConfig.liveSyncDuration = 12;
-      latencyController['config'].liveSyncDuration = 12;
+      hls.config.liveSyncDuration = 12;
       levelDetails.holdBack = 8;
       expect(latencyController.targetLatency).to.equal(12);
     });
 
     it('liveSyncDurationCount overrides holdBack when set by user', function () {
       hls.userConfig.liveSyncDurationCount = 2;
-      latencyController['config'].liveSyncDurationCount = 2;
+      hls.config.liveSyncDurationCount = 2;
       levelDetails.holdBack = 8;
       expect(latencyController.targetLatency).to.equal(10);
     });
 
     it('adds a second of latency for each stall up to targetduration', function () {
-      latencyController['config'].lowLatencyMode = true;
+      hls.config.lowLatencyMode = true;
       levelDetails.targetduration = 3.5;
       levelDetails.partHoldBack = 3;
       expect(latencyController.targetLatency).to.equal(3);
@@ -180,8 +181,8 @@ describe('LatencyController', function () {
     });
 
     it('liveSyncOnStallIncrease can control how fast targetduration increases on stall', function () {
-      latencyController['config'].lowLatencyMode = true;
-      latencyController['config'].liveSyncOnStallIncrease = 1.3;
+      hls.config.lowLatencyMode = true;
+      hls.config.liveSyncOnStallIncrease = 1.3;
       levelDetails.targetduration = 3.5;
       levelDetails.partHoldBack = 3;
       levelDetails.age = 0;
@@ -195,7 +196,7 @@ describe('LatencyController', function () {
     });
 
     it('can be set and will reset stallCount', function () {
-      latencyController['config'].lowLatencyMode = true;
+      hls.config.lowLatencyMode = true;
       levelDetails.targetduration = 3.5;
       levelDetails.partHoldBack = 3;
       levelDetails.age = 0;
@@ -203,10 +204,10 @@ describe('LatencyController', function () {
       latencyController['stallCount'] = 1;
 
       expect(latencyController.targetLatency).to.equal(4);
-      expect(latencyController['config'].liveSyncDuration).to.be.undefined;
+      expect(hls.config.liveSyncDuration).to.be.undefined;
       latencyController.targetLatency = 2;
       expect(latencyController['stallCount']).to.equal(0);
-      expect(latencyController['config'].liveSyncDuration).to.equal(2);
+      expect(hls.config.liveSyncDuration).to.equal(2);
       expect(latencyController['hls']?.userConfig.liveSyncDuration).to.be
         .undefined;
       expect(latencyController.targetLatency).to.equal(2);
@@ -225,7 +226,7 @@ describe('LatencyController', function () {
     });
 
     it('returns target currentTime based on edge and targetLatency', function () {
-      latencyController['config'].liveSyncDuration = 12;
+      hls.config.liveSyncDuration = 12;
       levelDetails.edge = 60;
       expect(latencyController.liveSyncPosition).to.equal(48);
     });
@@ -244,7 +245,7 @@ describe('LatencyController', function () {
     });
 
     it('accounts for level update age up to 3 part targets in low latency mode', function () {
-      latencyController['config'].lowLatencyMode = true;
+      hls.config.lowLatencyMode = true;
       levelDetails.partTarget = 1;
       levelDetails.partHoldBack = 3;
       levelDetails.edge = 60;
@@ -283,7 +284,7 @@ describe('LatencyController', function () {
     });
 
     it('returns the age seconds past 3 part targets in low latency mode', function () {
-      latencyController['config'].lowLatencyMode = true;
+      hls.config.lowLatencyMode = true;
       levelDetails.partTarget = 1;
       levelDetails.partHoldBack = 3;
       levelDetails.age = 0;
@@ -299,7 +300,7 @@ describe('LatencyController', function () {
 
   describe('when maxLiveSyncPlaybackRate is set', function () {
     beforeEach(function () {
-      latencyController['config'].maxLiveSyncPlaybackRate = 2;
+      hls.config.maxLiveSyncPlaybackRate = 2;
     });
 
     it('increases playbackRate when latency is greater than target latency on timeupdate', function () {


### PR DESCRIPTION
### This PR will...
- Fix Interstitial start dates snapping to the last segment when they first appear at a distance from the live edge
- Fix BUFFER_APPEND_NO_PROGRESS (#7941) false positives in asset buffering
- Ensure Interstitials are played at 1x over live primary

### Why is this Pull Request needed?
These issues interfere with append-in-place buffering across scheduled mid-rolls at a low-latency live edge.

### Resolves issues:
Fixes #7978
