### PR TITLE
Convert IMSC1 milliseconds to seconds instead of multiplying

### DIFF
--- a/src/utils/imsc1-ttml-parser.ts
+++ b/src/utils/imsc1-ttml-parser.ts
@@ -251,7 +251,7 @@ function parseTimeUnits(timeAttributeValue, rateInfo): number {
     case 'm':
       return value * 60;
     case 'ms':
-      return value * 1000;
+      return value / 1000;
     case 'f':
       return value / rateInfo.frameRate;
     case 't':

--- a/tests/index.js
+++ b/tests/index.js
@@ -53,6 +53,7 @@ import './unit/utils/error-helper';
 import './unit/utils/fetch-loader';
 import './unit/utils/discontinuities';
 import './unit/utils/exp-golomb';
+import './unit/utils/imsc1-ttml-parser';
 import './unit/utils/mediacapabilities-helper';
 import './unit/utils/mp4-tools';
 import './unit/utils/output-filter';

--- a/tests/unit/utils/imsc1-ttml-parser.ts
+++ b/tests/unit/utils/imsc1-ttml-parser.ts
@@ -1,0 +1,78 @@
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import { parseIMSC1 } from '../../../src/utils/imsc1-ttml-parser';
+import type VTTCue from '../../../src/utils/vttcue';
+
+use(sinonChai);
+
+function mdat(ttml: string): ArrayBuffer {
+  const body = new TextEncoder().encode(ttml);
+  const box = new Uint8Array(8 + body.length);
+  new DataView(box.buffer).setUint32(0, box.length);
+  box.set([0x6d, 0x64, 0x61, 0x74], 4); // 'mdat'
+  box.set(body, 8);
+  return box.buffer;
+}
+
+function ttmlWith(begin: string, end: string, attrs: string = ''): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter"${attrs}>` +
+    `<body><div><p begin="${begin}" end="${end}">Hello</p></div></body>` +
+    `</tt>`
+  );
+}
+
+function cuesFor(ttml: string): VTTCue[] {
+  let cues: VTTCue[] = [];
+  let error: Error | null = null;
+  parseIMSC1(
+    mdat(ttml),
+    { baseTime: 0, timescale: 1, trackId: 1 },
+    (parsed) => {
+      cues = parsed;
+    },
+    (err) => {
+      error = err;
+    },
+  );
+  expect(error).to.equal(null);
+  return cues;
+}
+
+describe('IMSC1 TTML parser', function () {
+  it('reads a cue timed in seconds', function () {
+    const cues = cuesFor(ttmlWith('1s', '3.5s'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(1);
+    expect(cues[0].endTime).to.equal(3.5);
+  });
+
+  it('reads a cue timed in milliseconds', function () {
+    const cues = cuesFor(ttmlWith('500ms', '2500ms'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(0.5);
+    expect(cues[0].endTime).to.equal(2.5);
+  });
+
+  it('reads a cue timed in hours and minutes', function () {
+    const cues = cuesFor(ttmlWith('1h', '90m'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(3600);
+    expect(cues[0].endTime).to.equal(5400);
+  });
+
+  it('reads a cue timed in frames', function () {
+    const cues = cuesFor(ttmlWith('15f', '45f', ' ttp:frameRate="30"'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(0.5);
+    expect(cues[0].endTime).to.equal(1.5);
+  });
+
+  it('reads a clock time', function () {
+    const cues = cuesFor(ttmlWith('00:00:01.500', '00:00:03.000'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(1.5);
+    expect(cues[0].endTime).to.equal(3);
+  });
+});


### PR DESCRIPTION
## What is happening

An IMSC1 cue timed in milliseconds lands a million times too far into the timeline, so it never shows.

```xml
<p begin="500ms" end="2500ms">Hello</p>
```

comes out as a `VTTCue` from 500000 to 2500000 seconds, roughly five days and eleven days in. Anything after `begin` in seconds, hours, minutes, frames or clock form is fine, which is why this only bites the subtitle tracks that happen to use the `ms` metric.

## Why

`parseTimeUnits` returns seconds for every metric, and the `ms` branch multiplies:

```ts
case 'ms':
  return value * 1000;
```

TTML `<offset-time>` counts milliseconds, so the conversion to seconds divides. The neighbours in the same switch already do the right thing: `h` multiplies by 3600, `m` by 60, `f` divides by the frame rate.

There is no unit test file for this module, which is the reason it went unnoticed.

## What I checked

New `tests/unit/utils/imsc1-ttml-parser.ts` drives the public `parseIMSC1` with a hand built `mdat`, one test per time form: seconds, milliseconds, hours and minutes, frames, and clock time. Four of the five pass on master, so they pin the behaviour that was already right; the milliseconds one fails on master with `expected 500000 to equal 0.5` and passes here.

`CI=1 karma start karma.conf.js` in ChromeHeadless: 1187 passing, none failing. Master with the same test file is 1186 passing and that one failing. `tsc --noEmit`, `eslint` and `prettier --check` are clean.

## One thing I left alone

While writing the tests I noticed `defaultRateInfo.tickRate` is `0`, so a document that uses the tick metric without a `ttp:tickRate` attribute divides by zero and gets `Infinity` for every cue time. TTML says the default should follow the frame rate and sub-frame rate when a frame rate is given, and be one tick per second otherwise, and this file always fills a frame rate in from its own default of 30, so getting that right means knowing whether the attribute was actually present. That felt like a call for you rather than something to fold into a one character fix, so I left it out. Happy to send it separately if you want it.
