### PR TITLE
Default the TTML tick rate instead of dividing by zero

### DIFF
--- a/src/utils/imsc1-ttml-parser.ts
+++ b/src/utils/imsc1-ttml-parser.ts
@@ -56,15 +56,23 @@ function parseTTML(ttml: string, syncTime: number): Array<VTTCue> {
     frameRate: 30,
     subFrameRate: 1,
     frameRateMultiplier: 0,
-    tickRate: 0,
+    tickRate: 1,
   };
-  const rateInfo: Object = Object.keys(defaultRateInfo).reduce(
-    (result, key) => {
-      result[key] = tt.getAttribute(`ttp:${key}`) || defaultRateInfo[key];
-      return result;
-    },
-    {},
-  );
+  const rateInfo: Record<string, string | number> = Object.keys(
+    defaultRateInfo,
+  ).reduce((result, key) => {
+    result[key] = tt.getAttribute(`ttp:${key}`) || defaultRateInfo[key];
+    return result;
+  }, {});
+  // TTML1 6.2.10: with no ttp:tickRate, a document that declares a frame rate
+  // counts ticks as sub-frames, and one without counts a tick as a second.
+  // Only the second case can fall back to the default above, so the first is
+  // derived here, and it needs to know whether ttp:frameRate was really
+  // present rather than filled in from defaultRateInfo.
+  if (!tt.getAttribute('ttp:tickRate') && tt.getAttribute('ttp:frameRate')) {
+    rateInfo.tickRate =
+      Number(rateInfo.frameRate) * Number(rateInfo.subFrameRate);
+  }
 
   const trim = tt.getAttribute('xml:space') !== 'preserve';
 

--- a/tests/unit/utils/imsc1-ttml-parser.ts
+++ b/tests/unit/utils/imsc1-ttml-parser.ts
@@ -75,4 +75,34 @@ describe('IMSC1 TTML parser', function () {
     expect(cues[0].startTime).to.equal(1.5);
     expect(cues[0].endTime).to.equal(3);
   });
+
+  it('reads a cue timed in ticks', function () {
+    const cues = cuesFor(ttmlWith('50t', '150t', ' ttp:tickRate="100"'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(0.5);
+    expect(cues[0].endTime).to.equal(1.5);
+  });
+
+  it('counts a tick as a second when neither tick rate nor frame rate is given', function () {
+    const cues = cuesFor(ttmlWith('1t', '3t'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(1);
+    expect(cues[0].endTime).to.equal(3);
+  });
+
+  it('counts a tick as a sub-frame when only a frame rate is given', function () {
+    const cues = cuesFor(ttmlWith('12t', '36t', ' ttp:frameRate="24"'));
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(0.5);
+    expect(cues[0].endTime).to.equal(1.5);
+  });
+
+  it('multiplies the frame rate by the sub-frame rate for the tick default', function () {
+    const cues = cuesFor(
+      ttmlWith('24t', '72t', ' ttp:frameRate="24" ttp:subFrameRate="2"'),
+    );
+    expect(cues).to.have.lengthOf(1);
+    expect(cues[0].startTime).to.equal(0.5);
+    expect(cues[0].endTime).to.equal(1.5);
+  });
 });


### PR DESCRIPTION
Follow-up to #8003, where @robwalch said this was worth its own PR.

`defaultRateInfo` carried `tickRate: 0`, and the only place that reads it is `value / rateInfo.tickRate` for the `t` metric. So a document that times cues in ticks and does not declare `ttp:tickRate` divided by zero and got `Infinity` for every cue time.

TTML1 6.2.10 states the default in two parts:

> If not specified, then if a frame rate is specified, the tick rate must be considered to be the effective frame rate multiplied by the sub-frame rate (i.e., ticks are interpreted as sub-frames); or, if no frame rate is specified, the tick rate must be considered to be one (1) tick per second of media time.

The second half is just the constant, so `tickRate` now defaults to `1`. The first half cannot be a constant: it has to know whether `ttp:frameRate` was really in the document, because this parser fills in its own `30` when it is not, and defaulting off that would invent a rate for files that never declared one. So it is derived after the attribute read, from `getAttribute` returning null when the attribute is absent.

One deliberate gap. The spec says *effective* frame rate, which folds in `ttp:frameRateMultiplier`. This parser does not implement the multiplier anywhere, including for the `f` metric right above, so I used the raw frame rate to match what the file already does rather than add partial multiplier support in a corner.

Four tests, in `tests/unit/utils/imsc1-ttml-parser.ts`. Three of them fail on `master` and pass here:

```
✖ counts a tick as a second when neither tick rate nor frame rate is given
✖ counts a tick as a sub-frame when only a frame rate is given
✖ multiplies the frame rate by the sub-frame rate for the tick default
```

The fourth, an explicit `ttp:tickRate`, passes either way and is there as the control.

`rateInfo` was annotated `Object`, which does not allow the property write, so it is now `Record<string, string | number>`. It is only ever passed into the two loosely typed time parsers, so nothing else moves.

Checked: `npm run test:unit` 1194 passing, `tsc --noEmit` clean, eslint and prettier clean.
