### PR TITLE
Cancel subtitle fragment loading when track changes or subtitles are disabled

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -255,6 +255,7 @@ export class SubtitleStreamController
   ) {
     this.currentTrackId = data.id;
 
+    this.abortCurrentFrag();
     if (!this.levels?.length || this.currentTrackId === -1) {
       this.clearInterval();
       return;

--- a/tests/unit/controller/subtitle-stream-controller.ts
+++ b/tests/unit/controller/subtitle-stream-controller.ts
@@ -107,6 +107,32 @@ describe('SubtitleStreamController', function () {
       });
       expect(subtitleStreamController.clearInterval).to.have.been.calledOnce;
     });
+
+    it('should cancel frag loading when disabling tracks', function () {
+      subtitleStreamController.state = State.FRAG_LOADING;
+      subtitleStreamController.fragCurrent = new Fragment(
+        PlaylistLevelType.SUBTITLE,
+        '',
+      );
+      hls.trigger(Events.SUBTITLE_TRACK_SWITCH, {
+        id: -1,
+      });
+      expect(subtitleStreamController.state).to.eq(State.IDLE);
+      expect(subtitleStreamController.fragCurrent).to.eq(null);
+    });
+
+    it('should cancel frag loading when changing tracks', function () {
+      subtitleStreamController.state = State.FRAG_LOADING;
+      subtitleStreamController.fragCurrent = new Fragment(
+        PlaylistLevelType.SUBTITLE,
+        '',
+      );
+      hls.trigger(Events.SUBTITLE_TRACK_SWITCH, {
+        id: 0,
+      });
+      expect(subtitleStreamController.state).to.eq(State.IDLE);
+      expect(subtitleStreamController.fragCurrent).to.eq(null);
+    });
   });
 
   describe('onSubtitleTrackLoaded', function () {


### PR DESCRIPTION
### This PR will...
Cancel subtitle fragment loading when track changes or subtitles are disabled.

### Why is this Pull Request needed?
Subtitle segment loading locks up when disabling subtitles while subtitle segments are in-flight (subtitle-stream-controller remains in FRAG_LOADING state).

### Resolves issues:
Fixes #8036

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
