### PR TITLE
fix(types): generate type declarations for the light build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
   "main": "./dist/hls.js",
   "module": "./dist/hls.mjs",
   "types": "./dist/hls.d.ts",
+  "typesVersions": {
+    "*": {
+      "light": [
+        "./dist/hls.light.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "import": "./dist/hls.mjs",
@@ -39,7 +46,7 @@
     "build:debug": "rollup --config --configType full --configType demo",
     "build:watch": "rollup --config --configType full --configType demo --watch",
     "build:types": "tsc --build tsconfig-lib.json && api-extractor run --local && npm run build:copy-types",
-    "build:copy-types": "cp ./dist/hls.d.ts ./dist/hls.d.mts && cp ./dist/hls.d.ts ./dist/hls.js.d.ts",
+    "build:copy-types": "cp ./dist/hls.d.ts ./dist/hls.d.mts && cp ./dist/hls.d.ts ./dist/hls.js.d.ts && node ./scripts/build-light-types.js",
     "dev": "run-p build:watch serve",
     "serve": "http-server -o /demo .",
     "size": "node ./scripts/dist-size.js",

--- a/scripts/build-light-types.js
+++ b/scripts/build-light-types.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/* eslint-env node */
+'use strict';
+
+/**
+ * Writes the type declarations for the light build (see #7574).
+ *
+ * The light build stubs out a number of modules (EME, CMCD, subtitles,
+ * alt-audio, variable substitution and advanced m2ts codecs — see
+ * `getAliasesForDist` in build-config.js), so there is no clean way to type the
+ * stubbed modules separately. The expectation is that consumers use the full
+ * types and avoid the features the light build leaves out.
+ *
+ * Each light declaration therefore re-exports the full types, rather than
+ * shipping another copy of hls.d.ts per entry point.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DIST = path.resolve(__dirname, '..', 'dist');
+
+// Each light declaration file, and the sibling declaration it re-exports.
+// The ESM declaration points at the ESM build so that it stays ESM-to-ESM.
+const declarations = [
+  ['hls.light.d.ts', './hls.js'],
+  ['hls.light.js.d.ts', './hls.js'],
+  ['hls.light.d.mts', './hls.mjs'],
+];
+
+declarations.forEach(([file, source]) => {
+  fs.writeFileSync(
+    path.join(DIST, file),
+    `export * from '${source}';\nexport { default } from '${source}';\n`,
+  );
+});


### PR DESCRIPTION
Fixes #7574

## The problem

`import Hls from 'hls.js/light'` resolves to no type declarations, so everything comes back as `any`, while the full build is typed correctly. `build:copy-types` only emitted declarations for the main entry point.

## The change

`build:copy-types` now also writes `hls.light.d.ts`, `hls.light.d.mts` and `hls.light.js.d.ts`, mirroring the three declarations already emitted for the main entry point.

Per your comment on the issue, the light build stubs out several modules and there is no clean way to type those stubs separately — the expectation is that consumers use the full types and avoid the features the light build leaves out. So each light declaration re-exports the full types:

```ts
export * from './hls.js';
export { default } from './hls.js';
```

I used a re-export rather than a literal copy of `hls.d.ts` so this doesn't add another ~150KB of identical declarations per entry point (~105KB gzipped across the three) to every install. The resulting public type surface is identical, and switching to literal copies is a one-line change if you'd prefer that.

`typesVersions` is added so classic (`node10`) resolution finds the light types too, since it doesn't read `exports`. Without it, `hls.js/light` fails to resolve at all under `moduleResolution: node10` — types and JS both.

Notably **no change to the `exports` map was needed**: once the declaration files exist, TypeScript finds them by extension substitution from the existing `import`/`require` targets, exactly as it already does for the main entry point.

## Verification

`@arethetypeswrong/cli` against a packed tarball.

Before:

|  | `hls.js` | `hls.js/light` |
|---|---|---|
| node10 | 🟢 | 💀 Resolution failed |
| node16 (from CJS) | 🟢 (CJS) | ❌ No types |
| node16 (from ESM) | 🟢 (ESM) | ❌ No types |
| bundler | 🟢 | ❌ No types |

After — `No problems found 🌟`:

|  | `hls.js` | `hls.js/light` |
|---|---|---|
| node10 | 🟢 | 🟢 |
| node16 (from CJS) | 🟢 (CJS) | 🟢 (CJS) |
| node16 (from ESM) | 🟢 (ESM) | 🟢 (ESM) |
| bundler | 🟢 | 🟢 |

I also compiled the issue's exact repro against the built package under `node16`, `nodenext`, `bundler` and `node10`, asserting `Hls.isSupported` resolves to `() => boolean` and not `any` — failing on all four before, passing on all four after. The same probe on the root `hls.js` import passes before and after, confirming `typesVersions` doesn't disturb existing resolution.

`prettier:verify`, `eslint`, `type-check` and `size:check` are clean. No `src/` changes.
