### PR TITLE
Search from the start when detecting Variable References

### DIFF
--- a/src/utils/variable-substitution.ts
+++ b/src/utils/variable-substitution.ts
@@ -6,6 +6,9 @@ import type { VariableMap } from '../types/level';
 const VARIABLE_REPLACEMENT_REGEX = /\{\$([a-zA-Z0-9-_]+)\}/g;
 
 export function hasVariableReferences(str: string): boolean {
+  // `test` advances `lastIndex` on a global regex and the next call would
+  // resume from there, so start each search at the beginning.
+  VARIABLE_REPLACEMENT_REGEX.lastIndex = 0;
   return VARIABLE_REPLACEMENT_REGEX.test(str);
 }
 

--- a/tests/unit/loader/m3u8-parser.ts
+++ b/tests/unit/loader/m3u8-parser.ts
@@ -2742,6 +2742,48 @@ http://proxy-62.x.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282
       );
     });
 
+    it('finds Variable References in a playlist parsed after one that was rejected', function () {
+      // A playlist that fails the #EXTM3U check returns before any substitution
+      // runs, so the shared Variable Reference regex is left holding the offset
+      // of its last match. The next playlist has to be searched from the start.
+      const filler = `#EXTINF:4,
+segment-without-a-variable.mp4
+`.repeat(30);
+      const truncated = `#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:4
+${filler}#EXT-X-DEFINE:NAME="host",VALUE="example.com"
+#EXTINF:4,
+https://{$host}/last.mp4`;
+      const playlist = `#EXTM3U
+#EXT-X-TARGETDURATION:4
+#EXTINF:4,
+https://{$host}/1.mp4`;
+
+      const rejected = M3U8Parser.parseLevelPlaylist(
+        truncated,
+        'http://example.com/a.m3u8',
+        0,
+        PlaylistLevelType.MAIN,
+        0,
+        null,
+      );
+      expectPlaylistParsingError(rejected, 'Missing format identifier #EXTM3U');
+
+      const details = M3U8Parser.parseLevelPlaylist(
+        playlist,
+        'http://example.com/b.m3u8',
+        0,
+        PlaylistLevelType.MAIN,
+        0,
+        null,
+      );
+      expect(details.hasVariableRefs, 'hasVariableRefs').to.be.true;
+      expectPlaylistParsingError(
+        details,
+        'Missing preceding EXT-X-DEFINE tag for Variable Reference: "host"',
+      );
+    });
+
     it('substitutes variable references in quoted strings, URI lines, and hexidecimal attributes, following EXT-X-DEFINE tags in Multivariant Playlists', function () {
       const manifest = `#EXTM3U
 #EXT-X-DEFINE:NAME="host",VALUE="example.com"


### PR DESCRIPTION
### This PR will...

Reset `VARIABLE_REPLACEMENT_REGEX.lastIndex` before `hasVariableReferences` runs `test` on it.

### Why is this Pull Request needed?

`hasVariableReferences` calls `test` on a module level regex that carries the `g` flag, so a match leaves `lastIndex` pointing past it and the next call resumes from that offset instead of from the beginning.

Inside a normal parse this clears itself, because the first `substituteVariables` call runs `String.replace`, which resets `lastIndex` to 0. It does not clear itself when the parse returns before any substitution runs, which is what both parsers do when the `#EXTM3U` line is missing:

```js
level.hasVariableRefs = hasVariableReferences(string);
if (LEVEL_PLAYLIST_REGEX_FAST.exec(string)?.[0] !== '#EXTM3U') {
  level.playlistParsingError = new Error('Missing format identifier #EXTM3U');
  return level;
}
```

So a truncated response that still carries a Variable Reference poisons the next playlist. Measured with `M3U8Parser.parseLevelPlaylist`, first on a long playlist with no `#EXTM3U` and a `{$host}` reference near the end, then on a short valid playlist whose reference sits near the start and which has no `EXT-X-DEFINE`:

| | before | after |
| --- | --- | --- |
| `hasVariableRefs` | `false` | `true` |
| `playlistParsingError` | `null` | `Missing preceding EXT-X-DEFINE tag for Variable Reference: "host"` |
| fragment url | `https://{$host}/1.mp4` | `https://{$host}/1.mp4` |

The url is wrong either way, since the variable cannot be resolved. What is lost is the error that says why, so instead of a playlist parsing error the player goes and requests a url with a literal `{$host}` in it and fails somewhere further downstream.

The three other global regexes in this code path are already handled this way: `parseAttrList` sets `ATTR_LIST_REGEX.lastIndex = 0` before its loop, and both `parseMasterPlaylist` and `parseLevelPlaylist` reset theirs. This one was the odd one out.

Dropping the `g` flag is not an option since `substituteVariables` needs it to replace every reference, and a second non global copy of the pattern would mean two places to keep in step. If you would rather have the separate pattern anyway, say so and I will change it.

### Are there any points in the code the reviewer needs to double check?

The offsets in the test are what make it fail without the change. The rejected playlist is padded so that its reference lands past the end of the following one. Shortening that padding makes the test pass either way.

### Resolves issues:

None open that I could find. Found while reading the parser.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md

New test in `tests/unit/loader/m3u8-parser.ts` under `#EXT-X-DEFINE`. It fails on master with `hasVariableRefs: expected false to be true` and passes with the change. Full unit run in ChromeHeadless: 1182 passing. `lint`, `prettier:verify` and `type-check` are clean. No API change, so nothing to add to API.md.
