### PR TITLE
fix(audio-track): match assocLang using its own guard, not lang's

### DIFF
--- a/src/utils/rendition-helper.ts
+++ b/src/utils/rendition-helper.ts
@@ -373,7 +373,7 @@ export function matchesOption(
     (groupId === undefined || track.groupId === groupId) &&
     (name === undefined || track.name === name) &&
     (lang === undefined || languagesMatch(lang, track.lang)) &&
-    (lang === undefined || track.assocLang === assocLang) &&
+    (assocLang === undefined || track.assocLang === assocLang) &&
     (isDefault === undefined || track.default === isDefault) &&
     (forced === undefined || track.forced === forced) &&
     (!('characteristics' in option) ||

--- a/tests/index.js
+++ b/tests/index.js
@@ -57,6 +57,7 @@ import './unit/utils/imsc1-ttml-parser';
 import './unit/utils/mediacapabilities-helper';
 import './unit/utils/mp4-tools';
 import './unit/utils/output-filter';
+import './unit/utils/rendition-helper';
 import './unit/utils/safe-json-stringify';
 import './unit/utils/texttrack-utils';
 import './unit/utils/url-tools';

--- a/tests/unit/utils/rendition-helper.ts
+++ b/tests/unit/utils/rendition-helper.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { AttrList } from '../../../src/utils/attr-list';
+import { matchesOption } from '../../../src/utils/rendition-helper';
+import type {
+  AudioSelectionOption,
+  MediaAttributes,
+  MediaPlaylist,
+} from '../../../src/types/media-playlist';
+
+function makeTrack(overrides: Partial<MediaPlaylist>): MediaPlaylist {
+  return {
+    attrs: new AttrList({}) as MediaAttributes,
+    bitrate: 0,
+    autoselect: false,
+    default: false,
+    forced: false,
+    groupId: 'g',
+    id: 0,
+    name: 'n',
+    type: 'AUDIO',
+    url: '',
+    ...overrides,
+  } as MediaPlaylist;
+}
+
+describe('matchesOption', function () {
+  it('only enforces assocLang when the option specifies it', function () {
+    const track = makeTrack({ lang: 'en', assocLang: 'fr' });
+
+    // An option requesting a different assocLang must not match, even when it
+    // does not constrain lang.
+    const differentAssoc: AudioSelectionOption = { assocLang: 'de' };
+    expect(matchesOption(differentAssoc, track)).to.equal(false);
+
+    // An option that constrains lang but not assocLang must still match a
+    // track that happens to carry an assocLang.
+    const langOnly: AudioSelectionOption = { lang: 'en' };
+    expect(matchesOption(langOnly, track)).to.equal(true);
+
+    // A matching assocLang still matches.
+    const sameAssoc: AudioSelectionOption = { assocLang: 'fr' };
+    expect(matchesOption(sameAssoc, track)).to.equal(true);
+  });
+});

--- a/tests/unit/utils/rendition-helper.ts
+++ b/tests/unit/utils/rendition-helper.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../../src/types/media-playlist';
 
 function makeTrack(overrides: Partial<MediaPlaylist>): MediaPlaylist {
-  return {
+  const track: MediaPlaylist = {
     attrs: new AttrList({}) as MediaAttributes,
     bitrate: 0,
     autoselect: false,
@@ -19,8 +19,9 @@ function makeTrack(overrides: Partial<MediaPlaylist>): MediaPlaylist {
     name: 'n',
     type: 'AUDIO',
     url: '',
-    ...overrides,
-  } as MediaPlaylist;
+  };
+
+  return { ...track, ...overrides };
 }
 
 describe('matchesOption', function () {


### PR DESCRIPTION
### Summary

In `matchesOption` (`src/utils/rendition-helper.ts`), the ASSOC-LANGUAGE clause is gated on the wrong variable:

```ts
(lang === undefined || languagesMatch(lang, track.lang)) &&
(lang === undefined || track.assocLang === assocLang) &&   // <- uses lang's guard
```

Every other clause follows `X === undefined || track.X === X`, but this one checks `assocLang` while gating on `lang`. Two consequences:

1. An option that requests a specific `assocLang` but doesn't constrain `lang` matches tracks with a **different** assocLang (the clause short-circuits to `true` because `lang === undefined`).
2. An option that constrains `lang` but not `assocLang` **fails** to match a track that carries an assocLang (because it then requires `track.assocLang === undefined`).

### Fix

Gate the clause on `assocLang === undefined`, like every sibling clause.

### Test

Added `tests/unit/utils/rendition-helper.ts` covering both directions. On `master` the "different assocLang" case wrongly matches and the "lang-only" case wrongly fails to match; both pass with this change.
