### PR TITLE
Do not mark end-of-stream on empty or GAP segments

### DIFF
--- a/src/controller/fragment-tracker.ts
+++ b/src/controller/fragment-tracker.ts
@@ -302,7 +302,7 @@ export class FragmentTracker implements ComponentAPI {
     fragmentEntity.buffered = true;
     const endList = (fragmentEntity.body.endList =
       frag.endList || fragmentEntity.body.endList);
-    if (endList) {
+    if (endList && !frag.gap) {
       this.endListFragments[fragmentEntity.body.type] = fragmentEntity;
     }
   }


### PR DESCRIPTION
### This PR will...
Prevent duration collapse on seek to gap at end.

### Why is this Pull Request needed?
Marking end-of-stream on segments that do not contribute to the buffer results in the last buffered content being considered the end.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:
Fixes #8025

