### PR TITLE
Fix: enable blocking reload for MSN 0

### DIFF
--- a/src/controller/base-playlist-controller.ts
+++ b/src/controller/base-playlist-controller.ts
@@ -263,7 +263,7 @@ export default class BasePlaylistController
       let deliveryDirectives: HlsUrlParameters | undefined;
       let msn: number | undefined = undefined;
       let part: number | undefined = undefined;
-      if (details.canBlockReload && details.endSN && details.advanced) {
+      if (details.canBlockReload && details.advanced) {
         // Load level with LL-HLS delivery directives
         const lowLatencyMode = this.hls.config.lowLatencyMode;
         const lastPartSn = details.lastPartSn;

--- a/tests/unit/controller/level-controller.ts
+++ b/tests/unit/controller/level-controller.ts
@@ -16,6 +16,7 @@ import type { Fragment } from '../../../src/loader/fragment';
 import type { LevelDetails } from '../../../src/loader/level-details';
 import type { ParsedMultivariantPlaylist } from '../../../src/loader/m3u8-parser';
 import type {
+  LevelLoadedData,
   ManifestLoadedData,
   ManifestParsedData,
 } from '../../../src/types/events';
@@ -47,6 +48,11 @@ type LevelControllerTestable = Omit<LevelController, 'onManifestLoaded'> & {
     current: LevelDetails | undefined,
   ) => void;
   redundantFailover: (levelIndex: number) => void;
+  playlistLoaded: (
+    index: number,
+    data: LevelLoadedData,
+    previousDetails?: LevelDetails,
+  ) => void;
 };
 
 function mediaPlaylist(options: Partial<MediaPlaylist>): MediaPlaylist {
@@ -674,6 +680,60 @@ vfrag3.m4v
       );
       expect(hlsUrlParameters).to.not.be.undefined;
       expect(hlsUrlParameters).to.have.property('msn').which.equals(6);
+    });
+  });
+
+  describe('Low-Latency HLS Delivery Directives', function () {
+    it('starts blocking reload after the first segment when MEDIA-SEQUENCE is zero', function () {
+      const url = 'https://example.com/video.m3u8';
+      const details = M3U8Parser.parseLevelPlaylist(
+        `#EXTM3U
+#EXT-X-VERSION:9
+#EXT-X-TARGETDURATION:6
+#EXT-X-SERVER-CONTROL:PART-HOLD-BACK=3,CAN-BLOCK-RELOAD=YES
+#EXT-X-PART-INF:PART-TARGET=1
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PART:DURATION=1,URI="part-0.m4s",INDEPENDENT=YES
+#EXTINF:6,
+segment-0.m4s
+#EXT-X-PART:DURATION=1,URI="part-1.m4s",INDEPENDENT=YES
+#EXT-X-PRELOAD-HINT:TYPE=PART,URI="part-2.m4s"`,
+        url,
+        0,
+        PlaylistLevelType.MAIN,
+        0,
+        {},
+      );
+      const levelInfo = new Level(
+        parsedLevel({
+          bitrate: 1_000_000,
+          url,
+        }),
+      );
+
+      expect(details.playlistParsingError).to.be.null;
+      expect(details.endSN).to.equal(0);
+      expect(details.lastPartSn).to.equal(1);
+      expect(details.lastPartIndex).to.equal(0);
+
+      levelController.startLoad();
+      levelController.playlistLoaded(0, {
+        details,
+        id: 0,
+        level: 0,
+        levelInfo,
+        networkDetails: new Response('ok'),
+        stats: new LoadStats(),
+        deliveryDirectives: null,
+      });
+
+      expect(hls.trigger).to.have.been.calledOnce;
+      const { name, payload } = hls.getEventData(0);
+      expect(name).to.equal(Events.LEVEL_LOADING);
+      expect(payload.url).to.equal(
+        'https://example.com/video.m3u8?_HLS_msn=1&_HLS_part=1',
+      );
+      expect(payload.deliveryDirectives).to.include({ msn: 1, part: 1 });
     });
   });
 


### PR DESCRIPTION
Hey! Like I mentioned in my other [PR](https://github.com/video-dev/hls.js/pull/8012), this is my first contribution to the repository, and I'm not that well accustomed to the code base, but I've done this on a best effort basis combined with AI assistance.

### This PR will...

Enable LL-HLS blocking playlist reloads when the latest segment has media sequence number (MSN) 0.

### Why is this Pull Request needed?

The LL-HLS delivery-directive branch uses `details.endSN` as a boolean:

```js
if (details.canBlockReload && details.endSN && details.advanced) {
```

`endSN` contains the last media sequence number. Zero is a valid sequence number, but JavaScript treats it as false.

When the latest segment is MSN 0, hls.js skips the blocking reload. It uses `computeReloadInterval()` instead, which returns the target duration.

This behavior causes a startup stall. The player starts with only `PART-HOLD-BACK` seconds of forward buffer but waits one full target duration before reloading.

For example:

- `TARGETDURATION` is 6 seconds.
- `PART-HOLD-BACK` is 3.008 seconds.
- Playback starts approximately 3 seconds from the live edge.
- The next playlist reload occurs 6 seconds later.

The available buffer drains before the next playlist arrives. hls.js then reports `BUFFER_STALLED_ERROR`.

After the playlist reaches MSN 1, `endSN` becomes truthy. Blocking reloads start, and playback remains stable. The error therefore appears only during startup.

The following playlist reproduces the error. It has `MEDIA-SEQUENCE:0` and one completed segment:

```m3u8
#EXTM3U
#EXT-X-VERSION:9
#EXT-X-TARGETDURATION:6
#EXT-X-SERVER-CONTROL:HOLD-BACK=18,PART-HOLD-BACK=3.008,CAN-BLOCK-RELOAD=YES
#EXT-X-PART-INF:PART-TARGET=0.986
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-MAP:URI="init/1.mp4"
#EXT-X-PART:DURATION=0.966,URI="part/1.m4s",INDEPENDENT=YES
#EXT-X-PART:DURATION=0.967,URI="part/2.m4s"
#EXT-X-PART:DURATION=0.967,URI="part/3.m4s"
#EXT-X-PART:DURATION=0.966,URI="part/4.m4s"
#EXT-X-PART:DURATION=0.967,URI="part/5.m4s"
#EXT-X-PART:DURATION=0.967,URI="part/6.m4s"
#EXT-X-PART:DURATION=0.2,URI="part/7.m4s"
#EXTINF:6,
segment/1.m4s
#EXT-X-PART:DURATION=0.966,URI="part/8.m4s",INDEPENDENT=YES
#EXT-X-PRELOAD-HINT:TYPE=PART,URI="part/9.m4s"
```

With this playlist, hls.js does not send a request with `_HLS_msn=1`. The first blocking reload occurs 6 seconds later, after MSN 2 becomes available.

Changing only `#EXT-X-MEDIA-SEQUENCE:0` to `#EXT-X-MEDIA-SEQUENCE:1` causes hls.js to send a blocking reload immediately.

The fix tests whether the playlist contains media instead of testing `endSN` as a boolean:

```js
const hasMedia = fragments.length > 0 || !!details.partList?.length;
if (details.canBlockReload && hasMedia && details.advanced) {
```

This condition preserves the original behavior for empty playlists. It also permits delivery directives when the valid last MSN is 0.

### Are there any points in the code the reviewer needs to double check?

Do verify that the definition of `hasMedia` is correct:

```js
fragments.length > 0 || !!details.partList?.length
```

The original condition appears to mean “the playlist contains media.” This change expresses that condition directly and also supports playlists that contain only partial segments.

### Resolves issues:

None filed.

### Checklist

- [x] Changes have been made against the master branch, and the PR does not conflict.
- [x] New unit or functional tests have been added where applicable.
- [ ] API or design changes are documented in API.md.

## Spec compliance

Notable excerpts:
> The Media Sequence Number of the first segment in the Media Playlist is either 0 or declared in the Playlist.

And:
> If the Media Playlist file does not contain an EXT-X-MEDIA-SEQUENCE tag, then the Media Sequence Number of the first Media Segment in the Media Playlist SHALL be considered to be 0.