### PR TITLE
Fix: process empty WebVTT parts

### DIFF
--- a/src/controller/timeline-controller.ts
+++ b/src/controller/timeline-controller.ts
@@ -406,7 +406,8 @@ export class TimelineController implements ComponentAPI {
       frag.type === PlaylistLevelType.SUBTITLE
     ) {
       // If fragment is subtitle type, parse as WebVTT.
-      if (payload.byteLength) {
+      // An empty payload is valid when an init segment supplies the WebVTT header.
+      if (payload.byteLength || frag.initSegment?.data?.byteLength) {
         const decryptData = frag.decryptdata;
         // fragment after decryption has a stats object
         const decrypted = 'stats' in data;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -476,7 +476,11 @@ export class Part extends BaseSegment {
       elementaryStreams.audio ||
       elementaryStreams.video ||
       elementaryStreams.audiovideo ||
-      (this.fragment.type === PlaylistLevelType.SUBTITLE && this.stats.loaded)
+      // Subtitle parts have no elementary streams. A completed request is the
+      // loaded marker because a mapped WebVTT part carrying no cues may
+      // legitimately transfer zero media bytes.
+      (this.fragment.type === PlaylistLevelType.SUBTITLE &&
+        this.stats.loading.end > 0)
     );
   }
 }

--- a/tests/unit/controller/timeline-controller.ts
+++ b/tests/unit/controller/timeline-controller.ts
@@ -1,8 +1,11 @@
 import { expect, use } from 'chai';
+import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { TimelineController } from '../../../src/controller/timeline-controller';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
+import { Fragment } from '../../../src/loader/fragment';
+import { PlaylistLevelType } from '../../../src/types/loader';
 
 use(sinonChai);
 
@@ -28,6 +31,67 @@ describe('TimelineController', function () {
       expect(videoElement.textTracks.length).to.equal(1);
       timelineController.onMediaDetaching(Events.MEDIA_DETACHING, {});
       expect(videoElement.textTracks.length).to.equal(0);
+    });
+  });
+
+  describe('mapped empty WebVTT parts', function () {
+    function subtitleFragment(withMap: boolean) {
+      const frag = new Fragment(PlaylistLevelType.SUBTITLE, '');
+      frag.sn = 1;
+      frag.level = 0;
+      frag.cc = 0;
+      frag.start = 0;
+      frag.duration = 0.5;
+      if (withMap) {
+        const init = new Fragment(PlaylistLevelType.SUBTITLE, '');
+        init.sn = 'initSegment';
+        init.data = new TextEncoder().encode(
+          'WEBVTT\nX-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:0\n\n',
+        );
+        frag.initSegment = init;
+      }
+      return frag;
+    }
+
+    it('processes a zero-byte part with a WebVTT map successfully', function () {
+      const processed = sinon.spy();
+      hls.on(Events.SUBTITLE_FRAG_PROCESSED, processed);
+      timelineController.tracks = [{ textCodec: 'wvtt' }];
+      timelineController.initPTS[0] = {
+        baseTime: 0,
+        timescale: 90_000,
+        trackId: -1,
+      };
+      const frag = subtitleFragment(true);
+
+      timelineController.onFragLoaded(Events.FRAG_LOADED, {
+        frag,
+        payload: new ArrayBuffer(0),
+      });
+
+      expect(processed).to.have.been.calledOnce;
+      expect(processed.firstCall.args[1]).to.include({
+        success: true,
+        frag,
+      });
+    });
+
+    it('rejects a zero-byte subtitle resource without a map', function () {
+      const processed = sinon.spy();
+      hls.on(Events.SUBTITLE_FRAG_PROCESSED, processed);
+      timelineController.tracks = [{ textCodec: 'wvtt' }];
+      const frag = subtitleFragment(false);
+
+      timelineController.onFragLoaded(Events.FRAG_LOADED, {
+        frag,
+        payload: new ArrayBuffer(0),
+      });
+
+      expect(processed).to.have.been.calledOnce;
+      expect(processed.firstCall.args[1]).to.include({
+        success: false,
+        frag,
+      });
     });
   });
 });

--- a/tests/unit/loader/fragment.ts
+++ b/tests/unit/loader/fragment.ts
@@ -1,8 +1,9 @@
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
-import { Fragment } from '../../../src/loader/fragment';
+import { Fragment, Part } from '../../../src/loader/fragment';
 import { LevelKey } from '../../../src/loader/level-key';
 import { PlaylistLevelType } from '../../../src/types/loader';
+import { AttrList } from '../../../src/utils/attr-list';
 
 use(sinonChai);
 
@@ -119,6 +120,43 @@ describe('Fragment class tests', function () {
       frag.programDateTime = 1000;
       frag.duration = NaN;
       expect(frag.endProgramDateTime).to.equal(1000);
+    });
+  });
+});
+
+describe('Part class tests', function () {
+  describe('loaded getter', function () {
+    function subtitlePart(): Part {
+      const frag = new Fragment(PlaylistLevelType.SUBTITLE, '');
+      frag.sn = 1;
+      return new Part(
+        new AttrList({ DURATION: '0.5', URI: 'part/1.vtt' }),
+        frag as any,
+        '',
+        0,
+      );
+    }
+
+    it('counts a zero-byte subtitle part as loaded once the request ends', function () {
+      const part = subtitlePart();
+      // A WebVTT part that no cue intersects transfers no bytes, but its
+      // request completes. Byte count cannot mark such a part as loaded.
+      part.stats.loaded = 0;
+      part.stats.total = 0;
+      part.stats.loading.start = 1;
+      part.stats.loading.first = 2;
+      part.stats.loading.end = 3;
+
+      expect(part.loaded).to.equal(true);
+    });
+
+    it('does not count a subtitle part in flight as loaded', function () {
+      const part = subtitlePart();
+      part.stats.loading.start = 1;
+      part.stats.loading.first = 2;
+      part.stats.loading.end = 0;
+
+      expect(part.loaded).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Hey! Let me preface this by saying that this is my first contribution to the repository, and I'm not that well accustomed to the code base, so I've done this on a best effort basis combined with AI assistance.

### This PR will...

Treat a successfully fetched, zero-byte WebVTT part as a completed load instead of an error, and return the subtitle controller to `IDLE` after every processed part.

Notably, the equivalent playlist has no issues in Safari.

### Why is this Pull Request needed?

A WebVTT part that covers an interval with no cues legitimately carries zero media bytes. With `EXT-X-MAP`, the header lives in the init section, so an empty part body is well-formed. Three separate places mishandle this:

1. `TimelineController.onFragLoaded()` gates parsing on `payload.byteLength`, so a zero-byte part never reaches `_parseVTTs()` and fails with `Empty subtitle payload`. Since `_parseVTTs()` prepends the init section, parsing that part in fact succeeds with zero cues.
2. `Part.loaded` uses `this.stats.loaded` (bytes transferred) for subtitle parts. A zero-byte part therefore never reports as loaded, so `getNextPart()` keeps re-selecting it indefinitely.
3. `SubtitleStreamController.onFragBuffered()` returns early on failure, on a missing track buffer, and on non-final parts without completing the load operation, leaving the controller parked outside `IDLE`.

Together these stall the subtitle track: the controller re-requests the same empty part in a loop and never advances.

A playlist that reproduces it - each part is a mapped WebVTT part, and any interval with no cue produces a zero-byte body:

```m3u8
#EXTM3U
#EXT-X-VERSION:9
#EXT-X-TARGETDURATION:6
#EXT-X-SERVER-CONTROL:HOLD-BACK=18,PART-HOLD-BACK=3.008,CAN-BLOCK-RELOAD=YES
#EXT-X-PART-INF:PART-TARGET=1
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-MAP:URI="init/1.vtt"
#EXT-X-PART:DURATION=1,URI="part/1.vtt",INDEPENDENT=YES
#EXT-X-PART:DURATION=1,URI="part/2.vtt",INDEPENDENT=YES
#EXT-X-PART:DURATION=1,URI="part/3.vtt",INDEPENDENT=YES
#EXTINF:6,
segment/1.vtt
#EXT-X-PART:DURATION=1,URI="part/4.vtt",INDEPENDENT=YES
#EXT-X-PRELOAD-HINT:TYPE=PART,URI="part/5.vtt"
```

Where `init/1.vtt` is the map and a silent part body is empty:

```
WEBVTT
X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:0
```

The changes are:

- Parse zero-byte payloads when the track is WebVTT (not IMSC1) and an init section with data is present.
- Derive subtitle `Part.loaded` from `stats.loading.end > 0` (request completed) rather than bytes transferred.
- Complete the load operation and tick on every processed part, including failures, non-final parts, and parts whose track was deselected mid-flight. Fragment tracking still waits for the fragment tail; only scheduler state changes.

### Are there any points in the code the reviewer needs to double check?

Two things:
1. The `mappedEmptyWebVtt` condition deliberately requires `frag.initSegment?.data?.byteLength` so that an unmapped empty payload still errors as before - is this the preferred solution?
2. Moving `fragBufferedComplete()` out of the `fragmentComplete` branch means intermediate parts now return to `IDLE` immediately instead of waiting for the 500ms tick; the buffered range end also becomes `Math.max(timeRange.end, end)` so out-of-order completion cannot shrink it.

### Resolves issues:

None filed.

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md

## Spec compliance:

Section 3.1.4 of latest HLS spec includes:
> Each WebVTT Segment MUST contain all subtitle cues that are intended to be displayed during the period indicated by the segment EXTINF duration. [...] A WebVTT Segment MAY contain no cues; this indicates that no subtitles are to be displayed during that period