### PR TITLE
fix(stream-controller): defer unsafe live upswitches

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -262,12 +262,10 @@ export default class StreamController
       return;
     }
 
-    const level = this.buffering ? hls.nextLoadLevel : hls.loadLevel;
+    let level = this.buffering ? hls.nextLoadLevel : hls.loadLevel;
     if (!levels?.[level]) {
       return;
     }
-
-    const levelInfo = levels[level];
 
     // if buffer length is less than maxBufLen try to load a new fragment
 
@@ -289,6 +287,10 @@ export default class StreamController
     if (!this.buffering) {
       return;
     }
+
+    // in case of live streams, make it possible to keep the level if there is not enough buffer
+    level = this.getLevelForLiveUpSwitch(level, bufferInfo);
+    const levelInfo = levels[level];
 
     // set next load level : this will trigger a playlist load if needed
     if (hls.loadLevel !== level && hls.manualLevel === -1) {
@@ -383,6 +385,106 @@ export default class StreamController
     }
 
     this.loadFragment(frag, levelInfo, targetBufferTime);
+  }
+
+  // Determine if we should switch up to a higher level for live streams, based on buffer length and playlist details.
+  private getLevelForLiveUpSwitch(
+    candidateLevel: number,
+    bufferInfo: BufferInfo,
+  ): number {
+    const { fragPrevious, levels } = this;
+    const currentLevel = fragPrevious?.level ?? -1;
+
+    // cases where we don't want to switch up (manual, or candidate is lower)
+    if (
+      this.hls.manualLevel !== -1 ||
+      !levels ||
+      currentLevel < 0 ||
+      candidateLevel <= currentLevel
+    ) {
+      return candidateLevel;
+    }
+
+    const currentDetails = levels[currentLevel]?.details;
+    const candidateDetails = levels[candidateLevel]?.details;
+
+    // do not switch up if either playlist is not live or has parts (low-latency)
+    if (
+      !currentDetails?.live ||
+      currentDetails.partList?.length ||
+      candidateDetails?.partList?.length
+    ) {
+      return candidateLevel;
+    }
+
+    const distanceToLiveEdge = currentDetails.fragmentEnd - bufferInfo.end;
+    // if we are away from the playlist edge, normal ABR selection has enough margin
+    if (
+      distanceToLiveEdge + this.config.maxFragLookUpTolerance >=
+      currentDetails.levelTargetDuration * 2
+    ) {
+      return candidateLevel;
+    }
+
+    // switch immediately when the candidate can extend the forward buffer.
+    if (
+      candidateDetails &&
+      this.hasFragmentAtBufferEnd(candidateDetails, bufferInfo.end)
+    ) {
+      return candidateLevel;
+    }
+
+    const currentReloadAt = currentDetails.requestScheduled;
+    const candidateReloadAt = candidateDetails?.requestScheduled ?? -1;
+    // Time until the candidate playlist's next scheduled refresh, in seconds.
+    const candidateReloadDelay = Math.max(
+      0,
+      (candidateReloadAt - self.performance.now()) / 1000,
+    );
+    // Retain half a target duration to request and append the candidate fragment.
+    const minBufferAfterCandidateReload =
+      currentDetails.levelTargetDuration / 2;
+    const canWaitForCandidate =
+      !!candidateDetails &&
+      bufferInfo.len -
+        candidateReloadDelay +
+        this.config.maxFragLookUpTolerance >=
+        minBufferAfterCandidateReload;
+
+    const currentHasFragment = this.hasFragmentAtBufferEnd(
+      currentDetails,
+      bufferInfo.end,
+    );
+
+    if (currentHasFragment) {
+      // Continue at the current level unless the buffer covers the candidate refresh.
+      return canWaitForCandidate ? candidateLevel : currentLevel;
+    }
+
+    // The current playlist cannot extend playback. Use the candidate if it can load first or safely wait.
+    const shouldUseCandidate =
+      !candidateDetails ||
+      candidateReloadAt <= currentReloadAt ||
+      canWaitForCandidate;
+    if (shouldUseCandidate) {
+      return candidateLevel;
+    }
+
+    this.log(
+      `Deferring live upswitch from level ${currentLevel} to ${candidateLevel}: candidate playlist does not extend past buffer end ${bufferInfo.end.toFixed(3)}`,
+    );
+    return currentLevel;
+  }
+
+  // helper to check if there is a fragment in the playlist that extends past the end of the buffer, within tolerance.
+  private hasFragmentAtBufferEnd(
+    details: LevelDetails,
+    bufferEnd: number,
+  ): boolean {
+    const fragment = this.getNextFragment(bufferEnd, details);
+    return !!(
+      fragment && fragment.end > bufferEnd + this.config.maxFragLookUpTolerance
+    );
   }
 
   protected loadFragment(

--- a/tests/unit/controller/stream-controller.ts
+++ b/tests/unit/controller/stream-controller.ts
@@ -8,7 +8,11 @@ import { FragmentState } from '../../../src/controller/fragment-tracker';
 import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import { Events } from '../../../src/events';
 import Hls from '../../../src/hls';
-import { ElementaryStreamTypes, Fragment } from '../../../src/loader/fragment';
+import {
+  ElementaryStreamTypes,
+  Fragment,
+  Part,
+} from '../../../src/loader/fragment';
 import { LevelDetails } from '../../../src/loader/level-details';
 import { LoadStats } from '../../../src/loader/load-stats';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
@@ -379,6 +383,208 @@ describe('StreamController', function () {
           expect(foundFragment).to.equal(null);
         });
       });
+    });
+  });
+
+  describe('live upswitch availability', function () {
+    const segmentDuration = 2;
+
+    function createFragment(
+      level: number,
+      sn: number,
+      start: number,
+    ): MediaFragment {
+      const fragment = new Fragment(
+        PlaylistLevelType.MAIN,
+        `level-${level}-${sn}.ts`,
+      ) as MediaFragment;
+      fragment.level = level;
+      fragment.sn = sn;
+      fragment.cc = 0;
+      fragment.setStart(start);
+      fragment.duration = segmentDuration;
+      return fragment;
+    }
+
+    function createLiveLevel(level: number, count: number): Level {
+      const details = new LevelDetails('');
+      details.live = true;
+      details.targetduration = segmentDuration;
+      details.fragments = Array.from({ length: count }, (_, index) =>
+        createFragment(level, 100 + index, index * segmentDuration),
+      );
+      details.startSN = 100;
+      details.endSN = 99 + count;
+      details.totalduration = count * segmentDuration;
+      details.requestScheduled = Number.POSITIVE_INFINITY;
+      const levelInfo = new Level({
+        name: `${level}`,
+        url: `level-${level}.m3u8`,
+        attrs,
+        bitrate: 500000 * (level + 1),
+      });
+      levelInfo.details = details;
+      return levelInfo;
+    }
+
+    function bufferInfo(len: number, end: number) {
+      return {
+        len,
+        start: end - len,
+        end,
+        bufferedIndex: 0,
+      };
+    }
+
+    function setLevels(currentCount: number, candidateCount?: number) {
+      const current = createLiveLevel(0, currentCount);
+      const candidate = createLiveLevel(1, candidateCount ?? 0);
+      if (candidateCount === undefined) {
+        candidate.details = undefined;
+      }
+      streamController['levels'] = [current, candidate];
+      return { current, candidate };
+    }
+
+    it('keeps loading the current rendition when a live upswitch playlist is unavailable near the edge', function () {
+      const { current } = setLevels(2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[0] as MediaFragment;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 2)),
+      ).to.equal(0);
+    });
+
+    it('loads an unavailable candidate playlist when the current rendition has no fragment', function () {
+      const { current } = setLevels(2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[1] as MediaFragment;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(4, 4)),
+      ).to.equal(1);
+    });
+
+    it('loads an upswitch fragment when the candidate playlist extends past the buffer end', function () {
+      const { current } = setLevels(2, 2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[0] as MediaFragment;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 2)),
+      ).to.equal(1);
+    });
+
+    it('returns to the current rendition when its playlist refresh is scheduled before the unavailable candidate', function () {
+      const { current, candidate } = setLevels(2, 2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[1] as MediaFragment;
+      const now = self.performance.now();
+      current.details!.requestScheduled = now + 100;
+      candidate.details!.requestScheduled = now + 2000;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(0.5, 4)),
+      ).to.equal(0);
+    });
+
+    it('waits on the candidate when its playlist refresh is scheduled first', function () {
+      const { current, candidate } = setLevels(2, 2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[1] as MediaFragment;
+      const now = self.performance.now();
+      current.details!.requestScheduled = now + 200;
+      candidate.details!.requestScheduled = now + 100;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(0.5, 4)),
+      ).to.equal(1);
+    });
+
+    it('waits for a later candidate refresh while the forward buffer has a safety margin', function () {
+      const { current, candidate } = setLevels(2, 2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[1] as MediaFragment;
+      const now = self.performance.now();
+      current.details!.requestScheduled = now + 100;
+      candidate.details!.requestScheduled = now + 2000;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(4, 4)),
+      ).to.equal(1);
+    });
+
+    it('waits briefly for a candidate refresh when one segment remains buffered', function () {
+      const { current, candidate } = setLevels(3, 2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[1] as MediaFragment;
+      const now = self.performance.now();
+      current.details!.requestScheduled = now + 200;
+      candidate.details!.requestScheduled = now + 100;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 4)),
+      ).to.equal(1);
+    });
+
+    it('keeps loading the current rendition when the candidate refresh would consume the safety margin', function () {
+      const { current, candidate } = setLevels(3, 2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[1] as MediaFragment;
+      const now = self.performance.now();
+      current.details!.requestScheduled = now + 2000;
+      candidate.details!.requestScheduled = now + 2000;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 4)),
+      ).to.equal(0);
+    });
+
+    it('does not defer an upswitch with two segments still published ahead', function () {
+      const { current } = setLevels(3);
+      streamController['fragPrevious'] = current.details!
+        .fragments[0] as MediaFragment;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 2)),
+      ).to.equal(1);
+    });
+
+    it('does not affect VOD upswitches', function () {
+      const { current } = setLevels(2);
+      current.details!.live = false;
+      streamController['fragPrevious'] = current.details!
+        .fragments[0] as MediaFragment;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 2)),
+      ).to.equal(1);
+    });
+
+    it('does not affect low-latency part playlists', function () {
+      const { current } = setLevels(2);
+      const fragment = current.details!.fragments[0] as MediaFragment;
+      current.details!.partList = [
+        new Part(new AttrList('DURATION=1,URI="part.ts"'), fragment, '', 0),
+      ];
+      streamController['fragPrevious'] = current.details!
+        .fragments[0] as MediaFragment;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 2)),
+      ).to.equal(1);
+    });
+
+    it('does not affect manual level selection', function () {
+      const { current } = setLevels(2);
+      streamController['fragPrevious'] = current.details!
+        .fragments[0] as MediaFragment;
+      hls['levelController']['manualLevelIndex'] = 1;
+
+      expect(
+        streamController['getLevelForLiveUpSwitch'](1, bufferInfo(2, 2)),
+      ).to.equal(1);
     });
   });
 


### PR DESCRIPTION
### This PR will...

This change checks whether segments are available before committing to an automatic live upswitch near the playlist
edge, and defers the upswitch if the next segment is not yet (predicted to be) available.

If the higher rendition already contains the next segment (i.e., a fragment that extends the forward buffer), the switch continues normally (as currently the case).

If the higher rendition has no next segment, hls.js either waits for its scheduled playlist refresh or just continues at the current rendition (i.e., it defers the upswitch).

We assume that we want at least half a segment duration remaining after the refresh. So we check the time stamps when the refresh will occur, and calculate the reserve.

Example 1:

    2.0 s buffered
    candidate playlist refresh in:  2.0 s
    remaining after refresh:        0 s
    required reserve:               1.0 s (half the target duration)

→ This would keep the current rendition and load its available next segment.

Example 2:

    2.0 s buffered
    candidate playlist refresh in:  0.2 s
    remaining after refresh:        1.8 s
    required reserve:               1.0 s (half the target duration)

→ the switch is permitted, we wait for the candidate playlist refresh.

This only applies to live playlists near the edge. We do not change VoD behavior, manual level selection, downswitches,
LL-HLS part playlists, or live playback where enough segments are published ahead of time.

### Why is this Pull Request needed?

We are investigating a streaming setup where the live playback sometimes stalls even though the estimated bandwidth
would be sufficient. The problem is that a low edge latency is the goal, yet playlist refreshes cannot always happen
in time.

Specifically, the setup uses `liveSyncDurationCount: 2`. While we acknowledge that this is explicitly documented as
prone to causing stalls, it still menas that a live stream can start with only one segment of playable buffer remaining.
The ABR would then select a higher rendition because the estimated bandwidth is indeed sufficient, even though that rendition's media playlist does not even contain the segment needed at the end of the current buffer.

The current `StreamController` just commits to this switch and enters the `WAITING_LEVEL`. Then, if the buffer is
exhausted, the player emits a short `waiting` event, then hls.js reports a `bufferStalledError`.
Once the missing segment becomes available, everything is back to normal.

These `waiting` events would trigger user-visible stalls and warnings during stream monitoring.

### Reproduction

We reproduced this on current `master` with the public _Das Erste_ live master playlist:
`https://daserste-live.ard-mcdn.de/daserste/live/hls/de/master.m3u8`.

We added unit test coverage to create `LevelDetails` that mimic what is going on in that live stream.

Configuration:

```js
{
  lowLatencyMode: true,
  liveSyncDurationCount: 2,
  backBufferLength: 90,
}
```

When we ran the current `master` vs this PR against the stream, we could observe no stalls with this PR while they did
occur on `master`.

We also verified that even with the defensive logic of this PR, it allowed all sessions to reach 1080p within a short amount of time (less than 1 s after startup), so it really only defers what is needed to avoid stalls, not more.

### Are there any points in the code the reviewer needs to double check?

There are some points:

1. We aren't quite sure if the _target duration / 2_ metric is the best choice. When we tried a _target duration ⨉ 2_ threshold, we found that in 40% of the test runs the quality wouldn't switch up at all. This would've been unacceptable.

2. As we're not so familiar with the code base, please check if `LevelDetails.requestScheduled` is used correctly here.

3. Is excluding LL-HLS part playlists done correctly?

Full disclosure: unit test coverage has been added with Codex + GPT-5.6 Sol (High). The unit tests were then reviewed and run by real humans™.

### Resolves issues:

No issue number.

### Test plan

```sh
npm run prettier
npm run sanity-check
npm run test:func
```

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable) (`tests/unit/controller/stream-controller.ts` under `live upswitch availability`)
- [x] API or design changes are documented in API.md → none needed IMO
