### PR TITLE
Resume buffering on "seeking"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -450,7 +450,7 @@ export const hlsDefaultConfig: HlsConfig = {
   capLevelToPlayerSize: false, // used by cap-level-controller
   ignoreDevicePixelRatio: false, // used by cap-level-controller
   maxDevicePixelRatio: Number.POSITIVE_INFINITY, // used by cap-level-controller
-  preferManagedMediaSource: true,
+  preferManagedMediaSource: false,
   initialLiveManifestSize: 1, // used by stream-controller
   maxBufferLength: 30, // used by stream-controller
   backBufferLength: Infinity, // used by buffer-controller

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -176,6 +176,8 @@ export default class BufferController extends Logger implements ComponentAPI {
     this._onMediaSourceEnded = null;
     // @ts-ignore
     this._onStartStreaming = this._onEndStreaming = null;
+    // @ts-ignore
+    this._onMediaEmptied = this._onMediaError = null;
   }
 
   private registerListeners() {
@@ -339,6 +341,10 @@ export default class BufferController extends Logger implements ComponentAPI {
       }
       addEventListener(media, 'emptied', this._onMediaEmptied);
       addEventListener(media, 'error', this._onMediaError);
+      if (this.appendSource) {
+        // Resume streaming on seeking (https://bugs.webkit.org/show_bug.cgi?id=321919)
+        addEventListener(media, 'seeking', this._onStartStreaming);
+      }
     }
   }
 
@@ -473,6 +479,10 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     if (this.mediaSource?.readyState !== 'open') {
       return;
     }
+    if (!this.media || this.media.seeking) {
+      // Ignore ManagedMediaSource while seeking (https://bugs.webkit.org/show_bug.cgi?id=321919)
+      return;
+    }
     this.hls.pauseBuffering();
   };
 
@@ -553,6 +563,7 @@ transfer tracks: ${stringify(transferredTracks, (key, value) => (key === 'initSe
     if (media) {
       removeEventListener(media, 'emptied', this._onMediaEmptied);
       removeEventListener(media, 'error', this._onMediaError);
+      removeEventListener(media, 'seeking', this._onStartStreaming);
       if (!transferringMedia) {
         if (_objectUrl) {
           self.URL.revokeObjectURL(_objectUrl);


### PR DESCRIPTION
### This PR will...
Resume buffering when "seeking" with `ManagedMediaSource`.

### Why is this Pull Request needed?
Works around an issue where ManagedMediaSource does not emit "startstreaming" when seeking:
https://bugs.webkit.org/show_bug.cgi?id=321919


### Resolves issues:
The final change will be included in v1.6.19 and v1.7.1 to address Safari playback in public beta and upcoming releases.
