### PR TITLE
Split remuxed output at in-band video config changes and correct misdeclared ADTS channel configuration

### DIFF
--- a/src/demux/audio/adts.ts
+++ b/src/demux/audio/adts.ts
@@ -51,7 +51,64 @@ export function getAudioConfig(
   }
   // MPEG-4 Audio Object Type (profile_ObjectType+1)
   const adtsObjectType = ((byte2 >> 6) & 0x3) + 1;
-  const channelCount = ((data[offset + 3] >> 6) & 0x3) | ((byte2 & 1) << 2);
+  let channelCount = ((data[offset + 3] >> 6) & 0x3) | ((byte2 & 1) << 2);
+  // The channel_configuration in ADTS headers is not always accurate: some
+  // encoders write stereo headers around mono frames (or the reverse). TS
+  // decoders probe the frames and cope, but once the header value is copied
+  // into the esds, strict MSE decoders configure the wrong channel layout and
+  // render silence (Safari, #3179). Trust the frame's first channel element
+  // (SCE 0b000 mono, CPE 0b001 stereo) over the header when they disagree,
+  // skipping any fill elements that precede it.
+  const payloadStart = offset + getHeaderLength(data, offset);
+  const frameLength = getFullFrameLength(data, offset);
+  const frameEnd =
+    frameLength > payloadStart - offset
+      ? Math.min(data.length, offset + frameLength)
+      : data.length;
+  if (payloadStart < frameEnd) {
+    const endBit = frameEnd * 8;
+    const readBits = (position: number, count: number): number => {
+      let value = 0;
+      for (let i = 0; i < count; i++, position++) {
+        value =
+          (value << 1) | ((data[position >> 3] >> (7 - (position & 7))) & 1);
+      }
+      return value;
+    };
+    let bitPos = payloadStart * 8;
+    let elementId = readBits(bitPos, 3);
+    bitPos += 3;
+    // A fill element is a 3 bit id and 4 bit count (an escaped count adds 8
+    // bits), followed by count bytes of payload; elements after it are not
+    // byte aligned
+    let guard = 8;
+    while (elementId === 6 && guard-- > 0 && bitPos + 4 <= endBit) {
+      let count = readBits(bitPos, 4);
+      bitPos += 4;
+      if (count === 15) {
+        count += readBits(bitPos, 8) - 1;
+        bitPos += 8;
+      }
+      bitPos += count * 8;
+      if (bitPos + 3 > endBit) {
+        elementId = -1;
+        break;
+      }
+      elementId = readBits(bitPos, 3);
+      bitPos += 3;
+    }
+    if (channelCount === 2 && elementId === 0) {
+      channelCount = 1;
+      logger.warn(
+        'ADTS header declares stereo but frames begin with a single channel element; treating as mono',
+      );
+    } else if (channelCount === 1 && elementId === 1) {
+      channelCount = 2;
+      logger.warn(
+        'ADTS header declares mono but frames begin with a channel pair element; treating as stereo',
+      );
+    }
+  }
   /* refer to http://wiki.multimedia.cx/index.php?title=MPEG-4_Audio#Audio_Specific_Config
       ISO/IEC 14496-3 - Table 1.13 — Syntax of AudioSpecificConfig()
     Audio Profile / Audio Object Type

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -543,9 +543,13 @@ export default class Transmuxer {
     const samples = videoTrack.samples;
     const pending = samples.slice(configSwitch.sampleIndex);
     videoTrack.samples = samples.slice(0, configSwitch.sampleIndex);
+    // References are enough for the round trip: only the remuxer runs between
+    // this snapshot and the restore below, and it does not mutate track.params
     const currentConfig: VideoConfig = {
       sps: videoTrack.sps,
       pps: videoTrack.pps,
+      vps: videoTrack.vps,
+      params: videoTrack.params,
       width: videoTrack.width,
       height: videoTrack.height,
       pixelRatio: videoTrack.pixelRatio,
@@ -657,6 +661,8 @@ function applyVideoConfig(
 ) {
   videoTrack.sps = config.sps;
   videoTrack.pps = config.pps;
+  videoTrack.vps = config.vps;
+  videoTrack.params = config.params;
   videoTrack.width = config.width;
   videoTrack.height = config.height;
   videoTrack.pixelRatio = config.pixelRatio;

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -15,7 +15,13 @@ import {
 import type { HlsConfig } from '../config';
 import type { HlsEventEmitter } from '../events';
 import type { DecryptData } from '../loader/level-key';
-import type { Demuxer, DemuxerResult, KeyData } from '../types/demuxer';
+import type {
+  Demuxer,
+  DemuxerResult,
+  KeyData,
+  VideoConfig,
+  VideoSample,
+} from '../types/demuxer';
 import type { PlaylistLevelType } from '../types/loader';
 import type { Remuxer } from '../types/remuxer';
 import type { ChunkMetadata, TransmuxerResult } from '../types/transmuxer';
@@ -283,6 +289,22 @@ export default class Transmuxer {
         chunkMeta.part > -1 ? ' part: ' + chunkMeta.part : ''
       } of ${this.id} playlist ${chunkMeta.level}`,
     );
+    // Remux samples preceding each in-band video config change as their own
+    // result so that each portion gets an init segment matching its config
+    let guard = videoTrack.configSwitches?.length ?? 0;
+    while (guard-- > 0) {
+      const configSwitchResult = this.remuxNextConfigSwitch(
+        demuxResult,
+        timeOffset,
+        accurateTimeOffset,
+        true,
+        chunkMeta,
+      );
+      if (!configSwitchResult) {
+        break;
+      }
+      transmuxResults.push(configSwitchResult);
+    }
     const remuxResult = this.remuxer.remux(
       audioTrack,
       videoTrack,
@@ -412,6 +434,18 @@ export default class Transmuxer {
       false,
       !this.config.progressive,
     );
+    const configSwitchResult = this.remuxNextConfigSwitch(
+      demuxResult,
+      timeOffset,
+      accurateTimeOffset,
+      false,
+      chunkMeta,
+    );
+    if (configSwitchResult) {
+      // Samples following the config change stay in the demuxed tracks and are
+      // remuxed with a new init segment on the next push or flush
+      return configSwitchResult;
+    }
     const { audioTrack, videoTrack, id3Track, textTrack } = demuxResult;
     const remuxResult = remuxer.remux(
       audioTrack,
@@ -445,6 +479,16 @@ export default class Transmuxer {
     return this.demuxer
       .demuxSampleAes(data, decryptData, timeOffset, chunkMeta)
       .then((demuxResult) => {
+        const configSwitchResult = this.remuxNextConfigSwitch(
+          demuxResult,
+          timeOffset,
+          accurateTimeOffset,
+          false,
+          chunkMeta,
+        );
+        if (configSwitchResult) {
+          return configSwitchResult;
+        }
         const remuxResult = this.remuxer!.remux(
           demuxResult.audioTrack,
           demuxResult.videoTrack,
@@ -463,6 +507,81 @@ export default class Transmuxer {
           chunkMeta,
         };
       });
+  }
+
+  // Remuxes the video samples that precede an in-band config change (SPS with
+  // new dimensions mid-segment) under the config they were encoded with, so
+  // that the samples following the change are remuxed separately behind a new
+  // init segment. Some MSE implementations (Safari) stop decoding when a config
+  // change is signalled only by in-band parameter sets within an avc1 track.
+  private remuxNextConfigSwitch(
+    demuxResult: DemuxerResult,
+    timeOffset: number,
+    accurateTimeOffset: boolean,
+    flush: boolean,
+    chunkMeta: ChunkMetadata,
+  ): TransmuxerResult | null {
+    const { remuxer } = this;
+    const videoTrack = demuxResult.videoTrack;
+    const configSwitches = videoTrack.configSwitches;
+    if (
+      !remuxer ||
+      !configSwitches?.length ||
+      !Array.isArray(videoTrack.samples)
+    ) {
+      return null;
+    }
+    // A boundary at index 0 needs no partitioning: all pending samples use the
+    // new config and the remuxer resets the init segment on its own
+    while (configSwitches.length && configSwitches[0].sampleIndex <= 0) {
+      configSwitches.shift();
+    }
+    const configSwitch = configSwitches[0];
+    if (!configSwitch) {
+      return null;
+    }
+    const samples = videoTrack.samples;
+    const pending = samples.slice(configSwitch.sampleIndex);
+    videoTrack.samples = samples.slice(0, configSwitch.sampleIndex);
+    const currentConfig: VideoConfig = {
+      sps: videoTrack.sps,
+      pps: videoTrack.pps,
+      width: videoTrack.width,
+      height: videoTrack.height,
+      pixelRatio: videoTrack.pixelRatio,
+      codec: videoTrack.codec,
+    };
+    applyVideoConfig(videoTrack, configSwitch.prev);
+    const remuxResult = remuxer.remux(
+      demuxResult.audioTrack,
+      videoTrack,
+      demuxResult.id3Track,
+      demuxResult.textTrack,
+      timeOffset,
+      accurateTimeOffset,
+      flush,
+      this.id,
+      chunkMeta,
+      demuxResult.initData,
+      demuxResult.sampleData,
+    );
+    // The remuxer defers a track with too few samples; carry any leftover ahead
+    // of the samples held back for the next result
+    const leftover = videoTrack.samples as VideoSample[];
+    applyVideoConfig(videoTrack, currentConfig);
+    videoTrack.samples = leftover.concat(pending);
+    if (leftover.length) {
+      configSwitch.sampleIndex = leftover.length;
+    } else {
+      configSwitches.shift();
+      configSwitches.forEach((s) => {
+        s.sampleIndex -= configSwitch.sampleIndex;
+      });
+    }
+    return {
+      remuxResult,
+      chunkMeta,
+    };
   }
 
   private configureTransmuxer(data: Uint8Array): undefined | Error {
@@ -530,6 +649,18 @@ function getEncryptionType(
     encryptionType = decryptData as KeyData;
   }
   return encryptionType;
+}
+
+function applyVideoConfig(
+  videoTrack: DemuxerResult['videoTrack'],
+  config: VideoConfig,
+) {
+  videoTrack.sps = config.sps;
+  videoTrack.pps = config.pps;
+  videoTrack.width = config.width;
+  videoTrack.height = config.height;
+  videoTrack.pixelRatio = config.pixelRatio;
+  videoTrack.codec = config.codec;
 }
 
 const emptyResult = (chunkMeta): TransmuxerResult => ({

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -581,6 +581,19 @@ export default class Transmuxer {
       configSwitches.forEach((s) => {
         s.sampleIndex -= configSwitch.sampleIndex;
       });
+      // The config the samples after this boundary were encoded with is the
+      // outgoing config of the next boundary, or the track's current config
+      const { prev } = configSwitch;
+      const next = configSwitches[0]?.prev || currentConfig;
+      this.logger.log(
+        `[transmuxer.ts]: In-band video config switch in ${this.id} sn: ${
+          chunkMeta.sn
+        }${chunkMeta.part > -1 ? ' part: ' + chunkMeta.part : ''} of ${
+          this.id
+        } playlist ${chunkMeta.level}: ${prev.codec} ${prev.width}x${
+          prev.height
+        } to ${next.codec} ${next.width}x${next.height}`,
+      );
     }
     return {
       remuxResult,

--- a/src/demux/video/avc-video-parser.ts
+++ b/src/demux/video/avc-video-parser.ts
@@ -131,6 +131,23 @@ class AvcVideoParser extends BaseVideoParser {
             track.pixelRatio?.[0] !== config.pixelRatio[0] ||
             track.pixelRatio?.[1] !== config.pixelRatio[1]
           ) {
+            if (track.sps && track.samples.length) {
+              // In-band config change with samples pending: record the boundary
+              // so that the transmuxer can remux the preceding samples under the
+              // config they were encoded with (track.pps still holds the old PPS
+              // here since the new one is parsed after this SPS)
+              (track.configSwitches ||= []).push({
+                sampleIndex: track.samples.length,
+                prev: {
+                  sps: track.sps,
+                  pps: track.pps,
+                  width: track.width,
+                  height: track.height,
+                  pixelRatio: track.pixelRatio,
+                  codec: track.codec,
+                },
+              });
+            }
             track.width = config.width;
             track.height = config.height;
             track.pixelRatio = config.pixelRatio;

--- a/src/demux/video/hevc-video-parser.ts
+++ b/src/demux/video/hevc-video-parser.ts
@@ -11,6 +11,7 @@ import type { PES } from '../tsdemuxer';
 
 class HevcVideoParser extends BaseVideoParser {
   protected initVPS: Uint8Array | null = null;
+  private prevVPS: Uint8Array[] | null = null;
 
   public parsePES(
     track: DemuxedVideoTrack,
@@ -125,6 +126,13 @@ class HevcVideoParser extends BaseVideoParser {
             track.params = Object.assign(track.params, this.readVPS(unit.data));
             this.initVPS = unit.data;
           }
+          if (track.vps && !this.prevVPS) {
+            // The SPS that follows may reset the config; hold the outgoing VPS
+            // aside so that the boundary snapshot can keep it. Only the first
+            // VPS of the access unit takes this path so that repeated VPS NALs
+            // do not replace the outgoing config's VPS with an incoming one
+            this.prevVPS = track.vps;
+          }
           track.vps = [unit.data];
           break;
 
@@ -138,6 +146,28 @@ class HevcVideoParser extends BaseVideoParser {
             track.sps !== undefined &&
             !this.matchSPS(track.sps[0], unit.data)
           ) {
+            if (track.samples.length) {
+              // In-band config change with samples pending: record the boundary
+              // so that the transmuxer can remux the preceding samples under the
+              // config they were encoded with (track.params is mutated in place
+              // by readSPS/readPPS, so the snapshot needs a copy). If a VPS
+              // arrived earlier in this access unit, prevVPS holds the outgoing
+              // config's VPS; otherwise track.vps still is the outgoing VPS
+              (track.configSwitches ||= []).push({
+                sampleIndex: track.samples.length,
+                prev: {
+                  sps: track.sps,
+                  pps: track.pps,
+                  vps: this.prevVPS || track.vps,
+                  width: track.width,
+                  height: track.height,
+                  pixelRatio: track.pixelRatio,
+                  codec: track.codec,
+                  params: track.params ? { ...track.params } : undefined,
+                },
+              });
+            }
+            this.prevVPS = null;
             this.initVPS = track.vps[0];
             track.sps = track.pps = undefined;
           }
@@ -291,6 +321,7 @@ class HevcVideoParser extends BaseVideoParser {
     videoTrack: DemuxedVideoTrack,
   ) {
     super.pushAccessUnit(VideoSample, videoTrack);
+    this.prevVPS = null;
     if (this.initVPS) {
       this.initVPS = null; // null initVPS to prevent possible track's sps/pps growth until next VPS
     }

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -105,6 +105,21 @@ export interface DemuxedVideoTrackBase extends DemuxedTrack {
   manifestCodec?: string;
   samples: VideoSample[] | Uint8Array;
   params?: object;
+  configSwitches?: VideoConfigSwitch[];
+}
+
+export interface VideoConfig {
+  sps?: Uint8Array[];
+  pps?: Uint8Array[];
+  width?: number;
+  height?: number;
+  pixelRatio?: [number, number];
+  codec?: string;
+}
+
+export interface VideoConfigSwitch {
+  sampleIndex: number;
+  prev: VideoConfig;
 }
 
 export interface DemuxedVideoTrack extends DemuxedVideoTrackBase {

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -111,6 +111,8 @@ export interface DemuxedVideoTrackBase extends DemuxedTrack {
 export interface VideoConfig {
   sps?: Uint8Array[];
   pps?: Uint8Array[];
+  vps?: Uint8Array[];
+  params?: object;
   width?: number;
   height?: number;
   pixelRatio?: [number, number];

--- a/tests/index.js
+++ b/tests/index.js
@@ -62,3 +62,4 @@ import './unit/utils/url-tools';
 import './unit/utils/vttparser';
 import './unit/utils/utf8';
 import './unit/demuxer/transmuxer';
+import './unit/demuxer/transmuxer-config-switch';

--- a/tests/unit/demuxer/adts.js
+++ b/tests/unit/demuxer/adts.js
@@ -87,6 +87,52 @@ describe('getAudioConfig', function () {
     });
   });
 
+  it('should trust a mono frame payload over a stereo ADTS header', function () {
+    const observer = new EventEmitter();
+    const data = new Uint8Array(new ArrayBuffer(8));
+    data[0] = 0xff;
+    data[1] = 0xf1; // ID = 0 (MPEG-4), layer = 00, protection_absent = 1
+    data[2] = 0x60; // profile = 1 (AAC LC), sampling_frequency_index = 8 (16000Hz)
+    data[3] = 0x80; // channel_configuration = 2 (stereo)
+    data[7] = 0x00; // first payload syntax element = SCE (mono)
+
+    const result = getAudioConfig(observer, data, 0, undefined);
+    expect(result, JSON.stringify(result)).to.deep.equal({
+      config: [20, 8],
+      samplerate: 16000,
+      channelCount: 1,
+      codec: 'mp4a.40.2',
+      parsedCodec: 'mp4a.40.2',
+      manifestCodec: undefined,
+    });
+  });
+
+  it('should skip fill elements when checking the frame channel layout', function () {
+    const observer = new EventEmitter();
+    const data = new Uint8Array(new ArrayBuffer(10));
+    data[0] = 0xff;
+    data[1] = 0xf1; // ID = 0 (MPEG-4), layer = 00, protection_absent = 1
+    data[2] = 0x60; // profile = 1 (AAC LC), sampling_frequency_index = 8 (16000Hz)
+    data[3] = 0x80; // channel_configuration = 2 (stereo)
+    data[4] = 0x01; // frame_length = 10
+    data[5] = 0x40;
+    // payload: FIL element (id 6, count 1, one fill byte), then SCE (mono),
+    // which is no longer byte aligned
+    data[7] = 0xc2;
+    data[8] = 0x00;
+    data[9] = 0x00;
+
+    const result = getAudioConfig(observer, data, 0, undefined);
+    expect(result, JSON.stringify(result)).to.deep.equal({
+      config: [20, 8],
+      samplerate: 16000,
+      channelCount: 1,
+      codec: 'mp4a.40.2',
+      parsedCodec: 'mp4a.40.2',
+      manifestCodec: undefined,
+    });
+  });
+
   it('should return audio config if there is no audio codec', function () {
     const observer = new EventEmitter();
     const data = new Uint8Array(new ArrayBuffer(4));

--- a/tests/unit/demuxer/transmuxer-config-switch.ts
+++ b/tests/unit/demuxer/transmuxer-config-switch.ts
@@ -5,6 +5,7 @@ import Transmuxer, {
   TransmuxState,
 } from '../../../src/demux/transmuxer';
 import AvcVideoParser from '../../../src/demux/video/avc-video-parser';
+import HevcVideoParser from '../../../src/demux/video/hevc-video-parser';
 import { ChunkMetadata } from '../../../src/types/transmuxer';
 import type { PES } from '../../../src/demux/tsdemuxer';
 import type {
@@ -31,6 +32,33 @@ const SPS_1280x720 = [
 const PPS = [0x68, 0xce, 0x3c, 0x80];
 const AUD = [0x09, 0xf0];
 const IDR = [0x65, 0x88, 0x80, 0x40];
+
+// Parameter sets from two x265 streams (testsrc2, 320x180 and 640x360). 180 is
+// not a multiple of the minimum coding block size, so the 320x180 SPS carries a
+// conformance window crop.
+const HEVC_VPS_320x180 = [
+  0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90,
+  0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x3c, 0x95, 0x98, 0x09,
+];
+const HEVC_SPS_320x180 = [
+  0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03,
+  0x00, 0x00, 0x03, 0x00, 0x3c, 0xa0, 0x0a, 0x08, 0x0b, 0x9f, 0x79, 0x65, 0x66,
+  0x92, 0x4c, 0xaf, 0x01, 0x68, 0x08, 0x00, 0x00, 0x03, 0x00, 0x08, 0x00, 0x00,
+  0x03, 0x00, 0xf0, 0x40,
+];
+const HEVC_VPS_640x360 = [
+  0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90,
+  0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x3f, 0x95, 0x98, 0x09,
+];
+const HEVC_SPS_640x360 = [
+  0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03,
+  0x00, 0x00, 0x03, 0x00, 0x3f, 0xa0, 0x05, 0x02, 0x01, 0x69, 0x65, 0x95, 0x9a,
+  0x49, 0x32, 0xbc, 0x05, 0xa0, 0x20, 0x00, 0x00, 0x03, 0x00, 0x20, 0x00, 0x00,
+  0x03, 0x03, 0xc1,
+];
+const HEVC_PPS = [0x44, 0x01, 0xc1, 0x72, 0xb4, 0x62, 0x40];
+const HEVC_AUD = [0x46, 0x01, 0x50];
+const HEVC_IDR = [0x26, 0x01, 0xaf, 0x08];
 
 const startCode = [0, 0, 0, 1];
 
@@ -143,6 +171,112 @@ describe('AvcVideoParser in-band config switch', function () {
   });
 });
 
+describe('HevcVideoParser in-band config switch', function () {
+  function hevcParser() {
+    const parser = new HevcVideoParser();
+    const track = videoTrack();
+    track.segmentCodec = 'hevc';
+    const textTrack = { samples: [] } as unknown as DemuxedUserdataTrack;
+    let pts = 0;
+    const feed = (nalus: number[][], endOfSegment: boolean = false) => {
+      const data = annexB(nalus);
+      parser.parsePES(
+        track,
+        textTrack,
+        { data, pts, dts: pts, len: data.length },
+        endOfSegment,
+      );
+      pts += 3000;
+    };
+    return { track, feed };
+  }
+
+  it('records a config switch boundary when the SPS changes mid-stream', function () {
+    const { track, feed } = hevcParser();
+
+    feed([HEVC_AUD, HEVC_VPS_320x180, HEVC_SPS_320x180, HEVC_PPS, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_IDR]);
+    const spsBeforeSwitch = track.sps;
+    const ppsBeforeSwitch = track.pps;
+    const vpsBeforeSwitch = track.vps;
+    const paramsBeforeSwitch = { ...track.params };
+    feed([HEVC_AUD, HEVC_VPS_640x360, HEVC_SPS_640x360, HEVC_PPS, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_IDR], true);
+
+    expect(track.samples).to.have.lengthOf(5);
+    expect(track.width).to.equal(640);
+    expect(track.height).to.equal(360);
+    expect(track.configSwitches).to.have.lengthOf(1);
+    const configSwitch = track.configSwitches![0];
+    expect(configSwitch.sampleIndex).to.equal(3);
+    expect(configSwitch.prev.width).to.equal(320);
+    expect(configSwitch.prev.height).to.equal(180);
+    expect(configSwitch.prev.sps).to.equal(spsBeforeSwitch);
+    expect(configSwitch.prev.pps).to.equal(ppsBeforeSwitch);
+    // The VPS of the outgoing config is overwritten before the SPS arrives
+    expect(configSwitch.prev.vps).to.equal(vpsBeforeSwitch);
+    expect(track.vps).to.not.equal(vpsBeforeSwitch);
+    expect(configSwitch.prev.vps).to.not.equal(track.vps);
+    expect(configSwitch.prev.params).to.deep.equal(paramsBeforeSwitch);
+    expect(configSwitch.prev.params).to.not.equal(track.params);
+    (track.params as any).probe = true;
+    expect(configSwitch.prev.params).to.not.have.property('probe');
+  });
+
+  it('keeps the outgoing VPS when the switch access unit repeats its VPS', function () {
+    const { track, feed } = hevcParser();
+
+    feed([HEVC_AUD, HEVC_VPS_320x180, HEVC_SPS_320x180, HEVC_PPS, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_IDR]);
+    const vpsBeforeSwitch = track.vps;
+    feed([
+      HEVC_AUD,
+      HEVC_VPS_640x360,
+      HEVC_VPS_640x360,
+      HEVC_SPS_640x360,
+      HEVC_PPS,
+      HEVC_IDR,
+    ]);
+    feed([HEVC_AUD, HEVC_IDR], true);
+
+    expect(track.configSwitches).to.have.lengthOf(1);
+    const configSwitch = track.configSwitches![0];
+    expect(configSwitch.sampleIndex).to.equal(2);
+    expect(configSwitch.prev.vps).to.equal(vpsBeforeSwitch);
+    expect(configSwitch.prev.vps).to.not.equal(track.vps);
+  });
+
+  it('records a boundary for an SPS change without a new VPS', function () {
+    const { track, feed } = hevcParser();
+
+    feed([HEVC_AUD, HEVC_VPS_320x180, HEVC_SPS_320x180, HEVC_PPS, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_SPS_640x360, HEVC_PPS, HEVC_IDR]);
+    feed([HEVC_AUD, HEVC_IDR], true);
+
+    expect(track.width).to.equal(640);
+    expect(track.configSwitches).to.have.lengthOf(1);
+    const configSwitch = track.configSwitches![0];
+    expect(configSwitch.sampleIndex).to.equal(2);
+    expect(configSwitch.prev.width).to.equal(320);
+    expect(configSwitch.prev.vps).to.equal(track.vps);
+  });
+
+  it('does not record a boundary for the initial parameter sets', function () {
+    const { track, feed } = hevcParser();
+
+    feed(
+      [HEVC_AUD, HEVC_VPS_320x180, HEVC_SPS_320x180, HEVC_PPS, HEVC_IDR],
+      true,
+    );
+
+    expect(track.width).to.equal(320);
+    expect(track.height).to.equal(180);
+    expect(track.configSwitches).to.equal(undefined);
+  });
+});
+
 describe('Transmuxer video config switch splitting', function () {
   const config320: VideoConfig = {
     sps: [new Uint8Array(SPS_320x180)],
@@ -218,6 +352,8 @@ describe('Transmuxer video config switch splitting', function () {
       firstPts: number | undefined;
       width: number | undefined;
       sps: Uint8Array[] | undefined;
+      vps: Uint8Array[] | undefined;
+      params: object | undefined;
       flush: boolean;
     }> = [];
     const remux = sinon.spy(
@@ -235,6 +371,8 @@ describe('Transmuxer video config switch splitting', function () {
           firstPts: video.samples[0]?.pts,
           width: video.width,
           sps: video.sps,
+          vps: video.vps,
+          params: video.params,
           flush,
         });
         if (consumeSamples) {
@@ -373,6 +511,64 @@ describe('Transmuxer video config switch splitting', function () {
     expect(remuxCalls[2].width).to.equal(1280);
     expect(track.samples).to.have.lengthOf(0);
     expect(track.configSwitches).to.have.lengthOf(0);
+  });
+
+  it('remuxes hevc samples preceding the switch under the previous vps and params', function () {
+    const hevcConfig320: VideoConfig = {
+      sps: [new Uint8Array(HEVC_SPS_320x180)],
+      pps: [new Uint8Array(HEVC_PPS)],
+      vps: [new Uint8Array(HEVC_VPS_320x180)],
+      params: { general_level_idc: 60 },
+      width: 320,
+      height: 180,
+      pixelRatio: [1, 1],
+      codec: 'hvc1.1.6.L60.90',
+    };
+    const track = videoTrack();
+    Object.assign(track, {
+      segmentCodec: 'hevc',
+      width: 640,
+      height: 360,
+      sps: [new Uint8Array(HEVC_SPS_640x360)],
+      pps: [new Uint8Array(HEVC_PPS)],
+      vps: [new Uint8Array(HEVC_VPS_640x360)],
+      params: { general_level_idc: 63 },
+      codec: 'hvc1.1.6.L63.90',
+    });
+    const currentVps = track.vps;
+    const currentParams = track.params;
+    track.samples = fakeSamples(5, 0);
+    track.configSwitches = [{ sampleIndex: 3, prev: hevcConfig320 }];
+    const demuxResult = demuxResultWith(track);
+    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+    const result = transmuxer.push(
+      new ArrayBuffer(8),
+      null,
+      chunkMeta,
+      pushState(),
+    ) as TransmuxerResult;
+    expect(result.chunkMeta).to.equal(chunkMeta);
+
+    expect(remuxCalls).to.have.lengthOf(1);
+    expect(remuxCalls[0].sampleCount).to.equal(3);
+    expect(remuxCalls[0].width).to.equal(320);
+    expect(remuxCalls[0].sps).to.equal(hevcConfig320.sps);
+    expect(remuxCalls[0].vps).to.equal(hevcConfig320.vps);
+    expect(remuxCalls[0].params).to.equal(hevcConfig320.params);
+    // Samples after the switch are held back with the new config restored
+    expect(track.samples).to.have.lengthOf(2);
+    expect(track.vps).to.equal(currentVps);
+    expect(track.params).to.equal(currentParams);
+
+    const flushResults = transmuxer.flush(chunkMeta) as TransmuxerResult[];
+    expect(flushResults).to.have.lengthOf(1);
+    expect(remuxCalls).to.have.lengthOf(2);
+    expect(remuxCalls[1].sampleCount).to.equal(2);
+    expect(remuxCalls[1].width).to.equal(640);
+    expect(remuxCalls[1].vps).to.equal(currentVps);
+    expect(remuxCalls[1].params).to.equal(currentParams);
   });
 
   it('ignores a boundary at sample index 0', function () {

--- a/tests/unit/demuxer/transmuxer-config-switch.ts
+++ b/tests/unit/demuxer/transmuxer-config-switch.ts
@@ -1,0 +1,406 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Transmuxer, {
+  TransmuxConfig,
+  TransmuxState,
+} from '../../../src/demux/transmuxer';
+import AvcVideoParser from '../../../src/demux/video/avc-video-parser';
+import { ChunkMetadata } from '../../../src/types/transmuxer';
+import type { PES } from '../../../src/demux/tsdemuxer';
+import type {
+  DemuxedAudioTrack,
+  DemuxedMetadataTrack,
+  DemuxedUserdataTrack,
+  DemuxedVideoTrack,
+  DemuxerResult,
+  VideoConfig,
+  VideoSample,
+} from '../../../src/types/demuxer';
+import type { TransmuxerResult } from '../../../src/types/transmuxer';
+
+// Real parameter sets from the stream in https://github.com/video-dev/hls.js/issues/3179
+// (320x180 switching to 1280x720 in-band, mid-segment, without a discontinuity)
+const SPS_320x180 = [
+  0x67, 0x42, 0xc0, 0x1f, 0xda, 0x05, 0x06, 0x7e, 0x7c, 0x04, 0x40, 0x00, 0x00,
+  0x03, 0x00, 0x40, 0x00, 0x00, 0x0f, 0x23, 0xc6, 0x0c, 0xa8,
+];
+const SPS_1280x720 = [
+  0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xec, 0x04, 0x40, 0x00, 0x00,
+  0x03, 0x00, 0x40, 0x00, 0x00, 0x0f, 0x23, 0xc6, 0x0c, 0xa8,
+];
+const PPS = [0x68, 0xce, 0x3c, 0x80];
+const AUD = [0x09, 0xf0];
+const IDR = [0x65, 0x88, 0x80, 0x40];
+
+const startCode = [0, 0, 0, 1];
+
+function annexB(nalus: number[][]): Uint8Array {
+  const bytes: number[] = [];
+  nalus.forEach((nalu) => {
+    bytes.push(...startCode, ...nalu);
+  });
+  return new Uint8Array(bytes);
+}
+
+function videoTrack(): DemuxedVideoTrack {
+  return {
+    type: 'video',
+    id: 1,
+    pid: 0x100,
+    inputTimeScale: 90000,
+    sequenceNumber: 0,
+    samples: [],
+    dropped: 0,
+    segmentCodec: 'avc',
+    pixelRatio: [1, 1],
+    width: 0,
+    height: 0,
+  };
+}
+
+describe('AvcVideoParser in-band config switch', function () {
+  it('records a config switch boundary when SPS dimensions change mid-stream', function () {
+    const parser = new AvcVideoParser();
+    const track = videoTrack();
+    const textTrack = { samples: [] } as unknown as DemuxedUserdataTrack;
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+    const pes = (pts: number, data: Uint8Array): PES => ({
+      data,
+      pts,
+      dts: pts,
+      len: data.length,
+    });
+
+    parser.parsePES(
+      track,
+      textTrack,
+      pes(0, annexB([AUD, SPS_320x180, PPS, IDR])),
+      false,
+      chunkMeta,
+    );
+    parser.parsePES(
+      track,
+      textTrack,
+      pes(3000, annexB([AUD, IDR])),
+      false,
+      chunkMeta,
+    );
+    parser.parsePES(
+      track,
+      textTrack,
+      pes(6000, annexB([AUD, IDR])),
+      false,
+      chunkMeta,
+    );
+    const spsBeforeSwitch = track.sps;
+    parser.parsePES(
+      track,
+      textTrack,
+      pes(9000, annexB([AUD, SPS_1280x720, PPS, IDR])),
+      false,
+      chunkMeta,
+    );
+    parser.parsePES(
+      track,
+      textTrack,
+      pes(12000, annexB([AUD, IDR])),
+      true,
+      chunkMeta,
+    );
+
+    expect(track.samples).to.have.lengthOf(5);
+    expect(track.width).to.equal(1280);
+    expect(track.height).to.equal(720);
+    expect(track.configSwitches).to.have.lengthOf(1);
+    const configSwitch = track.configSwitches![0];
+    expect(configSwitch.sampleIndex).to.equal(3);
+    expect(configSwitch.prev.width).to.equal(320);
+    expect(configSwitch.prev.height).to.equal(180);
+    expect(configSwitch.prev.sps).to.equal(spsBeforeSwitch);
+  });
+
+  it('does not record a boundary for the initial SPS or without pending samples', function () {
+    const parser = new AvcVideoParser();
+    const track = videoTrack();
+    const textTrack = { samples: [] } as unknown as DemuxedUserdataTrack;
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+
+    parser.parsePES(
+      track,
+      textTrack,
+      {
+        data: annexB([AUD, SPS_320x180, PPS, IDR]),
+        pts: 0,
+        dts: 0,
+        len: 0,
+      },
+      true,
+      chunkMeta,
+    );
+
+    expect(track.width).to.equal(320);
+    expect(track.configSwitches).to.equal(undefined);
+  });
+});
+
+describe('Transmuxer video config switch splitting', function () {
+  const config320: VideoConfig = {
+    sps: [new Uint8Array(SPS_320x180)],
+    pps: [new Uint8Array(PPS)],
+    width: 320,
+    height: 180,
+    pixelRatio: [1, 1],
+    codec: 'avc1.42c01f',
+  };
+  const config640: VideoConfig = {
+    sps: [new Uint8Array(SPS_320x180)],
+    pps: [new Uint8Array(PPS)],
+    width: 640,
+    height: 360,
+    pixelRatio: [1, 1],
+    codec: 'avc1.42c01f',
+  };
+
+  function fakeSamples(count: number, firstPts: number): VideoSample[] {
+    const samples: VideoSample[] = [];
+    for (let i = 0; i < count; i++) {
+      samples.push({
+        pts: firstPts + i * 3000,
+        dts: firstPts + i * 3000,
+        key: i === 0,
+        frame: true,
+        units: [],
+        length: 0,
+      });
+    }
+    return samples;
+  }
+
+  function demuxResultWith(track: DemuxedVideoTrack): DemuxerResult {
+    return {
+      audioTrack: { pid: -1, samples: [] } as unknown as DemuxedAudioTrack,
+      videoTrack: track,
+      id3Track: { samples: [] } as unknown as DemuxedMetadataTrack,
+      textTrack: { samples: [] } as unknown as DemuxedUserdataTrack,
+    };
+  }
+
+  function setupTransmuxer(
+    demuxResult: DemuxerResult,
+    consumeSamples: boolean,
+  ) {
+    const observer = {
+      emit: () => {},
+      off: () => {},
+      removeAllListeners: () => {},
+    };
+    const logger = {
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+      info: () => {},
+      trace: () => {},
+    };
+    const transmuxer = new Transmuxer(
+      observer as any,
+      { mpeg: false, mp3: false, ac3: false } as any,
+      { progressive: false } as any,
+      '',
+      'main' as any,
+      logger as any,
+    );
+    transmuxer.configure(
+      new TransmuxConfig(undefined, undefined, undefined, 10),
+    );
+    const remuxCalls: Array<{
+      sampleCount: number;
+      firstPts: number | undefined;
+      width: number | undefined;
+      sps: Uint8Array[] | undefined;
+      flush: boolean;
+    }> = [];
+    const remux = sinon.spy(
+      (
+        audioTrack,
+        video: DemuxedVideoTrack,
+        id3,
+        text,
+        offset,
+        accurate,
+        flush,
+      ) => {
+        remuxCalls.push({
+          sampleCount: video.samples.length,
+          firstPts: video.samples[0]?.pts,
+          width: video.width,
+          sps: video.sps,
+          flush,
+        });
+        if (consumeSamples) {
+          video.samples = [];
+        }
+        return {};
+      },
+    );
+    (transmuxer as any).demuxer = {
+      demux: () => demuxResult,
+      flush: () => demuxResult,
+      resetTimeStamp: () => {},
+      resetContiguity: () => {},
+      resetInitSegment: () => {},
+      destroy: () => {},
+    };
+    (transmuxer as any).remuxer = {
+      remux,
+      resetTimeStamp: () => {},
+      resetNextTimestamp: () => {},
+      resetInitSegment: () => {},
+      destroy: () => {},
+    };
+    return { transmuxer, remuxCalls };
+  }
+
+  function pushState(): TransmuxState {
+    return new TransmuxState(false, true, true, false, 0, false);
+  }
+
+  it('remuxes samples preceding the switch under the previous config on push', function () {
+    const track = videoTrack();
+    Object.assign(track, {
+      width: 1280,
+      height: 720,
+      sps: [new Uint8Array(SPS_1280x720)],
+      pps: [new Uint8Array(PPS)],
+      codec: 'avc1.42c01f',
+    });
+    track.samples = fakeSamples(5, 0);
+    track.configSwitches = [{ sampleIndex: 3, prev: config320 }];
+    const demuxResult = demuxResultWith(track);
+    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+    const result = transmuxer.push(
+      new ArrayBuffer(8),
+      null,
+      chunkMeta,
+      pushState(),
+    ) as TransmuxerResult;
+
+    expect(result.chunkMeta).to.equal(chunkMeta);
+    expect(remuxCalls).to.have.lengthOf(1);
+    expect(remuxCalls[0].sampleCount).to.equal(3);
+    expect(remuxCalls[0].firstPts).to.equal(0);
+    expect(remuxCalls[0].width).to.equal(320);
+    expect(remuxCalls[0].sps).to.equal(config320.sps);
+    // Samples after the switch are held back with the new config restored
+    expect(track.samples).to.have.lengthOf(2);
+    expect(track.samples[0].pts).to.equal(9000);
+    expect(track.width).to.equal(1280);
+    expect(track.configSwitches).to.have.lengthOf(0);
+
+    const flushResults = transmuxer.flush(chunkMeta) as TransmuxerResult[];
+    expect(flushResults).to.have.lengthOf(1);
+    expect(remuxCalls).to.have.lengthOf(2);
+    expect(remuxCalls[1].sampleCount).to.equal(2);
+    expect(remuxCalls[1].firstPts).to.equal(9000);
+    expect(remuxCalls[1].width).to.equal(1280);
+    expect(remuxCalls[1].flush).to.equal(true);
+  });
+
+  it('keeps deferred samples ahead of held back samples when the remuxer does not consume them', function () {
+    const track = videoTrack();
+    Object.assign(track, {
+      width: 1280,
+      height: 720,
+      sps: [new Uint8Array(SPS_1280x720)],
+      pps: [new Uint8Array(PPS)],
+      codec: 'avc1.42c01f',
+    });
+    track.samples = fakeSamples(5, 0);
+    track.configSwitches = [{ sampleIndex: 3, prev: config320 }];
+    const demuxResult = demuxResultWith(track);
+    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, false);
+
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+    const result = transmuxer.push(
+      new ArrayBuffer(8),
+      null,
+      chunkMeta,
+      pushState(),
+    ) as TransmuxerResult;
+    expect(result.chunkMeta).to.equal(chunkMeta);
+
+    expect(remuxCalls).to.have.lengthOf(1);
+    expect(track.samples).to.have.lengthOf(5);
+    expect(track.samples[0].pts).to.equal(0);
+    expect(track.width).to.equal(1280);
+    expect(track.configSwitches).to.have.lengthOf(1);
+    expect(track.configSwitches![0].sampleIndex).to.equal(3);
+  });
+
+  it('emits one result per config on flush with multiple switches', function () {
+    const track = videoTrack();
+    Object.assign(track, {
+      width: 1280,
+      height: 720,
+      sps: [new Uint8Array(SPS_1280x720)],
+      pps: [new Uint8Array(PPS)],
+      codec: 'avc1.42c01f',
+    });
+    track.samples = fakeSamples(7, 0);
+    track.configSwitches = [
+      { sampleIndex: 3, prev: config320 },
+      { sampleIndex: 5, prev: config640 },
+    ];
+    const demuxResult = demuxResultWith(track);
+    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+    (transmuxer as any).currentTransmuxState = pushState();
+
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+    const flushResults = transmuxer.flush(chunkMeta) as TransmuxerResult[];
+
+    expect(flushResults).to.have.lengthOf(3);
+    expect(remuxCalls).to.have.lengthOf(3);
+    expect(remuxCalls[0].sampleCount).to.equal(3);
+    expect(remuxCalls[0].firstPts).to.equal(0);
+    expect(remuxCalls[0].width).to.equal(320);
+    expect(remuxCalls[1].sampleCount).to.equal(2);
+    expect(remuxCalls[1].firstPts).to.equal(9000);
+    expect(remuxCalls[1].width).to.equal(640);
+    expect(remuxCalls[2].sampleCount).to.equal(2);
+    expect(remuxCalls[2].firstPts).to.equal(15000);
+    expect(remuxCalls[2].width).to.equal(1280);
+    expect(track.samples).to.have.lengthOf(0);
+    expect(track.configSwitches).to.have.lengthOf(0);
+  });
+
+  it('ignores a boundary at sample index 0', function () {
+    const track = videoTrack();
+    Object.assign(track, {
+      width: 1280,
+      height: 720,
+      sps: [new Uint8Array(SPS_1280x720)],
+      pps: [new Uint8Array(PPS)],
+      codec: 'avc1.42c01f',
+    });
+    track.samples = fakeSamples(5, 0);
+    track.configSwitches = [{ sampleIndex: 0, prev: config320 }];
+    const demuxResult = demuxResultWith(track);
+    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+
+    const chunkMeta = new ChunkMetadata(0, 1, 0);
+    const result = transmuxer.push(
+      new ArrayBuffer(8),
+      null,
+      chunkMeta,
+      pushState(),
+    ) as TransmuxerResult;
+    expect(result.chunkMeta).to.equal(chunkMeta);
+
+    expect(remuxCalls).to.have.lengthOf(1);
+    expect(remuxCalls[0].sampleCount).to.equal(5);
+    expect(remuxCalls[0].width).to.equal(1280);
+    expect(track.configSwitches).to.have.lengthOf(0);
+  });
+});

--- a/tests/unit/demuxer/transmuxer-config-switch.ts
+++ b/tests/unit/demuxer/transmuxer-config-switch.ts
@@ -329,7 +329,7 @@ describe('Transmuxer video config switch splitting', function () {
       removeAllListeners: () => {},
     };
     const logger = {
-      log: () => {},
+      log: sinon.spy(),
       warn: () => {},
       error: () => {},
       debug: () => {},
@@ -396,7 +396,13 @@ describe('Transmuxer video config switch splitting', function () {
       resetInitSegment: () => {},
       destroy: () => {},
     };
-    return { transmuxer, remuxCalls };
+    return { transmuxer, remuxCalls, log: logger.log };
+  }
+
+  function configSwitchLogs(log: sinon.SinonSpy): string[] {
+    return log.args
+      .map((args) => args[0] as string)
+      .filter((message) => message.includes('In-band video config switch'));
   }
 
   function pushState(): TransmuxState {
@@ -415,7 +421,7 @@ describe('Transmuxer video config switch splitting', function () {
     track.samples = fakeSamples(5, 0);
     track.configSwitches = [{ sampleIndex: 3, prev: config320 }];
     const demuxResult = demuxResultWith(track);
-    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+    const { transmuxer, remuxCalls, log } = setupTransmuxer(demuxResult, true);
 
     const chunkMeta = new ChunkMetadata(0, 1, 0);
     const result = transmuxer.push(
@@ -428,6 +434,10 @@ describe('Transmuxer video config switch splitting', function () {
     expect(result.chunkMeta).to.equal(chunkMeta);
     expect(remuxCalls).to.have.lengthOf(1);
     expect(remuxCalls[0].sampleCount).to.equal(3);
+    const logs = configSwitchLogs(log);
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0]).to.include('sn: 1');
+    expect(logs[0]).to.include('320x180 to avc1.42c01f 1280x720');
     expect(remuxCalls[0].firstPts).to.equal(0);
     expect(remuxCalls[0].width).to.equal(320);
     expect(remuxCalls[0].sps).to.equal(config320.sps);
@@ -458,7 +468,7 @@ describe('Transmuxer video config switch splitting', function () {
     track.samples = fakeSamples(5, 0);
     track.configSwitches = [{ sampleIndex: 3, prev: config320 }];
     const demuxResult = demuxResultWith(track);
-    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, false);
+    const { transmuxer, remuxCalls, log } = setupTransmuxer(demuxResult, false);
 
     const chunkMeta = new ChunkMetadata(0, 1, 0);
     const result = transmuxer.push(
@@ -470,6 +480,7 @@ describe('Transmuxer video config switch splitting', function () {
     expect(result.chunkMeta).to.equal(chunkMeta);
 
     expect(remuxCalls).to.have.lengthOf(1);
+    expect(configSwitchLogs(log)).to.have.lengthOf(0);
     expect(track.samples).to.have.lengthOf(5);
     expect(track.samples[0].pts).to.equal(0);
     expect(track.width).to.equal(1280);
@@ -492,7 +503,7 @@ describe('Transmuxer video config switch splitting', function () {
       { sampleIndex: 5, prev: config640 },
     ];
     const demuxResult = demuxResultWith(track);
-    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+    const { transmuxer, remuxCalls, log } = setupTransmuxer(demuxResult, true);
     (transmuxer as any).currentTransmuxState = pushState();
 
     const chunkMeta = new ChunkMetadata(0, 1, 0);
@@ -500,6 +511,10 @@ describe('Transmuxer video config switch splitting', function () {
 
     expect(flushResults).to.have.lengthOf(3);
     expect(remuxCalls).to.have.lengthOf(3);
+    const logs = configSwitchLogs(log);
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[0]).to.include('320x180 to avc1.42c01f 640x360');
+    expect(logs[1]).to.include('640x360 to avc1.42c01f 1280x720');
     expect(remuxCalls[0].sampleCount).to.equal(3);
     expect(remuxCalls[0].firstPts).to.equal(0);
     expect(remuxCalls[0].width).to.equal(320);
@@ -583,7 +598,7 @@ describe('Transmuxer video config switch splitting', function () {
     track.samples = fakeSamples(5, 0);
     track.configSwitches = [{ sampleIndex: 0, prev: config320 }];
     const demuxResult = demuxResultWith(track);
-    const { transmuxer, remuxCalls } = setupTransmuxer(demuxResult, true);
+    const { transmuxer, remuxCalls, log } = setupTransmuxer(demuxResult, true);
 
     const chunkMeta = new ChunkMetadata(0, 1, 0);
     const result = transmuxer.push(
@@ -598,5 +613,6 @@ describe('Transmuxer video config switch splitting', function () {
     expect(remuxCalls[0].sampleCount).to.equal(5);
     expect(remuxCalls[0].width).to.equal(1280);
     expect(track.configSwitches).to.have.lengthOf(0);
+    expect(configSwitchLogs(log)).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
### This PR will...

Split the remuxed output at an in-band video config change so the samples on each side get an init segment matching their config, for AVC and HEVC. Also correct the ADTS channel configuration when the frame data disagrees with the header.

### Why is this Pull Request needed?

The streams in #3179 change resolution mid-segment with no discontinuity tag, and advertise `channel_configuration=2` around frames that only carry a single channel element. Safari plays them natively because the TS path probes the bitstream, but through MSE the init segment and `esds` are the contract: video stops decoding at the switch, and the audio renders silent with playback slaved to the starved audio clock. #5794 regenerates the init segment when the config changes between fragments; this handles the change landing inside one.

Verified against the second stream in the issue, which is still up. Diagnosis details are in the issue thread.

### Are there any points in the code the reviewer needs to double check?

The channel correction treats a stereo header over SCE frames as mono. For HE-AACv2 that matches implicit PS signalling, so PS-capable decoders still output stereo. If you've seen streams in the wild that signal `channel_configuration=2` around an SCE core, that's the case worth a test stream.

The init regeneration still only compares dimensions and PAR, so a config change with unchanged geometry records a boundary without a new init segment. Existing limitation, left alone here.

### Resolves issues:

Resolves #3179

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
